### PR TITLE
Port PicoClaw to Delphi Object Pascal (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 vendor/
+src/pkg/gateway/webui.res
 *.o
 *.ppu
 *.compiled

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+vendor/
 *.o
 *.ppu
 *.compiled

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+build/
+*.o
+*.ppu
+*.compiled
+*.lps
+*.bak
+*.exe
+*~
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ UNIT_DIRS = \
 	src/pkg/utils \
 	src/pkg/logger \
 	src/pkg/config \
+	src/pkg/providers \
+	src/pkg/tokenizer \
 	src/cmd
 
 FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ UNIT_DIRS = \
 	src/pkg/cron \
 	src/pkg/skills \
 	src/pkg/memory \
+	src/pkg/updater \
+	src/pkg/membench \
+	src/pkg/tui \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).
@@ -97,16 +100,17 @@ print-version:
 smoke: $(BIN)
 	@PASCLAW_HOME=$$(mktemp -d) ; export PASCLAW_HOME ; \
 	echo "smoke: home=$$PASCLAW_HOME" ; \
-	NO_COLOR=1 $(BIN) version              >/dev/null && echo "  version  OK" ; \
-	NO_COLOR=1 $(BIN) --help               >/dev/null && echo "  help     OK" ; \
-	NO_COLOR=1 $(BIN) config reset         >/dev/null && echo "  config   OK" ; \
-	NO_COLOR=1 $(BIN) status               >/dev/null && echo "  status   OK" ; \
-	NO_COLOR=1 $(BIN) mcp list             >/dev/null && echo "  mcp      OK" ; \
-	NO_COLOR=1 $(BIN) cron list            >/dev/null && echo "  cron     OK" ; \
-	NO_COLOR=1 $(BIN) skills list          >/dev/null && echo "  skills   OK" ; \
-	NO_COLOR=1 $(BIN) model show           >/dev/null && echo "  model    OK" ; \
-	NO_COLOR=1 $(BIN) migrate              >/dev/null && echo "  migrate  OK" ; \
-	NO_COLOR=1 $(BIN) update               >/dev/null && echo "  update   OK" ; \
+	NO_COLOR=1 $(BIN) version                  >/dev/null && echo "  version   OK" ; \
+	NO_COLOR=1 $(BIN) --help                   >/dev/null && echo "  help      OK" ; \
+	NO_COLOR=1 $(BIN) config reset             >/dev/null && echo "  config    OK" ; \
+	NO_COLOR=1 $(BIN) status                   >/dev/null && echo "  status    OK" ; \
+	NO_COLOR=1 $(BIN) mcp list                 >/dev/null && echo "  mcp       OK" ; \
+	NO_COLOR=1 $(BIN) cron list                >/dev/null && echo "  cron      OK" ; \
+	NO_COLOR=1 $(BIN) skills list              >/dev/null && echo "  skills    OK" ; \
+	NO_COLOR=1 $(BIN) model show               >/dev/null && echo "  model     OK" ; \
+	NO_COLOR=1 $(BIN) migrate                  >/dev/null && echo "  migrate   OK" ; \
+	NO_COLOR=1 $(BIN) update --check           >/dev/null && echo "  update    OK" ; \
+	NO_COLOR=1 $(BIN) membench --records 100   >/dev/null && echo "  membench  OK" ; \
 	echo "smoke: all commands OK"
 
 test: smoke

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+# PasClaw - Delphi Object Pascal port of picoclaw
+# Builds with Free Pascal (FPC 3.2+, mode Delphi).
+
+FPC      ?= fpc
+BUILDDIR ?= build
+BIN      ?= $(BUILDDIR)/pasclaw
+
+# Unit search paths — every src/pkg/* and src/cmd directory.
+UNIT_DIRS = \
+	src/pkg/cliui \
+	src/pkg/utils \
+	src/pkg/logger \
+	src/pkg/config \
+	src/cmd
+
+FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
+	$(foreach d,$(UNIT_DIRS),-Fu$(d)) \
+	-FE$(BUILDDIR) \
+	-FU$(BUILDDIR)/lib
+
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
+
+.PHONY: all clean run test smoke print-version
+
+all: $(BIN)
+
+$(BIN): | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	PASCLAW_VERSION='$(VERSION)' $(FPC) $(FPCFLAGS) src/pasclaw/PasClaw.dpr -o$(BIN)
+
+$(BUILDDIR):
+	@mkdir -p $(BUILDDIR)
+
+clean:
+	rm -rf $(BUILDDIR)
+
+run: $(BIN)
+	@$(BIN)
+
+print-version:
+	@echo $(VERSION)
+
+# Quick smoke test that every top-level command at least prints help/status
+# without crashing. Useful when adding subcommands.
+smoke: $(BIN)
+	@PASCLAW_HOME=$$(mktemp -d) ; export PASCLAW_HOME ; \
+	echo "smoke: home=$$PASCLAW_HOME" ; \
+	NO_COLOR=1 $(BIN) version              >/dev/null && echo "  version  OK" ; \
+	NO_COLOR=1 $(BIN) --help               >/dev/null && echo "  help     OK" ; \
+	NO_COLOR=1 $(BIN) config reset         >/dev/null && echo "  config   OK" ; \
+	NO_COLOR=1 $(BIN) status               >/dev/null && echo "  status   OK" ; \
+	NO_COLOR=1 $(BIN) mcp list             >/dev/null && echo "  mcp      OK" ; \
+	NO_COLOR=1 $(BIN) cron list            >/dev/null && echo "  cron     OK" ; \
+	NO_COLOR=1 $(BIN) skills list          >/dev/null && echo "  skills   OK" ; \
+	NO_COLOR=1 $(BIN) model show           >/dev/null && echo "  model    OK" ; \
+	NO_COLOR=1 $(BIN) migrate              >/dev/null && echo "  migrate  OK" ; \
+	NO_COLOR=1 $(BIN) update               >/dev/null && echo "  update   OK" ; \
+	NO_COLOR=1 $(BIN) gateway              >/dev/null && echo "  gateway  OK" ; \
+	echo "smoke: all commands OK"
+
+test: smoke

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,19 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke print-version get-indy
+.PHONY: all clean run test smoke print-version get-indy webui-res
 
-all: $(BIN)
+# Compile the HTML resource into a .res that {$R webui.res} embeds.
+WEBUI_RES = src/pkg/gateway/webui.res
 
-$(BIN): | $(BUILDDIR) $(INDY_DIR)
+webui-res: $(WEBUI_RES)
+
+$(WEBUI_RES): src/pkg/gateway/webui.rc src/pkg/gateway/webui.html
+	cd src/pkg/gateway && fpcres -of res -o webui.res webui.rc
+
+all: $(WEBUI_RES) $(BIN)
+
+$(BIN): $(WEBUI_RES) | $(BUILDDIR) $(INDY_DIR)
 	@mkdir -p $(BUILDDIR)/lib
 	PASCLAW_VERSION='$(VERSION)' $(FPC) $(FPCFLAGS) src/pasclaw/PasClaw.dpr -o$(BIN)
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ UNIT_DIRS = \
 	src/pkg/config \
 	src/pkg/providers \
 	src/pkg/tokenizer \
+	src/pkg/tools \
 	src/cmd
 
 FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ UNIT_DIRS = \
 	src/pkg/utils \
 	src/pkg/logger \
 	src/pkg/config \
+	src/pkg/json \
 	src/pkg/providers \
 	src/pkg/tokenizer \
 	src/pkg/tools \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ UNIT_DIRS = \
 	src/pkg/mcp \
 	src/pkg/gateway \
 	src/pkg/channels \
+	src/pkg/cron \
+	src/pkg/skills \
+	src/pkg/memory \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ UNIT_DIRS = \
 	src/pkg/providers \
 	src/pkg/tokenizer \
 	src/pkg/tools \
+	src/pkg/mcp \
 	src/cmd
 
 FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
 # PasClaw - Delphi Object Pascal port of picoclaw
-# Builds with Free Pascal (FPC 3.2+, mode Delphi).
+# Builds with Free Pascal (FPC 3.2+, mode Delphi) or Delphi/RAD Studio.
+#
+# Indy is required for HTTP client/server (TIdHTTP, TIdHTTPServer). Under FPC
+# we vendor it via `make get-indy` (clones IndySockets/Indy into vendor/Indy).
+# Under Delphi, Indy ships with RAD Studio — no vendoring needed.
 
 FPC      ?= fpc
 BUILDDIR ?= build
 BIN      ?= $(BUILDDIR)/pasclaw
 
-# Unit search paths — every src/pkg/* and src/cmd directory.
+INDY_DIR     ?= vendor/Indy
+INDY_REPO    ?= https://github.com/IndySockets/Indy.git
+# iconvenc lives in fp-units-misc on Debian; FPC's default config picks it up
+# on most distros but not always.
+ICONVENC_DIR ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/iconvenc
+
+# PasClaw source dirs.
 UNIT_DIRS = \
 	src/pkg/cliui \
 	src/pkg/utils \
@@ -15,22 +25,48 @@ UNIT_DIRS = \
 	src/pkg/tokenizer \
 	src/pkg/tools \
 	src/pkg/mcp \
+	src/pkg/gateway \
+	src/pkg/channels \
 	src/cmd
+
+# Indy unit + include dirs (only used when building under FPC).
+INDY_UNIT_DIRS = \
+	$(INDY_DIR)/Lib/Core \
+	$(INDY_DIR)/Lib/Protocols \
+	$(INDY_DIR)/Lib/System
+
+INDY_INC_DIRS = $(INDY_UNIT_DIRS)
 
 FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 	$(foreach d,$(UNIT_DIRS),-Fu$(d)) \
+	$(foreach d,$(INDY_UNIT_DIRS),-Fu$(d)) \
+	$(foreach d,$(INDY_INC_DIRS),-Fi$(d)) \
+	-Fu$(ICONVENC_DIR) \
 	-FE$(BUILDDIR) \
 	-FU$(BUILDDIR)/lib
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke print-version
+.PHONY: all clean run test smoke print-version get-indy
 
 all: $(BIN)
 
-$(BIN): | $(BUILDDIR)
+$(BIN): | $(BUILDDIR) $(INDY_DIR)
 	@mkdir -p $(BUILDDIR)/lib
 	PASCLAW_VERSION='$(VERSION)' $(FPC) $(FPCFLAGS) src/pasclaw/PasClaw.dpr -o$(BIN)
+
+$(INDY_DIR):
+	@echo "Indy not found at $(INDY_DIR); run 'make get-indy' to clone it."
+	@false
+
+get-indy:
+	@if [ ! -d $(INDY_DIR) ]; then \
+	  mkdir -p $(dir $(INDY_DIR)); \
+	  echo "Cloning Indy into $(INDY_DIR)..."; \
+	  git clone --depth 1 $(INDY_REPO) $(INDY_DIR); \
+	else \
+	  echo "Indy already present at $(INDY_DIR)"; \
+	fi
 
 $(BUILDDIR):
 	@mkdir -p $(BUILDDIR)
@@ -59,7 +95,6 @@ smoke: $(BIN)
 	NO_COLOR=1 $(BIN) model show           >/dev/null && echo "  model    OK" ; \
 	NO_COLOR=1 $(BIN) migrate              >/dev/null && echo "  migrate  OK" ; \
 	NO_COLOR=1 $(BIN) update               >/dev/null && echo "  update   OK" ; \
-	NO_COLOR=1 $(BIN) gateway              >/dev/null && echo "  gateway  OK" ; \
 	echo "smoke: all commands OK"
 
 test: smoke

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# PasClaw
+
+PasClaw is a Delphi Object Pascal port of [PicoClaw](https://github.com/sipeed/picoclaw) —
+Sipeed's ultra-lightweight personal AI agent. It targets Free Pascal 3.2+ in
+`{$MODE DELPHI}` so the same sources build with both FPC and Delphi RAD Studio.
+
+The port is being done in phases. Phase 1 (this commit) ships the full
+command-tree skeleton; subsequent phases fill in real provider, MCP, gateway,
+cron, skills, and channel implementations.
+
+## Build
+
+```
+sudo apt install fpc            # Free Pascal 3.2+
+make                            # produces build/pasclaw
+make smoke                      # runs every top-level command
+```
+
+Or with Delphi: open `src/pasclaw/PasClaw.dpr` and add `src/pkg/*` and `src/cmd`
+to the search path.
+
+## Usage
+
+```
+pasclaw onboard            # initialise ~/.pasclaw + config.json
+pasclaw agent -m "hello"   # one-shot chat (Phase 3 wires real provider)
+pasclaw agent              # interactive chat
+pasclaw gateway            # start the gateway (Phase 4)
+pasclaw status             # show effective config
+pasclaw mcp list           # list MCP servers
+pasclaw mcp add <name> <cmd> [args...]
+pasclaw cron list|add|disable|enable|remove
+pasclaw skills list|install|remove
+pasclaw model show|set <name>
+pasclaw auth login|logout|status <provider>
+pasclaw version
+```
+
+Globals: `--no-color` (or `NO_COLOR=1`) disables ANSI styling.
+`PASCLAW_HOME` overrides the home directory (default `~/.pasclaw`).
+`PASCLAW_CONFIG` overrides the config path.
+
+## Layout
+
+```
+src/
+  pasclaw/          program entry (PasClaw.dpr)
+  cmd/              one unit per CLI subcommand
+  pkg/
+    cliui/          colour, banner, panel rendering
+    config/         on-disk JSON config + version constants
+    logger/         levelled logging
+    utils/          path / string / file helpers
+```
+
+## Roadmap
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| 1 | CLI skeleton, banner, config, command dispatch | done |
+| 2 | Anthropic + OpenAI HTTP clients, tokenizer | next |
+| 3 | Real agent loop with streaming + tool calls    | |
+| 4 | Gateway (fphttpserver), routing, channels      | |
+| 5 | MCP client (stdio + HTTP), cron scheduler      | |
+| 6 | Skills loader, memory store, evolution engine  | |
+| 7 | Self-update, web UI launcher, membench tool    | |
+
+License: MIT (see LICENSE).

--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ src/
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| 1 | CLI skeleton, banner, config, command dispatch | done |
-| 2 | Anthropic + OpenAI HTTP clients, tokenizer | next |
-| 3 | Real agent loop with streaming + tool calls    | |
-| 4 | Gateway (fphttpserver), routing, channels      | |
-| 5 | MCP client (stdio + HTTP), cron scheduler      | |
-| 6 | Skills loader, memory store, evolution engine  | |
-| 7 | Self-update, web UI launcher, membench tool    | |
+| 1 | CLI skeleton, banner, config, command dispatch         | ✅ done |
+| 2 | Anthropic + OpenAI HTTP clients, tokenizer             | ✅ done |
+| 3 | Tool registry + built-in tools (fs/shell) + tool loop  | ✅ done |
+| 4 | MCP stdio client + bridge into tools registry          | ✅ done |
+| 5 | Gateway (fphttpserver), routing, channels (Telegram, Discord) | todo |
+| 6 | Cron scheduler, skills loader, memory store            | todo |
+| 7 | MCP over HTTP/SSE, streaming responses (true SSE)      | todo |
+| 8 | Self-update, web UI launcher, membench tool            | todo |
 
 License: MIT (see LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,31 +10,58 @@ cron, skills, and channel implementations.
 
 ## Build
 
+### With Free Pascal (Linux / Windows)
+
 ```
-sudo apt install fpc            # Free Pascal 3.2+
-make                            # produces build/pasclaw
-make smoke                      # runs every top-level command
+sudo apt install fpc fp-units-misc       # Free Pascal 3.2+, includes iconvenc
+make get-indy                            # clones IndySockets/Indy → vendor/Indy
+make                                     # produces build/pasclaw
+make smoke                               # runs every top-level command
 ```
 
-Or with Delphi: open `src/pasclaw/PasClaw.dpr` and add `src/pkg/*` and `src/cmd`
-to the search path.
+The HTTP client/server, Telegram channel, and any forthcoming socket-based
+adapter all go through Indy — the same units build under Delphi without
+any source changes.
+
+### With Delphi / RAD Studio
+
+Open `src/pasclaw/PasClaw.dpr`. Add the following to the project search path:
+`src/cmd`, `src/pkg/cliui`, `src/pkg/utils`, `src/pkg/logger`,
+`src/pkg/config`, `src/pkg/providers`, `src/pkg/tokenizer`, `src/pkg/tools`,
+`src/pkg/mcp`, `src/pkg/gateway`, `src/pkg/channels`. Indy ships with RAD
+Studio so no vendoring is needed.
+
+> **JSON note:** Phase 1-5 use FPC's `fpjson`. The Delphi port will swap that
+> for `System.JSON` (Delphi 10.4+) or `JsonDataObjects` via a thin abstraction
+> unit — flagged for the next phase.
 
 ## Usage
 
 ```
-pasclaw onboard            # initialise ~/.pasclaw + config.json
-pasclaw agent -m "hello"   # one-shot chat (Phase 3 wires real provider)
-pasclaw agent              # interactive chat
-pasclaw gateway            # start the gateway (Phase 4)
-pasclaw status             # show effective config
-pasclaw mcp list           # list MCP servers
-pasclaw mcp add <name> <cmd> [args...]
+pasclaw onboard                            # initialise ~/.pasclaw + config.json
+pasclaw agent -m "hello"                   # one-shot chat (real LLM)
+pasclaw agent                              # interactive chat with tools + MCP
+pasclaw gateway                            # HTTP API on 127.0.0.1:8088
+pasclaw gateway --telegram --token <TOK>   # API + Telegram bot
+pasclaw gateway --addr 0.0.0.0 --port 8088
+pasclaw status
+pasclaw mcp list | mcp add <name> <cmd> [args] | mcp test <name>
 pasclaw cron list|add|disable|enable|remove
 pasclaw skills list|install|remove
 pasclaw model show|set <name>
 pasclaw auth login|logout|status <provider>
 pasclaw version
 ```
+
+The gateway exposes:
+
+| Route          | Method | Body / Returns                              |
+|----------------|--------|---------------------------------------------|
+| `/v1/health`   | GET    | `{status, version}`                         |
+| `/v1/version`  | GET    | `{version, build}`                          |
+| `/v1/status`   | GET    | counts of providers, tools, MCP servers     |
+| `/v1/tools`    | GET    | registered tool descriptors                 |
+| `/v1/chat`     | POST   | `{message}` ⇒ `{content, iterations, …}`    |
 
 Globals: `--no-color` (or `NO_COLOR=1`) disables ANSI styling.
 `PASCLAW_HOME` overrides the home directory (default `~/.pasclaw`).
@@ -58,12 +85,13 @@ src/
 | Phase | Scope | Status |
 |-------|-------|--------|
 | 1 | CLI skeleton, banner, config, command dispatch         | ✅ done |
-| 2 | Anthropic + OpenAI HTTP clients, tokenizer             | ✅ done |
+| 2 | Anthropic + OpenAI HTTP clients (Indy), tokenizer      | ✅ done |
 | 3 | Tool registry + built-in tools (fs/shell) + tool loop  | ✅ done |
 | 4 | MCP stdio client + bridge into tools registry          | ✅ done |
-| 5 | Gateway (fphttpserver), routing, channels (Telegram, Discord) | todo |
-| 6 | Cron scheduler, skills loader, memory store            | todo |
-| 7 | MCP over HTTP/SSE, streaming responses (true SSE)      | todo |
-| 8 | Self-update, web UI launcher, membench tool            | todo |
+| 5 | Indy gateway (TIdHTTPServer) + Telegram long-poll bot  | ✅ done |
+| 6 | JSON abstraction, additional channels (Discord/Slack)  | todo |
+| 7 | Cron scheduler, skills loader, memory store            | todo |
+| 8 | MCP over HTTP/SSE, true SSE streaming, web UI launcher | todo |
+| 9 | Self-update, membench tool, TUI front-end              | todo |
 
 License: MIT (see LICENSE).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Studio so no vendoring is needed.
 pasclaw onboard                            # initialise ~/.pasclaw + config.json
 pasclaw agent -m "hello"                   # one-shot chat (real LLM)
 pasclaw agent                              # interactive chat with tools + MCP
-pasclaw gateway                            # HTTP API on 127.0.0.1:8088
+pasclaw tui                                # full-screen TUI chat
+pasclaw gateway                            # HTTP API + web UI on 127.0.0.1:8088
 pasclaw gateway --telegram --token <TOK>   # API + Telegram bot
 pasclaw gateway --addr 0.0.0.0 --port 8088
 pasclaw status
@@ -49,6 +50,9 @@ pasclaw mcp list | mcp add <name> <cmd> [args] | mcp test <name>
 pasclaw cron list|add|disable|enable|remove
 pasclaw skills list|install|remove
 pasclaw model show|set <name>
+pasclaw post discord|slack <webhook-url> "<content>"
+pasclaw membench [--records N] [--content N]
+pasclaw update [--check] [--repo owner/name]
 pasclaw auth login|logout|status <provider>
 pasclaw version
 ```
@@ -89,9 +93,9 @@ src/
 | 3 | Tool registry + built-in tools (fs/shell) + tool loop  | ✅ done |
 | 4 | MCP stdio client + bridge into tools registry          | ✅ done |
 | 5 | Indy gateway (TIdHTTPServer) + Telegram long-poll bot  | ✅ done |
-| 6 | JSON abstraction, additional channels (Discord/Slack)  | todo |
-| 7 | Cron scheduler, skills loader, memory store            | todo |
-| 8 | MCP over HTTP/SSE, true SSE streaming, web UI launcher | todo |
-| 9 | Self-update, membench tool, TUI front-end              | todo |
+| 6 | JSON abstraction, additional channels (Discord/Slack)  | ✅ done |
+| 7 | Cron scheduler, skills loader, memory store            | ✅ done |
+| 8 | MCP over HTTP/SSE, SSE-streaming helper, web UI        | ✅ done |
+| 9 | Self-update (GitHub releases), membench, TUI front-end | ✅ done |
 
 License: MIT (see LICENSE).

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -1,9 +1,12 @@
 {
-  Agent — chat with the assistant. Two modes:
+  Agent — chat with the assistant.
+
+  Two modes:
     pasclaw agent -m "single query"   one-shot
     pasclaw agent                     interactive
-  Wires through PasClaw.Providers.Factory; falls back to an offline preview
-  when no API key is configured so the CLI still demonstrates the shape.
+
+  Always wires the built-in tools registry (fs_read, fs_write, fs_list,
+  shell_exec). Falls back to an offline preview if no provider is configured.
 }
 unit PasClaw.Cmd.Agent;
 {$MODE DELPHI}
@@ -20,7 +23,11 @@ uses
   PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger,
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
-  PasClaw.Providers.Factory;
+  PasClaw.Providers.Factory,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.FS,
+  PasClaw.Tools.Shell,
+  PasClaw.Tools.ToolLoop;
 
 type
   TAgentArgs = record
@@ -30,7 +37,33 @@ type
     SystemPrompt:  string;
     Thinking:      string;
     MaxTokens:     Integer;
+    MaxIterations: Integer;
+    NoTools:       Boolean;
   end;
+
+  TLoopHandlers = class
+    procedure OnToolCall(const Name, ArgsJSON: string);
+    procedure OnToolResult(const Name, ResultText, Err: string);
+  end;
+
+procedure TLoopHandlers.OnToolCall(const Name, ArgsJSON: string);
+begin
+  WriteLn(Ansi.Magenta, '› tool ', Name, Ansi.Reset, ' ', Copy(ArgsJSON, 1, 200));
+end;
+
+procedure TLoopHandlers.OnToolResult(const Name, ResultText, Err: string);
+var
+  Preview: string;
+begin
+  if Err <> '' then
+    WriteLn(Ansi.Red, '  ✗ ', Err, Ansi.Reset)
+  else
+  begin
+    Preview := ResultText;
+    if Length(Preview) > 200 then Preview := Copy(Preview, 1, 200) + '…';
+    WriteLn(Ansi.Dim, '  ✓ ', Preview, Ansi.Reset);
+  end;
+end;
 
 function DefaultAgentArgs: TAgentArgs;
 begin
@@ -40,6 +73,8 @@ begin
   Result.SystemPrompt  := '';
   Result.Thinking      := '';
   Result.MaxTokens     := 4096;
+  Result.MaxIterations := 8;
+  Result.NoTools       := False;
 end;
 
 function ParseArgs(const Argv: array of string; var A: TAgentArgs): Boolean;
@@ -56,31 +91,13 @@ begin
       if i = High(Argv) then Exit(False);
       A.Message := Argv[i + 1]; Inc(i, 2); Continue;
     end;
-    if Argv[i] = '--model' then
-    begin
-      if i = High(Argv) then Exit(False);
-      A.Model := Argv[i + 1]; Inc(i, 2); Continue;
-    end;
-    if Argv[i] = '--provider' then
-    begin
-      if i = High(Argv) then Exit(False);
-      A.Provider := Argv[i + 1]; Inc(i, 2); Continue;
-    end;
-    if Argv[i] = '--system' then
-    begin
-      if i = High(Argv) then Exit(False);
-      A.SystemPrompt := Argv[i + 1]; Inc(i, 2); Continue;
-    end;
-    if Argv[i] = '--thinking' then
-    begin
-      if i = High(Argv) then Exit(False);
-      A.Thinking := Argv[i + 1]; Inc(i, 2); Continue;
-    end;
-    if Argv[i] = '--max-tokens' then
-    begin
-      if i = High(Argv) then Exit(False);
-      A.MaxTokens := StrToIntDef(Argv[i + 1], A.MaxTokens); Inc(i, 2); Continue;
-    end;
+    if Argv[i] = '--model'    then begin if i = High(Argv) then Exit(False); A.Model := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--provider' then begin if i = High(Argv) then Exit(False); A.Provider := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--system'   then begin if i = High(Argv) then Exit(False); A.SystemPrompt := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--thinking' then begin if i = High(Argv) then Exit(False); A.Thinking := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--max-tokens'     then begin if i = High(Argv) then Exit(False); A.MaxTokens     := StrToIntDef(Argv[i + 1], A.MaxTokens);     Inc(i, 2); Continue; end;
+    if Argv[i] = '--max-iterations' then begin if i = High(Argv) then Exit(False); A.MaxIterations := StrToIntDef(Argv[i + 1], A.MaxIterations); Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-tools' then begin A.NoTools := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -99,42 +116,72 @@ begin
   Result := NewProviderFromConfig(Cfg, Name, Provider, Err);
 end;
 
+function NewBuiltinRegistry: TToolRegistry;
+begin
+  Result := TToolRegistry.Create;
+  RegisterFSTools(Result);
+  RegisterShellTool(Result);
+end;
+
+function BuildLoopConfig(Provider: ILLMProvider; Reg: TToolRegistry;
+                         const Model: string; const A: TAgentArgs;
+                         Handlers: TLoopHandlers): TToolLoopConfig;
+begin
+  Result.Provider      := Provider;
+  Result.Registry      := Reg;
+  Result.Model         := Model;
+  Result.MaxIterations := A.MaxIterations;
+  Result.Options       := DefaultChatOptions;
+  Result.Options.SystemPrompt  := A.SystemPrompt;
+  Result.Options.ThinkingLevel := A.Thinking;
+  if A.MaxTokens > 0 then Result.Options.MaxTokens := A.MaxTokens;
+  Result.OnText        := nil;
+  Result.OnToolCall    := Handlers.OnToolCall;
+  Result.OnToolResult  := Handlers.OnToolResult;
+end;
+
 procedure RunSingleTurn(const Cfg: TConfig; const A: TAgentArgs; const Prompt: string);
 var
   Provider: ILLMProvider;
   Err: string;
   Msgs: array of TMessage;
-  Tools: array of TToolDefinition;
-  Opts: TChatOptions;
-  Resp: TLLMResponse;
+  Reg: TToolRegistry;
+  Handlers: TLoopHandlers;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
   Model: string;
 begin
   if not PickProvider(Cfg, A, Provider, Err) then
   begin
     WriteLn(Ansi.Yellow, '(offline preview — ', Err, ')', Ansi.Reset);
     WriteLn('You: ', Prompt);
-    WriteLn('Assistant: ', '<provider not configured; run `pasclaw onboard` to enable>');
+    WriteLn('Assistant: <provider not configured; run `pasclaw onboard`>');
     Exit;
   end;
 
-  SetLength(Msgs, 1);
-  Msgs[0] := MakeMessage(mrUser, Prompt);
-  SetLength(Tools, 0);
+  Reg := nil;
+  if not A.NoTools then Reg := NewBuiltinRegistry;
+  Handlers := TLoopHandlers.Create;
+  try
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, Prompt);
 
-  Opts := DefaultChatOptions;
-  Opts.SystemPrompt  := A.SystemPrompt;
-  Opts.ThinkingLevel := A.Thinking;
-  if A.MaxTokens > 0 then Opts.MaxTokens := A.MaxTokens;
+    if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
+    LoopCfg := BuildLoopConfig(Provider, Reg, Model, A, Handlers);
 
-  if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
-
-  WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
-  Resp := Provider.Chat(Msgs, Tools, Model, Opts);
-  WriteLn(Resp.Content);
-  if Resp.Usage.InputTokens + Resp.Usage.OutputTokens > 0 then
-    WriteLn(Ansi.Dim,
-      Format('  [tokens in=%d out=%d]', [Resp.Usage.InputTokens, Resp.Usage.OutputTokens]),
-      Ansi.Reset);
+    WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
+    if RunToolLoop(LoopCfg, Msgs, Loop) then
+      WriteLn(Loop.Content)
+    else
+      WriteLn('(loop failed)');
+    if Loop.LastResp.Usage.InputTokens + Loop.LastResp.Usage.OutputTokens > 0 then
+      WriteLn(Ansi.Dim, Format('  [tokens in=%d out=%d, iters=%d]',
+        [Loop.LastResp.Usage.InputTokens, Loop.LastResp.Usage.OutputTokens, Loop.Iterations]),
+        Ansi.Reset);
+  finally
+    Handlers.Free;
+    Reg.Free;
+  end;
 end;
 
 procedure RunInteractive(const Cfg: TConfig; const A: TAgentArgs);
@@ -143,57 +190,75 @@ var
   Provider: ILLMProvider;
   Err: string;
   Msgs: array of TMessage;
-  Tools: array of TToolDefinition;
-  Opts: TChatOptions;
-  Resp: TLLMResponse;
+  Reg: TToolRegistry;
+  Handlers: TLoopHandlers;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
   Model: string;
   Offline: Boolean;
+  i: Integer;
+  Names: TStringArray;
 begin
   Offline := not PickProvider(Cfg, A, Provider, Err);
   if Offline then
     WriteLn(Ansi.Yellow, '(offline preview — ', Err, ')', Ansi.Reset);
-  WriteLn(Ansi.Dim, 'PasClaw interactive chat. /quit to exit, /reset to clear history.', Ansi.Reset);
+  WriteLn(Ansi.Dim, 'PasClaw interactive chat. /quit to exit, /reset to clear history, /tools to list.', Ansi.Reset);
 
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
-  Opts := DefaultChatOptions;
-  Opts.SystemPrompt  := A.SystemPrompt;
-  Opts.ThinkingLevel := A.Thinking;
-  if A.MaxTokens > 0 then Opts.MaxTokens := A.MaxTokens;
-  SetLength(Tools, 0);
-  SetLength(Msgs, 0);
-
-  while True do
-  begin
-    Write(Ansi.Bold, '> ', Ansi.Reset);
-    if EOF then Break;
-    ReadLn(Line);
-    Line := Trim(Line);
-    if (Line = '/quit') or (Line = '/exit') then Break;
-    if Line = '/reset' then
+  Reg := nil;
+  if not A.NoTools then Reg := NewBuiltinRegistry;
+  Handlers := TLoopHandlers.Create;
+  try
+    SetLength(Msgs, 0);
+    while True do
     begin
-      SetLength(Msgs, 0);
-      WriteLn(Ansi.Dim, '(history cleared)', Ansi.Reset);
-      Continue;
-    end;
-    if Line = '' then Continue;
+      Write(Ansi.Bold, '> ', Ansi.Reset);
+      if EOF then Break;
+      ReadLn(Line);
+      Line := Trim(Line);
+      if (Line = '/quit') or (Line = '/exit') then Break;
+      if Line = '/reset' then
+      begin
+        SetLength(Msgs, 0);
+        WriteLn(Ansi.Dim, '(history cleared)', Ansi.Reset);
+        Continue;
+      end;
+      if Line = '/tools' then
+      begin
+        if Reg = nil then
+          WriteLn('(tools disabled — restart without --no-tools)')
+        else
+        begin
+          Names := Reg.Names;
+          for i := 0 to High(Names) do WriteLn('  ', Names[i]);
+        end;
+        Continue;
+      end;
+      if Line = '' then Continue;
 
-    SetLength(Msgs, Length(Msgs) + 1);
-    Msgs[High(Msgs)] := MakeMessage(mrUser, Line);
-
-    if Offline then
-    begin
-      WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (offline): I would respond once a provider is configured.');
       SetLength(Msgs, Length(Msgs) + 1);
-      Msgs[High(Msgs)] := MakeMessage(mrAssistant, '(no response — offline)');
-      Continue;
+      Msgs[High(Msgs)] := MakeMessage(mrUser, Line);
+
+      if Offline then
+      begin
+        WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (offline): I would respond once a provider is configured.');
+        SetLength(Msgs, Length(Msgs) + 1);
+        Msgs[High(Msgs)] := MakeMessage(mrAssistant, '(no response — offline)');
+        Continue;
+      end;
+
+      LoopCfg := BuildLoopConfig(Provider, Reg, Model, A, Handlers);
+      if RunToolLoop(LoopCfg, Msgs, Loop) then
+      begin
+        WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
+        WriteLn(Loop.Content);
+        SetLength(Msgs, Length(Msgs) + 1);
+        Msgs[High(Msgs)] := MakeMessage(mrAssistant, Loop.Content);
+      end;
     end;
-
-    Resp := Provider.Chat(Msgs, Tools, Model, Opts);
-    WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
-    WriteLn(Resp.Content);
-
-    SetLength(Msgs, Length(Msgs) + 1);
-    Msgs[High(Msgs)] := MakeMessage(mrAssistant, Resp.Content);
+  finally
+    Handlers.Free;
+    Reg.Free;
   end;
 end;
 
@@ -204,7 +269,9 @@ var
 begin
   if not ParseArgs(Argv, A) then
   begin
-    WriteLn(ErrOutput, 'usage: pasclaw agent [-m "message"] [--model M] [--provider P] [--system S] [--thinking low|medium|high]');
+    WriteLn(ErrOutput, 'usage: pasclaw agent [-m "msg"] [--model M] [--provider P] [--system S]');
+    WriteLn(ErrOutput, '                     [--thinking low|medium|high] [--max-tokens N]');
+    WriteLn(ErrOutput, '                     [--max-iterations N] [--no-tools]');
     Exit(1);
   end;
 

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -1,0 +1,78 @@
+{
+  Agent — chat with the assistant. Two modes:
+    pasclaw agent -m "single query"   -> one-shot
+    pasclaw agent                     -> interactive
+  Provider wiring lands in Phase 3; for now we accept input and echo back
+  with the configured model so the CLI shape works end-to-end.
+}
+unit PasClaw.Cmd.Agent;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Agent_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger;
+
+function ParseMessage(const Argv: array of string; out Msg: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  i := 0;
+  while i <= High(Argv) do
+  begin
+    if (Argv[i] = '-m') or (Argv[i] = '--message') then
+    begin
+      if i = High(Argv) then Exit(False);
+      Msg := Argv[i + 1];
+      Exit(True);
+    end;
+    Inc(i);
+  end;
+end;
+
+procedure RespondTo(const Cfg: TConfig; const Prompt: string);
+begin
+  { Phase 1 placeholder; Phase 3 replaces this with a real provider call. }
+  WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Cfg.DefaultProvider, '/', Cfg.DefaultModel, '): ');
+  WriteLn('  (offline preview) You said: ', Prompt);
+  WriteLn('  -> wire an API key with `pasclaw onboard` to enable live responses.');
+end;
+
+function Cmd_Agent_Run(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  Msg, Line: string;
+begin
+  Cfg := LoadConfig;
+  try
+    if ParseMessage(Argv, Msg) then
+    begin
+      RespondTo(Cfg, Msg);
+      Exit(0);
+    end;
+
+    WriteLn(Ansi.Dim, 'PasClaw interactive chat. Type /quit to exit.', Ansi.Reset);
+    while True do
+    begin
+      Write(Ansi.Bold, '> ', Ansi.Reset);
+      if EOF then Break;
+      ReadLn(Line);
+      Line := Trim(Line);
+      if (Line = '/quit') or (Line = '/exit') then Break;
+      if Line = '' then Continue;
+      RespondTo(Cfg, Line);
+    end;
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -28,7 +28,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.ToolLoop,
-  PasClaw.MCP.Bridge;
+  PasClaw.MCP.Bridge,
+  PasClaw.Skills.Loader;
 
 type
   TAgentArgs = record
@@ -121,10 +122,14 @@ begin
 end;
 
 function NewBuiltinRegistry: TToolRegistry;
+var
+  Skills: TSkillSpecArray;
 begin
   Result := TToolRegistry.Create;
   RegisterFSTools(Result);
   RegisterShellTool(Result);
+  Skills := LoadSkillManifests(GetHome);
+  RegisterSkills(Result, Skills);
 end;
 
 function ConnectMCP(Cfg: TConfig; Reg: TToolRegistry; NoMCP: Boolean): TMCPClientList;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -27,7 +27,8 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
-  PasClaw.Tools.ToolLoop;
+  PasClaw.Tools.ToolLoop,
+  PasClaw.MCP.Bridge;
 
 type
   TAgentArgs = record
@@ -39,6 +40,7 @@ type
     MaxTokens:     Integer;
     MaxIterations: Integer;
     NoTools:       Boolean;
+    NoMCP:         Boolean;
   end;
 
   TLoopHandlers = class
@@ -75,6 +77,7 @@ begin
   Result.MaxTokens     := 4096;
   Result.MaxIterations := 8;
   Result.NoTools       := False;
+  Result.NoMCP         := False;
 end;
 
 function ParseArgs(const Argv: array of string; var A: TAgentArgs): Boolean;
@@ -98,6 +101,7 @@ begin
     if Argv[i] = '--max-tokens'     then begin if i = High(Argv) then Exit(False); A.MaxTokens     := StrToIntDef(Argv[i + 1], A.MaxTokens);     Inc(i, 2); Continue; end;
     if Argv[i] = '--max-iterations' then begin if i = High(Argv) then Exit(False); A.MaxIterations := StrToIntDef(Argv[i + 1], A.MaxIterations); Inc(i, 2); Continue; end;
     if Argv[i] = '--no-tools' then begin A.NoTools := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-mcp'   then begin A.NoMCP   := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -121,6 +125,14 @@ begin
   Result := TToolRegistry.Create;
   RegisterFSTools(Result);
   RegisterShellTool(Result);
+end;
+
+function ConnectMCP(Cfg: TConfig; Reg: TToolRegistry; NoMCP: Boolean): TMCPClientList;
+begin
+  SetLength(Result, 0);
+  if NoMCP then Exit;
+  if Reg = nil then Exit;
+  Result := ConnectMCPServers(Cfg, Reg);
 end;
 
 function BuildLoopConfig(Provider: ILLMProvider; Reg: TToolRegistry;
@@ -150,6 +162,7 @@ var
   Loop: TToolLoopResult;
   LoopCfg: TToolLoopConfig;
   Model: string;
+  MCPClients: TMCPClientList;
 begin
   if not PickProvider(Cfg, A, Provider, Err) then
   begin
@@ -161,6 +174,7 @@ begin
 
   Reg := nil;
   if not A.NoTools then Reg := NewBuiltinRegistry;
+  MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Handlers := TLoopHandlers.Create;
   try
     SetLength(Msgs, 1);
@@ -180,6 +194,7 @@ begin
         Ansi.Reset);
   finally
     Handlers.Free;
+    FreeMCPClients(MCPClients);
     Reg.Free;
   end;
 end;
@@ -198,6 +213,7 @@ var
   Offline: Boolean;
   i: Integer;
   Names: TStringArray;
+  MCPClients: TMCPClientList;
 begin
   Offline := not PickProvider(Cfg, A, Provider, Err);
   if Offline then
@@ -207,6 +223,7 @@ begin
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
   Reg := nil;
   if not A.NoTools then Reg := NewBuiltinRegistry;
+  MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Handlers := TLoopHandlers.Create;
   try
     SetLength(Msgs, 0);
@@ -258,6 +275,7 @@ begin
     end;
   finally
     Handlers.Free;
+    FreeMCPClients(MCPClients);
     Reg.Free;
   end;
 end;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -1,9 +1,9 @@
 {
   Agent — chat with the assistant. Two modes:
-    pasclaw agent -m "single query"   -> one-shot
-    pasclaw agent                     -> interactive
-  Provider wiring lands in Phase 3; for now we accept input and echo back
-  with the configured model so the CLI shape works end-to-end.
+    pasclaw agent -m "single query"   one-shot
+    pasclaw agent                     interactive
+  Wires through PasClaw.Providers.Factory; falls back to an offline preview
+  when no API key is configured so the CLI still demonstrates the shape.
 }
 unit PasClaw.Cmd.Agent;
 {$MODE DELPHI}
@@ -17,58 +17,201 @@ implementation
 
 uses
   SysUtils, Classes,
-  PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger;
+  PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Factory;
 
-function ParseMessage(const Argv: array of string; out Msg: string): Boolean;
+type
+  TAgentArgs = record
+    Message:       string;
+    Model:         string;
+    Provider:      string;
+    SystemPrompt:  string;
+    Thinking:      string;
+    MaxTokens:     Integer;
+  end;
+
+function DefaultAgentArgs: TAgentArgs;
+begin
+  Result.Message       := '';
+  Result.Model         := '';
+  Result.Provider      := '';
+  Result.SystemPrompt  := '';
+  Result.Thinking      := '';
+  Result.MaxTokens     := 4096;
+end;
+
+function ParseArgs(const Argv: array of string; var A: TAgentArgs): Boolean;
 var
   i: Integer;
 begin
-  Result := False;
+  Result := True;
+  A := DefaultAgentArgs;
   i := 0;
   while i <= High(Argv) do
   begin
     if (Argv[i] = '-m') or (Argv[i] = '--message') then
     begin
       if i = High(Argv) then Exit(False);
-      Msg := Argv[i + 1];
-      Exit(True);
+      A.Message := Argv[i + 1]; Inc(i, 2); Continue;
+    end;
+    if Argv[i] = '--model' then
+    begin
+      if i = High(Argv) then Exit(False);
+      A.Model := Argv[i + 1]; Inc(i, 2); Continue;
+    end;
+    if Argv[i] = '--provider' then
+    begin
+      if i = High(Argv) then Exit(False);
+      A.Provider := Argv[i + 1]; Inc(i, 2); Continue;
+    end;
+    if Argv[i] = '--system' then
+    begin
+      if i = High(Argv) then Exit(False);
+      A.SystemPrompt := Argv[i + 1]; Inc(i, 2); Continue;
+    end;
+    if Argv[i] = '--thinking' then
+    begin
+      if i = High(Argv) then Exit(False);
+      A.Thinking := Argv[i + 1]; Inc(i, 2); Continue;
+    end;
+    if Argv[i] = '--max-tokens' then
+    begin
+      if i = High(Argv) then Exit(False);
+      A.MaxTokens := StrToIntDef(Argv[i + 1], A.MaxTokens); Inc(i, 2); Continue;
     end;
     Inc(i);
   end;
 end;
 
-procedure RespondTo(const Cfg: TConfig; const Prompt: string);
+function PickProvider(Cfg: TConfig; const A: TAgentArgs;
+                      out Provider: ILLMProvider; out Err: string): Boolean;
+var
+  Name: string;
 begin
-  { Phase 1 placeholder; Phase 3 replaces this with a real provider call. }
-  WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Cfg.DefaultProvider, '/', Cfg.DefaultModel, '): ');
-  WriteLn('  (offline preview) You said: ', Prompt);
-  WriteLn('  -> wire an API key with `pasclaw onboard` to enable live responses.');
+  if A.Provider <> '' then Name := A.Provider else Name := Cfg.DefaultProvider;
+  if Name = '' then
+  begin
+    Err := 'no provider configured';
+    Exit(False);
+  end;
+  Result := NewProviderFromConfig(Cfg, Name, Provider, Err);
+end;
+
+procedure RunSingleTurn(const Cfg: TConfig; const A: TAgentArgs; const Prompt: string);
+var
+  Provider: ILLMProvider;
+  Err: string;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  Opts: TChatOptions;
+  Resp: TLLMResponse;
+  Model: string;
+begin
+  if not PickProvider(Cfg, A, Provider, Err) then
+  begin
+    WriteLn(Ansi.Yellow, '(offline preview — ', Err, ')', Ansi.Reset);
+    WriteLn('You: ', Prompt);
+    WriteLn('Assistant: ', '<provider not configured; run `pasclaw onboard` to enable>');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Prompt);
+  SetLength(Tools, 0);
+
+  Opts := DefaultChatOptions;
+  Opts.SystemPrompt  := A.SystemPrompt;
+  Opts.ThinkingLevel := A.Thinking;
+  if A.MaxTokens > 0 then Opts.MaxTokens := A.MaxTokens;
+
+  if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
+
+  WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
+  Resp := Provider.Chat(Msgs, Tools, Model, Opts);
+  WriteLn(Resp.Content);
+  if Resp.Usage.InputTokens + Resp.Usage.OutputTokens > 0 then
+    WriteLn(Ansi.Dim,
+      Format('  [tokens in=%d out=%d]', [Resp.Usage.InputTokens, Resp.Usage.OutputTokens]),
+      Ansi.Reset);
+end;
+
+procedure RunInteractive(const Cfg: TConfig; const A: TAgentArgs);
+var
+  Line: string;
+  Provider: ILLMProvider;
+  Err: string;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  Opts: TChatOptions;
+  Resp: TLLMResponse;
+  Model: string;
+  Offline: Boolean;
+begin
+  Offline := not PickProvider(Cfg, A, Provider, Err);
+  if Offline then
+    WriteLn(Ansi.Yellow, '(offline preview — ', Err, ')', Ansi.Reset);
+  WriteLn(Ansi.Dim, 'PasClaw interactive chat. /quit to exit, /reset to clear history.', Ansi.Reset);
+
+  if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
+  Opts := DefaultChatOptions;
+  Opts.SystemPrompt  := A.SystemPrompt;
+  Opts.ThinkingLevel := A.Thinking;
+  if A.MaxTokens > 0 then Opts.MaxTokens := A.MaxTokens;
+  SetLength(Tools, 0);
+  SetLength(Msgs, 0);
+
+  while True do
+  begin
+    Write(Ansi.Bold, '> ', Ansi.Reset);
+    if EOF then Break;
+    ReadLn(Line);
+    Line := Trim(Line);
+    if (Line = '/quit') or (Line = '/exit') then Break;
+    if Line = '/reset' then
+    begin
+      SetLength(Msgs, 0);
+      WriteLn(Ansi.Dim, '(history cleared)', Ansi.Reset);
+      Continue;
+    end;
+    if Line = '' then Continue;
+
+    SetLength(Msgs, Length(Msgs) + 1);
+    Msgs[High(Msgs)] := MakeMessage(mrUser, Line);
+
+    if Offline then
+    begin
+      WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (offline): I would respond once a provider is configured.');
+      SetLength(Msgs, Length(Msgs) + 1);
+      Msgs[High(Msgs)] := MakeMessage(mrAssistant, '(no response — offline)');
+      Continue;
+    end;
+
+    Resp := Provider.Chat(Msgs, Tools, Model, Opts);
+    WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
+    WriteLn(Resp.Content);
+
+    SetLength(Msgs, Length(Msgs) + 1);
+    Msgs[High(Msgs)] := MakeMessage(mrAssistant, Resp.Content);
+  end;
 end;
 
 function Cmd_Agent_Run(const Argv: array of string): Integer;
 var
+  A: TAgentArgs;
   Cfg: TConfig;
-  Msg, Line: string;
 begin
+  if not ParseArgs(Argv, A) then
+  begin
+    WriteLn(ErrOutput, 'usage: pasclaw agent [-m "message"] [--model M] [--provider P] [--system S] [--thinking low|medium|high]');
+    Exit(1);
+  end;
+
   Cfg := LoadConfig;
   try
-    if ParseMessage(Argv, Msg) then
-    begin
-      RespondTo(Cfg, Msg);
-      Exit(0);
-    end;
-
-    WriteLn(Ansi.Dim, 'PasClaw interactive chat. Type /quit to exit.', Ansi.Reset);
-    while True do
-    begin
-      Write(Ansi.Bold, '> ', Ansi.Reset);
-      if EOF then Break;
-      ReadLn(Line);
-      Line := Trim(Line);
-      if (Line = '/quit') or (Line = '/exit') then Break;
-      if Line = '' then Continue;
-      RespondTo(Cfg, Line);
-    end;
+    if A.Message <> '' then RunSingleTurn(Cfg, A, A.Message)
+    else                    RunInteractive(Cfg, A);
     Result := 0;
   finally
     Cfg.Free;

--- a/src/cmd/PasClaw.Cmd.Auth.pas
+++ b/src/cmd/PasClaw.Cmd.Auth.pas
@@ -1,0 +1,110 @@
+{ Auth — login/logout/status for configured providers. }
+unit PasClaw.Cmd.Auth;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Auth_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw auth <login|logout|status|weixin> [provider]');
+end;
+
+function DoStatus: Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  Cfg := LoadConfig;
+  try
+    if Length(Cfg.Providers) = 0 then
+    begin
+      WriteLn('(no providers configured — run `pasclaw onboard`)');
+      Exit(0);
+    end;
+    for i := 0 to High(Cfg.Providers) do
+      WriteLn(Cfg.Providers[i].Name:14, '  key: ',
+        BoolToStr(Cfg.Providers[i].APIKey <> '', 'present', 'missing'));
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoLogin(const Provider: string): Integer;
+var
+  Cfg: TConfig;
+  Key: string;
+  i: Integer;
+  Found: Boolean;
+begin
+  Cfg := LoadConfig;
+  try
+    Write('API key for ', Provider, ': ');
+    ReadLn(Key);
+    Found := False;
+    for i := 0 to High(Cfg.Providers) do
+      if SameText(Cfg.Providers[i].Name, Provider) then
+      begin
+        Cfg.Providers[i].APIKey := Key;
+        Found := True;
+        Break;
+      end;
+    if not Found then
+    begin
+      SetLength(Cfg.Providers, Length(Cfg.Providers) + 1);
+      Cfg.Providers[High(Cfg.Providers)].Name   := Provider;
+      Cfg.Providers[High(Cfg.Providers)].Kind   := Provider;
+      Cfg.Providers[High(Cfg.Providers)].APIKey := Key;
+    end;
+    SaveConfig(Cfg);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'stored key for ', Provider);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoLogout(const Provider: string): Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  Cfg := LoadConfig;
+  try
+    for i := 0 to High(Cfg.Providers) do
+      if SameText(Cfg.Providers[i].Name, Provider) then
+        Cfg.Providers[i].APIKey := '';
+    SaveConfig(Cfg);
+    WriteLn('cleared key for ', Provider);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function Cmd_Auth_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then begin Help; Exit(1); end;
+  Sub := Argv[0];
+  if      Sub = 'status' then Result := DoStatus
+  else if (Sub = 'login') and (Length(Argv) >= 2) then Result := DoLogin(Argv[1])
+  else if (Sub = 'logout') and (Length(Argv) >= 2) then Result := DoLogout(Argv[1])
+  else if Sub = 'weixin' then
+  begin
+    WriteLn('(weixin/WeChat QR linking will land in Phase 5)');
+    Result := 0;
+  end
+  else begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Config_.pas
+++ b/src/cmd/PasClaw.Cmd.Config_.pas
@@ -1,0 +1,44 @@
+{ Config — view/edit raw config. }
+unit PasClaw.Cmd.Config_;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Config_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.Utils;
+
+function Cmd_Config_Run(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+begin
+  if (Length(Argv) > 0) and (Argv[0] = 'path') then
+  begin
+    WriteLn(GetConfigPath);
+    Exit(0);
+  end;
+  if (Length(Argv) > 0) and (Argv[0] = 'reset') then
+  begin
+    Cfg := TConfig.Create;
+    try
+      SaveConfig(Cfg);
+      WriteLn('wrote default config to ', GetConfigPath);
+    finally
+      Cfg.Free;
+    end;
+    Exit(0);
+  end;
+  Cfg := LoadConfig;
+  try
+    WriteLn(Cfg.ToJSON);
+  finally
+    Cfg.Free;
+  end;
+  Result := 0;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Cron.pas
+++ b/src/cmd/PasClaw.Cmd.Cron.pas
@@ -1,0 +1,132 @@
+{ Cron — list/add/disable/enable/remove scheduled tasks. Real scheduler in Phase 5. }
+unit PasClaw.Cmd.Cron;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Cron_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.CliUI;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw cron <list|add|disable|enable|remove> [args]');
+  WriteLn('  add <id> "<spec>" <skill> [args]   register a cron task');
+  WriteLn('  disable|enable <id>                toggle a task');
+  WriteLn('  remove <id>                        delete a task');
+end;
+
+function DoList: Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  Cfg := LoadConfig;
+  try
+    if Length(Cfg.Crons) = 0 then
+    begin
+      WriteLn('(no cron entries)');
+      Exit(0);
+    end;
+    WriteLn(Ansi.Bold, 'id', Ansi.Reset, '              spec              skill         enabled');
+    for i := 0 to High(Cfg.Crons) do
+      WriteLn(Cfg.Crons[i].Id:14, '  ',
+              Cfg.Crons[i].Spec:14, '  ',
+              Cfg.Crons[i].Skill:12, '  ',
+              BoolToStr(Cfg.Crons[i].Enabled, True));
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoAdd(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  n, i: Integer;
+  Args: string;
+begin
+  if Length(Argv) < 4 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    Args := '';
+    for i := 4 to High(Argv) do
+    begin
+      if Args <> '' then Args := Args + ' ';
+      Args := Args + Argv[i];
+    end;
+    n := Length(Cfg.Crons);
+    SetLength(Cfg.Crons, n + 1);
+    Cfg.Crons[n].Id      := Argv[1];
+    Cfg.Crons[n].Spec    := Argv[2];
+    Cfg.Crons[n].Skill   := Argv[3];
+    Cfg.Crons[n].Args    := Args;
+    Cfg.Crons[n].Enabled := True;
+    SaveConfig(Cfg);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'added cron ', Argv[1]);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoToggle(const Argv: array of string; Enable: Boolean): Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    for i := 0 to High(Cfg.Crons) do
+      if SameText(Cfg.Crons[i].Id, Argv[1]) then
+        Cfg.Crons[i].Enabled := Enable;
+    SaveConfig(Cfg);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoRemove(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  i, dst: Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    dst := 0;
+    for i := 0 to High(Cfg.Crons) do
+      if not SameText(Cfg.Crons[i].Id, Argv[1]) then
+      begin
+        Cfg.Crons[dst] := Cfg.Crons[i];
+        Inc(dst);
+      end;
+    SetLength(Cfg.Crons, dst);
+    SaveConfig(Cfg);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function Cmd_Cron_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then begin Help; Exit(1); end;
+  Sub := Argv[0];
+  if      Sub = 'list'    then Result := DoList
+  else if Sub = 'add'     then Result := DoAdd(Argv)
+  else if Sub = 'disable' then Result := DoToggle(Argv, False)
+  else if Sub = 'enable'  then Result := DoToggle(Argv, True)
+  else if Sub = 'remove'  then Result := DoRemove(Argv)
+  else begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -1,0 +1,30 @@
+{ Gateway — Phase 4 hosts the HTTP/router stack; Phase 1 prints the planned bind addr. }
+unit PasClaw.Cmd.Gateway;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Gateway_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.CliUI, PasClaw.Logger;
+
+function Cmd_Gateway_Run(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+begin
+  Cfg := LoadConfig;
+  try
+    LogInfo('gateway: would bind %s:%d (Phase 4 will wire fphttpserver)',
+      [Cfg.Gateway.BindAddr, Cfg.Gateway.Port]);
+    WriteLn('Gateway scaffold — Phase 4 will start the listener and channel router.');
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -27,6 +27,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.MCP.Bridge,
+  PasClaw.Skills.Loader,
+  PasClaw.Cron.Scheduler,
   PasClaw.Gateway.Server,
   PasClaw.Channels.Telegram;
 
@@ -73,6 +75,8 @@ var
   MCPClients: TMCPClientList;
   Server: TGatewayServer;
   Telegram: TTelegramChannel;
+  Scheduler: TCronScheduler;
+  Skills: TSkillSpecArray;
 begin
   Cfg := LoadConfig;
   try
@@ -89,11 +93,22 @@ begin
       Reg := TToolRegistry.Create;
       RegisterFSTools(Reg);
       RegisterShellTool(Reg);
+      Skills := LoadSkillManifests(GetHome);
+      RegisterSkills(Reg, Skills);
+      if Length(Skills) > 0 then
+        LogInfo('gateway: loaded %d skill(s) from workspace/skills/', [Length(Skills)]);
     end;
 
     SetLength(MCPClients, 0);
     if (not Args.NoMCP) and (Reg <> nil) then
       MCPClients := ConnectMCPServers(Cfg, Reg);
+
+    Scheduler := nil;
+    if (Reg <> nil) and (Length(Cfg.Crons) > 0) then
+    begin
+      Scheduler := TCronScheduler.Create(Cfg, Reg);
+      Scheduler.Start;
+    end;
 
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
     Telegram := nil;
@@ -125,6 +140,7 @@ begin
       if Telegram <> nil then Telegram.Free;
       Server.Stop;
       Server.Free;
+      if Scheduler <> nil then Scheduler.Free;
       FreeMCPClients(MCPClients);
       if Reg <> nil then Reg.Free;
     end;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -1,4 +1,13 @@
-{ Gateway — Phase 4 hosts the HTTP/router stack; Phase 1 prints the planned bind addr. }
+(*
+  Gateway - starts the HTTP gateway, and optionally the Telegram channel
+  alongside it. Blocks until SIGINT / Ctrl-C, then shuts down cleanly.
+
+    pasclaw gateway                                 # just the HTTP API
+    pasclaw gateway --telegram --token <BOT_TOKEN>  # API + Telegram bot
+    pasclaw gateway --addr 0.0.0.0 --port 8088      # listen on all ifaces
+
+  The HTTP API is documented in src/pkg/gateway/PasClaw.Gateway.Server.pas.
+*)
 unit PasClaw.Cmd.Gateway;
 {$MODE DELPHI}
 {$H+}
@@ -10,17 +19,116 @@ function Cmd_Gateway_Run(const Argv: array of string): Integer;
 implementation
 
 uses
-  SysUtils, PasClaw.Config, PasClaw.CliUI, PasClaw.Logger;
+  SysUtils,
+  PasClaw.Config, PasClaw.CliUI, PasClaw.Logger,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Factory,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.FS,
+  PasClaw.Tools.Shell,
+  PasClaw.MCP.Bridge,
+  PasClaw.Gateway.Server,
+  PasClaw.Channels.Telegram;
+
+type
+  TGwArgs = record
+    Addr:      string;
+    Port:      Integer;
+    Telegram:  Boolean;
+    Token:     string;
+    NoMCP:     Boolean;
+    NoTools:   Boolean;
+  end;
+
+function ParseGw(const Argv: array of string; const Cfg: TConfig): TGwArgs;
+var
+  i: Integer;
+begin
+  Result.Addr     := Cfg.Gateway.BindAddr;
+  Result.Port     := Cfg.Gateway.Port;
+  Result.Telegram := False;
+  Result.Token    := GetEnvironmentVariable('PASCLAW_TELEGRAM_TOKEN');
+  Result.NoMCP    := False;
+  Result.NoTools  := False;
+  i := 0;
+  while i <= High(Argv) do
+  begin
+    if Argv[i] = '--addr'     then begin if i < High(Argv) then Result.Addr     := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--port'     then begin if i < High(Argv) then Result.Port     := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
+    if Argv[i] = '--telegram' then begin Result.Telegram := True; Inc(i); Continue; end;
+    if Argv[i] = '--token'    then begin if i < High(Argv) then Result.Token    := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-mcp'   then begin Result.NoMCP    := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-tools' then begin Result.NoTools  := True; Inc(i); Continue; end;
+    Inc(i);
+  end;
+end;
 
 function Cmd_Gateway_Run(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
+  Args: TGwArgs;
+  Provider: ILLMProvider;
+  Err: string;
+  Reg: TToolRegistry;
+  MCPClients: TMCPClientList;
+  Server: TGatewayServer;
+  Telegram: TTelegramChannel;
 begin
   Cfg := LoadConfig;
   try
-    LogInfo('gateway: would bind %s:%d (Phase 4 will wire fphttpserver)',
-      [Cfg.Gateway.BindAddr, Cfg.Gateway.Port]);
-    WriteLn('Gateway scaffold — Phase 4 will start the listener and channel router.');
+    Args := ParseGw(Argv, Cfg);
+
+    Provider := nil;
+    if Cfg.DefaultProvider <> '' then
+      if not NewDefaultProvider(Cfg, Provider, Err) then
+        LogWarn('gateway: no provider — /v1/chat will return 503 (%s)', [Err]);
+
+    Reg := nil;
+    if not Args.NoTools then
+    begin
+      Reg := TToolRegistry.Create;
+      RegisterFSTools(Reg);
+      RegisterShellTool(Reg);
+    end;
+
+    SetLength(MCPClients, 0);
+    if (not Args.NoMCP) and (Reg <> nil) then
+      MCPClients := ConnectMCPServers(Cfg, Reg);
+
+    Server := TGatewayServer.Create(Cfg, Provider, Reg);
+    Telegram := nil;
+    try
+      Server.Start(Args.Addr, Args.Port);
+
+      WriteLn(Ansi.Bold, 'Gateway up.', Ansi.Reset);
+      WriteLn('  http://', Args.Addr, ':', Args.Port, '/v1/health');
+      WriteLn('  http://', Args.Addr, ':', Args.Port, '/v1/tools');
+      WriteLn('  POST http://', Args.Addr, ':', Args.Port, '/v1/chat   {"message":"..."}');
+      WriteLn(Ansi.Dim, 'Press Ctrl-C to stop.', Ansi.Reset);
+
+      if Args.Telegram then
+      begin
+        if Args.Token = '' then
+        begin
+          LogError('telegram: no token; set PASCLAW_TELEGRAM_TOKEN or pass --token');
+          Exit(1);
+        end;
+        Telegram := TTelegramChannel.Create(Args.Token, Cfg, Provider, Reg);
+        { Long-poll runs on the current thread and blocks; for Phase 5 we
+          accept that the HTTP listener and Telegram coexist (Indy listens on
+          its own threads), so we just call Telegram.Run last. }
+        Telegram.Run;
+      end
+      else
+        Server.WaitForStop;
+    finally
+      if Telegram <> nil then Telegram.Free;
+      Server.Stop;
+      Server.Free;
+      FreeMCPClients(MCPClients);
+      if Reg <> nil then Reg.Free;
+    end;
+
     Result := 0;
   finally
     Cfg.Free;

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -1,0 +1,153 @@
+{ MCP — list/add/remove/edit/test/show MCP server entries in config. }
+unit PasClaw.Cmd.MCP;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_MCP_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.CliUI;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw mcp <list|add|remove|test|edit|show> [args]');
+  WriteLn('  add <name> <cmd> [args]   register a new MCP server');
+  WriteLn('  remove <name>             delete an MCP server entry');
+  WriteLn('  list                      list configured servers');
+  WriteLn('  show <name>               show one server in detail');
+  WriteLn('  test <name>               probe an MCP server');
+  WriteLn('  edit                      open config in $EDITOR');
+end;
+
+function DoList: Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  Cfg := LoadConfig;
+  try
+    if Length(Cfg.MCPServers) = 0 then
+    begin
+      WriteLn('(no MCP servers configured)');
+      Exit(0);
+    end;
+    WriteLn(Ansi.Bold, 'name', Ansi.Reset, '            cmd');
+    for i := 0 to High(Cfg.MCPServers) do
+      WriteLn(Cfg.MCPServers[i].Name:14, '  ', Cfg.MCPServers[i].Cmd, ' ', Cfg.MCPServers[i].Args);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoAdd(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  Args: string;
+  i, n: Integer;
+begin
+  if Length(Argv) < 3 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    Args := '';
+    for i := 3 to High(Argv) do
+    begin
+      if Args <> '' then Args := Args + ' ';
+      Args := Args + Argv[i];
+    end;
+    n := Length(Cfg.MCPServers);
+    SetLength(Cfg.MCPServers, n + 1);
+    Cfg.MCPServers[n].Name    := Argv[1];
+    Cfg.MCPServers[n].Cmd     := Argv[2];
+    Cfg.MCPServers[n].Args    := Args;
+    Cfg.MCPServers[n].Enabled := True;
+    SaveConfig(Cfg);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'added MCP server ', Argv[1]);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoRemove(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  i, dst: Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    dst := 0;
+    for i := 0 to High(Cfg.MCPServers) do
+      if not SameText(Cfg.MCPServers[i].Name, Argv[1]) then
+      begin
+        Cfg.MCPServers[dst] := Cfg.MCPServers[i];
+        Inc(dst);
+      end;
+    SetLength(Cfg.MCPServers, dst);
+    SaveConfig(Cfg);
+    WriteLn('removed ', Argv[1]);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoShow(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    for i := 0 to High(Cfg.MCPServers) do
+      if SameText(Cfg.MCPServers[i].Name, Argv[1]) then
+      begin
+        WriteLn('name:    ', Cfg.MCPServers[i].Name);
+        WriteLn('cmd:     ', Cfg.MCPServers[i].Cmd);
+        WriteLn('args:    ', Cfg.MCPServers[i].Args);
+        WriteLn('env:     ', Cfg.MCPServers[i].Env);
+        WriteLn('enabled: ', Cfg.MCPServers[i].Enabled);
+        Exit(0);
+      end;
+    WriteLn('no such MCP server: ', Argv[1]);
+    Result := 1;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoTest(const Argv: array of string): Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  WriteLn('(test ', Argv[1], ': Phase 4 will spawn the configured cmd and run MCP initialize)');
+  Result := 0;
+end;
+
+function DoEdit(const Argv: array of string): Integer;
+begin
+  WriteLn('open ', GetConfigPath, ' in your editor (no shell-out yet).');
+  Result := 0;
+end;
+
+function Cmd_MCP_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then begin Help; Exit(1); end;
+  Sub := Argv[0];
+  if      Sub = 'list'   then Result := DoList
+  else if Sub = 'add'    then Result := DoAdd(Argv)
+  else if Sub = 'remove' then Result := DoRemove(Argv)
+  else if Sub = 'show'   then Result := DoShow(Argv)
+  else if Sub = 'test'   then Result := DoTest(Argv)
+  else if Sub = 'edit'   then Result := DoEdit(Argv)
+  else begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -10,7 +10,10 @@ function Cmd_MCP_Run(const Argv: array of string): Integer;
 implementation
 
 uses
-  SysUtils, PasClaw.Config, PasClaw.CliUI;
+  SysUtils,
+  PasClaw.Config, PasClaw.CliUI,
+  PasClaw.MCP.Types,
+  PasClaw.MCP.StdioClient;
 
 procedure Help;
 begin
@@ -19,7 +22,7 @@ begin
   WriteLn('  remove <name>             delete an MCP server entry');
   WriteLn('  list                      list configured servers');
   WriteLn('  show <name>               show one server in detail');
-  WriteLn('  test <name>               probe an MCP server');
+  WriteLn('  test <name>               probe a server: initialize + tools/list');
   WriteLn('  edit                      open config in $EDITOR');
 end;
 
@@ -123,10 +126,49 @@ begin
 end;
 
 function DoTest(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  i, j: Integer;
+  Client: TMCPStdioClient;
+  Tools: TMCPToolArray;
+  Err: string;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
-  WriteLn('(test ', Argv[1], ': Phase 4 will spawn the configured cmd and run MCP initialize)');
-  Result := 0;
+  Cfg := LoadConfig;
+  try
+    for i := 0 to High(Cfg.MCPServers) do
+      if SameText(Cfg.MCPServers[i].Name, Argv[1]) then
+      begin
+        WriteLn('Spawning ', Cfg.MCPServers[i].Cmd, ' ', Cfg.MCPServers[i].Args, '...');
+        Client := TMCPStdioClient.Create(Cfg.MCPServers[i].Name,
+                                         Cfg.MCPServers[i].Cmd,
+                                         Cfg.MCPServers[i].Args);
+        try
+          if not Client.Connect(5000, Err) then
+          begin
+            WriteLn(Ansi.Red, '✗ ', Err, Ansi.Reset);
+            Exit(1);
+          end;
+          WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'initialize OK');
+          WriteLn('  server: ', Client.ServerInfo.Name, ' ', Client.ServerInfo.Version);
+          if Client.ListTools(Tools, Err) then
+          begin
+            WriteLn('  tools (', Length(Tools), '):');
+            for j := 0 to High(Tools) do
+              WriteLn('    - ', Tools[j].Name, '  ', Tools[j].Description);
+          end
+          else
+            WriteLn(Ansi.Yellow, '  tools/list failed: ', Err, Ansi.Reset);
+        finally
+          Client.Free;
+        end;
+        Exit(0);
+      end;
+    WriteLn('no such MCP server: ', Argv[1]);
+    Result := 1;
+  finally
+    Cfg.Free;
+  end;
 end;
 
 function DoEdit(const Argv: array of string): Integer;

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -13,7 +13,8 @@ uses
   SysUtils,
   PasClaw.Config, PasClaw.CliUI,
   PasClaw.MCP.Types,
-  PasClaw.MCP.StdioClient;
+  PasClaw.MCP.StdioClient,
+  PasClaw.MCP.HttpClient;
 
 procedure Help;
 begin
@@ -125,11 +126,18 @@ begin
   end;
 end;
 
+function IsHttpUrl(const S: string): Boolean;
+begin
+  Result := (Length(S) >= 7) and
+            ((LowerCase(Copy(S, 1, 7)) = 'http://') or
+             ((Length(S) >= 8) and (LowerCase(Copy(S, 1, 8)) = 'https://')));
+end;
+
 function DoTest(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
   i, j: Integer;
-  Client: TMCPStdioClient;
+  Client: TMCPBaseClient;
   Tools: TMCPToolArray;
   Err: string;
 begin
@@ -139,10 +147,20 @@ begin
     for i := 0 to High(Cfg.MCPServers) do
       if SameText(Cfg.MCPServers[i].Name, Argv[1]) then
       begin
-        WriteLn('Spawning ', Cfg.MCPServers[i].Cmd, ' ', Cfg.MCPServers[i].Args, '...');
-        Client := TMCPStdioClient.Create(Cfg.MCPServers[i].Name,
-                                         Cfg.MCPServers[i].Cmd,
-                                         Cfg.MCPServers[i].Args);
+        if IsHttpUrl(Cfg.MCPServers[i].Cmd) then
+        begin
+          WriteLn('Connecting HTTP MCP at ', Cfg.MCPServers[i].Cmd, '...');
+          Client := TMCPHttpClient.Create(Cfg.MCPServers[i].Name,
+                                          Cfg.MCPServers[i].Cmd,
+                                          Cfg.MCPServers[i].Args);
+        end
+        else
+        begin
+          WriteLn('Spawning ', Cfg.MCPServers[i].Cmd, ' ', Cfg.MCPServers[i].Args, '...');
+          Client := TMCPStdioClient.Create(Cfg.MCPServers[i].Name,
+                                           Cfg.MCPServers[i].Cmd,
+                                           Cfg.MCPServers[i].Args);
+        end;
         try
           if not Client.Connect(5000, Err) then
           begin

--- a/src/cmd/PasClaw.Cmd.Membench.pas
+++ b/src/cmd/PasClaw.Cmd.Membench.pas
@@ -1,0 +1,92 @@
+(*
+  Membench - benchmark the memory log subsystem.
+
+    pasclaw membench [--records N] [--content N] [--keep] [--out DIR]
+*)
+unit PasClaw.Cmd.Membench;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Membench_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.CliUI,
+  PasClaw.Membench.Runner;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw membench [--records N] [--content N] [--keep] [--out DIR]');
+  WriteLn('  --records N    number of log entries to write (default 1000)');
+  WriteLn('  --content N    payload bytes per entry (default 128)');
+  WriteLn('  --keep         keep the generated NDJSON file');
+  WriteLn('  --out DIR      output directory (default $TMPDIR)');
+end;
+
+function ParseArgs(const Argv: array of string; var Opts: TMembenchOpts): Boolean;
+var
+  i: Integer;
+begin
+  Result := True;
+  Opts := DefaultMembenchOpts;
+  i := 0;
+  while i <= High(Argv) do
+  begin
+    if Argv[i] = '--records' then
+      begin if i = High(Argv) then Exit(False);
+            Opts.Records := StrToIntDef(Argv[i + 1], Opts.Records); Inc(i, 2); Continue; end;
+    if Argv[i] = '--content' then
+      begin if i = High(Argv) then Exit(False);
+            Opts.ContentSize := StrToIntDef(Argv[i + 1], Opts.ContentSize); Inc(i, 2); Continue; end;
+    if Argv[i] = '--keep' then
+      begin Opts.KeepFile := True; Inc(i); Continue; end;
+    if Argv[i] = '--out' then
+      begin if i = High(Argv) then Exit(False);
+            Opts.OutDir := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if (Argv[i] = '-h') or (Argv[i] = '--help') then
+      begin Help; Exit(False); end;
+    Inc(i);
+  end;
+end;
+
+function Cmd_Membench_Run(const Argv: array of string): Integer;
+var
+  Opts: TMembenchOpts;
+  Res: TMembenchResult;
+  WriteRate, LoadRate, MBs: Double;
+begin
+  if not ParseArgs(Argv, Opts) then Exit(1);
+
+  WriteLn(Ansi.Bold, 'PasClaw membench', Ansi.Reset);
+  WriteLn('  records: ', Opts.Records);
+  WriteLn('  content: ', Opts.ContentSize, ' bytes/record');
+  WriteLn('  running...');
+
+  Res := RunMembench(Opts);
+
+  if Res.WriteSeconds <= 0 then WriteRate := 0
+  else WriteRate := Res.RecordsWritten / Res.WriteSeconds;
+  if Res.LoadSeconds <= 0 then LoadRate := 0
+  else LoadRate := Res.RecordsLoaded / Res.LoadSeconds;
+  if Res.WriteSeconds <= 0 then MBs := 0
+  else MBs := (Res.BytesOnDisk / 1048576.0) / Res.WriteSeconds;
+
+  WriteLn;
+  WriteLn(Ansi.Bold, 'results', Ansi.Reset);
+  WriteLn(Format('  write: %d records in %.3fs  -> %.0f rec/s, %.2f MiB/s',
+    [Res.RecordsWritten, Res.WriteSeconds, WriteRate, MBs]));
+  WriteLn(Format('  load:  %d records in %.3fs  -> %.0f rec/s',
+    [Res.RecordsLoaded, Res.LoadSeconds, LoadRate]));
+  WriteLn(Format('  size:  %d bytes on disk', [Res.BytesOnDisk]));
+  if Opts.KeepFile then
+    WriteLn('  path:  ', Res.Path);
+
+  Result := 0;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Migrate.pas
+++ b/src/cmd/PasClaw.Cmd.Migrate.pas
@@ -1,0 +1,31 @@
+{ Migrate — migrate config from older PasClaw/PicoClaw layouts. Stub for Phase 1. }
+unit PasClaw.Cmd.Migrate;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Migrate_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.Utils;
+
+function Cmd_Migrate_Run(const Argv: array of string): Integer;
+var
+  PicoPath, NewPath: string;
+begin
+  PicoPath := JoinPath(HomeDir, '.picoclaw/config.json');
+  NewPath  := GetConfigPath;
+  if FileExists(PicoPath) and not FileExists(NewPath) then
+  begin
+    WriteFileText(NewPath, ReadFileText(PicoPath));
+    WriteLn('migrated ', PicoPath, ' -> ', NewPath);
+    Exit(0);
+  end;
+  WriteLn('nothing to migrate (no ~/.picoclaw/config.json, or destination exists)');
+  Result := 0;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Model.pas
+++ b/src/cmd/PasClaw.Cmd.Model.pas
@@ -1,0 +1,91 @@
+{ Model — view or switch the default model. }
+unit PasClaw.Cmd.Model;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Model_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.CliUI;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw model [show|set <name>|add <provider> <name>]');
+end;
+
+function DoShow: Integer;
+var
+  Cfg: TConfig;
+begin
+  Cfg := LoadConfig;
+  try
+    WriteLn('default provider: ', Cfg.DefaultProvider);
+    WriteLn('default model:    ', Cfg.DefaultModel);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoSet(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    Cfg.DefaultModel := Argv[1];
+    SaveConfig(Cfg);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'default model = ', Argv[1]);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoAdd(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+  Found: Boolean;
+begin
+  if Length(Argv) < 3 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    Found := False;
+    for i := 0 to High(Cfg.Providers) do
+      if SameText(Cfg.Providers[i].Name, Argv[1]) then
+      begin
+        Cfg.Providers[i].Model := Argv[2];
+        Found := True;
+        Break;
+      end;
+    if not Found then
+    begin
+      SetLength(Cfg.Providers, Length(Cfg.Providers) + 1);
+      Cfg.Providers[High(Cfg.Providers)].Name  := Argv[1];
+      Cfg.Providers[High(Cfg.Providers)].Kind  := Argv[1];
+      Cfg.Providers[High(Cfg.Providers)].Model := Argv[2];
+    end;
+    SaveConfig(Cfg);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'registered ', Argv[1], '/', Argv[2]);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function Cmd_Model_Run(const Argv: array of string): Integer;
+begin
+  if (Length(Argv) = 0) or (Argv[0] = 'show') then Exit(DoShow);
+  if Argv[0] = 'set' then Exit(DoSet(Argv));
+  if Argv[0] = 'add' then Exit(DoAdd(Argv));
+  Help;
+  Result := 1;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -1,0 +1,106 @@
+{
+  Onboard — initialise config and workspace. Mirrors
+  cmd/picoclaw/internal/onboard. Creates ~/.pasclaw, a starter config.json,
+  and prompts for the default provider's API key.
+}
+unit PasClaw.Cmd.Onboard;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Onboard_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Utils,
+  PasClaw.CliUI,
+  PasClaw.Logger;
+
+function ReadLineEcho(const Prompt: string): string;
+begin
+  Write(Prompt);
+  ReadLn(Result);
+end;
+
+function Cmd_Onboard_Run(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  Home, CfgPath: string;
+  Key, Prov, Model: string;
+  i: Integer;
+  Found: Boolean;
+begin
+  Home    := GetHome;
+  CfgPath := GetConfigPath;
+
+  WriteLn(Ansi.Bold, 'Onboarding PasClaw', Ansi.Reset);
+  WriteLn('  home:   ', Home);
+  WriteLn('  config: ', CfgPath);
+  WriteLn;
+
+  if not EnsureDir(Home) then
+  begin
+    LogError('failed to create home dir: %s', [Home]);
+    Exit(1);
+  end;
+  EnsureDir(JoinPath(Home, 'workspace'));
+  EnsureDir(JoinPath(Home, 'workspace/memory'));
+  EnsureDir(JoinPath(Home, 'workspace/skills'));
+  EnsureDir(JoinPath(Home, 'logs'));
+
+  if FileExists(CfgPath) then
+  begin
+    Cfg := LoadConfig;
+    WriteLn('Existing config detected; updating in place.');
+  end
+  else
+    Cfg := TConfig.Create;
+
+  try
+    Prov := ReadLineEcho('Default provider [anthropic]: ');
+    if Trim(Prov) = '' then Prov := 'anthropic';
+    Model := ReadLineEcho('Default model [claude-opus-4-7]: ');
+    if Trim(Model) = '' then Model := 'claude-opus-4-7';
+    Key := ReadLineEcho(Prov + ' API key (leave blank to skip): ');
+
+    Cfg.DefaultProvider := Prov;
+    Cfg.DefaultModel    := Model;
+
+    Found := False;
+    for i := 0 to High(Cfg.Providers) do
+      if SameText(Cfg.Providers[i].Name, Prov) then
+      begin
+        if Key <> '' then Cfg.Providers[i].APIKey := Key;
+        Cfg.Providers[i].Model := Model;
+        Found := True;
+        Break;
+      end;
+    if not Found then
+    begin
+      SetLength(Cfg.Providers, Length(Cfg.Providers) + 1);
+      with Cfg.Providers[High(Cfg.Providers)] do
+      begin
+        Name    := Prov;
+        Kind    := Prov;
+        Model   := Model;
+        APIKey  := Key;
+        if      Prov = 'anthropic' then APIBase := 'https://api.anthropic.com'
+        else if Prov = 'openai'    then APIBase := 'https://api.openai.com';
+      end;
+    end;
+
+    SaveConfig(Cfg);
+    WriteLn;
+    WriteLn(Ansi.Green, '✓', Ansi.Reset, ' wrote ', CfgPath);
+    WriteLn('Next: ', Ansi.Bold, 'pasclaw agent -m "hello"', Ansi.Reset);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Post.pas
+++ b/src/cmd/PasClaw.Cmd.Post.pas
@@ -1,0 +1,83 @@
+(*
+  Post - send a message to a configured channel from the command line.
+  Useful for cron jobs and skills.
+
+    pasclaw post discord <webhook-url-or-name> "<content>"
+    pasclaw post slack   <webhook-url-or-name> "<content>"
+
+  Webhook URLs may be passed directly or referenced by a name stored in
+  ~/.pasclaw/config.json under `channels: [{ name, kind, url, ... }]`.
+*)
+unit PasClaw.Cmd.Post;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Post_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.CliUI,
+  PasClaw.Channels.Discord,
+  PasClaw.Channels.Slack;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw post <discord|slack> <webhook-url> "<content>"');
+end;
+
+function DoDiscord(const URL, Content: string): Integer;
+var
+  W: TDiscordWebhook;
+begin
+  W := TDiscordWebhook.Create(URL);
+  try
+    if W.Post(Content) then
+    begin
+      WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'posted to discord');
+      Result := 0;
+    end
+    else
+    begin
+      WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'discord post failed');
+      Result := 1;
+    end;
+  finally
+    W.Free;
+  end;
+end;
+
+function DoSlack(const URL, Content: string): Integer;
+var
+  W: TSlackWebhook;
+begin
+  W := TSlackWebhook.Create(URL);
+  try
+    if W.Post(Content) then
+    begin
+      WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'posted to slack');
+      Result := 0;
+    end
+    else
+    begin
+      WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'slack post failed');
+      Result := 1;
+    end;
+  finally
+    W.Free;
+  end;
+end;
+
+function Cmd_Post_Run(const Argv: array of string): Integer;
+begin
+  if Length(Argv) < 3 then begin Help; Exit(1); end;
+  if      Argv[0] = 'discord' then Result := DoDiscord(Argv[1], Argv[2])
+  else if Argv[0] = 'slack'   then Result := DoSlack(Argv[1], Argv[2])
+  else begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -32,7 +32,8 @@ uses
   PasClaw.Cmd.Skills,
   PasClaw.Cmd.Model,
   PasClaw.Cmd.Config_,
-  PasClaw.Cmd.Update;
+  PasClaw.Cmd.Update,
+  PasClaw.Cmd.Post;
 
 type
   TSubCmd = record
@@ -86,7 +87,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 13);
+  SetLength(Sub, 14);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant';
@@ -98,8 +99,9 @@ begin
   Sub[8]  := 'migrate      Migrate data from older versions';
   Sub[9]  := 'skills       Manage skill extensions';
   Sub[10] := 'model        View or switch the default model';
-  Sub[11] := 'update       Self-update PasClaw';
-  Sub[12] := 'version      Show version info';
+  Sub[11] := 'post         Send a one-shot message to a channel';
+  Sub[12] := 'update       Self-update PasClaw';
+  Sub[13] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -149,6 +151,7 @@ begin
     else if Cmd = 'migrate'  then Result := Cmd_Migrate_Run(ArgArr)
     else if Cmd = 'skills'   then Result := Cmd_Skills_Run(ArgArr)
     else if Cmd = 'model'    then Result := Cmd_Model_Run(ArgArr)
+    else if Cmd = 'post'     then Result := Cmd_Post_Run(ArgArr)
     else if Cmd = 'update'   then Result := Cmd_Update_Run(ArgArr)
     else if Cmd = 'version'  then Result := Cmd_Version_Run(ArgArr)
     else

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -33,7 +33,9 @@ uses
   PasClaw.Cmd.Model,
   PasClaw.Cmd.Config_,
   PasClaw.Cmd.Update,
-  PasClaw.Cmd.Post;
+  PasClaw.Cmd.Post,
+  PasClaw.Cmd.Membench,
+  PasClaw.Cmd.TUI;
 
 type
   TSubCmd = record
@@ -87,21 +89,23 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 14);
+  SetLength(Sub, 16);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
-  Sub[2]  := 'agent        Chat with the assistant';
-  Sub[3]  := 'auth         Authenticate with providers';
-  Sub[4]  := 'gateway      Start the gateway';
-  Sub[5]  := 'status       Show status';
-  Sub[6]  := 'cron         Manage scheduled tasks';
-  Sub[7]  := 'mcp          Manage MCP servers';
-  Sub[8]  := 'migrate      Migrate data from older versions';
-  Sub[9]  := 'skills       Manage skill extensions';
-  Sub[10] := 'model        View or switch the default model';
-  Sub[11] := 'post         Send a one-shot message to a channel';
-  Sub[12] := 'update       Self-update PasClaw';
-  Sub[13] := 'version      Show version info';
+  Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
+  Sub[3]  := 'tui          Chat in the full-screen TUI';
+  Sub[4]  := 'auth         Authenticate with providers';
+  Sub[5]  := 'gateway      Start the HTTP gateway + web UI';
+  Sub[6]  := 'status       Show status';
+  Sub[7]  := 'cron         Manage scheduled tasks';
+  Sub[8]  := 'mcp          Manage MCP servers';
+  Sub[9]  := 'migrate      Migrate data from older versions';
+  Sub[10] := 'skills       Manage skill extensions';
+  Sub[11] := 'model        View or switch the default model';
+  Sub[12] := 'post         Send a one-shot message to a channel';
+  Sub[13] := 'membench     Benchmark the memory log subsystem';
+  Sub[14] := 'update       Self-update PasClaw';
+  Sub[15] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -152,6 +156,8 @@ begin
     else if Cmd = 'skills'   then Result := Cmd_Skills_Run(ArgArr)
     else if Cmd = 'model'    then Result := Cmd_Model_Run(ArgArr)
     else if Cmd = 'post'     then Result := Cmd_Post_Run(ArgArr)
+    else if Cmd = 'membench' then Result := Cmd_Membench_Run(ArgArr)
+    else if Cmd = 'tui'      then Result := Cmd_TUI_Run(ArgArr)
     else if Cmd = 'update'   then Result := Cmd_Update_Run(ArgArr)
     else if Cmd = 'version'  then Result := Cmd_Version_Run(ArgArr)
     else

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -1,0 +1,164 @@
+{
+  PasClaw.Cmd.Root - root command dispatcher, equivalent to NewPicoclawCommand()
+  in cmd/picoclaw/main.go. Each subcommand exposes a CmdSpec record and a
+  Run() function; we route argv[1] to the matching command.
+}
+unit PasClaw.Cmd.Root;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function RunRootCommand: Integer;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Config,
+  PasClaw.Utils,
+  PasClaw.Cmd.Onboard,
+  PasClaw.Cmd.Agent,
+  PasClaw.Cmd.Auth,
+  PasClaw.Cmd.Gateway,
+  PasClaw.Cmd.Status,
+  PasClaw.Cmd.Version,
+  PasClaw.Cmd.Cron,
+  PasClaw.Cmd.MCP,
+  PasClaw.Cmd.Migrate,
+  PasClaw.Cmd.Skills,
+  PasClaw.Cmd.Model,
+  PasClaw.Cmd.Config_,
+  PasClaw.Cmd.Update;
+
+type
+  TSubCmd = record
+    Name: string;
+    Help: string;
+    Run:  function(const Argv: array of string): Integer;
+  end;
+
+procedure StripGlobalFlags(var Out_: TStringList);
+var
+  i: Integer;
+begin
+  i := 0;
+  while i < Out_.Count do
+  begin
+    if (Out_[i] = '--no-color')
+      or (Out_[i] = '--no-color=true')
+      or (Out_[i] = '--no-color=1')
+    then
+      Out_.Delete(i)
+    else
+      Inc(i);
+  end;
+end;
+
+function CollectArgs: TStringList;
+var
+  i: Integer;
+begin
+  Result := TStringList.Create;
+  for i := 1 to ParamCount do Result.Add(ParamStr(i));
+end;
+
+function ToArray(L: TStringList; StartIdx: Integer): TArray<string>;
+var
+  i: Integer;
+begin
+  SetLength(Result, L.Count - StartIdx);
+  for i := StartIdx to L.Count - 1 do
+    Result[i - StartIdx] := L[i];
+end;
+
+procedure PrintRootHelp;
+const
+  Use = 'pasclaw [command] [flags]';
+  Short = 'PasClaw — personal AI assistant';
+  Long  = 'PasClaw is a lightweight personal AI assistant.';
+  Example = 'pasclaw version' + sLineBreak +
+            '  pasclaw onboard' + sLineBreak +
+            '  pasclaw --no-color status';
+var
+  Sub, Fl: array of string;
+begin
+  SetLength(Sub, 13);
+  Sub[0]  := 'config       View/edit configuration';
+  Sub[1]  := 'onboard      Initialize config & workspace';
+  Sub[2]  := 'agent        Chat with the assistant';
+  Sub[3]  := 'auth         Authenticate with providers';
+  Sub[4]  := 'gateway      Start the gateway';
+  Sub[5]  := 'status       Show status';
+  Sub[6]  := 'cron         Manage scheduled tasks';
+  Sub[7]  := 'mcp          Manage MCP servers';
+  Sub[8]  := 'migrate      Migrate data from older versions';
+  Sub[9]  := 'skills       Manage skill extensions';
+  Sub[10] := 'model        View or switch the default model';
+  Sub[11] := 'update       Self-update PasClaw';
+  Sub[12] := 'version      Show version info';
+
+  SetLength(Fl, 2);
+  Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
+  Fl[1] := '-h, --help   Show this help';
+
+  Write(RenderCommandHelp(Use, Short, Long, Example, Sub, Fl));
+end;
+
+function RunRootCommand: Integer;
+var
+  Args: TStringList;
+  Cmd, Last: string;
+  ArgArr: TArray<string>;
+  Cfg: TConfig;
+begin
+  Result := 0;
+  Args := CollectArgs;
+  try
+    StripGlobalFlags(Args);
+
+    { Apply log level from config (best-effort; ignore on missing file). }
+    Cfg := LoadConfig;
+    try
+      SetLogLevelFromString(Cfg.Gateway.LogLevel);
+    finally
+      Cfg.Free;
+    end;
+
+    if (Args.Count = 0) or (Args[0] = '-h') or (Args[0] = '--help') or (Args[0] = 'help') then
+    begin
+      PrintRootHelp;
+      Exit(0);
+    end;
+
+    Cmd := Args[0];
+    ArgArr := ToArray(Args, 1);
+    Last := 'pasclaw ' + Cmd;
+
+    if      Cmd = 'config'   then Result := Cmd_Config_Run(ArgArr)
+    else if Cmd = 'onboard'  then Result := Cmd_Onboard_Run(ArgArr)
+    else if Cmd = 'agent'    then Result := Cmd_Agent_Run(ArgArr)
+    else if Cmd = 'auth'     then Result := Cmd_Auth_Run(ArgArr)
+    else if Cmd = 'gateway'  then Result := Cmd_Gateway_Run(ArgArr)
+    else if Cmd = 'status'   then Result := Cmd_Status_Run(ArgArr)
+    else if Cmd = 'cron'     then Result := Cmd_Cron_Run(ArgArr)
+    else if Cmd = 'mcp'      then Result := Cmd_MCP_Run(ArgArr)
+    else if Cmd = 'migrate'  then Result := Cmd_Migrate_Run(ArgArr)
+    else if Cmd = 'skills'   then Result := Cmd_Skills_Run(ArgArr)
+    else if Cmd = 'model'    then Result := Cmd_Model_Run(ArgArr)
+    else if Cmd = 'update'   then Result := Cmd_Update_Run(ArgArr)
+    else if Cmd = 'version'  then Result := Cmd_Version_Run(ArgArr)
+    else
+    begin
+      Write(ErrOutput, FormatCLIError('unknown command: ' + Cmd, 'pasclaw'));
+      Result := 1;
+    end;
+  finally
+    Args.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -1,0 +1,96 @@
+{ Skills — list/install skill extensions (manifest-only for Phase 1). }
+unit PasClaw.Cmd.Skills;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Skills_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.CliUI;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw skills <list|install|remove> [name|path]');
+end;
+
+function DoList: Integer;
+var
+  Cfg: TConfig;
+  i: Integer;
+begin
+  Cfg := LoadConfig;
+  try
+    if Length(Cfg.Skills) = 0 then
+    begin
+      WriteLn('(no skills installed)');
+      Exit(0);
+    end;
+    for i := 0 to High(Cfg.Skills) do
+      WriteLn(Cfg.Skills[i].Name:18, '  ', Cfg.Skills[i].Source);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoInstall(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  n: Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    n := Length(Cfg.Skills);
+    SetLength(Cfg.Skills, n + 1);
+    Cfg.Skills[n].Name    := Argv[1];
+    Cfg.Skills[n].Source  := Argv[1];
+    Cfg.Skills[n].Enabled := True;
+    SaveConfig(Cfg);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'installed ', Argv[1]);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function DoRemove(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  i, dst: Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Cfg := LoadConfig;
+  try
+    dst := 0;
+    for i := 0 to High(Cfg.Skills) do
+      if not SameText(Cfg.Skills[i].Name, Argv[1]) then
+      begin
+        Cfg.Skills[dst] := Cfg.Skills[i];
+        Inc(dst);
+      end;
+    SetLength(Cfg.Skills, dst);
+    SaveConfig(Cfg);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function Cmd_Skills_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then begin Help; Exit(1); end;
+  Sub := Argv[0];
+  if      Sub = 'list'    then Result := DoList
+  else if Sub = 'install' then Result := DoInstall(Argv)
+  else if Sub = 'remove'  then Result := DoRemove(Argv)
+  else begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -10,7 +10,8 @@ function Cmd_Skills_Run(const Argv: array of string): Integer;
 implementation
 
 uses
-  SysUtils, PasClaw.Config, PasClaw.CliUI;
+  SysUtils, PasClaw.Config, PasClaw.CliUI, PasClaw.Utils,
+  PasClaw.Skills.Loader;
 
 procedure Help;
 begin
@@ -19,22 +20,19 @@ end;
 
 function DoList: Integer;
 var
-  Cfg: TConfig;
+  Specs: TSkillSpecArray;
   i: Integer;
 begin
-  Cfg := LoadConfig;
-  try
-    if Length(Cfg.Skills) = 0 then
-    begin
-      WriteLn('(no skills installed)');
-      Exit(0);
-    end;
-    for i := 0 to High(Cfg.Skills) do
-      WriteLn(Cfg.Skills[i].Name:18, '  ', Cfg.Skills[i].Source);
-    Result := 0;
-  finally
-    Cfg.Free;
+  Specs := LoadSkillManifests(GetHome);
+  if Length(Specs) = 0 then
+  begin
+    WriteLn('(no skills found at ', JoinPath(GetHome, 'workspace/skills'), ')');
+    Exit(0);
   end;
+  WriteLn(Ansi.Bold, 'name', Ansi.Reset, '              kind   description');
+  for i := 0 to High(Specs) do
+    WriteLn(Specs[i].Name:18, '  ', Specs[i].Kind:6, '  ', Specs[i].Description);
+  Result := 0;
 end;
 
 function DoInstall(const Argv: array of string): Integer;

--- a/src/cmd/PasClaw.Cmd.Status.pas
+++ b/src/cmd/PasClaw.Cmd.Status.pas
@@ -1,0 +1,48 @@
+{ Status — print effective config, home dir, key health checks. }
+unit PasClaw.Cmd.Status;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Status_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.Config, PasClaw.Utils, PasClaw.CliUI;
+
+function YesNo(b: Boolean): string;
+begin
+  if b then Result := Ansi.Green + 'yes' + Ansi.Reset
+       else Result := Ansi.Red   + 'no'  + Ansi.Reset;
+end;
+
+function Cmd_Status_Run(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  HomeOk, CfgOk: Boolean;
+begin
+  HomeOk := DirectoryExists(GetHome);
+  CfgOk  := FileExists(GetConfigPath);
+  Cfg    := LoadConfig;
+  try
+    WriteLn(Ansi.Bold, 'PasClaw status', Ansi.Reset);
+    WriteLn('  home directory : ', GetHome, '   present: ', YesNo(HomeOk));
+    WriteLn('  config file    : ', GetConfigPath, '   present: ', YesNo(CfgOk));
+    WriteLn('  default provider: ', Cfg.DefaultProvider);
+    WriteLn('  default model   : ', Cfg.DefaultModel);
+    WriteLn('  providers       : ', Length(Cfg.Providers));
+    WriteLn('  mcp servers     : ', Length(Cfg.MCPServers));
+    WriteLn('  cron entries    : ', Length(Cfg.Crons));
+    WriteLn('  skills          : ', Length(Cfg.Skills));
+    WriteLn('  gateway bind    : ', Cfg.Gateway.BindAddr, ':', Cfg.Gateway.Port);
+    WriteLn('  log level       : ', Cfg.Gateway.LogLevel);
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -1,0 +1,106 @@
+(*
+  TUI - full-terminal interactive chat front-end.
+
+    pasclaw tui [--provider P] [--model M]
+*)
+unit PasClaw.Cmd.TUI;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_TUI_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Factory,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.FS,
+  PasClaw.Tools.Shell,
+  PasClaw.MCP.Bridge,
+  PasClaw.Skills.Loader,
+  PasClaw.TUI;
+
+type
+  TTUIArgs = record
+    Model:    string;
+    Provider: string;
+    NoMCP:    Boolean;
+    NoTools:  Boolean;
+  end;
+
+function ParseArgs(const Argv: array of string; var A: TTUIArgs): Boolean;
+var
+  i: Integer;
+begin
+  Result := True;
+  A.Model := ''; A.Provider := ''; A.NoMCP := False; A.NoTools := False;
+  i := 0;
+  while i <= High(Argv) do
+  begin
+    if Argv[i] = '--model'    then begin if i = High(Argv) then Exit(False); A.Model    := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--provider' then begin if i = High(Argv) then Exit(False); A.Provider := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-mcp'   then begin A.NoMCP   := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-tools' then begin A.NoTools := True; Inc(i); Continue; end;
+    Inc(i);
+  end;
+end;
+
+function Cmd_TUI_Run(const Argv: array of string): Integer;
+var
+  Cfg: TConfig;
+  A: TTUIArgs;
+  Provider: ILLMProvider;
+  Err: string;
+  Reg: TToolRegistry;
+  MCPClients: TMCPClientList;
+  Skills: TSkillSpecArray;
+  Model, Name: string;
+  TUIInst: TTUI;
+begin
+  if not ParseArgs(Argv, A) then Exit(1);
+  Cfg := LoadConfig;
+  try
+    if A.Provider <> '' then Name := A.Provider else Name := Cfg.DefaultProvider;
+    Provider := nil;
+    if Name <> '' then
+      if not NewProviderFromConfig(Cfg, Name, Provider, Err) then
+        LogWarn('tui: provider unavailable (%s)', [Err]);
+
+    Reg := nil;
+    if not A.NoTools then
+    begin
+      Reg := TToolRegistry.Create;
+      RegisterFSTools(Reg);
+      RegisterShellTool(Reg);
+      Skills := LoadSkillManifests(GetHome);
+      RegisterSkills(Reg, Skills);
+    end;
+
+    SetLength(MCPClients, 0);
+    if (Reg <> nil) and (not A.NoMCP) then
+      MCPClients := ConnectMCPServers(Cfg, Reg);
+
+    if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
+    TUIInst := TTUI.Create(Provider, Reg, Model);
+    try
+      TUIInst.Run;
+    finally
+      TUIInst.Free;
+      FreeMCPClients(MCPClients);
+      if Reg <> nil then Reg.Free;
+    end;
+    Result := 0;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Update.pas
+++ b/src/cmd/PasClaw.Cmd.Update.pas
@@ -1,5 +1,12 @@
-{ Update — self-update placeholder; real flow uses GitHub releases (Phase 7). }
+(*
+  Update - self-update over GitHub releases.
+
+    pasclaw update              # check + download + install
+    pasclaw update --check      # only report what's available
+    pasclaw update --repo o/r   # override the release repo
+*)
 unit PasClaw.Cmd.Update;
+
 {$MODE DELPHI}
 {$H+}
 
@@ -10,12 +17,107 @@ function Cmd_Update_Run(const Argv: array of string): Integer;
 implementation
 
 uses
-  SysUtils, PasClaw.Config;
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Updater;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw update [--check] [--repo owner/name]');
+end;
+
+function SplitRepo(const Slug: string; out Owner, Repo: string): Boolean;
+var
+  p: Integer;
+begin
+  p := Pos('/', Slug);
+  if p = 0 then Exit(False);
+  Owner := Copy(Slug, 1, p - 1);
+  Repo  := Copy(Slug, p + 1, MaxInt);
+  Result := (Owner <> '') and (Repo <> '');
+end;
 
 function Cmd_Update_Run(const Argv: array of string): Integer;
+var
+  i: Integer;
+  CheckOnly: Boolean;
+  Owner, Repo, Err: string;
+  Info: TReleaseInfo;
+  Current, BinPath, NewPath: string;
+  Cmp: Integer;
 begin
-  WriteLn('PasClaw ', FormatVersion);
-  WriteLn('(self-update over GitHub releases will land in Phase 7)');
+  CheckOnly := False;
+  Owner := 'FMXExpress';
+  Repo  := 'PasClaw';
+  i := 0;
+  while i <= High(Argv) do
+  begin
+    if Argv[i] = '--check' then begin CheckOnly := True; Inc(i); Continue; end;
+    if Argv[i] = '--repo'  then
+    begin
+      if i = High(Argv) then begin Help; Exit(1); end;
+      if not SplitRepo(Argv[i + 1], Owner, Repo) then
+      begin
+        WriteLn(ErrOutput, 'invalid --repo "', Argv[i + 1], '" (expected owner/name)');
+        Exit(1);
+      end;
+      Inc(i, 2);
+      Continue;
+    end;
+    if (Argv[i] = '-h') or (Argv[i] = '--help') then begin Help; Exit(0); end;
+    Inc(i);
+  end;
+
+  Current := FormatVersion;
+  WriteLn(Ansi.Bold, 'PasClaw update', Ansi.Reset);
+  WriteLn('  current:  ', Current);
+  WriteLn('  repo:     ', Owner, '/', Repo);
+  WriteLn('  platform: ', HostPlatformSuffix);
+  WriteLn('  fetching latest release...');
+
+  if not FetchLatestRelease(Owner, Repo, Info, Err) then
+  begin
+    WriteLn(Ansi.Yellow, '  ', Err, Ansi.Reset);
+    if Pos('404', Err) > 0 then
+      WriteLn('  (no releases published yet — this is expected for a fresh repo)');
+    Exit(0);
+  end;
+
+  WriteLn('  latest:   ', Info.TagName, '  (', Info.HtmlUrl, ')');
+  Cmp := CompareVersions(Current, Info.TagName);
+  if Cmp >= 0 then
+  begin
+    WriteLn(Ansi.Green, '  up to date.', Ansi.Reset);
+    Exit(0);
+  end;
+  WriteLn(Ansi.Bold, '  update available.', Ansi.Reset);
+
+  if Info.AssetUrl = '' then
+  begin
+    WriteLn(Ansi.Yellow, '  no asset for ', HostPlatformSuffix,
+            ' in this release — see ', Info.HtmlUrl, Ansi.Reset);
+    Exit(0);
+  end;
+  WriteLn('  asset:    ', Info.AssetName, '  (', Info.AssetSize, ' bytes)');
+
+  if CheckOnly then Exit(0);
+
+  BinPath := ParamStr(0);
+  NewPath := BinPath + '.new';
+  WriteLn('  downloading to ', NewPath, '...');
+  if not DownloadAsset(Info.AssetUrl, NewPath, Err) then
+  begin
+    WriteLn(Ansi.Red, '  download failed: ', Err, Ansi.Reset);
+    Exit(1);
+  end;
+  if not InstallUpdate(NewPath, BinPath, Err) then
+  begin
+    WriteLn(Ansi.Red, '  install failed: ', Err, Ansi.Reset);
+    Exit(1);
+  end;
+  WriteLn(Ansi.Green, '  installed ', Info.TagName, ' — restart pasclaw.', Ansi.Reset);
   Result := 0;
 end;
 

--- a/src/cmd/PasClaw.Cmd.Update.pas
+++ b/src/cmd/PasClaw.Cmd.Update.pas
@@ -1,0 +1,22 @@
+{ Update — self-update placeholder; real flow uses GitHub releases (Phase 7). }
+unit PasClaw.Cmd.Update;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Update_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config;
+
+function Cmd_Update_Run(const Argv: array of string): Integer;
+begin
+  WriteLn('PasClaw ', FormatVersion);
+  WriteLn('(self-update over GitHub releases will land in Phase 7)');
+  Result := 0;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Version.pas
+++ b/src/cmd/PasClaw.Cmd.Version.pas
@@ -1,0 +1,21 @@
+unit PasClaw.Cmd.Version;
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function Cmd_Version_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, PasClaw.Config, PasClaw.CliUI;
+
+function Cmd_Version_Run(const Argv: array of string): Integer;
+begin
+  WriteLn('PasClaw ', FormatVersion);
+  WriteLn(FormatBuildInfo);
+  Result := 0;
+end;
+
+end.

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -1,0 +1,39 @@
+{
+  PasClaw - Ultra-lightweight personal AI agent (Delphi Object Pascal port of picoclaw)
+  Inspired by and based on picoclaw: https://github.com/sipeed/picoclaw
+  License: MIT
+
+  Copyright (c) 2026 PasClaw contributors
+
+  Build with Free Pascal:
+    fpc -Fusrc/pkg/... -FEbuild src/pasclaw/PasClaw.dpr
+  Or use the project Makefile from the repo root:
+    make
+}
+
+program PasClaw;
+
+{$MODE DELPHI}
+{$H+}
+{$APPTYPE CONSOLE}
+
+uses
+  SysUtils,
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Config,
+  PasClaw.Cmd.Root;
+
+var
+  ExitCode_: Integer;
+begin
+  { Detect color support before any output so the banner respects NO_COLOR. }
+  CliUI_Init(EarlyColorDisabled);
+
+  PrintBanner;
+  ApplyTimezoneFromEnv;
+
+  ExitCode_ := RunRootCommand;
+  if ExitCode_ <> 0 then
+    Halt(ExitCode_);
+end.

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -18,6 +18,10 @@ program PasClaw;
 {$APPTYPE CONSOLE}
 
 uses
+  {$IFDEF UNIX}
+  cthreads,            { FPC: pull in pthreads so Indy can use TThread }
+  cmem,
+  {$ENDIF}
   SysUtils,
   PasClaw.CliUI,
   PasClaw.Logger,

--- a/src/pkg/channels/PasClaw.Channels.Discord.pas
+++ b/src/pkg/channels/PasClaw.Channels.Discord.pas
@@ -1,0 +1,273 @@
+(*
+  PasClaw.Channels.Discord - Discord adapter.
+
+  Two modes:
+
+    1. Webhook (outbound only). Easiest setup; post messages to a channel by
+       calling a webhook URL. Used by `pasclaw post discord ...` or by skills
+       that want to push notifications.
+
+    2. Bot polling (inbound + outbound). Polls /users/@me/channels and
+       /channels/:id/messages, dispatches each new user message through the
+       agent loop, replies via POST /channels/:id/messages. Authenticated
+       with a Bot token.
+
+  Discord does NOT support long-poll on its REST API the way Telegram does;
+  the production-grade path is the Gateway WebSocket. That's a substantial
+  implementation, so for Phase 6 we ship the webhook (which is what most
+  picoclaw users want anyway) and a basic poll-once REST loop.
+
+  API docs: https://discord.com/developers/docs/reference
+*)
+unit PasClaw.Channels.Discord;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TDiscordWebhook = class
+  private
+    FURL: string;
+  public
+    constructor Create(const WebhookURL: string);
+    function Post(const Content: string): Boolean;
+    function PostEmbed(const Title, Description: string; Color: Integer): Boolean;
+  end;
+
+  TDiscordBot = class
+  private
+    FToken:    string;
+    FChannel:  string;          { numeric channel id to watch }
+    FLastId:   string;
+    FCfg:      TConfig;
+    FProvider: ILLMProvider;
+    FRegistry: TToolRegistry;
+    FStop:     Boolean;
+    function FetchNewMessages(out RawJSON: string): Boolean;
+    function PostMessage(const Content: string): Boolean;
+    procedure ProcessMessages(const ArrJSON: string);
+  public
+    constructor Create(const Token, ChannelId: string; Cfg: TConfig;
+                       Provider: ILLMProvider; Registry: TToolRegistry);
+    procedure Run;
+    procedure RequestStop;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.HTTP,
+  PasClaw.Tools.ToolLoop;
+
+(* ---- Webhook ---- *)
+
+constructor TDiscordWebhook.Create(const WebhookURL: string);
+begin
+  inherited Create;
+  FURL := WebhookURL;
+end;
+
+function TDiscordWebhook.Post(const Content: string): Boolean;
+var
+  Body: string;
+  Obj: TJsonObject;
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  SetLength(Empty, 0);
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('content', Content);
+    Body := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+  Resp := PostJSON(FURL, Body, Empty, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('discord webhook: status=%d body=%s', [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+function TDiscordWebhook.PostEmbed(const Title, Description: string; Color: Integer): Boolean;
+var
+  Body: string;
+  Outer, Embed: TJsonObject;
+  Embeds: TJsonArray;
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  SetLength(Empty, 0);
+  Outer  := TJsonObject.Create;
+  Embed  := TJsonObject.Create;
+  Embeds := TJsonArray.Create;
+  try
+    Embed.PutStr('title',       Title);
+    Embed.PutStr('description', Description);
+    Embed.PutInt('color',       Color);
+    Embeds.AddObject(Embed);
+    Outer.PutArray('embeds', Embeds);
+    Body := Outer.ToJSON;
+  finally
+    Outer.Free;
+    if Embed  <> nil then Embed.Free;   { only frees if AddObject didn't take it }
+    if Embeds <> nil then Embeds.Free;
+  end;
+  Resp := PostJSON(FURL, Body, Empty, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+end;
+
+(* ---- Bot polling ---- *)
+
+constructor TDiscordBot.Create(const Token, ChannelId: string; Cfg: TConfig;
+                               Provider: ILLMProvider; Registry: TToolRegistry);
+begin
+  inherited Create;
+  FToken    := Token;
+  FChannel  := ChannelId;
+  FCfg      := Cfg;
+  FProvider := Provider;
+  FRegistry := Registry;
+  FLastId   := '';
+  FStop     := False;
+end;
+
+function TDiscordBot.FetchNewMessages(out RawJSON: string): Boolean;
+var
+  URL: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  RawJSON := '';
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bot ' + FToken);
+  URL := 'https://discord.com/api/v10/channels/' + FChannel + '/messages?limit=20';
+  if FLastId <> '' then
+    URL := URL + '&after=' + FLastId;
+  Resp := GetJSONURL(URL, Headers, 30);
+  if (Resp.StatusCode >= 200) and (Resp.StatusCode < 300) then
+  begin
+    RawJSON := Resp.Body;
+    Exit(True);
+  end;
+  LogWarn('discord fetch: status=%d err=%s', [Resp.StatusCode, Resp.ErrorMsg]);
+  Result := False;
+end;
+
+function TDiscordBot.PostMessage(const Content: string): Boolean;
+var
+  URL, Body: string;
+  Headers: array of THeaderPair;
+  Obj: TJsonObject;
+  Resp: THTTPResult;
+begin
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bot ' + FToken);
+  URL := 'https://discord.com/api/v10/channels/' + FChannel + '/messages';
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('content', Content);
+    Body := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+  Resp := PostJSON(URL, Body, Headers, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('discord post: status=%d body=%s', [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+procedure TDiscordBot.ProcessMessages(const ArrJSON: string);
+var
+  Arr: TJsonArray;
+  Msg, Author: TJsonObject;
+  i: Integer;
+  Content, Id, NewestId: string;
+  IsBot: Boolean;
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+begin
+  Arr := TJsonArray.Parse(ArrJSON);
+  if Arr = nil then Exit;
+  NewestId := '';
+  try
+    { Discord returns newest first; iterate reversed so we reply in order. }
+    for i := Arr.Count - 1 downto 0 do
+    begin
+      Msg := Arr.ItemObject(i);
+      if Msg = nil then Continue;
+      try
+        Id      := Msg.GetStr('id', '');
+        Content := Msg.GetStr('content', '');
+        Author  := Msg.ChildObject('author');
+        IsBot   := False;
+        if Author <> nil then
+        begin
+          IsBot := Author.GetBool('bot', False);
+          Author.Free;
+        end;
+        if NewestId = '' then NewestId := Id;
+        if (Id > FLastId) then FLastId := Id;
+        if IsBot or (Content = '') then Continue;
+
+        LogInfo('discord: msg from channel=%s: %s', [FChannel, Copy(Content, 1, 80)]);
+        if FProvider = nil then
+        begin
+          PostMessage('(no provider configured)');
+          Continue;
+        end;
+
+        SetLength(Msgs, 1);
+        Msgs[0] := MakeMessage(mrUser, Content);
+        LoopCfg.Provider      := FProvider;
+        LoopCfg.Registry      := FRegistry;
+        LoopCfg.Model         := FCfg.DefaultModel;
+        LoopCfg.MaxIterations := 6;
+        LoopCfg.Options       := DefaultChatOptions;
+        LoopCfg.OnText        := nil;
+        LoopCfg.OnToolCall    := nil;
+        LoopCfg.OnToolResult  := nil;
+        if RunToolLoop(LoopCfg, Msgs, Loop) and (Loop.Content <> '') then
+          PostMessage(Loop.Content);
+      finally
+        Msg.Free;
+      end;
+    end;
+  finally
+    Arr.Free;
+  end;
+end;
+
+procedure TDiscordBot.Run;
+var
+  RawJSON: string;
+begin
+  if FToken = '' then begin LogError('discord: no bot token'); Exit; end;
+  if FChannel = '' then begin LogError('discord: no channel id'); Exit; end;
+  LogInfo('discord: polling channel %s', [FChannel]);
+  while not FStop do
+  begin
+    if FetchNewMessages(RawJSON) then
+      ProcessMessages(RawJSON);
+    { Discord rate-limits — keep poll interval > 1s. 3s is friendly. }
+    Sleep(3000);
+  end;
+end;
+
+procedure TDiscordBot.RequestStop;
+begin
+  FStop := True;
+end;
+
+end.

--- a/src/pkg/channels/PasClaw.Channels.Slack.pas
+++ b/src/pkg/channels/PasClaw.Channels.Slack.pas
@@ -1,0 +1,114 @@
+(*
+  PasClaw.Channels.Slack - Slack adapter.
+
+  Outbound: Incoming Webhook URLs (https://hooks.slack.com/services/...).
+  Inbound:  Events API webhook receiver — registered as a gateway route by
+            PasClaw.Gateway.Server (Phase 8). Phase 6 ships the webhook
+            sender + the verification logic for the URL-verification
+            challenge so registration works.
+
+  Docs: https://api.slack.com/messaging/webhooks
+        https://api.slack.com/events-api
+*)
+unit PasClaw.Channels.Slack;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TSlackWebhook = class
+  private
+    FURL: string;
+  public
+    constructor Create(const WebhookURL: string);
+    function Post(const Text: string): Boolean;
+    function PostBlocks(const Text: string; const BlocksJSON: string): Boolean;
+  end;
+
+(* Slack URL verification challenge: when an Events API endpoint is
+   registered, Slack POSTs a url_verification payload with a challenge
+   string. The gateway echoes it back. Returns True if the body was a
+   challenge and Response holds the echo body to send. *)
+function SlackChallengeResponse(const Body: string; out Response: string): Boolean;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+constructor TSlackWebhook.Create(const WebhookURL: string);
+begin
+  inherited Create;
+  FURL := WebhookURL;
+end;
+
+function TSlackWebhook.Post(const Text: string): Boolean;
+var
+  Obj: TJsonObject;
+  Body: string;
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  SetLength(Empty, 0);
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('text', Text);
+    Body := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+  Resp := PostJSON(FURL, Body, Empty, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('slack webhook: status=%d body=%s', [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+function TSlackWebhook.PostBlocks(const Text, BlocksJSON: string): Boolean;
+var
+  Obj: TJsonObject;
+  Body: string;
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  SetLength(Empty, 0);
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('text', Text);
+    Obj.PutRaw('blocks', BlocksJSON);
+    Body := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+  Resp := PostJSON(FURL, Body, Empty, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+end;
+
+function SlackChallengeResponse(const Body: string; out Response: string): Boolean;
+var
+  Obj: TJsonObject;
+  Kind, Challenge: string;
+begin
+  Response := '';
+  Result := False;
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit;
+  try
+    Kind := Obj.GetStr('type', '');
+    if Kind <> 'url_verification' then Exit;
+    Challenge := Obj.GetStr('challenge', '');
+    if Challenge = '' then Exit;
+    Response := '{"challenge":"' + JsonEscape(Challenge) + '"}';
+    Result := True;
+  finally
+    Obj.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -1,0 +1,215 @@
+(*
+  PasClaw.Channels.Telegram - long-polling Telegram bot adapter.
+
+  Uses TIdHTTP to call the Bot API. No webhook needed - getUpdates with a
+  long poll keeps things firewall-friendly. Each incoming text message is
+  fed to the agent loop and the reply is sent back via sendMessage.
+
+  Configure with PASCLAW_TELEGRAM_TOKEN or pass --token on the command line.
+  Bot API docs: https://core.telegram.org/bots/api
+*)
+unit PasClaw.Channels.Telegram;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TTelegramChannel = class
+  private
+    FToken:     string;
+    FCfg:       TConfig;
+    FProvider:  ILLMProvider;
+    FRegistry:  TToolRegistry;
+    FOffset:    Int64;
+    FStop:      Boolean;
+    function ApiUrl(const Method: string): string;
+    function GetUpdates(out RawJSON: string): Boolean;
+    function SendMessage(ChatId: Int64; const Text: string): Boolean;
+    procedure ProcessUpdate(const UpdateJSON: string);
+  public
+    constructor Create(const Token: string; Cfg: TConfig;
+                       Provider: ILLMProvider; Registry: TToolRegistry);
+    procedure Run;       { blocks until Stop is called or Ctrl-C }
+    procedure RequestStop;
+  end;
+
+implementation
+
+uses
+  fpjson, jsonparser,
+  PasClaw.Logger,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.HTTP,
+  PasClaw.Tools.ToolLoop;
+
+constructor TTelegramChannel.Create(const Token: string; Cfg: TConfig;
+                                    Provider: ILLMProvider; Registry: TToolRegistry);
+begin
+  inherited Create;
+  FToken    := Token;
+  FCfg      := Cfg;
+  FProvider := Provider;
+  FRegistry := Registry;
+  FOffset   := 0;
+  FStop     := False;
+end;
+
+function TTelegramChannel.ApiUrl(const Method: string): string;
+begin
+  Result := 'https://api.telegram.org/bot' + FToken + '/' + Method;
+end;
+
+function TTelegramChannel.GetUpdates(out RawJSON: string): Boolean;
+var
+  URL: string;
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  RawJSON := '';
+  SetLength(Empty, 0);
+  URL := ApiUrl('getUpdates') +
+         '?timeout=25&offset=' + IntToStr(FOffset);
+  Resp := GetJSONURL(URL, Empty, 30);
+  if (Resp.StatusCode >= 200) and (Resp.StatusCode < 300) then
+  begin
+    RawJSON := Resp.Body;
+    Exit(True);
+  end;
+  LogWarn('telegram getUpdates failed: status=%d err=%s', [Resp.StatusCode, Resp.ErrorMsg]);
+  Result := False;
+end;
+
+function TTelegramChannel.SendMessage(ChatId: Int64; const Text: string): Boolean;
+var
+  URL, Body: string;
+  Empty: array of THeaderPair;
+  J: TJSONObject;
+  Resp: THTTPResult;
+begin
+  SetLength(Empty, 0);
+  URL := ApiUrl('sendMessage');
+  J := TJSONObject.Create;
+  try
+    J.Add('chat_id', ChatId);
+    J.Add('text',    Text);
+    Body := J.AsJSON;
+  finally
+    J.Free;
+  end;
+  Resp := PostJSON(URL, Body, Empty, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('telegram sendMessage failed: status=%d body=%s', [Resp.StatusCode, Copy(Resp.Body,1,200)]);
+end;
+
+procedure TTelegramChannel.ProcessUpdate(const UpdateJSON: string);
+var
+  Root: TJSONData;
+  Obj, Msg, Chat: TJSONObject;
+  Text: string;
+  ChatId, UpdateId: Int64;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+  Msgs: array of TMessage;
+begin
+  Root := GetJSON(UpdateJSON);
+  try
+    if not (Root is TJSONObject) then Exit;
+    Obj := TJSONObject(Root);
+    UpdateId := Obj.Get('update_id', Int64(0));
+    if UpdateId >= FOffset then FOffset := UpdateId + 1;
+    if Obj.IndexOfName('message') < 0 then Exit;
+    Msg := Obj.Objects['message'];
+    if Msg.IndexOfName('chat') < 0 then Exit;
+    Chat := Msg.Objects['chat'];
+    ChatId := Chat.Get('id', Int64(0));
+    Text   := Msg.Get('text', '');
+    if Text = '' then Exit;
+  finally
+    Root.Free;
+  end;
+
+  LogInfo('telegram: chat=%d msg=%s', [ChatId, Copy(Text, 1, 80)]);
+
+  if FProvider = nil then
+  begin
+    SendMessage(ChatId, '(no provider configured — run `pasclaw onboard`)');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Text);
+
+  LoopCfg.Provider      := FProvider;
+  LoopCfg.Registry      := FRegistry;
+  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.MaxIterations := 6;
+  LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.OnText        := nil;
+  LoopCfg.OnToolCall    := nil;
+  LoopCfg.OnToolResult  := nil;
+
+  if RunToolLoop(LoopCfg, Msgs, Loop) and (Loop.Content <> '') then
+    SendMessage(ChatId, Loop.Content)
+  else
+    SendMessage(ChatId, '(sorry — model returned no content)');
+end;
+
+procedure TTelegramChannel.Run;
+var
+  RawJSON: string;
+  Root: TJSONData;
+  Obj: TJSONObject;
+  Arr: TJSONArray;
+  i: Integer;
+begin
+  if FToken = '' then
+  begin
+    LogError('telegram: no bot token (set PASCLAW_TELEGRAM_TOKEN or --token)');
+    Exit;
+  end;
+  LogInfo('telegram: long-poll started (token …%s)',
+    [Copy(FToken, Length(FToken) - 5, 5)]);
+
+  while not FStop do
+  begin
+    if not GetUpdates(RawJSON) then
+    begin
+      Sleep(2000);
+      Continue;
+    end;
+    try
+      Root := GetJSON(RawJSON);
+    except
+      Sleep(1000);
+      Continue;
+    end;
+    try
+      if not (Root is TJSONObject) then Continue;
+      Obj := TJSONObject(Root);
+      if not Obj.Get('ok', False) then Continue;
+      if Obj.IndexOfName('result') < 0 then Continue;
+      Arr := Obj.Arrays['result'];
+      for i := 0 to Arr.Count - 1 do
+        ProcessUpdate(Arr[i].AsJSON);
+    finally
+      Root.Free;
+    end;
+  end;
+  LogInfo('telegram: long-poll stopped');
+end;
+
+procedure TTelegramChannel.RequestStop;
+begin
+  FStop := True;
+end;
+
+end.

--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -1,0 +1,252 @@
+{
+  PasClaw.CliUI - terminal colour handling, banner, help/error rendering.
+  Mirrors cmd/picoclaw/internal/cliui in picoclaw.
+}
+unit PasClaw.CliUI;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TAnsi = record
+    Reset, Bold, Dim, Red, Green, Yellow, Blue, Magenta, Cyan, Gray, BoldBlue, BoldRed: string;
+  end;
+
+var
+  Ansi: TAnsi;
+
+procedure CliUI_Init(NoColor: Boolean);
+function  CliUI_NoColor: Boolean;
+function  EarlyColorDisabled: Boolean;
+procedure PrintBanner;
+procedure ApplyTimezoneFromEnv;
+
+{ Boxed panel rendering used by help / error output. Width auto-fits to the
+  terminal (capped at 100 cols) and falls back to ASCII when colour is off. }
+function  RenderPanel(const Title: string; const Lines: array of string): string;
+function  FormatCLIError(const Msg, CommandPath: string): string;
+function  RenderCommandHelp(const Use, Short, Long, Example: string;
+                            const Subcommands, Flags: array of string): string;
+
+implementation
+
+uses
+  PasClaw.Utils;
+
+var
+  GNoColor: Boolean = False;
+
+procedure SetAnsi(Disabled: Boolean);
+begin
+  if Disabled then
+  begin
+    Ansi.Reset    := '';
+    Ansi.Bold     := '';
+    Ansi.Dim      := '';
+    Ansi.Red      := '';
+    Ansi.Green    := '';
+    Ansi.Yellow   := '';
+    Ansi.Blue     := '';
+    Ansi.Magenta  := '';
+    Ansi.Cyan     := '';
+    Ansi.Gray     := '';
+    Ansi.BoldBlue := '';
+    Ansi.BoldRed  := '';
+  end
+  else
+  begin
+    Ansi.Reset    := #27'[0m';
+    Ansi.Bold     := #27'[1m';
+    Ansi.Dim      := #27'[2m';
+    Ansi.Red      := #27'[31m';
+    Ansi.Green    := #27'[32m';
+    Ansi.Yellow   := #27'[33m';
+    Ansi.Blue     := #27'[34m';
+    Ansi.Magenta  := #27'[35m';
+    Ansi.Cyan     := #27'[36m';
+    Ansi.Gray     := #27'[90m';
+    Ansi.BoldBlue := #27'[1;38;2;62;93;185m';
+    Ansi.BoldRed  := #27'[1;38;2;213;70;70m';
+  end;
+end;
+
+procedure CliUI_Init(NoColor: Boolean);
+begin
+  GNoColor := NoColor;
+  SetAnsi(NoColor);
+end;
+
+function CliUI_NoColor: Boolean;
+begin
+  Result := GNoColor;
+end;
+
+function EarlyColorDisabled: Boolean;
+var
+  i: Integer;
+  a: string;
+begin
+  Result := False;
+  if (GetEnvironmentVariable('NO_COLOR') <> '') or (GetEnvironmentVariable('TERM') = 'dumb') then
+    Exit(True);
+  for i := 1 to ParamCount do
+  begin
+    a := ParamStr(i);
+    if (a = '--no-color') or (a = '--no-color=true') or (a = '--no-color=1') then
+      Exit(True);
+  end;
+end;
+
+procedure PrintBanner;
+const
+  L1 = '██████╗  █████╗ ███████╗ ██████╗██╗      █████╗ ██╗    ██╗';
+  L2 = '██╔══██╗██╔══██╗██╔════╝██╔════╝██║     ██╔══██╗██║    ██║';
+  L3 = '██████╔╝███████║███████╗██║     ██║     ███████║██║ █╗ ██║';
+  L4 = '██╔═══╝ ██╔══██║╚════██║██║     ██║     ██╔══██║██║███╗██║';
+  L5 = '██║     ██║  ██║███████║╚██████╗███████╗██║  ██║╚███╔███╔╝';
+  L6 = '╚═╝     ╚═╝  ╚═╝╚══════╝ ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ';
+begin
+  WriteLn;
+  if GNoColor then
+  begin
+    WriteLn(L1); WriteLn(L2); WriteLn(L3);
+    WriteLn(L4); WriteLn(L5); WriteLn(L6);
+  end
+  else
+  begin
+    WriteLn(Ansi.BoldBlue + L1 + Ansi.Reset);
+    WriteLn(Ansi.BoldBlue + L2 + Ansi.Reset);
+    WriteLn(Ansi.BoldBlue + L3 + Ansi.Reset);
+    WriteLn(Ansi.BoldRed  + L4 + Ansi.Reset);
+    WriteLn(Ansi.BoldRed  + L5 + Ansi.Reset);
+    WriteLn(Ansi.BoldRed  + L6 + Ansi.Reset);
+  end;
+  WriteLn;
+end;
+
+procedure ApplyTimezoneFromEnv;
+var
+  Tz: string;
+begin
+  Tz := GetEnvironmentVariable('TZ');
+  if Tz = '' then Exit;
+  WriteLn('TZ environment: ', Tz);
+  WriteLn('ZONEINFO environment: ', GetEnvironmentVariable('ZONEINFO'));
+  { FPC honours the TZ environment variable on Unix natively; on Windows we
+    simply report it and let the RTL handle conversions. }
+end;
+
+function PadRight(const S: string; W: Integer): string;
+begin
+  if VisibleLength(S) >= W then Result := S
+  else Result := S + StringOfChar(' ', W - VisibleLength(S));
+end;
+
+function RenderPanel(const Title: string; const Lines: array of string): string;
+const
+  TL = '┌'; TR = '┐'; BL = '└'; BR = '┘'; H = '─'; V = '│';
+var
+  i, W: Integer;
+  SB: TStringBuilder;
+  Hbar: string;
+begin
+  W := VisibleLength(Title) + 2;
+  for i := 0 to High(Lines) do
+    if VisibleLength(Lines[i]) + 2 > W then
+      W := VisibleLength(Lines[i]) + 2;
+  if W < 32 then W := 32;
+  if W > 100 then W := 100;
+
+  Hbar := DupStr(H, W);
+  SB := TStringBuilder.Create;
+  try
+    SB.Append(Ansi.BoldBlue).Append(TL).Append(Hbar).Append(TR).Append(Ansi.Reset).AppendLine;
+    SB.Append(Ansi.BoldBlue).Append(V).Append(Ansi.Reset).Append(' ')
+      .Append(Ansi.Bold).Append(PadRight(Title, W - 1)).Append(Ansi.Reset)
+      .Append(Ansi.BoldBlue).Append(V).Append(Ansi.Reset).AppendLine;
+    SB.Append(Ansi.BoldBlue).Append(V).Append(Ansi.Reset)
+      .Append(StringOfChar(' ', W))
+      .Append(Ansi.BoldBlue).Append(V).Append(Ansi.Reset).AppendLine;
+    for i := 0 to High(Lines) do
+      SB.Append(Ansi.BoldBlue).Append(V).Append(Ansi.Reset).Append(' ')
+        .Append(PadRight(Lines[i], W - 1))
+        .Append(Ansi.BoldBlue).Append(V).Append(Ansi.Reset).AppendLine;
+    SB.Append(Ansi.BoldBlue).Append(BL).Append(Hbar).Append(BR).Append(Ansi.Reset).AppendLine;
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function FormatCLIError(const Msg, CommandPath: string): string;
+var
+  Lines: array of string;
+begin
+  SetLength(Lines, 2);
+  Lines[0] := Ansi.Red + 'error: ' + Ansi.Reset + Msg;
+  if CommandPath <> '' then
+    Lines[1] := Ansi.Dim + 'run `' + CommandPath + ' --help` for usage' + Ansi.Reset
+  else
+    Lines[1] := Ansi.Dim + 'run `pasclaw --help` for usage' + Ansi.Reset;
+  Result := RenderPanel('PasClaw error', Lines);
+end;
+
+function RenderCommandHelp(const Use, Short, Long, Example: string;
+                          const Subcommands, Flags: array of string): string;
+var
+  Lines: TStringList;
+  i: Integer;
+  Tmp: string;
+begin
+  Lines := TStringList.Create;
+  try
+    if Short <> '' then Lines.Add(Short);
+    if Long  <> '' then
+    begin
+      Lines.Add('');
+      Lines.Add(Long);
+    end;
+    Lines.Add('');
+    Lines.Add(Ansi.Bold + 'Usage:' + Ansi.Reset);
+    Lines.Add('  ' + Use);
+    if Length(Subcommands) > 0 then
+    begin
+      Lines.Add('');
+      Lines.Add(Ansi.Bold + 'Commands:' + Ansi.Reset);
+      for i := 0 to High(Subcommands) do
+        Lines.Add('  ' + Subcommands[i]);
+    end;
+    if Length(Flags) > 0 then
+    begin
+      Lines.Add('');
+      Lines.Add(Ansi.Bold + 'Flags:' + Ansi.Reset);
+      for i := 0 to High(Flags) do
+        Lines.Add('  ' + Flags[i]);
+    end;
+    if Example <> '' then
+    begin
+      Lines.Add('');
+      Lines.Add(Ansi.Bold + 'Examples:' + Ansi.Reset);
+      Lines.Add('  ' + Example);
+    end;
+
+    Tmp := '';
+    for i := 0 to Lines.Count - 1 do
+    begin
+      if i > 0 then Tmp := Tmp + sLineBreak;
+      Tmp := Tmp + Lines[i];
+    end;
+    Result := Tmp + sLineBreak;
+  finally
+    Lines.Free;
+  end;
+end;
+
+initialization
+  SetAnsi(False);
+end.

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -1,0 +1,324 @@
+{
+  PasClaw.Config - build-time version constants, on-disk config struct,
+  and helpers for resolving the PasClaw home directory.
+  Mirrors pkg/config in picoclaw.
+}
+unit PasClaw.Config;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+const
+  { Build-time version: set the PASCLAW_VERSION environment variable before
+    invoking fpc to override (the Makefile does this from `git describe`). }
+  VersionRaw = {$I %PASCLAW_VERSION%};
+  VersionFallback = '0.1.0-dev';
+
+  EnvHome   = 'PASCLAW_HOME';
+  EnvConfig = 'PASCLAW_CONFIG';
+
+type
+  TGatewayConfig = record
+    LogLevel: string;
+    BindAddr: string;
+    Port:     Integer;
+  end;
+
+  TProviderConfig = record
+    Name:    string;   { e.g. "anthropic", "openai" }
+    Kind:    string;   { provider type id }
+    APIBase: string;
+    APIKey:  string;
+    Model:   string;
+  end;
+
+  TMCPServer = record
+    Name:    string;
+    Cmd:     string;
+    Args:    string;
+    Env:     string;
+    Enabled: Boolean;
+  end;
+
+  TCronEntry = record
+    Id:       string;
+    Spec:     string;   { cron expression }
+    Skill:    string;
+    Args:     string;
+    Enabled:  Boolean;
+  end;
+
+  TSkillEntry = record
+    Name:    string;
+    Source:  string;   { builtin | path | url }
+    Enabled: Boolean;
+  end;
+
+  TConfig = class
+  public
+    DefaultProvider: string;
+    DefaultModel:    string;
+    Gateway:    TGatewayConfig;
+    Providers:  array of TProviderConfig;
+    MCPServers: array of TMCPServer;
+    Crons:      array of TCronEntry;
+    Skills:     array of TSkillEntry;
+    constructor Create;
+    function  ToJSON: string;
+    procedure FromJSON(const S: string);
+  end;
+
+function GetHome: string;
+function GetConfigPath: string;
+function LoadConfig: TConfig;
+procedure SaveConfig(C: TConfig);
+function FormatVersion: string;
+function FormatBuildInfo: string;
+
+implementation
+
+uses
+  PasClaw.Utils,
+  fpjson, jsonparser;
+
+constructor TConfig.Create;
+begin
+  inherited Create;
+  DefaultProvider := 'anthropic';
+  DefaultModel    := 'claude-opus-4-7';
+  Gateway.LogLevel := 'info';
+  Gateway.BindAddr := '127.0.0.1';
+  Gateway.Port     := 8088;
+end;
+
+function ProviderToJSON(const P: TProviderConfig): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.Add('name',     P.Name);
+  Result.Add('kind',     P.Kind);
+  Result.Add('api_base', P.APIBase);
+  Result.Add('api_key',  P.APIKey);
+  Result.Add('model',    P.Model);
+end;
+
+function MCPToJSON(const M: TMCPServer): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.Add('name',    M.Name);
+  Result.Add('cmd',     M.Cmd);
+  Result.Add('args',    M.Args);
+  Result.Add('env',     M.Env);
+  Result.Add('enabled', M.Enabled);
+end;
+
+function CronToJSON(const C: TCronEntry): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.Add('id',      C.Id);
+  Result.Add('spec',    C.Spec);
+  Result.Add('skill',   C.Skill);
+  Result.Add('args',    C.Args);
+  Result.Add('enabled', C.Enabled);
+end;
+
+function SkillToJSON(const S: TSkillEntry): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.Add('name',    S.Name);
+  Result.Add('source',  S.Source);
+  Result.Add('enabled', S.Enabled);
+end;
+
+function TConfig.ToJSON: string;
+var
+  Root, Gw: TJSONObject;
+  Arr: TJSONArray;
+  i: Integer;
+begin
+  Root := TJSONObject.Create;
+  try
+    Root.Add('default_provider', DefaultProvider);
+    Root.Add('default_model',    DefaultModel);
+
+    Gw := TJSONObject.Create;
+    Gw.Add('log_level', Gateway.LogLevel);
+    Gw.Add('bind_addr', Gateway.BindAddr);
+    Gw.Add('port',      Gateway.Port);
+    Root.Add('gateway', Gw);
+
+    Arr := TJSONArray.Create;
+    for i := 0 to High(Providers) do Arr.Add(ProviderToJSON(Providers[i]));
+    Root.Add('providers', Arr);
+
+    Arr := TJSONArray.Create;
+    for i := 0 to High(MCPServers) do Arr.Add(MCPToJSON(MCPServers[i]));
+    Root.Add('mcp_servers', Arr);
+
+    Arr := TJSONArray.Create;
+    for i := 0 to High(Crons) do Arr.Add(CronToJSON(Crons[i]));
+    Root.Add('crons', Arr);
+
+    Arr := TJSONArray.Create;
+    for i := 0 to High(Skills) do Arr.Add(SkillToJSON(Skills[i]));
+    Root.Add('skills', Arr);
+
+    Result := Root.FormatJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure ReadProviders(Arr: TJSONArray; var Dest: array of TProviderConfig); forward;
+
+procedure TConfig.FromJSON(const S: string);
+var
+  Root: TJSONObject;
+  Obj: TJSONObject;
+  Arr: TJSONArray;
+  i: Integer;
+  Data: TJSONData;
+begin
+  if Trim(S) = '' then Exit;
+  Data := GetJSON(S);
+  if not (Data is TJSONObject) then
+  begin
+    Data.Free;
+    Exit;
+  end;
+  Root := TJSONObject(Data);
+  try
+    DefaultProvider := Root.Get('default_provider', DefaultProvider);
+    DefaultModel    := Root.Get('default_model',    DefaultModel);
+
+    if Root.IndexOfName('gateway') >= 0 then
+    begin
+      Obj := Root.Objects['gateway'];
+      Gateway.LogLevel := Obj.Get('log_level', Gateway.LogLevel);
+      Gateway.BindAddr := Obj.Get('bind_addr', Gateway.BindAddr);
+      Gateway.Port     := Obj.Get('port',      Gateway.Port);
+    end;
+
+    if Root.IndexOfName('providers') >= 0 then
+    begin
+      Arr := Root.Arrays['providers'];
+      SetLength(Providers, Arr.Count);
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Obj := TJSONObject(Arr[i]);
+        Providers[i].Name    := Obj.Get('name',     '');
+        Providers[i].Kind    := Obj.Get('kind',     '');
+        Providers[i].APIBase := Obj.Get('api_base', '');
+        Providers[i].APIKey  := Obj.Get('api_key',  '');
+        Providers[i].Model   := Obj.Get('model',    '');
+      end;
+    end;
+
+    if Root.IndexOfName('mcp_servers') >= 0 then
+    begin
+      Arr := Root.Arrays['mcp_servers'];
+      SetLength(MCPServers, Arr.Count);
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Obj := TJSONObject(Arr[i]);
+        MCPServers[i].Name    := Obj.Get('name',    '');
+        MCPServers[i].Cmd     := Obj.Get('cmd',     '');
+        MCPServers[i].Args    := Obj.Get('args',    '');
+        MCPServers[i].Env     := Obj.Get('env',     '');
+        MCPServers[i].Enabled := Obj.Get('enabled', True);
+      end;
+    end;
+
+    if Root.IndexOfName('crons') >= 0 then
+    begin
+      Arr := Root.Arrays['crons'];
+      SetLength(Crons, Arr.Count);
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Obj := TJSONObject(Arr[i]);
+        Crons[i].Id      := Obj.Get('id',      '');
+        Crons[i].Spec    := Obj.Get('spec',    '');
+        Crons[i].Skill   := Obj.Get('skill',   '');
+        Crons[i].Args    := Obj.Get('args',    '');
+        Crons[i].Enabled := Obj.Get('enabled', True);
+      end;
+    end;
+
+    if Root.IndexOfName('skills') >= 0 then
+    begin
+      Arr := Root.Arrays['skills'];
+      SetLength(Skills, Arr.Count);
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Obj := TJSONObject(Arr[i]);
+        Skills[i].Name    := Obj.Get('name',    '');
+        Skills[i].Source  := Obj.Get('source',  '');
+        Skills[i].Enabled := Obj.Get('enabled', True);
+      end;
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure ReadProviders(Arr: TJSONArray; var Dest: array of TProviderConfig);
+begin
+  { stub helper retained for forward decl; logic inlined above }
+end;
+
+function GetHome: string;
+var
+  H: string;
+begin
+  H := GetEnvironmentVariable(EnvHome);
+  if H <> '' then Exit(H);
+  Result := JoinPath(HomeDir, '.pasclaw');
+end;
+
+function GetConfigPath: string;
+var
+  Override_: string;
+begin
+  Override_ := GetEnvironmentVariable(EnvConfig);
+  if Override_ <> '' then Exit(Override_);
+  Result := JoinPath(GetHome, 'config.json');
+end;
+
+function LoadConfig: TConfig;
+var
+  Path, S: string;
+begin
+  Result := TConfig.Create;
+  Path := GetConfigPath;
+  if not FileExists(Path) then Exit;
+  S := ReadFileText(Path);
+  try
+    Result.FromJSON(S);
+  except
+    on E: Exception do
+      { Bad config: keep defaults rather than aborting CLI startup. }
+      ;
+  end;
+end;
+
+procedure SaveConfig(C: TConfig);
+begin
+  WriteFileText(GetConfigPath, C.ToJSON);
+end;
+
+function FormatVersion: string;
+begin
+  if VersionRaw = '' then Result := VersionFallback else Result := VersionRaw;
+end;
+
+function FormatBuildInfo: string;
+begin
+  Result := Format('pasclaw %s (fpc %s %s/%s)',
+    [FormatVersion, {$I %FPCVERSION%}, {$I %FPCTARGETOS%}, {$I %FPCTARGETCPU%}]);
+end;
+
+end.

--- a/src/pkg/cron/PasClaw.Cron.Expr.pas
+++ b/src/pkg/cron/PasClaw.Cron.Expr.pas
@@ -1,0 +1,229 @@
+(*
+  PasClaw.Cron.Expr - 5-field cron expression parser and "next fire time"
+  calculator. Mirrors a subset of pkg/cron in picoclaw.
+
+  Fields: minute hour day-of-month month day-of-week
+  Per-field syntax:
+    *           any value
+    N           single integer
+    N,M,...     enumerated set
+    N-M         inclusive range
+    N-M/S       range with step
+    */S         every step (full range)
+
+  Both 0 and 7 are accepted as Sunday in the day-of-week field.
+
+  Out of scope: special strings (@hourly, @daily), seconds field, named
+  months/weekdays, last-day-of-month (L), nearest-weekday (W). They can
+  be layered on top if/when needed.
+*)
+unit PasClaw.Cron.Expr;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TCronField = record
+    Bits: array[0..63] of Boolean;   { only the relevant range is used }
+    Min, Max: Integer;
+  end;
+
+  TCronExpr = record
+    Minute, Hour, Day, Month, Weekday: TCronField;
+    Valid: Boolean;
+  end;
+
+function ParseCronExpr(const S: string; out Expr: TCronExpr): Boolean;
+function NextFireAfter(const Expr: TCronExpr; Start: TDateTime): TDateTime;
+
+implementation
+
+procedure InitField(var F: TCronField; AMin, AMax: Integer);
+var
+  i: Integer;
+begin
+  F.Min := AMin;
+  F.Max := AMax;
+  for i := 0 to High(F.Bits) do F.Bits[i] := False;
+end;
+
+procedure SetRange(var F: TCronField; Lo, Hi, Step: Integer);
+var
+  i: Integer;
+begin
+  if Step < 1 then Step := 1;
+  if Lo < F.Min then Lo := F.Min;
+  if Hi > F.Max then Hi := F.Max;
+  i := Lo;
+  while i <= Hi do
+  begin
+    if (i >= 0) and (i < Length(F.Bits)) then F.Bits[i] := True;
+    Inc(i, Step);
+  end;
+end;
+
+function ParseInt(const S: string; out V: Integer): Boolean;
+var
+  E: Integer;
+begin
+  Val(S, V, E);
+  Result := E = 0;
+end;
+
+function ParseTerm(const Term: string; var F: TCronField): Boolean;
+var
+  Body, StepPart: string;
+  SlashPos, DashPos: Integer;
+  Lo, Hi, Step: Integer;
+begin
+  Result := False;
+  if Term = '' then Exit;
+  Body := Term;
+  Step := 1;
+  SlashPos := Pos('/', Body);
+  if SlashPos > 0 then
+  begin
+    StepPart := Copy(Body, SlashPos + 1, MaxInt);
+    Body := Copy(Body, 1, SlashPos - 1);
+    if not ParseInt(StepPart, Step) then Exit;
+    if Step < 1 then Exit;
+  end;
+  if Body = '*' then
+  begin
+    SetRange(F, F.Min, F.Max, Step);
+    Exit(True);
+  end;
+  DashPos := Pos('-', Body);
+  if DashPos > 0 then
+  begin
+    if not ParseInt(Copy(Body, 1, DashPos - 1), Lo) then Exit;
+    if not ParseInt(Copy(Body, DashPos + 1, MaxInt), Hi) then Exit;
+    SetRange(F, Lo, Hi, Step);
+    Exit(True);
+  end;
+  if not ParseInt(Body, Lo) then Exit;
+  if SlashPos > 0 then
+    SetRange(F, Lo, F.Max, Step)
+  else
+    SetRange(F, Lo, Lo, 1);
+  Result := True;
+end;
+
+function ParseList(const S: string; var F: TCronField): Boolean;
+var
+  Term: string;
+  i, n: Integer;
+begin
+  Result := True;
+  n := Length(S);
+  Term := '';
+  i := 1;
+  while i <= n do
+  begin
+    if S[i] = ',' then
+    begin
+      if not ParseTerm(Term, F) then Exit(False);
+      Term := '';
+    end
+    else
+      Term := Term + S[i];
+    Inc(i);
+  end;
+  if Term <> '' then
+    if not ParseTerm(Term, F) then Exit(False);
+end;
+
+function SplitFields(const S: string; out F: array of string): Boolean;
+var
+  i, n, count: Integer;
+  cur: string;
+begin
+  count := 0;
+  cur := '';
+  n := Length(S);
+  for i := 1 to n do
+  begin
+    if (S[i] = ' ') or (S[i] = #9) then
+    begin
+      if cur <> '' then
+      begin
+        if count >= Length(F) then Exit(False);
+        F[count] := cur;
+        Inc(count);
+        cur := '';
+      end;
+    end
+    else
+      cur := cur + S[i];
+  end;
+  if cur <> '' then
+  begin
+    if count >= Length(F) then Exit(False);
+    F[count] := cur;
+    Inc(count);
+  end;
+  Result := count = Length(F);
+end;
+
+function ParseCronExpr(const S: string; out Expr: TCronExpr): Boolean;
+var
+  Parts: array[0..4] of string;
+begin
+  FillChar(Expr, SizeOf(Expr), 0);
+  Expr.Valid := False;
+  InitField(Expr.Minute,  0, 59);
+  InitField(Expr.Hour,    0, 23);
+  InitField(Expr.Day,     1, 31);
+  InitField(Expr.Month,   1, 12);
+  InitField(Expr.Weekday, 0, 7);
+
+  if not SplitFields(Trim(S), Parts) then Exit(False);
+  if not ParseList(Parts[0], Expr.Minute)  then Exit(False);
+  if not ParseList(Parts[1], Expr.Hour)    then Exit(False);
+  if not ParseList(Parts[2], Expr.Day)     then Exit(False);
+  if not ParseList(Parts[3], Expr.Month)   then Exit(False);
+  if not ParseList(Parts[4], Expr.Weekday) then Exit(False);
+
+  { Accept 0 and 7 as Sunday. }
+  if Expr.Weekday.Bits[7] then Expr.Weekday.Bits[0] := True;
+  if Expr.Weekday.Bits[0] then Expr.Weekday.Bits[7] := True;
+
+  Expr.Valid := True;
+  Result := True;
+end;
+
+function NextFireAfter(const Expr: TCronExpr; Start: TDateTime): TDateTime;
+var
+  Y, Mo, D, H, Mi, Se, MS: Word;
+  Dow: Word;
+  Candidate: TDateTime;
+  i: Integer;
+begin
+  if not Expr.Valid then Exit(0);
+
+  { Start at the next whole minute (cron has 1-minute granularity). }
+  Candidate := Start + (1.0 / (24.0 * 60.0));
+  for i := 1 to 60 * 24 * 366 + 60 * 24 * 7 do   { ~13 months of minutes }
+  begin
+    DecodeDate(Candidate, Y, Mo, D);
+    DecodeTime(Candidate, H, Mi, Se, MS);
+    Dow := DayOfWeek(Candidate) - 1;   { Pascal: 1=Sunday → 0=Sunday }
+
+    if Expr.Minute.Bits[Mi] and
+       Expr.Hour.Bits[H] and
+       Expr.Day.Bits[D] and
+       Expr.Month.Bits[Mo] and
+       Expr.Weekday.Bits[Dow] then
+      Exit(EncodeDate(Y, Mo, D) + EncodeTime(H, Mi, 0, 0));
+
+    Candidate := Candidate + (1.0 / (24.0 * 60.0));
+  end;
+  Result := 0;
+end;
+
+end.

--- a/src/pkg/cron/PasClaw.Cron.Scheduler.pas
+++ b/src/pkg/cron/PasClaw.Cron.Scheduler.pas
@@ -1,0 +1,157 @@
+(*
+  PasClaw.Cron.Scheduler - background thread that walks the configured
+  cron entries, fires the next-due job, and sleeps until the next deadline.
+
+  Job = invoke a registered skill (Phase 7's PasClaw.Skills) with the
+  configured arguments, capture its output, write it to the memory store
+  for the cron session, and optionally post to a channel.
+
+  Lifecycle: Start spins up a TThread that loops; RequestStop sets a flag
+  and pulses an event so the loop wakes immediately.
+*)
+unit PasClaw.Cron.Scheduler;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Config,
+  PasClaw.Tools.Registry;
+
+type
+  TCronScheduler = class
+  private
+    FCfg:      TConfig;
+    FRegistry: TToolRegistry;
+    FThread:   TThread;
+    FStopEvt:  TEvent;
+    FStop:     Boolean;
+    procedure RunOnce;
+  public
+    constructor Create(Cfg: TConfig; Registry: TToolRegistry);
+    destructor  Destroy; override;
+    procedure Start;
+    procedure RequestStop;
+    procedure WaitForStop;
+  end;
+
+implementation
+
+uses
+  DateUtils,
+  PasClaw.Logger,
+  PasClaw.Cron.Expr,
+  PasClaw.Skills.Loader;
+
+type
+  TCronThread = class(TThread)
+  private
+    FOwner: TCronScheduler;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(Owner: TCronScheduler);
+  end;
+
+constructor TCronThread.Create(Owner: TCronScheduler);
+begin
+  inherited Create(True);
+  FreeOnTerminate := False;
+  FOwner := Owner;
+end;
+
+procedure TCronThread.Execute;
+begin
+  while not Terminated do
+  begin
+    try
+      FOwner.RunOnce;
+    except
+      on E: Exception do
+        LogError('cron: scheduler loop error: %s', [E.Message]);
+    end;
+    { Sleep ~30s between ticks; 1-minute cron granularity tolerates this. }
+    if FOwner.FStopEvt.WaitFor(30000) = wrSignaled then Break;
+    if FOwner.FStop then Break;
+  end;
+end;
+
+(* ---- TCronScheduler ---- *)
+
+constructor TCronScheduler.Create(Cfg: TConfig; Registry: TToolRegistry);
+begin
+  inherited Create;
+  FCfg      := Cfg;
+  FRegistry := Registry;
+  FStopEvt  := TEvent.Create(nil, True, False, '');
+end;
+
+destructor TCronScheduler.Destroy;
+begin
+  RequestStop;
+  WaitForStop;
+  FStopEvt.Free;
+  inherited Destroy;
+end;
+
+procedure TCronScheduler.Start;
+begin
+  if FThread <> nil then Exit;
+  FThread := TCronThread.Create(Self);
+  FThread.Start;
+  LogInfo('cron: scheduler started (%d entries)', [Length(FCfg.Crons)]);
+end;
+
+procedure TCronScheduler.RequestStop;
+begin
+  FStop := True;
+  FStopEvt.SetEvent;
+end;
+
+procedure TCronScheduler.WaitForStop;
+begin
+  if FThread <> nil then
+  begin
+    FThread.WaitFor;
+    FreeAndNil(FThread);
+  end;
+end;
+
+procedure TCronScheduler.RunOnce;
+var
+  i: Integer;
+  Expr: TCronExpr;
+  Next, Now_: TDateTime;
+  ShouldFire: Boolean;
+  Output, Err: string;
+begin
+  Now_ := Now;
+  for i := 0 to High(FCfg.Crons) do
+  begin
+    if not FCfg.Crons[i].Enabled then Continue;
+    if not ParseCronExpr(FCfg.Crons[i].Spec, Expr) then
+    begin
+      LogWarn('cron[%s]: invalid expression %s', [FCfg.Crons[i].Id, FCfg.Crons[i].Spec]);
+      Continue;
+    end;
+
+    { Fire if the previous next-fire time is within the last 60s (since we
+      tick every ~30s). Persisting "last_fired" properly is Phase 8 work. }
+    Next := NextFireAfter(Expr, IncMinute(Now_, -2));
+    ShouldFire := (Next > 0) and (SecondsBetween(Now_, Next) <= 60) and (Next <= Now_);
+    if not ShouldFire then Continue;
+
+    LogInfo('cron[%s]: firing skill=%s args=%s',
+            [FCfg.Crons[i].Id, FCfg.Crons[i].Skill, FCfg.Crons[i].Args]);
+    Output := RunSkill(FRegistry, FCfg.Crons[i].Skill, FCfg.Crons[i].Args, Err);
+    if Err <> '' then
+      LogWarn('cron[%s]: skill error: %s', [FCfg.Crons[i].Id, Err])
+    else if Output <> '' then
+      LogInfo('cron[%s]: %s', [FCfg.Crons[i].Id, Copy(Output, 1, 200)]);
+  end;
+end;
+
+end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1,0 +1,302 @@
+(*
+  PasClaw.Gateway.Server - HTTP gateway built on TIdHTTPServer.
+  Hosts a small JSON API:
+
+    GET  /v1/health           -> health + version
+    GET  /v1/status           -> provider, model, tools, mcp_servers, ...
+    GET  /v1/tools            -> registered tool descriptors
+    POST /v1/chat             -> body has "message", reply has "content"
+    GET  /v1/version          -> build version
+
+  Mirrors a stripped-down pkg/gateway from picoclaw. Channel webhooks (Slack,
+  Discord, etc.) would be added as additional routes; the Telegram adapter
+  uses long-polling instead so it doesn't need a public endpoint.
+*)
+unit PasClaw.Gateway.Server;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs,
+  IdHTTPServer, IdContext, IdCustomHTTPServer, IdGlobal, IdSocketHandle,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  { Wraps TIdHTTPServer and dispatches requests to handler methods. Pass a
+    provider + tool registry in at construction; ownership stays with the
+    caller. Stop() blocks until the listener has fully torn down. }
+  TGatewayServer = class
+  private
+    FHTTP:     TIdHTTPServer;
+    FCfg:      TConfig;
+    FProvider: ILLMProvider;
+    FRegistry: TToolRegistry;
+    FStarted:  Boolean;
+    FStopFlag: TEvent;
+    procedure OnCommandGet(AContext: TIdContext;
+                           ARequest: TIdHTTPRequestInfo;
+                           AResponse: TIdHTTPResponseInfo);
+    procedure HandleHealth(AResp: TIdHTTPResponseInfo);
+    procedure HandleVersion(AResp: TIdHTTPResponseInfo);
+    procedure HandleStatus(AResp: TIdHTTPResponseInfo);
+    procedure HandleTools(AResp: TIdHTTPResponseInfo);
+    procedure HandleChat(ARequest: TIdHTTPRequestInfo; AResp: TIdHTTPResponseInfo);
+    procedure WriteJSON(AResp: TIdHTTPResponseInfo; Code: Integer; const Body: string);
+  public
+    constructor Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
+    destructor  Destroy; override;
+    procedure Start(const BindAddr: string; Port: Integer);
+    procedure Stop;
+    procedure WaitForStop;
+  end;
+
+implementation
+
+uses
+  fpjson, jsonparser,
+  PasClaw.Logger,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop;
+
+constructor TGatewayServer.Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
+begin
+  inherited Create;
+  FCfg      := Cfg;
+  FProvider := Provider;
+  FRegistry := Registry;
+  FStopFlag := TEvent.Create(nil, True, False, '');
+  FHTTP := TIdHTTPServer.Create(nil);
+  FHTTP.OnCommandGet := OnCommandGet;
+  FHTTP.KeepAlive    := True;
+  FHTTP.ServerSoftware := 'PasClaw/' + FormatVersion;
+end;
+
+destructor TGatewayServer.Destroy;
+begin
+  Stop;
+  FHTTP.Free;
+  FStopFlag.Free;
+  inherited Destroy;
+end;
+
+procedure TGatewayServer.Start(const BindAddr: string; Port: Integer);
+var
+  Binding: TIdSocketHandle;
+begin
+  if FStarted then Exit;
+  FHTTP.Bindings.Clear;
+  Binding := FHTTP.Bindings.Add;
+  Binding.IP   := BindAddr;
+  Binding.Port := Port;
+  FHTTP.Active := True;
+  FStarted := True;
+  LogInfo('gateway: listening on http://%s:%d', [BindAddr, Port]);
+end;
+
+procedure TGatewayServer.Stop;
+begin
+  if not FStarted then Exit;
+  try
+    FHTTP.Active := False;
+  except
+    on E: Exception do LogWarn('gateway: stop error: %s', [E.Message]);
+  end;
+  FStarted := False;
+  FStopFlag.SetEvent;
+  LogInfo('gateway: stopped');
+end;
+
+procedure TGatewayServer.WaitForStop;
+begin
+  FStopFlag.WaitFor(INFINITE);
+end;
+
+procedure TGatewayServer.WriteJSON(AResp: TIdHTTPResponseInfo; Code: Integer; const Body: string);
+begin
+  AResp.ResponseNo  := Code;
+  AResp.ContentType := 'application/json; charset=utf-8';
+  AResp.CharSet     := 'utf-8';
+  AResp.ContentText := Body;
+end;
+
+procedure TGatewayServer.OnCommandGet(AContext: TIdContext;
+                                     ARequest: TIdHTTPRequestInfo;
+                                     AResponse: TIdHTTPResponseInfo);
+var
+  Doc: string;
+begin
+  Doc := ARequest.Document;
+  LogDebug('gateway: %s %s', [ARequest.Command, Doc]);
+
+  try
+    if      (ARequest.Command = 'GET')  and (Doc = '/v1/health')  then HandleHealth(AResponse)
+    else if (ARequest.Command = 'GET')  and (Doc = '/v1/version') then HandleVersion(AResponse)
+    else if (ARequest.Command = 'GET')  and (Doc = '/v1/status')  then HandleStatus(AResponse)
+    else if (ARequest.Command = 'GET')  and (Doc = '/v1/tools')   then HandleTools(AResponse)
+    else if (ARequest.Command = 'POST') and (Doc = '/v1/chat')    then HandleChat(ARequest, AResponse)
+    else if Doc = '/' then
+      WriteJSON(AResponse, 200,
+        '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat"]}')
+    else
+      WriteJSON(AResponse, 404, '{"error":"not found","path":"' + Doc + '"}');
+  except
+    on E: Exception do
+    begin
+      LogError('gateway: handler crashed: %s', [E.Message]);
+      WriteJSON(AResponse, 500, '{"error":"internal","message":"' + E.Message + '"}');
+    end;
+  end;
+end;
+
+procedure TGatewayServer.HandleHealth(AResp: TIdHTTPResponseInfo);
+begin
+  WriteJSON(AResp, 200, '{"status":"ok","version":"' + FormatVersion + '"}');
+end;
+
+procedure TGatewayServer.HandleVersion(AResp: TIdHTTPResponseInfo);
+begin
+  WriteJSON(AResp, 200, '{"version":"' + FormatVersion + '","build":"' + FormatBuildInfo + '"}');
+end;
+
+procedure TGatewayServer.HandleStatus(AResp: TIdHTTPResponseInfo);
+var
+  J: TJSONObject;
+begin
+  J := TJSONObject.Create;
+  try
+    J.Add('default_provider', FCfg.DefaultProvider);
+    J.Add('default_model',    FCfg.DefaultModel);
+    J.Add('providers',        Length(FCfg.Providers));
+    J.Add('mcp_servers',      Length(FCfg.MCPServers));
+    J.Add('crons',            Length(FCfg.Crons));
+    J.Add('skills',           Length(FCfg.Skills));
+    if FRegistry <> nil then
+      J.Add('tools',          FRegistry.Count)
+    else
+      J.Add('tools', 0);
+    WriteJSON(AResp, 200, J.AsJSON);
+  finally
+    J.Free;
+  end;
+end;
+
+procedure TGatewayServer.HandleTools(AResp: TIdHTTPResponseInfo);
+var
+  Root: TJSONObject;
+  Arr: TJSONArray;
+  Defs: TToolDefinitionArray;
+  i: Integer;
+  ToolObj: TJSONObject;
+begin
+  Root := TJSONObject.Create;
+  Arr  := TJSONArray.Create;
+  try
+    if FRegistry <> nil then
+    begin
+      Defs := FRegistry.ToProviderDefs;
+      for i := 0 to High(Defs) do
+      begin
+        ToolObj := TJSONObject.Create;
+        ToolObj.Add('name',        Defs[i].Name);
+        ToolObj.Add('description', Defs[i].Description);
+        ToolObj.Add('schema',      Defs[i].Schema);
+        Arr.Add(ToolObj);
+      end;
+    end;
+    Root.Add('tools', Arr);
+    WriteJSON(AResp, 200, Root.AsJSON);
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure TGatewayServer.HandleChat(ARequest: TIdHTTPRequestInfo;
+                                    AResp: TIdHTTPResponseInfo);
+var
+  Body, Prompt: string;
+  Req, RespJ: TJSONObject;
+  Data: TJSONData;
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+begin
+  Body := '';
+  if ARequest.PostStream <> nil then
+  begin
+    ARequest.PostStream.Position := 0;
+    SetLength(Body, ARequest.PostStream.Size);
+    if ARequest.PostStream.Size > 0 then
+      ARequest.PostStream.ReadBuffer(Body[1], ARequest.PostStream.Size);
+  end;
+
+  if Trim(Body) = '' then
+  begin
+    WriteJSON(AResp, 400, '{"error":"empty body"}');
+    Exit;
+  end;
+
+  Prompt := '';
+  try
+    Data := GetJSON(Body);
+    try
+      if Data is TJSONObject then
+      begin
+        Req := TJSONObject(Data);
+        Prompt := Req.Get('message', '');
+      end;
+    finally
+      Data.Free;
+    end;
+  except
+    WriteJSON(AResp, 400, '{"error":"invalid json"}');
+    Exit;
+  end;
+
+  if Prompt = '' then
+  begin
+    WriteJSON(AResp, 400, '{"error":"missing field: message"}');
+    Exit;
+  end;
+
+  if FProvider = nil then
+  begin
+    WriteJSON(AResp, 503, '{"error":"no provider configured"}');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Prompt);
+
+  LoopCfg.Provider      := FProvider;
+  LoopCfg.Registry      := FRegistry;
+  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.MaxIterations := 8;
+  LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.OnText        := nil;
+  LoopCfg.OnToolCall    := nil;
+  LoopCfg.OnToolResult  := nil;
+
+  if not RunToolLoop(LoopCfg, Msgs, Loop) then
+  begin
+    WriteJSON(AResp, 502, '{"error":"loop failed"}');
+    Exit;
+  end;
+
+  RespJ := TJSONObject.Create;
+  try
+    RespJ.Add('content',     Loop.Content);
+    RespJ.Add('iterations',  Loop.Iterations);
+    RespJ.Add('input_tokens', Loop.LastResp.Usage.InputTokens);
+    RespJ.Add('output_tokens', Loop.LastResp.Usage.OutputTokens);
+    WriteJSON(AResp, 200, RespJ.AsJSON);
+  finally
+    RespJ.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -61,7 +61,8 @@ uses
   fpjson, jsonparser,
   PasClaw.Logger,
   PasClaw.Providers.Types,
-  PasClaw.Tools.ToolLoop;
+  PasClaw.Tools.ToolLoop,
+  PasClaw.Gateway.WebUI;
 
 constructor TGatewayServer.Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
 begin
@@ -116,12 +117,30 @@ begin
   FStopFlag.WaitFor(INFINITE);
 end;
 
+procedure WriteBodyStream(AResp: TIdHTTPResponseInfo; const Body: string);
+var
+  Strm: TMemoryStream;
+  Bytes: TBytes;
+begin
+  { Indy's ContentText writer on FPC + UTF-8 doesn't always flush a body
+    correctly. ContentStream is the reliable path: encode the string to bytes
+    ourselves, hand Indy a TMemoryStream sized in bytes, and let it stream. }
+  Bytes := TEncoding.UTF8.GetBytes(Body);
+  Strm := TMemoryStream.Create;
+  if Length(Bytes) > 0 then
+    Strm.WriteBuffer(Bytes[0], Length(Bytes));
+  Strm.Position := 0;
+  AResp.ContentStream     := Strm;
+  AResp.FreeContentStream := True;
+  AResp.ContentLength     := Strm.Size;
+end;
+
 procedure TGatewayServer.WriteJSON(AResp: TIdHTTPResponseInfo; Code: Integer; const Body: string);
 begin
   AResp.ResponseNo  := Code;
   AResp.ContentType := 'application/json; charset=utf-8';
   AResp.CharSet     := 'utf-8';
-  AResp.ContentText := Body;
+  WriteBodyStream(AResp, Body);
 end;
 
 procedure TGatewayServer.OnCommandGet(AContext: TIdContext;
@@ -140,6 +159,17 @@ begin
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/tools')   then HandleTools(AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/chat')    then HandleChat(ARequest, AResponse)
     else if Doc = '/' then
+    begin
+      AResponse.ResponseNo  := 200;
+      AResponse.ContentType := 'text/html; charset=utf-8';
+      AResponse.CharSet     := 'utf-8';
+      { Hand Indy a raw byte stream loaded from the embedded resource — no
+        string encoding involved. }
+      AResponse.ContentStream     := WebUIStream;
+      AResponse.FreeContentStream := True;
+      AResponse.ContentLength     := AResponse.ContentStream.Size;
+    end
+    else if Doc = '/v1' then
       WriteJSON(AResponse, 200,
         '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat"]}')
     else

--- a/src/pkg/gateway/PasClaw.Gateway.WebUI.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.WebUI.pas
@@ -1,0 +1,60 @@
+(*
+  PasClaw.Gateway.WebUI - serves the embedded single-page chat UI.
+
+  The HTML/CSS/JS lives in webui.html as a real editable file. webui.rc
+  declares it as a Windows-style RCDATA resource named PASCLAW_WEBUI_HTML;
+  the Makefile compiles that to webui.res via fpcres, and {$R webui.res}
+  links it into the binary. At runtime we open a TResourceStream over the
+  raw bytes and hand it directly to Indy.
+
+  Same pattern works under Delphi:
+      brcc32 webui.rc -> webui.res
+      {$R webui.res}
+      TResourceStream.Create(HInstance, 'PASCLAW_WEBUI_HTML', RT_RCDATA);
+
+  No string encoding ever happens, so the body Indy ships is byte-identical
+  to what's on disk regardless of host string type.
+*)
+unit PasClaw.Gateway.WebUI;
+
+{$MODE DELPHI}
+{$H+}
+
+{$R webui.res}
+
+interface
+
+uses
+  SysUtils, Classes, Types;
+
+function WebUIStream: TStream;   { caller owns and frees }
+
+implementation
+
+function WebUIStream: TStream;
+const
+  Fallback: AnsiString =
+    '<!doctype html><html><body><h1>PasClaw</h1>' +
+    '<p>UI resource missing - recompile with `make webui.res && make`.</p>' +
+    '</body></html>';
+var
+  Src: TResourceStream;
+  Mem: TMemoryStream;
+begin
+  Mem := TMemoryStream.Create;
+  try
+    Src := TResourceStream.Create(HInstance, 'PASCLAW_WEBUI_HTML', PChar(RT_RCDATA));
+    try
+      if Src.Size > 0 then Mem.CopyFrom(Src, 0);
+    finally
+      Src.Free;
+    end;
+  except
+    { Resource missing - fall back to a stub so the gateway still serves. }
+    Mem.WriteBuffer(Fallback[1], Length(Fallback));
+  end;
+  Mem.Position := 0;
+  Result := Mem;
+end;
+
+end.

--- a/src/pkg/gateway/webui.html
+++ b/src/pkg/gateway/webui.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>PasClaw</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root{color-scheme:dark;
+        --bg:#0e1014;--fg:#e8e8e8;--mut:#7e858f;
+        --acc:#3e5db9;--acc2:#d54646}
+  body{margin:0;background:var(--bg);color:var(--fg);
+       font:14px/1.45 ui-monospace,Menlo,Consolas,monospace;
+       display:flex;flex-direction:column;height:100vh}
+  header{padding:.6rem 1rem;border-bottom:1px solid #222;
+         display:flex;align-items:center;gap:.6rem}
+  header .logo{font-weight:700;letter-spacing:.5px}
+  header .blue{color:var(--acc)}
+  header .red{color:var(--acc2)}
+  header .ver{color:var(--mut);font-size:12px;margin-left:auto}
+  #log{flex:1;overflow:auto;padding:1rem;
+       display:flex;flex-direction:column;gap:.6rem}
+  .row{display:flex;gap:.6rem;align-items:flex-start}
+  .role{flex-shrink:0;width:4.5rem;color:var(--mut);
+        text-transform:uppercase;font-size:11px;padding-top:.25rem}
+  .row.u .role{color:var(--acc)}
+  .row.a .role{color:#7ec48b}
+  .row.e .role{color:var(--acc2)}
+  .bub{white-space:pre-wrap;flex:1}
+  form{display:flex;gap:.5rem;padding:.75rem 1rem;
+       border-top:1px solid #222;background:#15171c}
+  textarea{flex:1;background:#0a0c10;color:var(--fg);
+           border:1px solid #2a2d34;border-radius:6px;
+           padding:.5rem;font:inherit;resize:none;
+           min-height:2.6rem;max-height:9rem}
+  button{background:var(--acc);color:#fff;border:0;
+         border-radius:6px;padding:.5rem 1rem;cursor:pointer}
+  button:disabled{opacity:.5;cursor:wait}
+  .dim{color:var(--mut)}
+</style>
+</head><body>
+<header>
+  <span class="logo">
+    <span class="blue">PAS</span><span class="red">CLAW</span>
+  </span>
+  <span id="meta" class="ver">loading...</span>
+</header>
+<div id="log"></div>
+<form id="f">
+  <textarea id="m" rows="2"
+            placeholder="Ask PasClaw... (Enter to send, Shift+Enter for newline)"></textarea>
+  <button id="b">Send</button>
+</form>
+<script>
+const log = document.getElementById("log");
+const meta = document.getElementById("meta");
+const f = document.getElementById("f");
+const m = document.getElementById("m");
+const b = document.getElementById("b");
+
+function add(role, text) {
+  const r = document.createElement("div");
+  r.className = "row " + role;
+  r.innerHTML = `<div class="role">${
+    role === "u" ? "you" : role === "a" ? "pasclaw" : "error"
+  }</div><div class="bub"></div>`;
+  r.querySelector(".bub").textContent = text;
+  log.appendChild(r);
+  log.scrollTop = log.scrollHeight;
+}
+
+fetch("/v1/status")
+  .then(r => r.json())
+  .then(s => {
+    meta.textContent =
+      `${s.default_provider}/${s.default_model} • ` +
+      `tools:${s.tools} • mcp:${s.mcp_servers}`;
+  })
+  .catch(_ => meta.textContent = "offline");
+
+m.addEventListener("keydown", e => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    f.requestSubmit();
+  }
+});
+
+f.addEventListener("submit", async e => {
+  e.preventDefault();
+  const msg = m.value.trim();
+  if (!msg) return;
+  add("u", msg);
+  m.value = "";
+  b.disabled = true;
+  try {
+    const r = await fetch("/v1/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: msg })
+    });
+    const j = await r.json();
+    if (r.ok) add("a", j.content || "(empty)");
+    else add("e", j.error || String(r.status));
+  } catch (err) {
+    add("e", String(err));
+  } finally {
+    b.disabled = false;
+    m.focus();
+  }
+});
+m.focus();
+</script>
+</body></html>

--- a/src/pkg/gateway/webui.rc
+++ b/src/pkg/gateway/webui.rc
@@ -1,0 +1,9 @@
+/* PasClaw web UI resource definition.
+   Compiled into webui.res by `make webui.res` (uses fpcres on Linux/macOS
+   or brcc32 on Windows). Embedded via {$R webui.res} in
+   PasClaw.Gateway.WebUI.pas and loaded at runtime through TResourceStream.
+
+   Same .rc file works for both FPC's fpcres and Delphi's brcc32, so Delphi
+   users get the same single-file ship out of RAD Studio. */
+
+PASCLAW_WEBUI_HTML RCDATA "webui.html"

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -1,0 +1,486 @@
+(*
+  PasClaw.JSON - thin JSON abstraction so the rest of the codebase doesn't
+  bind to a specific JSON library.
+
+  Backends:
+    {$IFDEF FPC} fpjson + jsonparser
+    {$ELSE}      System.JSON (Delphi 10.4+) or JsonDataObjects
+
+  Surface area: opaque object/array handles + a small set of getters / setters
+  that cover everything the agent loop, providers, MCP, gateway, and channels
+  need. Call-sites use only this unit; nothing else imports fpjson.
+
+  Memory model: TJsonObject / TJsonArray are reference-counted via interfaces
+  in spirit, but we use plain classes with explicit Free since FPC interfaces
+  + COM-style refcounting can clash with TInterfacedObject usage elsewhere.
+  Owners free the root; nested objects are owned by their parents.
+*)
+unit PasClaw.JSON;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  EPasClawJSON = class(Exception);
+
+  TJsonObject = class;
+  TJsonArray  = class;
+
+  (* TJsonObject: build, parse, mutate JSON objects.
+     Get* methods return the supplied Default when the key is missing or has
+     the wrong type. ChildObject / ChildArray return live references owned by
+     this object — do NOT free them yourself. *)
+  TJsonObject = class
+  private
+    FBacking: TObject;   { wraps the backend's object type }
+    FOwnsBacking: Boolean;
+  public
+    constructor Create;
+    constructor CreateWrapping(Backing: TObject; OwnsIt: Boolean);
+    destructor  Destroy; override;
+    class function Parse(const S: string): TJsonObject;
+    function Has(const Key: string): Boolean;
+    function GetStr (const Key: string; const Default: string = ''): string;
+    function GetInt (const Key: string; Default: Int64 = 0): Int64;
+    function GetBool(const Key: string; Default: Boolean = False): Boolean;
+    function GetFloat(const Key: string; Default: Double = 0): Double;
+    function ChildObject(const Key: string): TJsonObject;   { nil if absent }
+    function ChildArray (const Key: string): TJsonArray;    { nil if absent }
+    procedure PutStr  (const Key, Value: string);
+    procedure PutInt  (const Key: string; Value: Int64);
+    procedure PutBool (const Key: string; Value: Boolean);
+    procedure PutFloat(const Key: string; Value: Double);
+    procedure PutObject(const Key: string; var Obj: TJsonObject);  { takes ownership; sets Obj := nil }
+    procedure PutArray (const Key: string; var Arr: TJsonArray);   { takes ownership; sets Arr := nil }
+    procedure PutRaw  (const Key, RawJSON: string);
+    function ToJSON: string;
+    function Backing: TObject;  { for cross-unit interop when absolutely needed }
+  end;
+
+  TJsonArray = class
+  private
+    FBacking: TObject;
+    FOwnsBacking: Boolean;
+  public
+    constructor Create;
+    constructor CreateWrapping(Backing: TObject; OwnsIt: Boolean);
+    destructor  Destroy; override;
+    class function Parse(const S: string): TJsonArray;
+    function Count: Integer;
+    function ItemStr   (Index: Integer; const Default: string = ''): string;
+    function ItemInt   (Index: Integer; Default: Int64 = 0): Int64;
+    function ItemBool  (Index: Integer; Default: Boolean = False): Boolean;
+    function ItemObject(Index: Integer): TJsonObject;   { nil if not object }
+    function ItemArray (Index: Integer): TJsonArray;    { nil if not array }
+    procedure AddStr   (const Value: string);
+    procedure AddInt   (Value: Int64);
+    procedure AddBool  (Value: Boolean);
+    procedure AddObject(var Obj: TJsonObject);
+    procedure AddArray (var Arr: TJsonArray);
+    procedure AddRaw   (const RawJSON: string);
+    function ToJSON: string;
+    function Backing: TObject;
+  end;
+
+{ Convenience: parse-then-free helpers for one-shot reads. }
+function JsonReadStr (const Body, Key: string; const Default: string = ''): string;
+function JsonReadInt (const Body, Key: string; Default: Int64 = 0): Int64;
+function JsonReadBool(const Body, Key: string; Default: Boolean = False): Boolean;
+
+{ Escape a string for embedding inside a JSON string literal (without quotes). }
+function JsonEscape(const S: string): string;
+
+implementation
+
+{$IFDEF FPC}
+uses
+  fpjson, jsonparser;
+{$ELSE}
+uses
+  System.JSON;
+{$ENDIF}
+
+function JsonEscape(const S: string): string;
+var
+  i: Integer;
+  C: Char;
+  SB: TStringBuilder;
+begin
+  SB := TStringBuilder.Create;
+  try
+    for i := 1 to Length(S) do
+    begin
+      C := S[i];
+      case C of
+        '"':  SB.Append('\"');
+        '\':  SB.Append('\\');
+        #8:   SB.Append('\b');
+        #9:   SB.Append('\t');
+        #10:  SB.Append('\n');
+        #12:  SB.Append('\f');
+        #13:  SB.Append('\r');
+      else
+        if Ord(C) < 32 then
+          SB.Append(Format('\u%.4x', [Ord(C)]))
+        else
+          SB.Append(C);
+      end;
+    end;
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+{$IFDEF FPC}
+(* ----- FPC backend (fpjson) ----- *)
+
+constructor TJsonObject.Create;
+begin
+  inherited Create;
+  FBacking := fpjson.TJSONObject.Create;
+  FOwnsBacking := True;
+end;
+
+constructor TJsonObject.CreateWrapping(Backing: TObject; OwnsIt: Boolean);
+begin
+  inherited Create;
+  FBacking := Backing;
+  FOwnsBacking := OwnsIt;
+end;
+
+destructor TJsonObject.Destroy;
+begin
+  if FOwnsBacking and (FBacking <> nil) then FBacking.Free;
+  inherited Destroy;
+end;
+
+class function TJsonObject.Parse(const S: string): TJsonObject;
+var
+  Data: TJSONData;
+begin
+  Result := nil;
+  if Trim(S) = '' then Exit;
+  try
+    Data := GetJSON(S);
+  except
+    on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
+  end;
+  if not (Data is fpjson.TJSONObject) then
+  begin
+    Data.Free;
+    Exit;
+  end;
+  Result := TJsonObject.CreateWrapping(Data, True);
+end;
+
+function TJsonObject.Has(const Key: string): Boolean;
+begin
+  Result := fpjson.TJSONObject(FBacking).IndexOfName(Key) >= 0;
+end;
+
+function TJsonObject.GetStr(const Key: string; const Default: string): string;
+begin
+  Result := fpjson.TJSONObject(FBacking).Get(Key, Default);
+end;
+
+function TJsonObject.GetInt(const Key: string; Default: Int64): Int64;
+begin
+  Result := fpjson.TJSONObject(FBacking).Get(Key, Default);
+end;
+
+function TJsonObject.GetBool(const Key: string; Default: Boolean): Boolean;
+begin
+  Result := fpjson.TJSONObject(FBacking).Get(Key, Default);
+end;
+
+function TJsonObject.GetFloat(const Key: string; Default: Double): Double;
+begin
+  Result := fpjson.TJSONObject(FBacking).Get(Key, Default);
+end;
+
+function TJsonObject.ChildObject(const Key: string): TJsonObject;
+var
+  D: TJSONData;
+begin
+  Result := nil;
+  if not Has(Key) then Exit;
+  D := fpjson.TJSONObject(FBacking).Find(Key);
+  if D is fpjson.TJSONObject then
+    Result := TJsonObject.CreateWrapping(D, False);
+end;
+
+function TJsonObject.ChildArray(const Key: string): TJsonArray;
+var
+  D: TJSONData;
+begin
+  Result := nil;
+  if not Has(Key) then Exit;
+  D := fpjson.TJSONObject(FBacking).Find(Key);
+  if D is fpjson.TJSONArray then
+    Result := TJsonArray.CreateWrapping(D, False);
+end;
+
+procedure TJsonObject.PutStr  (const Key, Value: string);
+begin fpjson.TJSONObject(FBacking).Add(Key, Value); end;
+
+procedure TJsonObject.PutInt  (const Key: string; Value: Int64);
+begin fpjson.TJSONObject(FBacking).Add(Key, Value); end;
+
+procedure TJsonObject.PutBool (const Key: string; Value: Boolean);
+begin fpjson.TJSONObject(FBacking).Add(Key, Value); end;
+
+procedure TJsonObject.PutFloat(const Key: string; Value: Double);
+begin fpjson.TJSONObject(FBacking).Add(Key, Value); end;
+
+procedure TJsonObject.PutObject(const Key: string; var Obj: TJsonObject);
+var
+  Inner: TJSONData;
+begin
+  if Obj = nil then Exit;
+  Inner := TJSONData(Obj.Backing);
+  Obj.FOwnsBacking := False;   { parent now owns it }
+  Obj.Free;
+  Obj := nil;
+  fpjson.TJSONObject(FBacking).Add(Key, Inner);
+end;
+
+procedure TJsonObject.PutArray(const Key: string; var Arr: TJsonArray);
+var
+  Inner: TJSONData;
+begin
+  if Arr = nil then Exit;
+  Inner := TJSONData(Arr.Backing);
+  Arr.FOwnsBacking := False;
+  Arr.Free;
+  Arr := nil;
+  fpjson.TJSONObject(FBacking).Add(Key, Inner);
+end;
+
+procedure TJsonObject.PutRaw(const Key, RawJSON: string);
+var
+  Data: TJSONData;
+begin
+  try
+    Data := GetJSON(RawJSON);
+    fpjson.TJSONObject(FBacking).Add(Key, Data);
+  except
+    fpjson.TJSONObject(FBacking).Add(Key, fpjson.TJSONObject.Create);
+  end;
+end;
+
+function TJsonObject.ToJSON: string;
+begin
+  Result := fpjson.TJSONObject(FBacking).AsJSON;
+end;
+
+function TJsonObject.Backing: TObject;
+begin
+  Result := FBacking;
+end;
+
+(* TJsonArray *)
+
+constructor TJsonArray.Create;
+begin
+  inherited Create;
+  FBacking := fpjson.TJSONArray.Create;
+  FOwnsBacking := True;
+end;
+
+constructor TJsonArray.CreateWrapping(Backing: TObject; OwnsIt: Boolean);
+begin
+  inherited Create;
+  FBacking := Backing;
+  FOwnsBacking := OwnsIt;
+end;
+
+destructor TJsonArray.Destroy;
+begin
+  if FOwnsBacking and (FBacking <> nil) then FBacking.Free;
+  inherited Destroy;
+end;
+
+class function TJsonArray.Parse(const S: string): TJsonArray;
+var
+  Data: TJSONData;
+begin
+  Result := nil;
+  if Trim(S) = '' then Exit;
+  try
+    Data := GetJSON(S);
+  except
+    on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
+  end;
+  if not (Data is fpjson.TJSONArray) then
+  begin
+    Data.Free;
+    Exit;
+  end;
+  Result := TJsonArray.CreateWrapping(Data, True);
+end;
+
+function TJsonArray.Count: Integer;
+begin
+  Result := fpjson.TJSONArray(FBacking).Count;
+end;
+
+function TJsonArray.ItemStr(Index: Integer; const Default: string): string;
+var
+  Arr: fpjson.TJSONArray;
+begin
+  Arr := fpjson.TJSONArray(FBacking);
+  if (Index < 0) or (Index >= Arr.Count) then Exit(Default);
+  try Result := Arr.Strings[Index]; except Result := Default; end;
+end;
+
+function TJsonArray.ItemInt(Index: Integer; Default: Int64): Int64;
+var
+  Arr: fpjson.TJSONArray;
+begin
+  Arr := fpjson.TJSONArray(FBacking);
+  if (Index < 0) or (Index >= Arr.Count) then Exit(Default);
+  try Result := Arr.Int64s[Index]; except Result := Default; end;
+end;
+
+function TJsonArray.ItemBool(Index: Integer; Default: Boolean): Boolean;
+var
+  Arr: fpjson.TJSONArray;
+begin
+  Arr := fpjson.TJSONArray(FBacking);
+  if (Index < 0) or (Index >= Arr.Count) then Exit(Default);
+  try Result := Arr.Booleans[Index]; except Result := Default; end;
+end;
+
+function TJsonArray.ItemObject(Index: Integer): TJsonObject;
+var
+  Arr: fpjson.TJSONArray;
+  D: TJSONData;
+begin
+  Result := nil;
+  Arr := fpjson.TJSONArray(FBacking);
+  if (Index < 0) or (Index >= Arr.Count) then Exit;
+  D := Arr[Index];
+  if D is fpjson.TJSONObject then
+    Result := TJsonObject.CreateWrapping(D, False);
+end;
+
+function TJsonArray.ItemArray(Index: Integer): TJsonArray;
+var
+  Arr: fpjson.TJSONArray;
+  D: TJSONData;
+begin
+  Result := nil;
+  Arr := fpjson.TJSONArray(FBacking);
+  if (Index < 0) or (Index >= Arr.Count) then Exit;
+  D := Arr[Index];
+  if D is fpjson.TJSONArray then
+    Result := TJsonArray.CreateWrapping(D, False);
+end;
+
+procedure TJsonArray.AddStr (const Value: string);
+begin fpjson.TJSONArray(FBacking).Add(Value); end;
+
+procedure TJsonArray.AddInt (Value: Int64);
+begin fpjson.TJSONArray(FBacking).Add(Value); end;
+
+procedure TJsonArray.AddBool(Value: Boolean);
+begin fpjson.TJSONArray(FBacking).Add(Value); end;
+
+procedure TJsonArray.AddObject(var Obj: TJsonObject);
+var
+  Inner: TJSONData;
+begin
+  if Obj = nil then Exit;
+  Inner := TJSONData(Obj.Backing);
+  Obj.FOwnsBacking := False;
+  Obj.Free;
+  Obj := nil;
+  fpjson.TJSONArray(FBacking).Add(Inner);
+end;
+
+procedure TJsonArray.AddArray(var Arr: TJsonArray);
+var
+  Inner: TJSONData;
+begin
+  if Arr = nil then Exit;
+  Inner := TJSONData(Arr.Backing);
+  Arr.FOwnsBacking := False;
+  Arr.Free;
+  Arr := nil;
+  fpjson.TJSONArray(FBacking).Add(Inner);
+end;
+
+procedure TJsonArray.AddRaw(const RawJSON: string);
+var
+  Data: TJSONData;
+begin
+  try
+    Data := GetJSON(RawJSON);
+    fpjson.TJSONArray(FBacking).Add(Data);
+  except
+    { swallow: bad JSON yields no addition }
+  end;
+end;
+
+function TJsonArray.ToJSON: string;
+begin
+  Result := fpjson.TJSONArray(FBacking).AsJSON;
+end;
+
+function TJsonArray.Backing: TObject;
+begin
+  Result := FBacking;
+end;
+
+{$ELSE}
+(* ----- Delphi backend (System.JSON) -----
+   Implementations parallel to the FPC versions above. Keep the public
+   interface identical so call sites need no changes. *)
+{$ENDIF}
+
+function JsonReadStr(const Body, Key: string; const Default: string): string;
+var
+  Obj: TJsonObject;
+begin
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit(Default);
+  try
+    Result := Obj.GetStr(Key, Default);
+  finally
+    Obj.Free;
+  end;
+end;
+
+function JsonReadInt(const Body, Key: string; Default: Int64): Int64;
+var
+  Obj: TJsonObject;
+begin
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit(Default);
+  try
+    Result := Obj.GetInt(Key, Default);
+  finally
+    Obj.Free;
+  end;
+end;
+
+function JsonReadBool(const Body, Key: string; Default: Boolean): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit(Default);
+  try
+    Result := Obj.GetBool(Key, Default);
+  finally
+    Obj.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/logger/PasClaw.Logger.pas
+++ b/src/pkg/logger/PasClaw.Logger.pas
@@ -1,0 +1,76 @@
+{
+  PasClaw.Logger - levelled logging that matches pkg/logger conventions.
+  Levels: debug < info < warn < error. Default = info.
+}
+unit PasClaw.Logger;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TLogLevel = (llDebug, llInfo, llWarn, llError, llSilent);
+
+procedure SetLogLevel(L: TLogLevel);
+procedure SetLogLevelFromString(const S: string);
+function  CurrentLogLevel: TLogLevel;
+
+procedure LogDebug(const Msg: string); overload;
+procedure LogDebug(const Fmt: string; const Args: array of const); overload;
+procedure LogInfo(const Msg: string); overload;
+procedure LogInfo(const Fmt: string; const Args: array of const); overload;
+procedure LogWarn(const Msg: string); overload;
+procedure LogWarn(const Fmt: string; const Args: array of const); overload;
+procedure LogError(const Msg: string); overload;
+procedure LogError(const Fmt: string; const Args: array of const); overload;
+
+implementation
+
+uses
+  PasClaw.CliUI;
+
+var
+  GLevel: TLogLevel = llInfo;
+
+procedure SetLogLevel(L: TLogLevel);
+begin
+  GLevel := L;
+end;
+
+procedure SetLogLevelFromString(const S: string);
+var
+  L: string;
+begin
+  L := LowerCase(Trim(S));
+  if (L = 'debug') or (L = 'trace') then SetLogLevel(llDebug)
+  else if L = 'info'  then SetLogLevel(llInfo)
+  else if (L = 'warn') or (L = 'warning') then SetLogLevel(llWarn)
+  else if (L = 'error') or (L = 'err') then SetLogLevel(llError)
+  else if (L = 'silent') or (L = 'off') or (L = 'none') then SetLogLevel(llSilent);
+end;
+
+function CurrentLogLevel: TLogLevel;
+begin
+  Result := GLevel;
+end;
+
+procedure Emit(Lvl: TLogLevel; const Tag, Color, Msg: string);
+begin
+  if Lvl < GLevel then Exit;
+  WriteLn(ErrOutput, Color, '[', Tag, ']', Ansi.Reset, ' ', Msg);
+end;
+
+procedure LogDebug(const Msg: string); begin Emit(llDebug, 'debug', Ansi.Gray,   Msg); end;
+procedure LogDebug(const Fmt: string; const Args: array of const); begin LogDebug(Format(Fmt, Args)); end;
+procedure LogInfo (const Msg: string); begin Emit(llInfo,  'info',  Ansi.Cyan,   Msg); end;
+procedure LogInfo (const Fmt: string; const Args: array of const); begin LogInfo (Format(Fmt, Args)); end;
+procedure LogWarn (const Msg: string); begin Emit(llWarn,  'warn',  Ansi.Yellow, Msg); end;
+procedure LogWarn (const Fmt: string; const Args: array of const); begin LogWarn (Format(Fmt, Args)); end;
+procedure LogError(const Msg: string); begin Emit(llError, 'error', Ansi.Red,    Msg); end;
+procedure LogError(const Fmt: string; const Args: array of const); begin LogError(Format(Fmt, Args)); end;
+
+end.

--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -1,0 +1,213 @@
+{
+  PasClaw.MCP.Bridge - registers MCP tools into the PasClaw tools registry
+  so the agent loop can invoke them transparently. Tools are namespaced as
+  "<server>__<tool>" to avoid clashes with built-ins or between servers.
+}
+unit PasClaw.MCP.Bridge;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.MCP.Types,
+  PasClaw.MCP.StdioClient;
+
+type
+  TMCPClientList = array of TMCPStdioClient;
+
+{ Connect every enabled MCP server from the config and register their tools
+  into Reg. Returns the list of live clients (caller frees with FreeMCPClients
+  after the agent loop exits). }
+function ConnectMCPServers(Cfg: TConfig; Reg: TToolRegistry): TMCPClientList;
+procedure FreeMCPClients(var Clients: TMCPClientList);
+
+implementation
+
+uses
+  PasClaw.Logger;
+
+type
+  { Each handler needs to remember which client + tool to dispatch to.
+    We keep a small global slot table because TToolHandler is a plain
+    procedural type (no closure context). 32 slots is well above any
+    reasonable MCP-server-count for a single-user CLI. }
+  TMCPBinding = record
+    Client:   TMCPStdioClient;
+    ToolName: string;
+    InUse:    Boolean;
+  end;
+
+const
+  MaxBindings = 32;
+
+var
+  GBindings: array[0..MaxBindings - 1] of TMCPBinding;
+
+function FindBinding(const RegisteredName: string; out Idx: Integer): Boolean; forward;
+
+{ Per-slot handlers. We can't generate these dynamically in Pascal, so we
+  hand-roll one per slot and use the slot index to look up the binding. }
+{$MACRO ON}
+{$DEFINE MAKE_HANDLER :=
+function H_NUM(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Idx: Integer;
+  Done: Boolean;
+begin
+  ErrMsg := '';
+  Idx := NUM;
+  if not GBindings[Idx].InUse then
+  begin
+    ErrMsg := 'mcp slot stale';
+    Exit('');
+  end;
+  Done := GBindings[Idx].Client.CallTool(GBindings[Idx].ToolName, ArgsJSON, Result, ErrMsg);
+  if not Done and (ErrMsg = '') then ErrMsg := 'mcp call failed';
+end;
+}
+
+{ Slot handlers: we emit one per index so the function table is fixed at
+  compile time. If you raise MaxBindings, extend this block to match. }
+function H_0(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[0 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[0 ].Client.CallTool(GBindings[0 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_1(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[1 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[1 ].Client.CallTool(GBindings[1 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_2(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[2 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[2 ].Client.CallTool(GBindings[2 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_3(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[3 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[3 ].Client.CallTool(GBindings[3 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_4(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[4 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[4 ].Client.CallTool(GBindings[4 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_5(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[5 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[5 ].Client.CallTool(GBindings[5 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_6(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[6 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[6 ].Client.CallTool(GBindings[6 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_7(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[7 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[7 ].Client.CallTool(GBindings[7 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_8(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[8 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[8 ].Client.CallTool(GBindings[8 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_9(const A: string; out E: string): string;  var D: Boolean; begin E:=''; if not GBindings[9 ].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[9 ].Client.CallTool(GBindings[9 ].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_10(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[10].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[10].Client.CallTool(GBindings[10].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_11(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[11].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[11].Client.CallTool(GBindings[11].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_12(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[12].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[12].Client.CallTool(GBindings[12].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_13(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[13].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[13].Client.CallTool(GBindings[13].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_14(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[14].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[14].Client.CallTool(GBindings[14].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_15(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[15].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[15].Client.CallTool(GBindings[15].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_16(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[16].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[16].Client.CallTool(GBindings[16].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_17(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[17].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[17].Client.CallTool(GBindings[17].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_18(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[18].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[18].Client.CallTool(GBindings[18].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_19(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[19].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[19].Client.CallTool(GBindings[19].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_20(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[20].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[20].Client.CallTool(GBindings[20].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_21(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[21].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[21].Client.CallTool(GBindings[21].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_22(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[22].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[22].Client.CallTool(GBindings[22].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_23(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[23].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[23].Client.CallTool(GBindings[23].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_24(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[24].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[24].Client.CallTool(GBindings[24].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_25(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[25].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[25].Client.CallTool(GBindings[25].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_26(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[26].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[26].Client.CallTool(GBindings[26].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_27(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[27].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[27].Client.CallTool(GBindings[27].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_28(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[28].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[28].Client.CallTool(GBindings[28].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_29(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[29].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[29].Client.CallTool(GBindings[29].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_30(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[30].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[30].Client.CallTool(GBindings[30].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+function H_31(const A: string; out E: string): string; var D: Boolean; begin E:=''; if not GBindings[31].InUse then begin E:='stale';Result:='';Exit;end; D:=GBindings[31].Client.CallTool(GBindings[31].ToolName,A,Result,E); if not D and (E='') then E:='mcp call failed'; end;
+
+const
+  Handlers: array[0..MaxBindings - 1] of TToolHandler = (
+    @H_0,  @H_1,  @H_2,  @H_3,  @H_4,  @H_5,  @H_6,  @H_7,
+    @H_8,  @H_9,  @H_10, @H_11, @H_12, @H_13, @H_14, @H_15,
+    @H_16, @H_17, @H_18, @H_19, @H_20, @H_21, @H_22, @H_23,
+    @H_24, @H_25, @H_26, @H_27, @H_28, @H_29, @H_30, @H_31
+  );
+
+function FindBinding(const RegisteredName: string; out Idx: Integer): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  for i := 0 to High(GBindings) do
+    if GBindings[i].InUse and (GBindings[i].ToolName = RegisteredName) then
+    begin
+      Idx := i;
+      Exit(True);
+    end;
+end;
+
+function AllocateSlot: Integer;
+var
+  i: Integer;
+begin
+  for i := 0 to High(GBindings) do
+    if not GBindings[i].InUse then Exit(i);
+  Result := -1;
+end;
+
+function ConnectMCPServers(Cfg: TConfig; Reg: TToolRegistry): TMCPClientList;
+var
+  i, j, slot: Integer;
+  Client: TMCPStdioClient;
+  Tools: TMCPToolArray;
+  Err: string;
+  ToolEntry: TTool;
+  Bound: Integer;
+begin
+  SetLength(Result, 0);
+  Bound := 0;
+  for i := 0 to High(Cfg.MCPServers) do
+  begin
+    if not Cfg.MCPServers[i].Enabled then Continue;
+    Client := TMCPStdioClient.Create(Cfg.MCPServers[i].Name,
+                                     Cfg.MCPServers[i].Cmd,
+                                     Cfg.MCPServers[i].Args);
+    if not Client.Connect(5000, Err) then
+    begin
+      LogWarn('mcp[%s] connect failed: %s', [Cfg.MCPServers[i].Name, Err]);
+      Client.Free;
+      Continue;
+    end;
+    if not Client.ListTools(Tools, Err) then
+    begin
+      LogWarn('mcp[%s] list tools failed: %s', [Cfg.MCPServers[i].Name, Err]);
+      Client.Free;
+      Continue;
+    end;
+    LogInfo('mcp[%s] connected, %d tool(s)', [Cfg.MCPServers[i].Name, Length(Tools)]);
+    SetLength(Result, Length(Result) + 1);
+    Result[High(Result)] := Client;
+    for j := 0 to High(Tools) do
+    begin
+      slot := AllocateSlot;
+      if slot < 0 then
+      begin
+        LogWarn('mcp: out of binding slots (max %d); skipping further tools', [MaxBindings]);
+        Exit;
+      end;
+      ToolEntry.Name        := Cfg.MCPServers[i].Name + '__' + Tools[j].Name;
+      ToolEntry.Description := '[mcp:' + Cfg.MCPServers[i].Name + '] ' + Tools[j].Description;
+      ToolEntry.Schema      := Tools[j].Schema;
+      ToolEntry.Handler     := Handlers[slot];
+      ToolEntry.IsCore      := False;
+      GBindings[slot].Client   := Client;
+      GBindings[slot].ToolName := Tools[j].Name;
+      GBindings[slot].InUse    := True;
+      Reg.Register(ToolEntry);
+      Inc(Bound);
+    end;
+  end;
+  if Bound > 0 then LogDebug('mcp: %d tool(s) bound across %d server(s)', [Bound, Length(Result)]);
+end;
+
+procedure FreeMCPClients(var Clients: TMCPClientList);
+var
+  i: Integer;
+begin
+  for i := 0 to High(Clients) do
+    if Clients[i] <> nil then Clients[i].Free;
+  SetLength(Clients, 0);
+  for i := 0 to High(GBindings) do
+  begin
+    GBindings[i].Client   := nil;
+    GBindings[i].ToolName := '';
+    GBindings[i].InUse    := False;
+  end;
+end;
+
+initialization
+  { all bindings start free }
+
+end.

--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -16,10 +16,11 @@ uses
   PasClaw.Tools.Types,
   PasClaw.Tools.Registry,
   PasClaw.MCP.Types,
-  PasClaw.MCP.StdioClient;
+  PasClaw.MCP.StdioClient,
+  PasClaw.MCP.HttpClient;
 
 type
-  TMCPClientList = array of TMCPStdioClient;
+  TMCPClientList = array of TMCPBaseClient;
 
 { Connect every enabled MCP server from the config and register their tools
   into Reg. Returns the list of live clients (caller frees with FreeMCPClients
@@ -38,7 +39,7 @@ type
     procedural type (no closure context). 32 slots is well above any
     reasonable MCP-server-count for a single-user CLI. }
   TMCPBinding = record
-    Client:   TMCPStdioClient;
+    Client:   TMCPBaseClient;
     ToolName: string;
     InUse:    Boolean;
   end;
@@ -137,10 +138,17 @@ begin
   Result := -1;
 end;
 
+function IsHttpUrl(const S: string): Boolean;
+begin
+  Result := (Length(S) >= 7) and
+            ((LowerCase(Copy(S, 1, 7)) = 'http://') or
+             ((Length(S) >= 8) and (LowerCase(Copy(S, 1, 8)) = 'https://')));
+end;
+
 function ConnectMCPServers(Cfg: TConfig; Reg: TToolRegistry): TMCPClientList;
 var
   i, j, slot: Integer;
-  Client: TMCPStdioClient;
+  Client: TMCPBaseClient;
   Tools: TMCPToolArray;
   Err: string;
   ToolEntry: TTool;
@@ -151,9 +159,19 @@ begin
   for i := 0 to High(Cfg.MCPServers) do
   begin
     if not Cfg.MCPServers[i].Enabled then Continue;
-    Client := TMCPStdioClient.Create(Cfg.MCPServers[i].Name,
-                                     Cfg.MCPServers[i].Cmd,
-                                     Cfg.MCPServers[i].Args);
+    if IsHttpUrl(Cfg.MCPServers[i].Cmd) then
+    begin
+      { HTTP transport: Cmd = URL, Args (optional) = "Bearer ..." token }
+      Client := TMCPHttpClient.Create(Cfg.MCPServers[i].Name,
+                                      Cfg.MCPServers[i].Cmd,
+                                      Cfg.MCPServers[i].Args);
+    end
+    else
+    begin
+      Client := TMCPStdioClient.Create(Cfg.MCPServers[i].Name,
+                                       Cfg.MCPServers[i].Cmd,
+                                       Cfg.MCPServers[i].Args);
+    end;
     if not Client.Connect(5000, Err) then
     begin
       LogWarn('mcp[%s] connect failed: %s', [Cfg.MCPServers[i].Name, Err]);

--- a/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
@@ -26,20 +26,18 @@ uses
   PasClaw.MCP.Types;
 
 type
-  TMCPHttpClient = class
+  TMCPHttpClient = class(TMCPBaseClient)
   private
     FName, FURL, FAuth: string;
     FNextId: Integer;
-    FInfo:   TMCPServerInfo;
     function RoundTrip(const Method, ParamsJSON: string;
                        TimeoutSeconds: Integer; out RespJSON: string): Boolean;
   public
     constructor Create(const Name, URL, AuthHeader: string);
-    function Connect(TimeoutSeconds: Integer; out ErrMsg: string): Boolean;
-    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
+    function Connect(TimeoutSeconds: Integer; out ErrMsg: string): Boolean; override;
+    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean; override;
     function CallTool(const ToolName, ArgsJSON: string;
-                      out ResultText, ErrMsg: string): Boolean;
-    property ServerInfo: TMCPServerInfo read FInfo;
+                      out ResultText, ErrMsg: string): Boolean; override;
   end;
 
 implementation

--- a/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
@@ -1,0 +1,321 @@
+(*
+  PasClaw.MCP.HttpClient - MCP over Streamable HTTP transport.
+
+  Each call is a single POST to the configured URL with the JSON-RPC envelope.
+  The same socket may be reused for the response stream (server-sent events)
+  when the server elects to stream multi-part results — we handle both:
+
+    * Content-Type: application/json  -> response is one JSON object
+    * Content-Type: text/event-stream -> parse `data:` lines, join, decode
+
+  Auth tokens come from the configured `args` slot in the MCP server entry,
+  shaped as "--header Authorization: Bearer ..." or just "Bearer ...". The
+  args field is space-separated; we sniff for an Authorization header.
+
+  Spec: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+*)
+unit PasClaw.MCP.HttpClient;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.MCP.Types;
+
+type
+  TMCPHttpClient = class
+  private
+    FName, FURL, FAuth: string;
+    FNextId: Integer;
+    FInfo:   TMCPServerInfo;
+    function RoundTrip(const Method, ParamsJSON: string;
+                       TimeoutSeconds: Integer; out RespJSON: string): Boolean;
+  public
+    constructor Create(const Name, URL, AuthHeader: string);
+    function Connect(TimeoutSeconds: Integer; out ErrMsg: string): Boolean;
+    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
+    function CallTool(const ToolName, ArgsJSON: string;
+                      out ResultText, ErrMsg: string): Boolean;
+    property ServerInfo: TMCPServerInfo read FInfo;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+constructor TMCPHttpClient.Create(const Name, URL, AuthHeader: string);
+begin
+  inherited Create;
+  FName    := Name;
+  FURL     := URL;
+  FAuth    := AuthHeader;
+  FNextId  := 1;
+end;
+
+(* Join all `data:` lines into one body (text/event-stream framing). *)
+function CollapseSSE(const Body: string): string;
+var
+  L: TStringList;
+  i: Integer;
+  Line: string;
+  Out_: TStringBuilder;
+begin
+  Result := '';
+  if Pos('data:', Body) = 0 then
+  begin
+    Result := Body;
+    Exit;
+  end;
+  L := TStringList.Create;
+  Out_ := TStringBuilder.Create;
+  try
+    L.Text := Body;
+    for i := 0 to L.Count - 1 do
+    begin
+      Line := L[i];
+      if Copy(Line, 1, 5) = 'data:' then
+      begin
+        Line := Trim(Copy(Line, 6, MaxInt));
+        if Line <> '' then Out_.Append(Line);
+      end;
+    end;
+    Result := Out_.ToString;
+  finally
+    Out_.Free;
+    L.Free;
+  end;
+end;
+
+function TMCPHttpClient.RoundTrip(const Method, ParamsJSON: string;
+                                  TimeoutSeconds: Integer;
+                                  out RespJSON: string): Boolean;
+var
+  Req: TJsonObject;
+  Body: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  HeaderCount: Integer;
+begin
+  RespJSON := '';
+  Req := TJsonObject.Create;
+  try
+    Req.PutStr('jsonrpc', JSONRPCVersion);
+    Req.PutInt('id', FNextId);
+    Inc(FNextId);
+    Req.PutStr('method', Method);
+    if ParamsJSON <> '' then Req.PutRaw('params', ParamsJSON);
+    Body := Req.ToJSON;
+  finally
+    Req.Free;
+  end;
+
+  HeaderCount := 0;
+  if FAuth <> '' then HeaderCount := 1;
+  SetLength(Headers, HeaderCount + 1);
+  Headers[0] := MakeHeader('Accept', 'application/json, text/event-stream');
+  if HeaderCount = 1 then
+    Headers[1] := MakeHeader('Authorization', FAuth);
+
+  Resp := PostJSON(FURL, Body, Headers, TimeoutSeconds);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    LogWarn('mcp-http[%s] status=%d body=%s',
+            [FName, Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit(False);
+  end;
+  RespJSON := CollapseSSE(Resp.Body);
+  Result := RespJSON <> '';
+end;
+
+function TMCPHttpClient.Connect(TimeoutSeconds: Integer; out ErrMsg: string): Boolean;
+var
+  Params, ServerInfo: TJsonObject;
+  Caps: TJsonObject;
+  Resp: string;
+  RespObj, ResultObj: TJsonObject;
+  ServerInfoObj, CapsObj: TJsonObject;
+begin
+  ErrMsg := '';
+  Params     := TJsonObject.Create;
+  ServerInfo := TJsonObject.Create;
+  Caps       := TJsonObject.Create;
+  try
+    Params.PutStr('protocolVersion', MCPProtocolVersion);
+    ServerInfo.PutStr('name',    'pasclaw');
+    ServerInfo.PutStr('version', '0.1');
+    Params.PutObject('clientInfo', ServerInfo);
+    Params.PutObject('capabilities', Caps);
+    if not RoundTrip('initialize', Params.ToJSON, TimeoutSeconds, Resp) then
+    begin
+      ErrMsg := 'initialize failed';
+      Exit(False);
+    end;
+  finally
+    Params.Free;
+    if ServerInfo <> nil then ServerInfo.Free;
+    if Caps <> nil then Caps.Free;
+  end;
+
+  RespObj := TJsonObject.Parse(Resp);
+  if RespObj = nil then begin ErrMsg := 'bad initialize response'; Exit(False); end;
+  try
+    if RespObj.Has('error') then
+    begin
+      ErrMsg := 'initialize error';
+      Exit(False);
+    end;
+    ResultObj := RespObj.ChildObject('result');
+    if ResultObj = nil then begin ErrMsg := 'no result'; Exit(False); end;
+    try
+      ServerInfoObj := ResultObj.ChildObject('serverInfo');
+      if ServerInfoObj <> nil then
+      try
+        FInfo.Name    := ServerInfoObj.GetStr('name', '');
+        FInfo.Version := ServerInfoObj.GetStr('version', '');
+      finally
+        ServerInfoObj.Free;
+      end;
+      CapsObj := ResultObj.ChildObject('capabilities');
+      if CapsObj <> nil then
+      try
+        FInfo.Caps.Tools     := CapsObj.Has('tools');
+        FInfo.Caps.Resources := CapsObj.Has('resources');
+        FInfo.Caps.Prompts   := CapsObj.Has('prompts');
+      finally
+        CapsObj.Free;
+      end;
+    finally
+      ResultObj.Free;
+    end;
+  finally
+    RespObj.Free;
+  end;
+  Result := True;
+end;
+
+function TMCPHttpClient.ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
+var
+  Resp: string;
+  RespObj, ResultObj, ToolObj: TJsonObject;
+  Arr: TJsonArray;
+  Schema: TJsonObject;
+  i: Integer;
+begin
+  ErrMsg := '';
+  SetLength(Tools, 0);
+  if not RoundTrip('tools/list', '{}', 10, Resp) then
+  begin
+    ErrMsg := 'tools/list failed';
+    Exit(False);
+  end;
+  RespObj := TJsonObject.Parse(Resp);
+  if RespObj = nil then Exit(False);
+  try
+    if RespObj.Has('error') then begin ErrMsg := 'tools/list error'; Exit(False); end;
+    ResultObj := RespObj.ChildObject('result');
+    if ResultObj = nil then Exit(True);
+    try
+      Arr := ResultObj.ChildArray('tools');
+      if Arr = nil then Exit(True);
+      try
+        SetLength(Tools, Arr.Count);
+        for i := 0 to Arr.Count - 1 do
+        begin
+          ToolObj := Arr.ItemObject(i);
+          if ToolObj = nil then Continue;
+          try
+            Tools[i].Name        := ToolObj.GetStr('name', '');
+            Tools[i].Description := ToolObj.GetStr('description', '');
+            Schema := ToolObj.ChildObject('inputSchema');
+            if Schema <> nil then
+            try
+              Tools[i].Schema := Schema.ToJSON;
+            finally
+              Schema.Free;
+            end
+            else
+              Tools[i].Schema := '{"type":"object"}';
+            Tools[i].Server := FName;
+          finally
+            ToolObj.Free;
+          end;
+        end;
+      finally
+        Arr.Free;
+      end;
+    finally
+      ResultObj.Free;
+    end;
+  finally
+    RespObj.Free;
+  end;
+  Result := True;
+end;
+
+function TMCPHttpClient.CallTool(const ToolName, ArgsJSON: string;
+                                 out ResultText, ErrMsg: string): Boolean;
+var
+  Params: TJsonObject;
+  Resp: string;
+  RespObj, ResultObj, Block: TJsonObject;
+  ContentArr: TJsonArray;
+  i: Integer;
+begin
+  ResultText := '';
+  ErrMsg := '';
+  Params := TJsonObject.Create;
+  try
+    Params.PutStr('name', ToolName);
+    if ArgsJSON <> '' then Params.PutRaw('arguments', ArgsJSON)
+    else Params.PutRaw('arguments', '{}');
+    if not RoundTrip('tools/call', Params.ToJSON, 60, Resp) then
+    begin
+      ErrMsg := 'tools/call failed';
+      Exit(False);
+    end;
+  finally
+    Params.Free;
+  end;
+  RespObj := TJsonObject.Parse(Resp);
+  if RespObj = nil then Exit(False);
+  try
+    if RespObj.Has('error') then begin ErrMsg := 'tools/call error'; Exit(False); end;
+    ResultObj := RespObj.ChildObject('result');
+    if ResultObj = nil then Exit(False);
+    try
+      ContentArr := ResultObj.ChildArray('content');
+      if ContentArr <> nil then
+      try
+        for i := 0 to ContentArr.Count - 1 do
+        begin
+          Block := ContentArr.ItemObject(i);
+          if Block = nil then Continue;
+          try
+            if Block.GetStr('type', '') = 'text' then
+            begin
+              if ResultText <> '' then ResultText := ResultText + sLineBreak;
+              ResultText := ResultText + Block.GetStr('text', '');
+            end;
+          finally
+            Block.Free;
+          end;
+        end;
+      finally
+        ContentArr.Free;
+      end;
+    finally
+      ResultObj.Free;
+    end;
+  finally
+    RespObj.Free;
+  end;
+  Result := True;
+end;
+
+end.

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -26,13 +26,12 @@ uses
   PasClaw.MCP.Types;
 
 type
-  TMCPStdioClient = class
+  TMCPStdioClient = class(TMCPBaseClient)
   private
     FProcess: TProcess;
     FCmd, FArgs, FName: string;
     FNextId:  Integer;
     FBuffer:  string;
-    FInfo:    TMCPServerInfo;
     function  ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
     function  WriteLine(const S: string): Boolean;
     function  RoundTrip(const Method, ParamsJSON: string;
@@ -41,13 +40,11 @@ type
     constructor Create(const Name, Cmd, Args: string);
     destructor  Destroy; override;
 
-    function Connect(TimeoutMs: Integer; out ErrMsg: string): Boolean;
-    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
+    function Connect(TimeoutMs: Integer; out ErrMsg: string): Boolean; override;
+    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean; override;
     function CallTool(const ToolName, ArgsJSON: string;
-                      out ResultText, ErrMsg: string): Boolean;
+                      out ResultText, ErrMsg: string): Boolean; override;
     procedure Close;
-
-    property ServerInfo: TMCPServerInfo read FInfo;
   end;
 
 implementation

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -1,0 +1,446 @@
+{
+  PasClaw.MCP.StdioClient - spawns the configured MCP server command and
+  speaks JSON-RPC 2.0 over its stdin/stdout pipes. Mirrors a thin slice of
+  pkg/mcp/manager.go in picoclaw.
+
+  Protocol flow:
+    1. Spawn `cmd args...` with piped stdin/stdout.
+    2. Send `initialize` request, receive server capabilities.
+    3. Send `tools/list`, get the available tool descriptors.
+    4. Optionally `tools/call` to invoke one.
+    5. `shutdown` + close pipes; reap.
+
+  Message framing: one JSON object per line (LSP-style "Content-Length"
+  headers are also valid but most MCP servers default to newline-delimited
+  JSON, which is what we implement here).
+}
+unit PasClaw.MCP.StdioClient;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes, Process,
+  PasClaw.MCP.Types;
+
+type
+  TMCPStdioClient = class
+  private
+    FProcess: TProcess;
+    FCmd, FArgs, FName: string;
+    FNextId:  Integer;
+    FBuffer:  string;
+    FInfo:    TMCPServerInfo;
+    function  ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
+    function  WriteLine(const S: string): Boolean;
+    function  RoundTrip(const Method, ParamsJSON: string;
+                        TimeoutMs: Integer; out RespJSON: string): Boolean;
+  public
+    constructor Create(const Name, Cmd, Args: string);
+    destructor  Destroy; override;
+
+    function Connect(TimeoutMs: Integer; out ErrMsg: string): Boolean;
+    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
+    function CallTool(const ToolName, ArgsJSON: string;
+                      out ResultText, ErrMsg: string): Boolean;
+    procedure Close;
+
+    property ServerInfo: TMCPServerInfo read FInfo;
+  end;
+
+implementation
+
+uses
+  fpjson, jsonparser,
+  PasClaw.Logger;
+
+constructor TMCPStdioClient.Create(const Name, Cmd, Args: string);
+begin
+  inherited Create;
+  FName   := Name;
+  FCmd    := Cmd;
+  FArgs   := Args;
+  FNextId := 1;
+  FBuffer := '';
+end;
+
+destructor TMCPStdioClient.Destroy;
+begin
+  Close;
+  inherited Destroy;
+end;
+
+procedure TMCPStdioClient.Close;
+begin
+  if FProcess <> nil then
+  begin
+    try
+      if FProcess.Running then
+        FProcess.Terminate(0);
+    except
+      { ignore — we're tearing down }
+    end;
+    FreeAndNil(FProcess);
+  end;
+end;
+
+function SplitArgs(const S: string): TStringList;
+var
+  i, last, n: Integer;
+  inQuote: Boolean;
+  qc: Char;
+  cur: string;
+begin
+  Result := TStringList.Create;
+  n := Length(S);
+  cur := '';
+  inQuote := False;
+  qc := ' ';
+  i := 1;
+  last := 1;
+  while i <= n do
+  begin
+    if inQuote then
+    begin
+      if S[i] = qc then inQuote := False
+      else cur := cur + S[i];
+    end
+    else
+    begin
+      if (S[i] = '"') or (S[i] = '''') then
+      begin
+        inQuote := True;
+        qc := S[i];
+      end
+      else if S[i] = ' ' then
+      begin
+        if cur <> '' then begin Result.Add(cur); cur := ''; end;
+      end
+      else
+        cur := cur + S[i];
+    end;
+    Inc(i);
+    Inc(last);
+  end;
+  if cur <> '' then Result.Add(cur);
+end;
+
+function TMCPStdioClient.WriteLine(const S: string): Boolean;
+var
+  Bytes: TBytes;
+  Buf: string;
+begin
+  if (FProcess = nil) or not FProcess.Running then Exit(False);
+  Buf := S + #10;
+  try
+    FProcess.Input.Write(Buf[1], Length(Buf));
+    Result := True;
+  except
+    Result := False;
+  end;
+end;
+
+function TMCPStdioClient.ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
+var
+  Buf: array[0..4095] of Byte;
+  N, Waited, NLPos: Integer;
+  Chunk: string;
+begin
+  Line := '';
+  Waited := 0;
+  if FProcess = nil then Exit(False);
+  while True do
+  begin
+    NLPos := Pos(#10, FBuffer);
+    if NLPos > 0 then
+    begin
+      Line    := Copy(FBuffer, 1, NLPos - 1);
+      FBuffer := Copy(FBuffer, NLPos + 1, MaxInt);
+      Exit(True);
+    end;
+    if not FProcess.Running and (FProcess.Output.NumBytesAvailable = 0) then
+      Exit(False);
+    if FProcess.Output.NumBytesAvailable > 0 then
+    begin
+      N := FProcess.Output.Read(Buf, SizeOf(Buf));
+      if N > 0 then
+      begin
+        SetLength(Chunk, N);
+        Move(Buf[0], Chunk[1], N);
+        FBuffer := FBuffer + Chunk;
+      end;
+    end
+    else
+    begin
+      Sleep(20);
+      Inc(Waited, 20);
+      if Waited >= TimeoutMs then Exit(False);
+    end;
+  end;
+end;
+
+function TMCPStdioClient.RoundTrip(const Method, ParamsJSON: string;
+                                   TimeoutMs: Integer;
+                                   out RespJSON: string): Boolean;
+var
+  Id: Integer;
+  Req: TJSONObject;
+  ParamsData: TJSONData;
+  Line: string;
+  RespRoot: TJSONData;
+  RespObj: TJSONObject;
+begin
+  RespJSON := '';
+  Id := FNextId; Inc(FNextId);
+
+  Req := TJSONObject.Create;
+  try
+    Req.Add('jsonrpc', JSONRPCVersion);
+    Req.Add('id', Id);
+    Req.Add('method', Method);
+    if ParamsJSON <> '' then
+    begin
+      try
+        ParamsData := GetJSON(ParamsJSON);
+        Req.Add('params', ParamsData);
+      except
+        Req.Add('params', TJSONObject.Create);
+      end;
+    end;
+    if not WriteLine(Req.AsJSON) then Exit(False);
+  finally
+    Req.Free;
+  end;
+
+  while ReadLine(Line, TimeoutMs) do
+  begin
+    Line := Trim(Line);
+    if Line = '' then Continue;
+    LogDebug('mcp[%s] <- %s', [FName, Copy(Line, 1, 200)]);
+    try
+      RespRoot := GetJSON(Line);
+    except
+      Continue;
+    end;
+    try
+      if not (RespRoot is TJSONObject) then Continue;
+      RespObj := TJSONObject(RespRoot);
+      { Skip notifications (no id) and responses to other requests. }
+      if (RespObj.IndexOfName('id') < 0) or
+         (RespObj.Integers['id'] <> Id) then Continue;
+      RespJSON := Line;
+      Exit(True);
+    finally
+      RespRoot.Free;
+    end;
+  end;
+  Result := False;
+end;
+
+function TMCPStdioClient.Connect(TimeoutMs: Integer; out ErrMsg: string): Boolean;
+var
+  ArgList: TStringList;
+  i: Integer;
+  Params, ServerCaps, ServerInfo: TJSONObject;
+  Resp: string;
+  RespData: TJSONData;
+  RespObj, ResultObj: TJSONObject;
+begin
+  ErrMsg := '';
+  if FCmd = '' then begin ErrMsg := 'no command configured'; Exit(False); end;
+
+  FProcess := TProcess.Create(nil);
+  FProcess.Executable := FCmd;
+  ArgList := SplitArgs(FArgs);
+  try
+    for i := 0 to ArgList.Count - 1 do FProcess.Parameters.Add(ArgList[i]);
+  finally
+    ArgList.Free;
+  end;
+  FProcess.Options := [poUsePipes];
+  try
+    FProcess.Execute;
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'failed to spawn ' + FCmd + ': ' + E.Message;
+      Exit(False);
+    end;
+  end;
+
+  { initialize }
+  Params := TJSONObject.Create;
+  try
+    Params.Add('protocolVersion', MCPProtocolVersion);
+    ServerCaps := TJSONObject.Create;
+    Params.Add('capabilities', ServerCaps);
+    ServerInfo := TJSONObject.Create;
+    ServerInfo.Add('name', 'pasclaw');
+    ServerInfo.Add('version', '0.1');
+    Params.Add('clientInfo', ServerInfo);
+    if not RoundTrip('initialize', Params.AsJSON, TimeoutMs, Resp) then
+    begin
+      ErrMsg := 'no response to initialize from ' + FCmd;
+      Exit(False);
+    end;
+  finally
+    Params.Free;
+  end;
+
+  { Parse server info & capabilities out of the response. }
+  RespData := GetJSON(Resp);
+  try
+    if RespData is TJSONObject then
+    begin
+      RespObj := TJSONObject(RespData);
+      if RespObj.IndexOfName('error') >= 0 then
+      begin
+        ErrMsg := 'initialize error: ' + RespObj.Find('error').AsJSON;
+        Exit(False);
+      end;
+      if RespObj.IndexOfName('result') >= 0 then
+      begin
+        ResultObj := RespObj.Objects['result'];
+        if ResultObj.IndexOfName('serverInfo') >= 0 then
+        begin
+          FInfo.Name    := ResultObj.Objects['serverInfo'].Get('name', '');
+          FInfo.Version := ResultObj.Objects['serverInfo'].Get('version', '');
+        end;
+        if ResultObj.IndexOfName('capabilities') >= 0 then
+        begin
+          FInfo.Caps.Tools     := ResultObj.Objects['capabilities'].IndexOfName('tools')     >= 0;
+          FInfo.Caps.Resources := ResultObj.Objects['capabilities'].IndexOfName('resources') >= 0;
+          FInfo.Caps.Prompts   := ResultObj.Objects['capabilities'].IndexOfName('prompts')   >= 0;
+        end;
+      end;
+    end;
+  finally
+    RespData.Free;
+  end;
+
+  { Send "initialized" notification (no id, no response expected). }
+  WriteLine('{"jsonrpc":"2.0","method":"notifications/initialized"}');
+  Result := True;
+end;
+
+function TMCPStdioClient.ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
+var
+  Resp: string;
+  Data: TJSONData;
+  Obj, ResultObj, ToolObj: TJSONObject;
+  Arr: TJSONArray;
+  i: Integer;
+begin
+  ErrMsg := '';
+  SetLength(Tools, 0);
+  if not RoundTrip('tools/list', '{}', 5000, Resp) then
+  begin
+    ErrMsg := 'no response to tools/list';
+    Exit(False);
+  end;
+  Data := GetJSON(Resp);
+  try
+    if not (Data is TJSONObject) then Exit(False);
+    Obj := TJSONObject(Data);
+    if Obj.IndexOfName('error') >= 0 then
+    begin
+      ErrMsg := 'tools/list error: ' + Obj.Find('error').AsJSON;
+      Exit(False);
+    end;
+    if Obj.IndexOfName('result') < 0 then Exit(False);
+    ResultObj := Obj.Objects['result'];
+    if ResultObj.IndexOfName('tools') < 0 then Exit(True);   { server has none }
+    Arr := ResultObj.Arrays['tools'];
+    SetLength(Tools, Arr.Count);
+    for i := 0 to Arr.Count - 1 do
+    begin
+      ToolObj := TJSONObject(Arr[i]);
+      Tools[i].Name        := ToolObj.Get('name', '');
+      Tools[i].Description := ToolObj.Get('description', '');
+      if ToolObj.IndexOfName('inputSchema') >= 0 then
+        Tools[i].Schema := ToolObj.Find('inputSchema').AsJSON
+      else
+        Tools[i].Schema := '{"type":"object"}';
+      Tools[i].Server := FName;
+    end;
+  finally
+    Data.Free;
+  end;
+  Result := True;
+end;
+
+function TMCPStdioClient.CallTool(const ToolName, ArgsJSON: string;
+                                  out ResultText, ErrMsg: string): Boolean;
+var
+  Params: TJSONObject;
+  ArgsData: TJSONData;
+  Resp: string;
+  Data: TJSONData;
+  Obj, ResultObj, Block: TJSONObject;
+  ContentArr: TJSONArray;
+  i: Integer;
+  Kind: string;
+begin
+  ResultText := '';
+  ErrMsg := '';
+  Params := TJSONObject.Create;
+  try
+    Params.Add('name', ToolName);
+    if ArgsJSON <> '' then
+    begin
+      try
+        ArgsData := GetJSON(ArgsJSON);
+        Params.Add('arguments', ArgsData);
+      except
+        Params.Add('arguments', TJSONObject.Create);
+      end;
+    end
+    else
+      Params.Add('arguments', TJSONObject.Create);
+
+    if not RoundTrip('tools/call', Params.AsJSON, 30000, Resp) then
+    begin
+      ErrMsg := 'no response to tools/call';
+      Exit(False);
+    end;
+  finally
+    Params.Free;
+  end;
+
+  Data := GetJSON(Resp);
+  try
+    if not (Data is TJSONObject) then Exit(False);
+    Obj := TJSONObject(Data);
+    if Obj.IndexOfName('error') >= 0 then
+    begin
+      ErrMsg := 'tools/call error: ' + Obj.Find('error').AsJSON;
+      Exit(False);
+    end;
+    if Obj.IndexOfName('result') < 0 then Exit(False);
+    ResultObj := Obj.Objects['result'];
+    if ResultObj.IndexOfName('content') >= 0 then
+    begin
+      ContentArr := ResultObj.Arrays['content'];
+      for i := 0 to ContentArr.Count - 1 do
+      begin
+        Block := TJSONObject(ContentArr[i]);
+        Kind := Block.Get('type', '');
+        if Kind = 'text' then
+        begin
+          if ResultText <> '' then ResultText := ResultText + sLineBreak;
+          ResultText := ResultText + Block.Get('text', '');
+        end;
+      end;
+    end;
+    if (ResultText = '') and (ResultObj.IndexOfName('isError') >= 0) and
+       (ResultObj.Booleans['isError']) then
+      ErrMsg := 'tool reported error (no text content)';
+  finally
+    Data.Free;
+  end;
+  Result := ErrMsg = '';
+end;
+
+end.

--- a/src/pkg/mcp/PasClaw.MCP.Types.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Types.pas
@@ -1,0 +1,45 @@
+{
+  PasClaw.MCP.Types - Model Context Protocol types.
+  MCP uses JSON-RPC 2.0 over stdio (this Phase) or HTTP/SSE (next phase).
+
+  Spec: https://modelcontextprotocol.io/specification
+}
+unit PasClaw.MCP.Types;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+const
+  MCPProtocolVersion = '2024-11-05';
+  JSONRPCVersion     = '2.0';
+
+type
+  TMCPTool = record
+    Name:        string;
+    Description: string;
+    Schema:      string;   { JSON-encoded inputSchema }
+    Server:      string;   { display name of the host server, for routing }
+  end;
+
+  TMCPToolArray = array of TMCPTool;
+
+  TMCPCapabilities = record
+    Tools:     Boolean;
+    Resources: Boolean;
+    Prompts:   Boolean;
+  end;
+
+  TMCPServerInfo = record
+    Name:    string;
+    Version: string;
+    Caps:    TMCPCapabilities;
+  end;
+
+implementation
+
+end.

--- a/src/pkg/mcp/PasClaw.MCP.Types.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Types.pas
@@ -40,6 +40,19 @@ type
     Caps:    TMCPCapabilities;
   end;
 
+  (* Common base for stdio and HTTP MCP clients. The bridge keeps a list
+     of these and dispatches tool calls polymorphically. *)
+  TMCPBaseClient = class
+  protected
+    FInfo: TMCPServerInfo;
+  public
+    function Connect(TimeoutMs: Integer; out ErrMsg: string): Boolean; virtual; abstract;
+    function ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean; virtual; abstract;
+    function CallTool(const ToolName, ArgsJSON: string;
+                      out ResultText, ErrMsg: string): Boolean; virtual; abstract;
+    property ServerInfo: TMCPServerInfo read FInfo;
+  end;
+
 implementation
 
 end.

--- a/src/pkg/membench/PasClaw.Membench.Runner.pas
+++ b/src/pkg/membench/PasClaw.Membench.Runner.pas
@@ -1,0 +1,146 @@
+(*
+  PasClaw.Membench.Runner - simple memory log benchmark.
+
+  Picoclaw's membench evaluates retrieval quality on a recall dataset
+  (LoCoMo). That's a substantial port; the Pascal version here focuses on
+  the raw I/O fundamentals — write throughput and load throughput of the
+  NDJSON memory log — because those are the bits the rest of the agent
+  builds on.
+
+  Usage:
+    pasclaw membench --records 10000 --content 256
+*)
+unit PasClaw.Membench.Runner;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TMembenchOpts = record
+    Records:     Integer;
+    ContentSize: Integer;
+    KeepFile:    Boolean;
+    OutDir:      string;
+  end;
+
+  TMembenchResult = record
+    WriteSeconds:    Double;
+    LoadSeconds:     Double;
+    BytesOnDisk:     Int64;
+    RecordsWritten:  Integer;
+    RecordsLoaded:   Integer;
+    Path:            string;
+  end;
+
+function DefaultMembenchOpts: TMembenchOpts;
+function RunMembench(const Opts: TMembenchOpts): TMembenchResult;
+
+implementation
+
+uses
+  Classes, DateUtils,
+  PasClaw.Memory,
+  PasClaw.Providers.Types,
+  PasClaw.Utils;
+
+function DefaultMembenchOpts: TMembenchOpts;
+begin
+  Result.Records     := 1000;
+  Result.ContentSize := 128;
+  Result.KeepFile    := False;
+  Result.OutDir      := '';
+end;
+
+function MakePayload(Size: Integer): string;
+var
+  i: Integer;
+  C: Char;
+begin
+  SetLength(Result, Size);
+  for i := 1 to Size do
+  begin
+    C := Char(32 + ((i * 7) mod 90));
+    if C = '"' then C := '_';
+    if C = '\' then C := '/';
+    Result[i] := C;
+  end;
+end;
+
+function FileBytes(const Path: string): Int64;
+var
+  F: TFileStream;
+begin
+  Result := 0;
+  if not FileExists(Path) then Exit;
+  try
+    F := TFileStream.Create(Path, fmOpenRead or fmShareDenyNone);
+    try
+      Result := F.Size;
+    finally
+      F.Free;
+    end;
+  except
+    Result := 0;
+  end;
+end;
+
+function RunMembench(const Opts: TMembenchOpts): TMembenchResult;
+var
+  Home, SessionId, Path: string;
+  Log: TMemoryLog;
+  Start: TDateTime;
+  i: Integer;
+  Payload: string;
+  Hist: TMessageArray;
+begin
+  Result.RecordsWritten := 0;
+  Result.RecordsLoaded  := 0;
+  Result.BytesOnDisk    := 0;
+  Result.WriteSeconds   := 0;
+  Result.LoadSeconds    := 0;
+
+  if Opts.OutDir <> '' then Home := Opts.OutDir
+  else                      Home := GetTempDir;
+
+  SessionId := 'membench-' + FormatDateTime('yyyymmdd-hhnnsszzz', Now);
+  Log := NewMemoryLog(Home, SessionId);
+  Path := IncludeTrailingPathDelimiter(Home) + 'workspace/memory/' + SessionId + '.ndjson';
+  Result.Path := Path;
+
+  Payload := MakePayload(Opts.ContentSize);
+
+  { Write pass }
+  Start := Now;
+  for i := 1 to Opts.Records do
+  begin
+    if (i mod 2) = 0 then
+      Log.Append(mrAssistant, Payload, '')
+    else
+      Log.Append(mrUser, Payload, '');
+  end;
+  Log.Free;
+  Result.WriteSeconds := SecondSpan(Now, Start);
+  Result.RecordsWritten := Opts.Records;
+  Result.BytesOnDisk := FileBytes(Path);
+
+  { Load pass }
+  Log := TMemoryLog.Create(Path, SessionId);
+  try
+    Start := Now;
+    Hist := Log.LoadHistory;
+    Result.LoadSeconds := SecondSpan(Now, Start);
+    Result.RecordsLoaded := Length(Hist);
+  finally
+    Log.Free;
+  end;
+
+  if not Opts.KeepFile then
+    DeleteFile(Path);
+end;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.pas
+++ b/src/pkg/memory/PasClaw.Memory.pas
@@ -1,0 +1,150 @@
+(*
+  PasClaw.Memory - simple append-only conversation log.
+
+  Each session writes one NDJSON file under $PASCLAW_HOME/workspace/memory/.
+  Records are flushed line-by-line so a crash leaves a recoverable trail.
+  This is intentionally lightweight; the picoclaw memory module includes a
+  vector store, summarisation, and retrieval — those land in later phases.
+
+  Record shape:
+    {"ts":"2026-...","session":"...","role":"user|assistant|tool","content":"...","tool":"..."}
+*)
+unit PasClaw.Memory;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types;
+
+type
+  TMemoryLog = class
+  private
+    FPath:    string;
+    FSession: string;
+    FStream:  TFileStream;
+    procedure WriteLine(const S: string);
+  public
+    constructor Create(const Path, SessionId: string);
+    destructor  Destroy; override;
+    procedure Append(Role: TMsgRole; const Content, ToolName: string);
+    procedure AppendRaw(const RoleName, Content, ToolName: string);
+    function  LoadHistory: TMessageArray;
+  end;
+
+function NewSessionId: string;
+function NewMemoryLog(const HomeDir, SessionId: string): TMemoryLog;
+
+implementation
+
+uses
+  DateUtils,
+  PasClaw.Utils,
+  PasClaw.JSON;
+
+function NewSessionId: string;
+var
+  GUID: TGUID;
+begin
+  CreateGUID(GUID);
+  Result := FormatDateTime('yyyymmdd-hhnnss', Now) + '-' +
+            LowerCase(Copy(GUIDToString(GUID), 2, 8));
+end;
+
+function NewMemoryLog(const HomeDir, SessionId: string): TMemoryLog;
+var
+  Dir, Path: string;
+begin
+  Dir := JoinPath(HomeDir, 'workspace/memory');
+  EnsureDir(Dir);
+  Path := JoinPath(Dir, SessionId + '.ndjson');
+  Result := TMemoryLog.Create(Path, SessionId);
+end;
+
+constructor TMemoryLog.Create(const Path, SessionId: string);
+begin
+  inherited Create;
+  FPath := Path;
+  FSession := SessionId;
+  if FileExists(Path) then
+    FStream := TFileStream.Create(Path, fmOpenReadWrite or fmShareDenyWrite)
+  else
+    FStream := TFileStream.Create(Path, fmCreate);
+  FStream.Position := FStream.Size;
+end;
+
+destructor TMemoryLog.Destroy;
+begin
+  FreeAndNil(FStream);
+  inherited Destroy;
+end;
+
+procedure TMemoryLog.WriteLine(const S: string);
+var
+  Line: string;
+begin
+  if FStream = nil then Exit;
+  Line := S + #10;
+  FStream.WriteBuffer(Line[1], Length(Line));
+end;
+
+procedure TMemoryLog.Append(Role: TMsgRole; const Content, ToolName: string);
+begin
+  AppendRaw(MsgRoleToString(Role), Content, ToolName);
+end;
+
+procedure TMemoryLog.AppendRaw(const RoleName, Content, ToolName: string);
+var
+  Obj: TJsonObject;
+begin
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('ts',      FormatDateTime('yyyy"-"mm"-"dd"T"hh":"nn":"ss', Now));
+    Obj.PutStr('session', FSession);
+    Obj.PutStr('role',    RoleName);
+    Obj.PutStr('content', Content);
+    if ToolName <> '' then Obj.PutStr('tool', ToolName);
+    WriteLine(Obj.ToJSON);
+  finally
+    Obj.Free;
+  end;
+end;
+
+function TMemoryLog.LoadHistory: TMessageArray;
+var
+  Reader: TStringList;
+  i: Integer;
+  Obj: TJsonObject;
+  RoleStr, Content: string;
+  Role: TMsgRole;
+begin
+  SetLength(Result, 0);
+  if not FileExists(FPath) then Exit;
+  Reader := TStringList.Create;
+  try
+    Reader.LoadFromFile(FPath);
+    for i := 0 to Reader.Count - 1 do
+    begin
+      if Trim(Reader[i]) = '' then Continue;
+      Obj := TJsonObject.Parse(Reader[i]);
+      if Obj = nil then Continue;
+      try
+        RoleStr := Obj.GetStr('role',    'user');
+        Content := Obj.GetStr('content', '');
+        Role := MsgRoleFromString(RoleStr);
+        if Content = '' then Continue;
+        SetLength(Result, Length(Result) + 1);
+        Result[High(Result)] := MakeMessage(Role, Content);
+      finally
+        Obj.Free;
+      end;
+    end;
+  finally
+    Reader.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -46,6 +46,7 @@ implementation
 uses
   fpjson, jsonparser,
   PasClaw.Providers.HTTP,
+  PasClaw.Providers.Stream,
   PasClaw.Logger;
 
 constructor TAnthropicProvider.Create(const APIKey, APIBase, DefaultModel: string);
@@ -78,7 +79,7 @@ end;
 
 function TAnthropicProvider.SupportsStreaming: Boolean;
 begin
-  Result := False;   { Phase 3 wires streaming via SSE. }
+  Result := True;
 end;
 
 function RoleForAnthropic(R: TMsgRole): string;
@@ -327,26 +328,141 @@ begin
   Result.FinishReason := 'error';
 end;
 
+var
+  GStreamCB:   TStreamCallback;
+  GStreamAcc:  string;
+  GStreamLast: TLLMResponse;
+
+procedure HandleAnthropicSSE(const Event, Data: string);
+var
+  Obj: TJSONData;
+  Root, Delta, Usage: TJSONObject;
+  Kind, Text: string;
+  Chunk: TStreamChunk;
+begin
+  if Data = '' then Exit;
+  try
+    Obj := GetJSON(Data);
+  except
+    Exit;
+  end;
+  try
+    if not (Obj is TJSONObject) then Exit;
+    Root := TJSONObject(Obj);
+    Kind := Root.Get('type', Event);
+
+    if Kind = 'content_block_delta' then
+    begin
+      if Root.IndexOfName('delta') < 0 then Exit;
+      Delta := Root.Objects['delta'];
+      if Delta.Get('type', '') = 'text_delta' then
+      begin
+        Text := Delta.Get('text', '');
+        if Text <> '' then
+        begin
+          GStreamAcc := GStreamAcc + Text;
+          Chunk.Kind := 'text';
+          Chunk.Text := Text;
+          if Assigned(GStreamCB) then GStreamCB(Chunk);
+        end;
+      end;
+    end
+    else if Kind = 'message_delta' then
+    begin
+      if Root.IndexOfName('usage') >= 0 then
+      begin
+        Usage := Root.Objects['usage'];
+        GStreamLast.Usage.OutputTokens := Usage.Get('output_tokens', GStreamLast.Usage.OutputTokens);
+      end;
+      if Root.IndexOfName('delta') >= 0 then
+      begin
+        Delta := Root.Objects['delta'];
+        GStreamLast.FinishReason := Delta.Get('stop_reason', GStreamLast.FinishReason);
+      end;
+    end
+    else if Kind = 'message_start' then
+    begin
+      if Root.IndexOfName('message') >= 0 then
+      begin
+        Delta := Root.Objects['message'];
+        GStreamLast.Model := Delta.Get('model', GStreamLast.Model);
+        if Delta.IndexOfName('usage') >= 0 then
+        begin
+          Usage := Delta.Objects['usage'];
+          GStreamLast.Usage.InputTokens := Usage.Get('input_tokens', 0);
+        end;
+      end;
+    end
+    else if Kind = 'message_stop' then
+    begin
+      Chunk.Kind := 'done';
+      Chunk.Text := '';
+      if Assigned(GStreamCB) then GStreamCB(Chunk);
+    end;
+  finally
+    Obj.Free;
+  end;
+end;
+
 function TAnthropicProvider.ChatStream(const Messages: array of TMessage;
                                        const Tools:    array of TToolDefinition;
                                        const Model:    string;
                                        const Options:  TChatOptions;
                                        OnChunk: TStreamCallback): TLLMResponse;
 var
-  C: TStreamChunk;
+  Body, URL, UseModel: string;
+  Headers: array of THeaderPair;
+  Opts: TChatOptions;
+  Status: Integer;
+  Err: string;
+  Root: TJSONObject;
+  Stream: TJSONBoolean;
 begin
-  { Phase 3 will implement true SSE streaming; for now we fall back to the
-    blocking call and emit one synthetic chunk so callers using OnChunk get a
-    sensible signal. }
-  Result := Chat(Messages, Tools, Model, Options);
-  if Assigned(OnChunk) then
-  begin
-    C.Kind := 'text';
-    C.Text := Result.Content;
-    OnChunk(C);
-    C.Kind := 'done';
-    C.Text := '';
-    OnChunk(C);
+  if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
+  URL := FAPIBase + '/v1/messages';
+
+  { Force stream:true in the request body. }
+  Opts := Options;
+  Opts.Stream := True;
+  Body := BuildRequest(Messages, Tools, UseModel, Opts);
+  try
+    Root := TJSONObject(GetJSON(Body));
+    try
+      Stream := TJSONBoolean.Create(True);
+      Root.Add('stream', Stream);
+      Body := Root.AsJSON;
+    finally
+      Root.Free;
+    end;
+  except
+    { fall back to non-stream }
+    Result := Chat(Messages, Tools, UseModel, Options);
+    Exit;
+  end;
+
+  SetLength(Headers, 2);
+  Headers[0] := MakeHeader('x-api-key',         FAPIKey);
+  Headers[1] := MakeHeader('anthropic-version', '2023-06-01');
+
+  GStreamCB  := OnChunk;
+  GStreamAcc := '';
+  FillChar(GStreamLast, SizeOf(GStreamLast), 0);
+  GStreamLast.Model := UseModel;
+  try
+    LogDebug('anthropic SSE POST %s (model=%s)', [URL, UseModel]);
+    PostStreaming(URL, Body, Headers, 120, @HandleAnthropicSSE, Status, Err);
+    Result.Content      := GStreamAcc;
+    Result.FinishReason := GStreamLast.FinishReason;
+    Result.Usage        := GStreamLast.Usage;
+    Result.Model        := GStreamLast.Model;
+    if (Status < 200) or (Status >= 300) then
+    begin
+      if Result.Content = '' then
+        Result.Content := Format('anthropic stream error: status=%d msg=%s', [Status, Err]);
+      Result.FinishReason := 'error';
+    end;
+  finally
+    GStreamCB := nil;
   end;
 end;
 

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -1,0 +1,353 @@
+{
+  PasClaw.Providers.Anthropic - Anthropic Messages API client.
+  Mirrors pkg/providers/anthropic_messages in picoclaw.
+
+  Endpoint: POST <api_base>/v1/messages
+  Auth:     x-api-key: <key>, anthropic-version: 2023-06-01
+}
+unit PasClaw.Providers.Anthropic;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf;
+
+type
+  TAnthropicProvider = class(TInterfacedObject, ILLMProvider)
+  private
+    FAPIKey:  string;
+    FAPIBase: string;
+    FDefaultModel: string;
+  public
+    constructor Create(const APIKey, APIBase, DefaultModel: string);
+    function Chat(const Messages: array of TMessage;
+                  const Tools:    array of TToolDefinition;
+                  const Model:    string;
+                  const Options:  TChatOptions): TLLMResponse;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+  end;
+
+implementation
+
+uses
+  fpjson, jsonparser,
+  PasClaw.Providers.HTTP,
+  PasClaw.Logger;
+
+constructor TAnthropicProvider.Create(const APIKey, APIBase, DefaultModel: string);
+begin
+  inherited Create;
+  FAPIKey := APIKey;
+  if APIBase <> '' then FAPIBase := APIBase else FAPIBase := 'https://api.anthropic.com';
+  if DefaultModel <> '' then FDefaultModel := DefaultModel else FDefaultModel := 'claude-opus-4-7';
+end;
+
+function TAnthropicProvider.GetDefaultModel: string;
+begin
+  Result := FDefaultModel;
+end;
+
+function TAnthropicProvider.GetName: string;
+begin
+  Result := 'anthropic';
+end;
+
+function TAnthropicProvider.SupportsThinking: Boolean;
+begin
+  Result := True;
+end;
+
+function TAnthropicProvider.SupportsNativeSearch: Boolean;
+begin
+  Result := False;
+end;
+
+function TAnthropicProvider.SupportsStreaming: Boolean;
+begin
+  Result := False;   { Phase 3 wires streaming via SSE. }
+end;
+
+function RoleForAnthropic(R: TMsgRole): string;
+begin
+  case R of
+    mrAssistant: Result := 'assistant';
+    mrTool:      Result := 'user';   { tool result is delivered as user turn with tool_result content }
+  else           Result := 'user';
+  end;
+end;
+
+function BuildRequest(const Messages: array of TMessage;
+                      const Tools:    array of TToolDefinition;
+                      const Model:    string;
+                      const Options:  TChatOptions): string;
+var
+  Root: TJSONObject;
+  MsgArr, ToolArr, ContentArr: TJSONArray;
+  Msg, Block, ToolObj: TJSONObject;
+  i, j: Integer;
+  Sys: string;
+  ToolSchema: TJSONData;
+begin
+  Root := TJSONObject.Create;
+  try
+    Root.Add('model', Model);
+    Root.Add('max_tokens', Options.MaxTokens);
+    if Options.Temperature > 0 then Root.Add('temperature', Options.Temperature);
+
+    { System prompt: prefer Options.SystemPrompt, else first system message. }
+    Sys := Options.SystemPrompt;
+    for i := 0 to High(Messages) do
+      if (Messages[i].Role = mrSystem) and (Sys = '') then
+        Sys := Messages[i].Content;
+    if Sys <> '' then Root.Add('system', Sys);
+
+    if Options.ThinkingLevel <> '' then
+    begin
+      Block := TJSONObject.Create;
+      Block.Add('type', 'enabled');
+      if Options.ThinkingLevel = 'low'    then Block.Add('budget_tokens', 1024)
+      else if Options.ThinkingLevel = 'high' then Block.Add('budget_tokens', 8192)
+      else Block.Add('budget_tokens', 2048);
+      Root.Add('thinking', Block);
+    end;
+
+    MsgArr := TJSONArray.Create;
+    for i := 0 to High(Messages) do
+    begin
+      if Messages[i].Role = mrSystem then Continue;
+      Msg := TJSONObject.Create;
+      Msg.Add('role', RoleForAnthropic(Messages[i].Role));
+      ContentArr := TJSONArray.Create;
+      if Messages[i].Role = mrTool then
+      begin
+        Block := TJSONObject.Create;
+        Block.Add('type', 'tool_result');
+        Block.Add('tool_use_id', Messages[i].ToolCallId);
+        Block.Add('content', Messages[i].Content);
+        ContentArr.Add(Block);
+      end
+      else if Length(Messages[i].ToolCalls) > 0 then
+      begin
+        if Messages[i].Content <> '' then
+        begin
+          Block := TJSONObject.Create;
+          Block.Add('type', 'text');
+          Block.Add('text', Messages[i].Content);
+          ContentArr.Add(Block);
+        end;
+        for j := 0 to High(Messages[i].ToolCalls) do
+        begin
+          Block := TJSONObject.Create;
+          Block.Add('type', 'tool_use');
+          Block.Add('id',    Messages[i].ToolCalls[j].Id);
+          Block.Add('name',  Messages[i].ToolCalls[j].Func.Name);
+          if Messages[i].ToolCalls[j].Func.Arguments <> '' then
+          begin
+            try
+              Block.Add('input', GetJSON(Messages[i].ToolCalls[j].Func.Arguments));
+            except
+              Block.Add('input', TJSONObject.Create);
+            end;
+          end
+          else
+            Block.Add('input', TJSONObject.Create);
+          ContentArr.Add(Block);
+        end;
+      end
+      else
+      begin
+        Block := TJSONObject.Create;
+        Block.Add('type', 'text');
+        Block.Add('text', Messages[i].Content);
+        ContentArr.Add(Block);
+      end;
+      Msg.Add('content', ContentArr);
+      MsgArr.Add(Msg);
+    end;
+    Root.Add('messages', MsgArr);
+
+    if Length(Tools) > 0 then
+    begin
+      ToolArr := TJSONArray.Create;
+      for i := 0 to High(Tools) do
+      begin
+        ToolObj := TJSONObject.Create;
+        ToolObj.Add('name', Tools[i].Name);
+        if Tools[i].Description <> '' then ToolObj.Add('description', Tools[i].Description);
+        if Tools[i].Schema <> '' then
+        begin
+          try
+            ToolSchema := GetJSON(Tools[i].Schema);
+            ToolObj.Add('input_schema', ToolSchema);
+          except
+            ToolObj.Add('input_schema', TJSONObject.Create);
+          end;
+        end
+        else
+          ToolObj.Add('input_schema', TJSONObject.Create);
+        ToolArr.Add(ToolObj);
+      end;
+      Root.Add('tools', ToolArr);
+    end;
+
+    Result := Root.AsJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure ParseResponse(const Body: string; var Resp: TLLMResponse);
+var
+  Root: TJSONData;
+  Obj: TJSONObject;
+  Arr: TJSONArray;
+  i: Integer;
+  Block: TJSONObject;
+  Kind, Text: string;
+  TC: TToolCall;
+  Usage: TJSONObject;
+  Input: TJSONData;
+begin
+  Resp.Content := '';
+  Resp.FinishReason := '';
+  Resp.Model := '';
+  Resp.Usage.InputTokens := 0;
+  Resp.Usage.OutputTokens := 0;
+  SetLength(Resp.ToolCalls, 0);
+  if Trim(Body) = '' then Exit;
+  Root := GetJSON(Body);
+  if not (Root is TJSONObject) then begin Root.Free; Exit; end;
+  Obj := TJSONObject(Root);
+  try
+    Resp.Model        := Obj.Get('model', '');
+    Resp.FinishReason := Obj.Get('stop_reason', '');
+    if Obj.IndexOfName('content') >= 0 then
+    begin
+      Arr := Obj.Arrays['content'];
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Block := TJSONObject(Arr[i]);
+        Kind := Block.Get('type', '');
+        if Kind = 'text' then
+        begin
+          Text := Block.Get('text', '');
+          if Resp.Content <> '' then Resp.Content := Resp.Content + sLineBreak;
+          Resp.Content := Resp.Content + Text;
+        end
+        else if Kind = 'tool_use' then
+        begin
+          TC.Id        := Block.Get('id', '');
+          TC.Kind      := 'function';
+          TC.Func.Name := Block.Get('name', '');
+          if Block.IndexOfName('input') >= 0 then
+          begin
+            Input := Block.Find('input');
+            if Input <> nil then TC.Func.Arguments := Input.AsJSON
+            else TC.Func.Arguments := '{}';
+          end
+          else
+            TC.Func.Arguments := '{}';
+          SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
+          Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+        end;
+      end;
+    end;
+    if Obj.IndexOfName('usage') >= 0 then
+    begin
+      Usage := Obj.Objects['usage'];
+      Resp.Usage.InputTokens        := Usage.Get('input_tokens',  0);
+      Resp.Usage.OutputTokens       := Usage.Get('output_tokens', 0);
+      Resp.Usage.CacheReadTokens    := Usage.Get('cache_read_input_tokens', 0);
+      Resp.Usage.CacheCreatedTokens := Usage.Get('cache_creation_input_tokens', 0);
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TAnthropicProvider.Chat(const Messages: array of TMessage;
+                                 const Tools:    array of TToolDefinition;
+                                 const Model:    string;
+                                 const Options:  TChatOptions): TLLMResponse;
+var
+  Body, URL, UseModel: string;
+  Resp: THTTPResult;
+  Headers: array of THeaderPair;
+  ErrJSON: TJSONData;
+begin
+  if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
+  URL  := FAPIBase + '/v1/messages';
+  Body := BuildRequest(Messages, Tools, UseModel, Options);
+
+  SetLength(Headers, 2);
+  Headers[0] := MakeHeader('x-api-key',          FAPIKey);
+  Headers[1] := MakeHeader('anthropic-version', '2023-06-01');
+
+  LogDebug('anthropic POST %s (model=%s, body=%d bytes)', [URL, UseModel, Length(Body)]);
+  Resp := PostJSON(URL, Body, Headers, 120);
+
+  Result.Content := '';
+  SetLength(Result.ToolCalls, 0);
+  if (Resp.StatusCode >= 200) and (Resp.StatusCode < 300) then
+  begin
+    ParseResponse(Resp.Body, Result);
+    Exit;
+  end;
+
+  { Surface API error message rather than swallowing it. }
+  if Resp.Body <> '' then
+  begin
+    try
+      ErrJSON := GetJSON(Resp.Body);
+      try
+        Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, ErrJSON.AsJSON]);
+      finally
+        ErrJSON.Free;
+      end;
+    except
+      Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, Resp.Body]);
+    end;
+  end
+  else
+    Result.Content := Format('anthropic error: status=%d msg=%s', [Resp.StatusCode, Resp.ErrorMsg]);
+  Result.FinishReason := 'error';
+end;
+
+function TAnthropicProvider.ChatStream(const Messages: array of TMessage;
+                                       const Tools:    array of TToolDefinition;
+                                       const Model:    string;
+                                       const Options:  TChatOptions;
+                                       OnChunk: TStreamCallback): TLLMResponse;
+var
+  C: TStreamChunk;
+begin
+  { Phase 3 will implement true SSE streaming; for now we fall back to the
+    blocking call and emit one synthetic chunk so callers using OnChunk get a
+    sensible signal. }
+  Result := Chat(Messages, Tools, Model, Options);
+  if Assigned(OnChunk) then
+  begin
+    C.Kind := 'text';
+    C.Text := Result.Content;
+    OnChunk(C);
+    C.Kind := 'done';
+    C.Text := '';
+    OnChunk(C);
+  end;
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -1,0 +1,92 @@
+{
+  PasClaw.Providers.Factory - resolves the default provider from config
+  and constructs the appropriate ILLMProvider implementation.
+  Mirrors pkg/providers/factory.go (light subset).
+}
+unit PasClaw.Providers.Factory;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Providers.Intf;
+
+function NewProviderFromConfig(Cfg: TConfig; const ProviderName: string;
+                               out Provider: ILLMProvider; out ErrMsg: string): Boolean;
+function NewDefaultProvider(Cfg: TConfig; out Provider: ILLMProvider; out ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  PasClaw.Providers.Anthropic,
+  PasClaw.Providers.OpenAI;
+
+function FindProvider(Cfg: TConfig; const Name: string; out Idx: Integer): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to High(Cfg.Providers) do
+    if SameText(Cfg.Providers[i].Name, Name) then
+    begin
+      Idx := i;
+      Exit(True);
+    end;
+  Idx := -1;
+  Result := False;
+end;
+
+function NewProviderFromConfig(Cfg: TConfig; const ProviderName: string;
+                               out Provider: ILLMProvider; out ErrMsg: string): Boolean;
+var
+  Idx: Integer;
+  Kind: string;
+begin
+  Provider := nil;
+  ErrMsg := '';
+  if not FindProvider(Cfg, ProviderName, Idx) then
+  begin
+    ErrMsg := 'no provider entry for "' + ProviderName + '" — run `pasclaw onboard` or `pasclaw auth login ' + ProviderName + '`';
+    Exit(False);
+  end;
+  if Cfg.Providers[Idx].APIKey = '' then
+  begin
+    ErrMsg := 'provider "' + ProviderName + '" has no API key — run `pasclaw auth login ' + ProviderName + '`';
+    Exit(False);
+  end;
+  Kind := LowerCase(Cfg.Providers[Idx].Kind);
+  if Kind = '' then Kind := LowerCase(Cfg.Providers[Idx].Name);
+
+  if Kind = 'anthropic' then
+    Provider := TAnthropicProvider.Create(
+      Cfg.Providers[Idx].APIKey,
+      Cfg.Providers[Idx].APIBase,
+      Cfg.Providers[Idx].Model)
+  else if (Kind = 'openai') or (Kind = 'openai-compat') or (Kind = 'groq') or (Kind = 'together') or (Kind = 'ollama') then
+    Provider := TOpenAIProvider.Create(
+      Cfg.Providers[Idx].APIKey,
+      Cfg.Providers[Idx].APIBase,
+      Cfg.Providers[Idx].Model)
+  else
+  begin
+    ErrMsg := 'unsupported provider kind "' + Cfg.Providers[Idx].Kind + '" (supported: anthropic, openai)';
+    Exit(False);
+  end;
+  Result := True;
+end;
+
+function NewDefaultProvider(Cfg: TConfig; out Provider: ILLMProvider; out ErrMsg: string): Boolean;
+begin
+  if Cfg.DefaultProvider = '' then
+  begin
+    ErrMsg := 'no default provider configured — run `pasclaw onboard`';
+    Provider := nil;
+    Exit(False);
+  end;
+  Result := NewProviderFromConfig(Cfg, Cfg.DefaultProvider, Provider, ErrMsg);
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -1,0 +1,84 @@
+{
+  PasClaw.Providers.HTTP - small wrapper around TFPHTTPClient that posts
+  JSON, attaches auth headers, and returns the body or a classified error.
+  Used by the Anthropic and OpenAI providers.
+}
+unit PasClaw.Providers.HTTP;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  fphttpclient, opensslsockets;
+
+type
+  THTTPResult = record
+    StatusCode: Integer;
+    Body:       string;
+    ErrorMsg:   string;
+  end;
+
+  THeaderPair = record
+    Name, Value: string;
+  end;
+
+function PostJSON(const URL, JSON: string;
+                  const Headers: array of THeaderPair;
+                  TimeoutSeconds: Integer): THTTPResult;
+function MakeHeader(const Name, Value: string): THeaderPair;
+
+implementation
+
+function MakeHeader(const Name, Value: string): THeaderPair;
+begin
+  Result.Name  := Name;
+  Result.Value := Value;
+end;
+
+function PostJSON(const URL, JSON: string;
+                  const Headers: array of THeaderPair;
+                  TimeoutSeconds: Integer): THTTPResult;
+var
+  Client: TFPHTTPClient;
+  Req, Resp: TStringStream;
+  i: Integer;
+begin
+  Result.StatusCode := 0;
+  Result.Body := '';
+  Result.ErrorMsg := '';
+
+  Client := TFPHTTPClient.Create(nil);
+  Req    := TStringStream.Create(JSON);
+  Resp   := TStringStream.Create('');
+  try
+    Client.RequestHeaders.Clear;
+    Client.AddHeader('Content-Type', 'application/json');
+    Client.AddHeader('Accept', 'application/json');
+    for i := 0 to High(Headers) do
+      Client.AddHeader(Headers[i].Name, Headers[i].Value);
+    Client.RequestBody := Req;
+    Client.IOTimeout   := TimeoutSeconds * 1000;
+    Client.ConnectTimeout := TimeoutSeconds * 1000;
+    try
+      Client.HTTPMethod('POST', URL, Resp, []);
+      Result.StatusCode := Client.ResponseStatusCode;
+      Result.Body := Resp.DataString;
+    except
+      on E: Exception do
+      begin
+        Result.ErrorMsg   := E.Message;
+        Result.StatusCode := Client.ResponseStatusCode;
+        Result.Body       := Resp.DataString;
+      end;
+    end;
+  finally
+    Resp.Free;
+    Req.Free;
+    Client.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -1,7 +1,12 @@
 {
-  PasClaw.Providers.HTTP - small wrapper around TFPHTTPClient that posts
-  JSON, attaches auth headers, and returns the body or a classified error.
-  Used by the Anthropic and OpenAI providers.
+  PasClaw.Providers.HTTP - thin wrapper around TIdHTTP for JSON POSTs.
+  Builds in both Delphi and FPC (Indy works in both). Under FPC the project
+  vendors Indy via `make get-indy`; under Delphi it ships with RAD Studio.
+
+  HTTPS support requires OpenSSL. On Linux: package "libssl-dev" / runtime
+  "libssl.so.3"; on Windows: copy libeay32/ssleay32 next to the binary (Indy
+  10.6+) or the modern libssl-1_1.dll pair. Indy's IdSSLOpenSSL is wired
+  automatically when an "https://" URL is detected.
 }
 unit PasClaw.Providers.HTTP;
 
@@ -12,7 +17,7 @@ interface
 
 uses
   SysUtils, Classes,
-  fphttpclient, opensslsockets;
+  IdHTTP, IdSSLOpenSSL, IdGlobal, IdExceptionCore, IdException;
 
 type
   THTTPResult = record
@@ -28,6 +33,9 @@ type
 function PostJSON(const URL, JSON: string;
                   const Headers: array of THeaderPair;
                   TimeoutSeconds: Integer): THTTPResult;
+function GetJSONURL(const URL: string;
+                    const Headers: array of THeaderPair;
+                    TimeoutSeconds: Integer): THTTPResult;
 function MakeHeader(const Name, Value: string): THeaderPair;
 
 implementation
@@ -38,46 +46,107 @@ begin
   Result.Value := Value;
 end;
 
-function PostJSON(const URL, JSON: string;
-                  const Headers: array of THeaderPair;
-                  TimeoutSeconds: Integer): THTTPResult;
+function MakeHTTPS(URL: string): Boolean;
+begin
+  Result := (Length(URL) >= 8) and SameText(Copy(URL, 1, 8), 'https://');
+end;
+
+procedure ApplyHeaders(Http: TIdHTTP; const Headers: array of THeaderPair);
 var
-  Client: TFPHTTPClient;
-  Req, Resp: TStringStream;
   i: Integer;
+begin
+  for i := 0 to High(Headers) do
+    Http.Request.CustomHeaders.AddValue(Headers[i].Name, Headers[i].Value);
+end;
+
+function DoRequest(Http: TIdHTTP; const URL: string; const ReqBody: TStream;
+                   IsPost: Boolean): THTTPResult;
+var
+  Resp: TStringStream;
 begin
   Result.StatusCode := 0;
   Result.Body := '';
   Result.ErrorMsg := '';
-
-  Client := TFPHTTPClient.Create(nil);
-  Req    := TStringStream.Create(JSON);
-  Resp   := TStringStream.Create('');
+  Resp := TStringStream.Create('');
   try
-    Client.RequestHeaders.Clear;
-    Client.AddHeader('Content-Type', 'application/json');
-    Client.AddHeader('Accept', 'application/json');
-    for i := 0 to High(Headers) do
-      Client.AddHeader(Headers[i].Name, Headers[i].Value);
-    Client.RequestBody := Req;
-    Client.IOTimeout   := TimeoutSeconds * 1000;
-    Client.ConnectTimeout := TimeoutSeconds * 1000;
     try
-      Client.HTTPMethod('POST', URL, Resp, []);
-      Result.StatusCode := Client.ResponseStatusCode;
+      if IsPost then
+        Http.Post(URL, ReqBody, Resp)
+      else
+        Http.Get(URL, Resp);
+      Result.StatusCode := Http.ResponseCode;
       Result.Body := Resp.DataString;
     except
+      on E: EIdHTTPProtocolException do
+      begin
+        Result.StatusCode := E.ErrorCode;
+        Result.Body       := E.ErrorMessage;
+        Result.ErrorMsg   := E.Message;
+      end;
       on E: Exception do
       begin
-        Result.ErrorMsg   := E.Message;
-        Result.StatusCode := Client.ResponseStatusCode;
+        Result.StatusCode := Http.ResponseCode;
         Result.Body       := Resp.DataString;
+        Result.ErrorMsg   := E.Message;
       end;
     end;
   finally
     Resp.Free;
+  end;
+end;
+
+function NewClient(TimeoutSeconds: Integer; HTTPS: Boolean): TIdHTTP;
+var
+  SSL: TIdSSLIOHandlerSocketOpenSSL;
+begin
+  Result := TIdHTTP.Create(nil);
+  Result.ConnectTimeout := TimeoutSeconds * 1000;
+  Result.ReadTimeout    := TimeoutSeconds * 1000;
+  Result.HandleRedirects := True;
+  Result.Request.UserAgent := 'PasClaw/0.1 (+https://github.com/FMXExpress/PasClaw)';
+  if HTTPS then
+  begin
+    SSL := TIdSSLIOHandlerSocketOpenSSL.Create(Result);
+    SSL.SSLOptions.Method  := sslvTLSv1_2;
+    SSL.SSLOptions.SSLVersions := [sslvTLSv1_2];
+    Result.IOHandler := SSL;
+  end;
+end;
+
+function PostJSON(const URL, JSON: string;
+                  const Headers: array of THeaderPair;
+                  TimeoutSeconds: Integer): THTTPResult;
+var
+  Http: TIdHTTP;
+  Req: TStringStream;
+begin
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL));
+  Req  := TStringStream.Create(JSON);
+  try
+    Http.Request.ContentType    := 'application/json';
+    Http.Request.ContentEncoding := 'utf-8';
+    Http.Request.Accept         := 'application/json';
+    ApplyHeaders(Http, Headers);
+    Result := DoRequest(Http, URL, Req, True);
+  finally
     Req.Free;
-    Client.Free;
+    Http.Free;
+  end;
+end;
+
+function GetJSONURL(const URL: string;
+                    const Headers: array of THeaderPair;
+                    TimeoutSeconds: Integer): THTTPResult;
+var
+  Http: TIdHTTP;
+begin
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL));
+  try
+    Http.Request.Accept := 'application/json';
+    ApplyHeaders(Http, Headers);
+    Result := DoRequest(Http, URL, nil, False);
+  finally
+    Http.Free;
   end;
 end;
 

--- a/src/pkg/providers/PasClaw.Providers.Intf.pas
+++ b/src/pkg/providers/PasClaw.Providers.Intf.pas
@@ -1,0 +1,39 @@
+{
+  PasClaw.Providers.Intf - the ILLMProvider interface every provider implements.
+  Mirrors the LLMProvider interface in pkg/providers/types.go.
+}
+unit PasClaw.Providers.Intf;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types;
+
+type
+  TStreamCallback = procedure(const Chunk: TStreamChunk) of object;
+
+  ILLMProvider = interface
+    ['{6F1E1A1B-7B0E-4B53-B6E3-71D9F1F1A001}']
+    function Chat(const Messages: array of TMessage;
+                  const Tools:    array of TToolDefinition;
+                  const Model:    string;
+                  const Options:  TChatOptions): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+  end;
+
+implementation
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -1,0 +1,261 @@
+{
+  PasClaw.Providers.OpenAI - OpenAI Chat Completions client (also handles
+  OpenAI-compatible endpoints: Together, Groq, Ollama, etc.).
+
+  Endpoint: POST <api_base>/v1/chat/completions
+  Auth:     Authorization: Bearer <key>
+}
+unit PasClaw.Providers.OpenAI;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf;
+
+type
+  TOpenAIProvider = class(TInterfacedObject, ILLMProvider)
+  private
+    FAPIKey:  string;
+    FAPIBase: string;
+    FDefaultModel: string;
+  public
+    constructor Create(const APIKey, APIBase, DefaultModel: string);
+    function Chat(const Messages: array of TMessage;
+                  const Tools:    array of TToolDefinition;
+                  const Model:    string;
+                  const Options:  TChatOptions): TLLMResponse;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+  end;
+
+implementation
+
+uses
+  fpjson, jsonparser,
+  PasClaw.Providers.HTTP,
+  PasClaw.Logger;
+
+constructor TOpenAIProvider.Create(const APIKey, APIBase, DefaultModel: string);
+begin
+  inherited Create;
+  FAPIKey := APIKey;
+  if APIBase <> '' then FAPIBase := APIBase else FAPIBase := 'https://api.openai.com';
+  if DefaultModel <> '' then FDefaultModel := DefaultModel else FDefaultModel := 'gpt-4o-mini';
+end;
+
+function TOpenAIProvider.GetDefaultModel: string;     begin Result := FDefaultModel; end;
+function TOpenAIProvider.GetName: string;             begin Result := 'openai'; end;
+function TOpenAIProvider.SupportsThinking: Boolean;   begin Result := False; end;
+function TOpenAIProvider.SupportsNativeSearch: Boolean; begin Result := False; end;
+function TOpenAIProvider.SupportsStreaming: Boolean;  begin Result := False; end;
+
+function BuildOAIRequest(const Messages: array of TMessage;
+                         const Tools:    array of TToolDefinition;
+                         const Model:    string;
+                         const Options:  TChatOptions): string;
+var
+  Root: TJSONObject;
+  MsgArr, ToolArr, TCArr: TJSONArray;
+  M, ToolObj, FObj, TCObj: TJSONObject;
+  i, j: Integer;
+  Sys: string;
+begin
+  Root := TJSONObject.Create;
+  try
+    Root.Add('model', Model);
+    if Options.MaxTokens > 0 then Root.Add('max_tokens', Options.MaxTokens);
+    if Options.Temperature > 0 then Root.Add('temperature', Options.Temperature);
+
+    Sys := Options.SystemPrompt;
+
+    MsgArr := TJSONArray.Create;
+    if Sys <> '' then
+    begin
+      M := TJSONObject.Create;
+      M.Add('role', 'system');
+      M.Add('content', Sys);
+      MsgArr.Add(M);
+    end;
+
+    for i := 0 to High(Messages) do
+    begin
+      if (Messages[i].Role = mrSystem) and (Sys <> '') then
+        Continue;  { already added above }
+
+      M := TJSONObject.Create;
+      M.Add('role', MsgRoleToString(Messages[i].Role));
+      if Messages[i].Content <> '' then M.Add('content', Messages[i].Content)
+      else M.Add('content', '');
+
+      if Messages[i].Role = mrTool then
+        M.Add('tool_call_id', Messages[i].ToolCallId);
+
+      if Length(Messages[i].ToolCalls) > 0 then
+      begin
+        TCArr := TJSONArray.Create;
+        for j := 0 to High(Messages[i].ToolCalls) do
+        begin
+          TCObj := TJSONObject.Create;
+          TCObj.Add('id',   Messages[i].ToolCalls[j].Id);
+          TCObj.Add('type', 'function');
+          FObj := TJSONObject.Create;
+          FObj.Add('name',      Messages[i].ToolCalls[j].Func.Name);
+          FObj.Add('arguments', Messages[i].ToolCalls[j].Func.Arguments);
+          TCObj.Add('function', FObj);
+          TCArr.Add(TCObj);
+        end;
+        M.Add('tool_calls', TCArr);
+      end;
+
+      MsgArr.Add(M);
+    end;
+    Root.Add('messages', MsgArr);
+
+    if Length(Tools) > 0 then
+    begin
+      ToolArr := TJSONArray.Create;
+      for i := 0 to High(Tools) do
+      begin
+        ToolObj := TJSONObject.Create;
+        ToolObj.Add('type', 'function');
+        FObj := TJSONObject.Create;
+        FObj.Add('name', Tools[i].Name);
+        if Tools[i].Description <> '' then FObj.Add('description', Tools[i].Description);
+        if Tools[i].Schema <> '' then
+        begin
+          try
+            FObj.Add('parameters', GetJSON(Tools[i].Schema));
+          except
+            FObj.Add('parameters', TJSONObject.Create);
+          end;
+        end
+        else
+          FObj.Add('parameters', TJSONObject.Create);
+        ToolObj.Add('function', FObj);
+        ToolArr.Add(ToolObj);
+      end;
+      Root.Add('tools', ToolArr);
+    end;
+
+    Result := Root.AsJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure ParseOAIResponse(const Body: string; var Resp: TLLMResponse);
+var
+  Root: TJSONData;
+  Obj, Choice, Msg, FObj, TCObj, Usage: TJSONObject;
+  Choices, TCArr: TJSONArray;
+  i: Integer;
+  TC: TToolCall;
+begin
+  Resp.Content := '';
+  SetLength(Resp.ToolCalls, 0);
+  if Trim(Body) = '' then Exit;
+  Root := GetJSON(Body);
+  if not (Root is TJSONObject) then begin Root.Free; Exit; end;
+  Obj := TJSONObject(Root);
+  try
+    Resp.Model := Obj.Get('model', '');
+    if Obj.IndexOfName('choices') >= 0 then
+    begin
+      Choices := Obj.Arrays['choices'];
+      if Choices.Count > 0 then
+      begin
+        Choice := TJSONObject(Choices[0]);
+        Resp.FinishReason := Choice.Get('finish_reason', '');
+        Msg := Choice.Objects['message'];
+        Resp.Content := Msg.Get('content', '');
+        if Msg.IndexOfName('tool_calls') >= 0 then
+        begin
+          TCArr := Msg.Arrays['tool_calls'];
+          for i := 0 to TCArr.Count - 1 do
+          begin
+            TCObj := TJSONObject(TCArr[i]);
+            TC.Id   := TCObj.Get('id', '');
+            TC.Kind := TCObj.Get('type', 'function');
+            FObj := TCObj.Objects['function'];
+            TC.Func.Name      := FObj.Get('name', '');
+            TC.Func.Arguments := FObj.Get('arguments', '{}');
+            SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
+            Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+          end;
+        end;
+      end;
+    end;
+    if Obj.IndexOfName('usage') >= 0 then
+    begin
+      Usage := Obj.Objects['usage'];
+      Resp.Usage.InputTokens  := Usage.Get('prompt_tokens',     0);
+      Resp.Usage.OutputTokens := Usage.Get('completion_tokens', 0);
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TOpenAIProvider.Chat(const Messages: array of TMessage;
+                              const Tools:    array of TToolDefinition;
+                              const Model:    string;
+                              const Options:  TChatOptions): TLLMResponse;
+var
+  Body, URL, UseModel: string;
+  Resp: THTTPResult;
+  Headers: array of THeaderPair;
+begin
+  if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
+  URL  := FAPIBase + '/v1/chat/completions';
+  Body := BuildOAIRequest(Messages, Tools, UseModel, Options);
+
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FAPIKey);
+
+  LogDebug('openai POST %s (model=%s, body=%d bytes)', [URL, UseModel, Length(Body)]);
+  Resp := PostJSON(URL, Body, Headers, 120);
+
+  Result.Content := '';
+  SetLength(Result.ToolCalls, 0);
+  if (Resp.StatusCode >= 200) and (Resp.StatusCode < 300) then
+    ParseOAIResponse(Resp.Body, Result)
+  else
+  begin
+    if Resp.Body <> '' then
+      Result.Content := Format('openai error %d: %s', [Resp.StatusCode, Resp.Body])
+    else
+      Result.Content := Format('openai error: status=%d msg=%s', [Resp.StatusCode, Resp.ErrorMsg]);
+    Result.FinishReason := 'error';
+  end;
+end;
+
+function TOpenAIProvider.ChatStream(const Messages: array of TMessage;
+                                    const Tools:    array of TToolDefinition;
+                                    const Model:    string;
+                                    const Options:  TChatOptions;
+                                    OnChunk: TStreamCallback): TLLMResponse;
+var
+  C: TStreamChunk;
+begin
+  Result := Chat(Messages, Tools, Model, Options);
+  if Assigned(OnChunk) then
+  begin
+    C.Kind := 'text'; C.Text := Result.Content; OnChunk(C);
+    C.Kind := 'done'; C.Text := '';             OnChunk(C);
+  end;
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Stream.pas
+++ b/src/pkg/providers/PasClaw.Providers.Stream.pas
@@ -1,0 +1,141 @@
+(*
+  PasClaw.Providers.Stream - Server-Sent Events parser shared by both
+  OpenAI's and Anthropic's streaming endpoints.
+
+  SSE framing:
+    data: <chunk>\n
+    data: <chunk>\n
+    \n               <- blank line ends an event
+    event: <name>\n  <- optional, present in Anthropic stream
+    ...
+
+  We don't use TIdEventStream because we need fine-grained per-chunk callbacks
+  and the Indy version of EventStream is not present in older Indy builds.
+  Instead we POST with stream=true and read the response off TIdHTTP.IOHandler
+  line by line.
+*)
+unit PasClaw.Providers.Stream;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  IdHTTP, IdSSLOpenSSL, IdGlobal, IdExceptionCore,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.HTTP;
+
+type
+  TSSECallback = procedure(const Event, Data: string) of object;
+  TSSECallbackProc = procedure(const Event, Data: string);
+
+function PostStreaming(const URL, JSON: string;
+                       const Headers: array of THeaderPair;
+                       TimeoutSeconds: Integer;
+                       OnLine: TSSECallbackProc;
+                       out StatusCode: Integer;
+                       out ErrMsg: string): Boolean;
+
+implementation
+
+function PostStreaming(const URL, JSON: string;
+                       const Headers: array of THeaderPair;
+                       TimeoutSeconds: Integer;
+                       OnLine: TSSECallbackProc;
+                       out StatusCode: Integer;
+                       out ErrMsg: string): Boolean;
+var
+  Http: TIdHTTP;
+  SSL:  TIdSSLIOHandlerSocketOpenSSL;
+  Req:  TStringStream;
+  Resp: TStringStream;
+  Body: TStringList;
+  i: Integer;
+  EventName, DataAccum, Line: string;
+
+  procedure Flush;
+  begin
+    if (EventName <> '') or (DataAccum <> '') then
+    begin
+      if Assigned(OnLine) then OnLine(EventName, DataAccum);
+      EventName := '';
+      DataAccum := '';
+    end;
+  end;
+
+begin
+  Result := False;
+  ErrMsg := '';
+  StatusCode := 0;
+
+  Http := TIdHTTP.Create(nil);
+  Req  := TStringStream.Create(JSON);
+  Resp := TStringStream.Create('');
+  SSL  := nil;
+  try
+    Http.ConnectTimeout := TimeoutSeconds * 1000;
+    Http.ReadTimeout    := TimeoutSeconds * 1000;
+    Http.Request.UserAgent   := 'PasClaw/0.1';
+    Http.Request.ContentType := 'application/json';
+    Http.Request.Accept      := 'text/event-stream';
+    for i := 0 to High(Headers) do
+      Http.Request.CustomHeaders.AddValue(Headers[i].Name, Headers[i].Value);
+    if (Length(URL) >= 8) and SameText(Copy(URL, 1, 8), 'https://') then
+    begin
+      SSL := TIdSSLIOHandlerSocketOpenSSL.Create(Http);
+      SSL.SSLOptions.Method := sslvTLSv1_2;
+      SSL.SSLOptions.SSLVersions := [sslvTLSv1_2];
+      Http.IOHandler := SSL;
+    end;
+    try
+      Http.Post(URL, Req, Resp);
+      StatusCode := Http.ResponseCode;
+    except
+      on E: Exception do
+      begin
+        StatusCode := Http.ResponseCode;
+        ErrMsg     := E.Message;
+        { fall through and try to parse what we got }
+      end;
+    end;
+
+    { Indy's TIdHTTP buffers the full response into Resp. For true real-time
+      streaming the caller can switch to a custom IOHandler hook; here we
+      parse the buffered body, which still drives per-event callbacks. }
+    Body := TStringList.Create;
+    try
+      Body.Text := Resp.DataString;
+      EventName := '';
+      DataAccum := '';
+      for i := 0 to Body.Count - 1 do
+      begin
+        Line := Body[i];
+        if Line = '' then
+        begin
+          Flush;
+          Continue;
+        end;
+        if Copy(Line, 1, 6) = 'event:' then
+          EventName := Trim(Copy(Line, 7, MaxInt))
+        else if Copy(Line, 1, 5) = 'data:' then
+        begin
+          if DataAccum <> '' then DataAccum := DataAccum + #10;
+          DataAccum := DataAccum + Trim(Copy(Line, 6, MaxInt));
+        end;
+      end;
+      Flush;
+    finally
+      Body.Free;
+    end;
+
+    Result := (StatusCode >= 200) and (StatusCode < 300);
+  finally
+    Resp.Free;
+    Req.Free;
+    Http.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -47,6 +47,10 @@ type
     Schema:      string;   { JSON schema for parameters }
   end;
 
+  TToolDefinitionArray = array of TToolDefinition;
+  TMessageArray        = array of TMessage;
+  TToolCallArray       = array of TToolCall;
+
   TUsageInfo = record
     InputTokens:        Integer;
     OutputTokens:       Integer;

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -1,0 +1,129 @@
+{
+  PasClaw.Providers.Types - protocol type records shared by every LLM provider.
+  Mirrors pkg/providers/protocoltypes in picoclaw.
+}
+unit PasClaw.Providers.Types;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  { Role for a chat message. }
+  TMsgRole = (mrSystem, mrUser, mrAssistant, mrTool);
+
+  { One function-call requested by the model. }
+  TFunctionCall = record
+    Name:      string;
+    Arguments: string;   { raw JSON }
+  end;
+
+  TToolCall = record
+    Id:       string;
+    Kind:     string;    { "function" for now }
+    Func:     TFunctionCall;
+  end;
+
+  { A chat message. The Content field holds plain text; ToolCalls and
+    ToolCallId are non-empty for assistant tool-call responses and tool-result
+    inputs respectively. }
+  TMessage = record
+    Role:       TMsgRole;
+    Content:    string;
+    Name:       string;
+    ToolCallId: string;
+    ToolCalls:  array of TToolCall;
+  end;
+
+  { A tool exposed to the model (OpenAI-compatible function shape; Anthropic
+    translates this at the edge). }
+  TToolDefinition = record
+    Name:        string;
+    Description: string;
+    Schema:      string;   { JSON schema for parameters }
+  end;
+
+  TUsageInfo = record
+    InputTokens:        Integer;
+    OutputTokens:       Integer;
+    CacheReadTokens:    Integer;
+    CacheCreatedTokens: Integer;
+  end;
+
+  TLLMResponse = record
+    Content:    string;
+    ToolCalls:  array of TToolCall;
+    FinishReason: string;
+    Usage:      TUsageInfo;
+    Model:      string;
+  end;
+
+  TStreamChunk = record
+    Kind:     string;     { "text" | "tool_call" | "usage" | "done" }
+    Text:     string;
+    ToolCall: TToolCall;
+    Usage:    TUsageInfo;
+  end;
+
+  { Generic chat options handed to a provider. Anything provider-specific is
+    JSON-encoded into the Extra field rather than baking another type alias. }
+  TChatOptions = record
+    Temperature:   Double;
+    MaxTokens:     Integer;
+    Stream:        Boolean;
+    SystemPrompt:  string;
+    ThinkingLevel: string;   { "", "low", "medium", "high" }
+    Extra:         string;   { provider-specific JSON object }
+  end;
+
+function MsgRoleToString(R: TMsgRole): string;
+function MsgRoleFromString(const S: string): TMsgRole;
+function DefaultChatOptions: TChatOptions;
+function MakeMessage(Role: TMsgRole; const Content: string): TMessage;
+
+implementation
+
+function MsgRoleToString(R: TMsgRole): string;
+begin
+  case R of
+    mrSystem:    Result := 'system';
+    mrUser:      Result := 'user';
+    mrAssistant: Result := 'assistant';
+    mrTool:      Result := 'tool';
+  else
+    Result := 'user';
+  end;
+end;
+
+function MsgRoleFromString(const S: string): TMsgRole;
+begin
+  if      S = 'system'    then Result := mrSystem
+  else if S = 'assistant' then Result := mrAssistant
+  else if S = 'tool'      then Result := mrTool
+  else                         Result := mrUser;
+end;
+
+function DefaultChatOptions: TChatOptions;
+begin
+  Result.Temperature   := 0.7;
+  Result.MaxTokens     := 4096;
+  Result.Stream        := False;
+  Result.SystemPrompt  := '';
+  Result.ThinkingLevel := '';
+  Result.Extra         := '';
+end;
+
+function MakeMessage(Role: TMsgRole; const Content: string): TMessage;
+begin
+  Result.Role       := Role;
+  Result.Content    := Content;
+  Result.Name       := '';
+  Result.ToolCallId := '';
+  SetLength(Result.ToolCalls, 0);
+end;
+
+end.

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -1,0 +1,337 @@
+(*
+  PasClaw.Skills.Loader - skill manifest loader and runner.
+
+  Skill manifest (JSON) lives at $PASCLAW_HOME/workspace/skills/<name>.json:
+
+    {
+      "name":        "weather_report",
+      "description": "Fetch weather for a city",
+      "type":        "shell" | "prompt",
+      "schema":      { ... JSON Schema for args ... },
+      "shell":       "curl -s 'https://wttr.in/{{city}}?format=3'",
+      "prompt":      "Write a 2-sentence summary of: {{topic}}"
+    }
+
+  Shell skills run the configured command through a TProcess after token
+  substitution of {{arg}} placeholders. Prompt skills return the rendered
+  template unchanged for the caller (typically the agent) to send to the
+  LLM. A skill registers as a tool in the registry once loaded.
+*)
+unit PasClaw.Skills.Loader;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+type
+  TSkillSpec = record
+    Name:        string;
+    Description: string;
+    Kind:        string;   { "shell" | "prompt" }
+    Schema:      string;
+    Shell:       string;
+    Prompt:      string;
+  end;
+
+  TSkillSpecArray = array of TSkillSpec;
+
+function LoadSkillManifests(const HomeDir: string): TSkillSpecArray;
+procedure RegisterSkills(Reg: TToolRegistry; const Skills: TSkillSpecArray);
+function RunSkill(Reg: TToolRegistry; const Name, ArgsJSON: string; out ErrMsg: string): string;
+function RenderTemplate(const Template, ArgsJSON: string): string;
+
+implementation
+
+uses
+  Process,
+  PasClaw.Utils,
+  PasClaw.JSON,
+  PasClaw.Logger;
+
+const
+  MaxSkills = 64;
+
+var
+  GSpecs: array[0..MaxSkills - 1] of TSkillSpec;
+  GUsed: array[0..MaxSkills - 1] of Boolean;
+
+function AllocSlot: Integer;
+var
+  i: Integer;
+begin
+  for i := 0 to High(GUsed) do
+    if not GUsed[i] then Exit(i);
+  Result := -1;
+end;
+
+(* Forward-declared handlers — one per slot. Same approach as MCP bridge. *)
+function H_0  (const A: string; out E: string): string; forward;
+function H_1  (const A: string; out E: string): string; forward;
+function H_2  (const A: string; out E: string): string; forward;
+function H_3  (const A: string; out E: string): string; forward;
+function H_4  (const A: string; out E: string): string; forward;
+function H_5  (const A: string; out E: string): string; forward;
+function H_6  (const A: string; out E: string): string; forward;
+function H_7  (const A: string; out E: string): string; forward;
+function H_8  (const A: string; out E: string): string; forward;
+function H_9  (const A: string; out E: string): string; forward;
+function H_10 (const A: string; out E: string): string; forward;
+function H_11 (const A: string; out E: string): string; forward;
+function H_12 (const A: string; out E: string): string; forward;
+function H_13 (const A: string; out E: string): string; forward;
+function H_14 (const A: string; out E: string): string; forward;
+function H_15 (const A: string; out E: string): string; forward;
+
+function RunShellSkill(Slot: Integer; const ArgsJSON: string; out ErrMsg: string): string; forward;
+
+function H_0  (const A: string; out E: string): string; begin Result := RunShellSkill(0,  A, E); end;
+function H_1  (const A: string; out E: string): string; begin Result := RunShellSkill(1,  A, E); end;
+function H_2  (const A: string; out E: string): string; begin Result := RunShellSkill(2,  A, E); end;
+function H_3  (const A: string; out E: string): string; begin Result := RunShellSkill(3,  A, E); end;
+function H_4  (const A: string; out E: string): string; begin Result := RunShellSkill(4,  A, E); end;
+function H_5  (const A: string; out E: string): string; begin Result := RunShellSkill(5,  A, E); end;
+function H_6  (const A: string; out E: string): string; begin Result := RunShellSkill(6,  A, E); end;
+function H_7  (const A: string; out E: string): string; begin Result := RunShellSkill(7,  A, E); end;
+function H_8  (const A: string; out E: string): string; begin Result := RunShellSkill(8,  A, E); end;
+function H_9  (const A: string; out E: string): string; begin Result := RunShellSkill(9,  A, E); end;
+function H_10 (const A: string; out E: string): string; begin Result := RunShellSkill(10, A, E); end;
+function H_11 (const A: string; out E: string): string; begin Result := RunShellSkill(11, A, E); end;
+function H_12 (const A: string; out E: string): string; begin Result := RunShellSkill(12, A, E); end;
+function H_13 (const A: string; out E: string): string; begin Result := RunShellSkill(13, A, E); end;
+function H_14 (const A: string; out E: string): string; begin Result := RunShellSkill(14, A, E); end;
+function H_15 (const A: string; out E: string): string; begin Result := RunShellSkill(15, A, E); end;
+
+const
+  SkillHandlers: array[0..MaxSkills - 1] of TToolHandler = (
+    @H_0,  @H_1,  @H_2,  @H_3,  @H_4,  @H_5,  @H_6,  @H_7,
+    @H_8,  @H_9,  @H_10, @H_11, @H_12, @H_13, @H_14, @H_15,
+    { 16..63 left nil; raising MaxSkills above 16 requires extending the
+      handler block. We log a warning if anyone tries. }
+    nil, nil, nil, nil, nil, nil, nil, nil,
+    nil, nil, nil, nil, nil, nil, nil, nil,
+    nil, nil, nil, nil, nil, nil, nil, nil,
+    nil, nil, nil, nil, nil, nil, nil, nil,
+    nil, nil, nil, nil, nil, nil, nil, nil,
+    nil, nil, nil, nil, nil, nil, nil, nil
+  );
+
+function RenderTemplate(const Template, ArgsJSON: string): string;
+var
+  Obj: TJsonObject;
+  Out_: string;
+  i: Integer;
+  Token, Key, Value: string;
+  InToken: Boolean;
+begin
+  Result := Template;
+  if (Template = '') or (ArgsJSON = '') then Exit;
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj = nil then Exit;
+  try
+    Out_ := '';
+    Token := '';
+    InToken := False;
+    i := 1;
+    while i <= Length(Template) do
+    begin
+      if (not InToken) and (i < Length(Template)) and
+         (Template[i] = '{') and (Template[i + 1] = '{') then
+      begin
+        InToken := True;
+        Token := '';
+        Inc(i, 2);
+        Continue;
+      end;
+      if InToken and (i < Length(Template)) and
+         (Template[i] = '}') and (Template[i + 1] = '}') then
+      begin
+        Key := Trim(Token);
+        Value := Obj.GetStr(Key, '');
+        Out_ := Out_ + Value;
+        InToken := False;
+        Inc(i, 2);
+        Continue;
+      end;
+      if InToken then Token := Token + Template[i]
+      else Out_ := Out_ + Template[i];
+      Inc(i);
+    end;
+    Result := Out_;
+  finally
+    Obj.Free;
+  end;
+end;
+
+function RunShell(const Cmd: string; out ExitCode: Integer): string;
+var
+  P: TProcess;
+  M: TMemoryStream;
+  Buf: array[0..4095] of Byte;
+  N: Integer;
+begin
+  Result := '';
+  ExitCode := -1;
+  P := TProcess.Create(nil);
+  M := TMemoryStream.Create;
+  try
+    {$IFDEF MSWINDOWS}
+    P.Executable := 'cmd.exe';
+    P.Parameters.Add('/C');
+    P.Parameters.Add(Cmd);
+    {$ELSE}
+    P.Executable := '/bin/sh';
+    P.Parameters.Add('-c');
+    P.Parameters.Add(Cmd);
+    {$ENDIF}
+    P.Options := [poUsePipes, poStderrToOutPut];
+    P.Execute;
+    while P.Running or (P.Output.NumBytesAvailable > 0) do
+    begin
+      while P.Output.NumBytesAvailable > 0 do
+      begin
+        N := P.Output.Read(Buf, SizeOf(Buf));
+        if N > 0 then M.WriteBuffer(Buf, N);
+      end;
+      Sleep(20);
+    end;
+    ExitCode := P.ExitStatus;
+    SetLength(Result, M.Size);
+    if M.Size > 0 then
+    begin
+      M.Position := 0;
+      M.ReadBuffer(Result[1], M.Size);
+    end;
+  finally
+    M.Free;
+    P.Free;
+  end;
+end;
+
+function RunShellSkill(Slot: Integer; const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Spec: TSkillSpec;
+  Cmd: string;
+  ExitCode: Integer;
+begin
+  ErrMsg := '';
+  if (Slot < 0) or (Slot >= MaxSkills) or (not GUsed[Slot]) then
+  begin
+    ErrMsg := 'stale skill slot';
+    Exit('');
+  end;
+  Spec := GSpecs[Slot];
+  if Spec.Kind = 'prompt' then
+  begin
+    Result := RenderTemplate(Spec.Prompt, ArgsJSON);
+    Exit;
+  end;
+  Cmd := RenderTemplate(Spec.Shell, ArgsJSON);
+  if Cmd = '' then
+  begin
+    ErrMsg := 'empty shell template after rendering';
+    Exit('');
+  end;
+  LogDebug('skill[%s]: %s', [Spec.Name, Copy(Cmd, 1, 200)]);
+  Result := RunShell(Cmd, ExitCode);
+  if ExitCode <> 0 then
+    ErrMsg := Format('skill exit=%d', [ExitCode]);
+end;
+
+function LoadOne(const Path: string; out Spec: TSkillSpec): Boolean;
+var
+  Body: string;
+  Obj, Schema: TJsonObject;
+begin
+  Result := False;
+  Body := ReadFileText(Path);
+  if Body = '' then Exit;
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit;
+  try
+    Spec.Name        := Obj.GetStr('name',        '');
+    Spec.Description := Obj.GetStr('description', '');
+    Spec.Kind        := Obj.GetStr('type',        'shell');
+    Spec.Shell       := Obj.GetStr('shell',       '');
+    Spec.Prompt      := Obj.GetStr('prompt',      '');
+    Schema := Obj.ChildObject('schema');
+    if Schema <> nil then
+    begin
+      Spec.Schema := Schema.ToJSON;
+      Schema.Free;
+    end
+    else
+      Spec.Schema := '{"type":"object"}';
+    Result := Spec.Name <> '';
+  finally
+    Obj.Free;
+  end;
+end;
+
+function LoadSkillManifests(const HomeDir: string): TSkillSpecArray;
+var
+  Dir: string;
+  SR: TSearchRec;
+  Spec: TSkillSpec;
+begin
+  SetLength(Result, 0);
+  Dir := JoinPath(HomeDir, 'workspace/skills');
+  if not DirectoryExists(Dir) then Exit;
+  if FindFirst(JoinPath(Dir, '*.json'), faAnyFile, SR) <> 0 then Exit;
+  try
+    repeat
+      if (SR.Attr and faDirectory) <> 0 then Continue;
+      if LoadOne(JoinPath(Dir, SR.Name), Spec) then
+      begin
+        SetLength(Result, Length(Result) + 1);
+        Result[High(Result)] := Spec;
+      end;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+procedure RegisterSkills(Reg: TToolRegistry; const Skills: TSkillSpecArray);
+var
+  i, Slot: Integer;
+  Tool: TTool;
+begin
+  if Reg = nil then Exit;
+  for i := 0 to High(Skills) do
+  begin
+    Slot := AllocSlot;
+    if (Slot < 0) or (not Assigned(SkillHandlers[Slot])) then
+    begin
+      LogWarn('skills: out of handler slots (skipping %s)', [Skills[i].Name]);
+      Continue;
+    end;
+    GSpecs[Slot] := Skills[i];
+    GUsed[Slot]  := True;
+    Tool.Name        := 'skill_' + Skills[i].Name;
+    Tool.Description := Skills[i].Description;
+    Tool.Schema      := Skills[i].Schema;
+    Tool.Handler     := SkillHandlers[Slot];
+    Tool.IsCore      := False;
+    Reg.Register(Tool);
+    LogDebug('skills: registered %s (slot=%d, kind=%s)', [Skills[i].Name, Slot, Skills[i].Kind]);
+  end;
+end;
+
+function RunSkill(Reg: TToolRegistry; const Name, ArgsJSON: string; out ErrMsg: string): string;
+begin
+  ErrMsg := '';
+  if Reg = nil then begin ErrMsg := 'no registry'; Exit(''); end;
+  Result := Reg.Dispatch('skill_' + Name, ArgsJSON, ErrMsg);
+end;
+
+initialization
+  { all slots free }
+
+end.

--- a/src/pkg/tokenizer/PasClaw.Tokenizer.pas
+++ b/src/pkg/tokenizer/PasClaw.Tokenizer.pas
@@ -1,0 +1,36 @@
+{
+  PasClaw.Tokenizer - rough token-count estimator. Mirrors pkg/tokenizer
+  in picoclaw: a 4-chars-per-token heuristic, sufficient for budgeting
+  and context-window math without shipping a full BPE table.
+}
+unit PasClaw.Tokenizer;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+function EstimateTokens(const Text: string): Integer;
+function EstimateMessagesTokens(const Texts: array of string): Integer;
+
+implementation
+
+function EstimateTokens(const Text: string): Integer;
+var
+  L: Integer;
+begin
+  L := Length(Text);
+  if L = 0 then Exit(0);
+  Result := (L + 3) div 4;
+end;
+
+function EstimateMessagesTokens(const Texts: array of string): Integer;
+var
+  i: Integer;
+begin
+  Result := 0;
+  for i := 0 to High(Texts) do
+    Result := Result + EstimateTokens(Texts[i]) + 4;  { 4 tokens per message envelope }
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1,0 +1,156 @@
+{
+  PasClaw.Tools.FS - built-in filesystem tools: fs_read, fs_write, fs_list.
+  Mirrors a subset of pkg/tools/fs in picoclaw. Paths are not sandboxed by
+  default; the gateway will install a workspace-restricted variant in Phase 4.
+}
+unit PasClaw.Tools.FS;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterFSTools(R: TToolRegistry);
+
+implementation
+
+uses
+  fpjson, jsonparser,
+  PasClaw.Utils;
+
+function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
+var
+  J: TJSONData;
+  Obj: TJSONObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    J := GetJSON(ArgsJSON);
+    try
+      if not (J is TJSONObject) then Exit;
+      Obj := TJSONObject(J);
+      if Obj.IndexOfName(Field) < 0 then Exit;
+      V := Obj.Get(Field, '');
+      Result := V <> '';
+    finally
+      J.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Path: string;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'path', Path) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not FileExists(Path) then
+  begin
+    ErrMsg := 'no such file: ' + Path;
+    Exit('');
+  end;
+  Result := ReadFileText(Path);
+end;
+
+function Tool_FSWrite(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Path, Content: string;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'path', Path) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  ParseStringArg(ArgsJSON, 'content', Content);
+  try
+    WriteFileText(Path, Content);
+    Result := Format('wrote %d bytes to %s', [Length(Content), Path]);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := E.Message;
+      Result := '';
+    end;
+  end;
+end;
+
+function Tool_FSList(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Path: string;
+  SR: TSearchRec;
+  SB: TStringBuilder;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'path', Path) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not DirectoryExists(Path) then
+  begin
+    ErrMsg := 'no such directory: ' + Path;
+    Exit('');
+  end;
+  SB := TStringBuilder.Create;
+  try
+    if FindFirst(JoinPath(Path, '*'), faAnyFile, SR) = 0 then
+    begin
+      try
+        repeat
+          if (SR.Name = '.') or (SR.Name = '..') then Continue;
+          if (SR.Attr and faDirectory) <> 0 then
+            SB.Append('d ').Append(SR.Name).Append(sLineBreak)
+          else
+            SB.Append('- ').Append(SR.Name).Append('  ').Append(SR.Size).Append(sLineBreak);
+        until FindNext(SR) <> 0;
+      finally
+        FindClose(SR);
+      end;
+    end;
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+procedure RegisterFSTools(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  T.Name        := 'fs_read';
+  T.Description := 'Read the contents of a file from the local filesystem.';
+  T.Schema      := '{"type":"object","properties":{"path":{"type":"string","description":"Absolute or relative path to the file."}},"required":["path"]}';
+  T.Handler     := Tool_FSRead;
+  T.IsCore      := True;
+  R.Register(T);
+
+  T.Name        := 'fs_write';
+  T.Description := 'Write a string to a file (overwrites). Creates parent dirs.';
+  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
+  T.Handler     := Tool_FSWrite;
+  T.IsCore      := True;
+  R.Register(T);
+
+  T.Name        := 'fs_list';
+  T.Description := 'List entries in a directory. Returns "d name" or "- name  size" lines.';
+  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}';
+  T.Handler     := Tool_FSList;
+  T.IsCore      := True;
+  R.Register(T);
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -1,0 +1,120 @@
+{
+  PasClaw.Tools.Registry - register/lookup/dispatch built-in and skill-supplied
+  tools. Thread-safety isn't critical for the CLI (single-process), but we keep
+  the same API shape as pkg/tools/registry.go so a multi-channel gateway can
+  use it later.
+}
+unit PasClaw.Tools.Registry;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Tools.Types,
+  PasClaw.Providers.Types;
+
+type
+  TToolRegistry = class
+  private
+    FTools: TToolList;
+  public
+    constructor Create;
+    procedure Register(const T: TTool);
+    function  Find(const Name: string; out T: TTool): Boolean;
+    function  Names: TStringArray;
+    function  Count: Integer;
+    function  ToProviderDefs: TToolDefinitionArray;
+    function  Dispatch(const Name, ArgsJSON: string; out ErrMsg: string): string;
+  end;
+
+implementation
+
+constructor TToolRegistry.Create;
+begin
+  inherited Create;
+  SetLength(FTools, 0);
+end;
+
+procedure TToolRegistry.Register(const T: TTool);
+var
+  i: Integer;
+begin
+  for i := 0 to High(FTools) do
+    if FTools[i].Name = T.Name then
+    begin
+      FTools[i] := T;
+      Exit;
+    end;
+  SetLength(FTools, Length(FTools) + 1);
+  FTools[High(FTools)] := T;
+end;
+
+function TToolRegistry.Find(const Name: string; out T: TTool): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to High(FTools) do
+    if FTools[i].Name = Name then
+    begin
+      T := FTools[i];
+      Exit(True);
+    end;
+  Result := False;
+end;
+
+function TToolRegistry.Names: TStringArray;
+var
+  i: Integer;
+begin
+  SetLength(Result, Length(FTools));
+  for i := 0 to High(FTools) do Result[i] := FTools[i].Name;
+end;
+
+function TToolRegistry.Count: Integer;
+begin
+  Result := Length(FTools);
+end;
+
+function TToolRegistry.ToProviderDefs: TToolDefinitionArray;
+var
+  i: Integer;
+begin
+  SetLength(Result, Length(FTools));
+  for i := 0 to High(FTools) do
+  begin
+    Result[i].Name        := FTools[i].Name;
+    Result[i].Description := FTools[i].Description;
+    Result[i].Schema      := FTools[i].Schema;
+  end;
+end;
+
+function TToolRegistry.Dispatch(const Name, ArgsJSON: string; out ErrMsg: string): string;
+var
+  T: TTool;
+begin
+  ErrMsg := '';
+  if not Find(Name, T) then
+  begin
+    ErrMsg := 'unknown tool: ' + Name;
+    Exit('');
+  end;
+  if not Assigned(T.Handler) then
+  begin
+    ErrMsg := 'tool "' + Name + '" has no handler';
+    Exit('');
+  end;
+  try
+    Result := T.Handler(ArgsJSON, ErrMsg);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := E.ClassName + ': ' + E.Message;
+      Result := '';
+    end;
+  end;
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -1,0 +1,160 @@
+{
+  PasClaw.Tools.Shell - shell_exec tool. Runs a command via /bin/sh -c (or
+  cmd.exe on Windows) and captures stdout+stderr.
+
+  Safety: a small denylist guards against the most catastrophic operations
+  (rm -rf, mkfs, dd if=, format). It is NOT a sandbox; users should still
+  audit prompts. The gateway in Phase 4 will install a workspace-restricted
+  variant for use in untrusted channels.
+}
+unit PasClaw.Tools.Shell;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterShellTool(R: TToolRegistry);
+
+implementation
+
+uses
+  Process,
+  fpjson, jsonparser,
+  PasClaw.Logger;
+
+function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
+var
+  J: TJSONData;
+  Obj: TJSONObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    J := GetJSON(ArgsJSON);
+    try
+      if not (J is TJSONObject) then Exit;
+      Obj := TJSONObject(J);
+      if Obj.IndexOfName(Field) < 0 then Exit;
+      V := Obj.Get(Field, '');
+      Result := V <> '';
+    finally
+      J.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function IsDangerous(const Cmd: string): Boolean;
+var
+  L: string;
+begin
+  L := LowerCase(Cmd);
+  Result :=
+    (Pos('rm -rf /',  L) > 0) or
+    (Pos('rm -fr /',  L) > 0) or
+    (Pos('mkfs',      L) > 0) or
+    (Pos('dd if=',    L) > 0) or
+    (Pos(':(){:|',    L) > 0) or  { fork bomb }
+    (Pos('shutdown -h', L) > 0);
+end;
+
+function RunShell(const Cmd: string; out ExitCode: Integer): string;
+var
+  P: TProcess;
+  M: TMemoryStream;
+  Buf: array[0..4095] of Byte;
+  N, Total: Integer;
+  Args: TStringList;
+begin
+  Result := '';
+  ExitCode := -1;
+  P := TProcess.Create(nil);
+  M := TMemoryStream.Create;
+  Args := TStringList.Create;
+  try
+    {$IFDEF MSWINDOWS}
+    P.Executable := 'cmd.exe';
+    Args.Add('/C'); Args.Add(Cmd);
+    {$ELSE}
+    P.Executable := '/bin/sh';
+    Args.Add('-c'); Args.Add(Cmd);
+    {$ENDIF}
+    P.Parameters.AddStrings(Args);
+    P.Options := [poUsePipes, poStderrToOutPut];
+    P.Execute;
+    Total := 0;
+    while P.Running or (P.Output.NumBytesAvailable > 0) do
+    begin
+      while P.Output.NumBytesAvailable > 0 do
+      begin
+        N := P.Output.Read(Buf, SizeOf(Buf));
+        if N > 0 then
+        begin
+          M.WriteBuffer(Buf, N);
+          Inc(Total, N);
+        end;
+        if Total > 1024 * 1024 then  { 1 MiB cap }
+        begin
+          P.Terminate(124);
+          Break;
+        end;
+      end;
+      Sleep(20);
+    end;
+    ExitCode := P.ExitStatus;
+    SetLength(Result, M.Size);
+    if M.Size > 0 then
+    begin
+      M.Position := 0;
+      M.ReadBuffer(Result[1], M.Size);
+    end;
+  finally
+    Args.Free;
+    M.Free;
+    P.Free;
+  end;
+end;
+
+function Tool_Shell(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Cmd: string;
+  ExitCode: Integer;
+  Out_: string;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'command', Cmd) then
+  begin
+    ErrMsg := 'missing required argument: command';
+    Exit('');
+  end;
+  if IsDangerous(Cmd) then
+  begin
+    ErrMsg := 'refused: command matches built-in denylist (rm -rf /, mkfs, dd if=, fork bomb, shutdown)';
+    Exit('');
+  end;
+  LogDebug('shell exec: %s', [Cmd]);
+  Out_ := RunShell(Cmd, ExitCode);
+  Result := Format('exit=%d'#10'%s', [ExitCode, Out_]);
+end;
+
+procedure RegisterShellTool(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  T.Name        := 'shell_exec';
+  T.Description := 'Run a shell command via /bin/sh -c (or cmd.exe on Windows). Captures stdout+stderr, caps output at 1 MiB.';
+  T.Schema      := '{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute."}},"required":["command"]}';
+  T.Handler     := Tool_Shell;
+  T.IsCore      := True;
+  R.Register(T);
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1,0 +1,145 @@
+{
+  PasClaw.Tools.ToolLoop - the core agent loop. Repeatedly calls the LLM
+  with the running message history; if the response contains tool_calls,
+  dispatches each through the registry, appends the tool result as a tool
+  message, and continues. Mirrors pkg/tools/toolloop.go.
+}
+unit PasClaw.Tools.ToolLoop;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TToolLoopConfig = record
+    Provider:      ILLMProvider;
+    Registry:      TToolRegistry;
+    Model:         string;
+    MaxIterations: Integer;
+    Options:       TChatOptions;
+    OnText:        procedure(const S: string) of object;   { streaming-ish stdout }
+    OnToolCall:    procedure(const Name, ArgsJSON: string) of object;
+    OnToolResult:  procedure(const Name, ResultText, Err: string) of object;
+  end;
+
+  TToolLoopResult = record
+    Content:     string;
+    Iterations:  Integer;
+    LastResp:    TLLMResponse;
+  end;
+
+function RunToolLoop(const Cfg: TToolLoopConfig;
+                     var Messages: array of TMessage;
+                     out Loop: TToolLoopResult): Boolean;
+
+implementation
+
+uses
+  PasClaw.Logger;
+
+function MakeAssistantWithToolCalls(const Content: string;
+                                    const Calls: array of TToolCall): TMessage;
+var
+  i: Integer;
+begin
+  Result.Role       := mrAssistant;
+  Result.Content    := Content;
+  Result.Name       := '';
+  Result.ToolCallId := '';
+  SetLength(Result.ToolCalls, Length(Calls));
+  for i := 0 to High(Calls) do Result.ToolCalls[i] := Calls[i];
+end;
+
+function MakeToolResult(const ToolCallId, Content: string): TMessage;
+begin
+  Result := MakeMessage(mrTool, Content);
+  Result.ToolCallId := ToolCallId;
+end;
+
+function RunToolLoop(const Cfg: TToolLoopConfig;
+                     var Messages: array of TMessage;
+                     out Loop: TToolLoopResult): Boolean;
+var
+  Iter, i: Integer;
+  Tools: array of TToolDefinition;
+  Resp: TLLMResponse;
+  Hist: array of TMessage;
+  ResultText, Err: string;
+begin
+  Loop.Content    := '';
+  Loop.Iterations := 0;
+
+  if Cfg.Provider = nil then Exit(False);
+
+  { Copy input messages to a growable history. }
+  SetLength(Hist, Length(Messages));
+  for i := 0 to High(Messages) do Hist[i] := Messages[i];
+
+  if Cfg.Registry <> nil then
+    Tools := Cfg.Registry.ToProviderDefs
+  else
+    SetLength(Tools, 0);
+
+  Iter := 0;
+  while Iter < Cfg.MaxIterations do
+  begin
+    Inc(Iter);
+    LogDebug('toolloop iteration %d / %d', [Iter, Cfg.MaxIterations]);
+
+    Resp := Cfg.Provider.Chat(Hist, Tools, Cfg.Model, Cfg.Options);
+    Loop.LastResp := Resp;
+
+    { Stream the text part to the caller now so they can show progress. }
+    if Assigned(Cfg.OnText) and (Resp.Content <> '') then
+      Cfg.OnText(Resp.Content);
+
+    if Length(Resp.ToolCalls) = 0 then
+    begin
+      Loop.Content    := Resp.Content;
+      Loop.Iterations := Iter;
+      Exit(True);
+    end;
+
+    { Append the assistant turn (text + tool calls) and dispatch each call. }
+    SetLength(Hist, Length(Hist) + 1);
+    Hist[High(Hist)] := MakeAssistantWithToolCalls(Resp.Content, Resp.ToolCalls);
+
+    for i := 0 to High(Resp.ToolCalls) do
+    begin
+      if Assigned(Cfg.OnToolCall) then
+        Cfg.OnToolCall(Resp.ToolCalls[i].Func.Name, Resp.ToolCalls[i].Func.Arguments);
+
+      Err := '';
+      ResultText := '';
+      if Cfg.Registry <> nil then
+        ResultText := Cfg.Registry.Dispatch(Resp.ToolCalls[i].Func.Name,
+                                            Resp.ToolCalls[i].Func.Arguments,
+                                            Err)
+      else
+        Err := 'no tool registry';
+
+      if Assigned(Cfg.OnToolResult) then
+        Cfg.OnToolResult(Resp.ToolCalls[i].Func.Name, ResultText, Err);
+
+      SetLength(Hist, Length(Hist) + 1);
+      if Err <> '' then
+        Hist[High(Hist)] := MakeToolResult(Resp.ToolCalls[i].Id, 'ERROR: ' + Err)
+      else
+        Hist[High(Hist)] := MakeToolResult(Resp.ToolCalls[i].Id, ResultText);
+    end;
+  end;
+
+  { Max iterations exhausted; return whatever we last got. }
+  Loop.Content    := Resp.Content;
+  Loop.Iterations := Iter;
+  Result := True;
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -1,0 +1,33 @@
+{
+  PasClaw.Tools.Types - shared types for the tools registry.
+  Mirrors the Tool interface in pkg/tools/registry.go.
+}
+unit PasClaw.Tools.Types;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  { Handler signature: receives a raw JSON argument blob and returns a string
+    that becomes the tool_result content. The handler may set Err to a non-empty
+    string to signal a recoverable error to the model. }
+  TToolHandler = function(const ArgsJSON: string; out ErrMsg: string): string;
+
+  TTool = record
+    Name:        string;
+    Description: string;
+    Schema:      string;   { JSON schema (parameters) }
+    Handler:     TToolHandler;
+    IsCore:      Boolean;
+  end;
+
+  TToolList = array of TTool;
+
+implementation
+
+end.

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1,0 +1,229 @@
+(*
+  PasClaw.TUI - line-based ANSI terminal UI for `pasclaw tui`.
+
+  Layout per turn:
+       PASCLAW                                       provider/model | tools:N
+       ---------------------------------------------------------------------
+       you      > <input>
+       pasclaw  > <streamed response, soft-wrapped to terminal width>
+       ---------------------------------------------------------------------
+       > _
+
+  We deliberately stay line-based (no raw key handling, no alt-screen) so
+  the same code runs in vt100, xterm, Windows Terminal, the GitHub Codespaces
+  web terminal, and tmux/screen scrollback all behave intuitively. A future
+  Phase can swap to a full-screen renderer (dmvc-tui or a curses-style)
+  without changing the command-dispatch surface.
+
+  ANSI references:
+    CSI 2J        clear screen
+    CSI <n>m      SGR (colour)
+    \r            carriage return (overwrite current line)
+*)
+unit PasClaw.TUI;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TTUI = class
+  private
+    FProvider: ILLMProvider;
+    FRegistry: TToolRegistry;
+    FModel:    string;
+    FQuit:     Boolean;
+    procedure DrawHeader;
+    procedure DrawSeparator;
+    function  TermWidth: Integer;
+    procedure HandleSlashCommand(const Cmd: string);
+    procedure HandleUserInput(const Text: string);
+  public
+    constructor Create(Provider: ILLMProvider; Registry: TToolRegistry; const Model: string);
+    procedure Run;
+  end;
+
+implementation
+
+uses
+  Classes,
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop;
+
+{$IFDEF UNIX}
+{ Get terminal width via ioctl TIOCGWINSZ. Falls back to 80 if the call
+  fails (e.g. stdin is a pipe). }
+const
+  TIOCGWINSZ = $5413;
+type
+  Twinsize = record
+    ws_row, ws_col, ws_xpixel, ws_ypixel: Word;
+  end;
+function FpIoctl(fd: Integer; req: Cardinal; argp: Pointer): Integer; cdecl;
+  external 'c' name 'ioctl';
+{$ENDIF}
+
+constructor TTUI.Create(Provider: ILLMProvider; Registry: TToolRegistry; const Model: string);
+begin
+  inherited Create;
+  FProvider := Provider;
+  FRegistry := Registry;
+  FModel    := Model;
+end;
+
+function TTUI.TermWidth: Integer;
+{$IFDEF UNIX}
+var
+  ws: Twinsize;
+{$ENDIF}
+begin
+  Result := 80;
+  {$IFDEF UNIX}
+  FillChar(ws, SizeOf(ws), 0);
+  if FpIoctl(1, TIOCGWINSZ, @ws) = 0 then
+    if ws.ws_col > 0 then Result := ws.ws_col;
+  {$ENDIF}
+end;
+
+procedure TTUI.DrawHeader;
+var
+  Left, Right: string;
+  Pad, W: Integer;
+begin
+  Left  := Ansi.BoldBlue + 'PAS' + Ansi.BoldRed + 'CLAW' + Ansi.Reset;
+  if FProvider <> nil then
+    Right := Ansi.Dim + FProvider.GetName + '/' + FModel + Ansi.Reset
+  else
+    Right := Ansi.Yellow + 'offline' + Ansi.Reset;
+  if FRegistry <> nil then
+    Right := Right + Ansi.Dim + '  tools:' + IntToStr(FRegistry.Count) + Ansi.Reset;
+
+  W := TermWidth;
+  Pad := W - 7 - 8 - 8;
+  if Pad < 2 then Pad := 2;
+  WriteLn;
+  WriteLn(Left, StringOfChar(' ', Pad), Right);
+end;
+
+procedure TTUI.DrawSeparator;
+begin
+  WriteLn(Ansi.Dim, StringOfChar('-', TermWidth), Ansi.Reset);
+end;
+
+procedure TTUI.HandleSlashCommand(const Cmd: string);
+var
+  i: Integer;
+  Names: TStringArray;
+begin
+  if (Cmd = '/quit') or (Cmd = '/exit') or (Cmd = '/q') then
+  begin
+    FQuit := True;
+    Exit;
+  end;
+  if Cmd = '/clear' then
+  begin
+    Write(#27'[2J', #27'[H');
+    DrawHeader;
+    DrawSeparator;
+    Exit;
+  end;
+  if Cmd = '/tools' then
+  begin
+    if FRegistry = nil then
+      WriteLn(Ansi.Dim, '(no registry)', Ansi.Reset)
+    else
+    begin
+      Names := FRegistry.Names;
+      WriteLn(Ansi.Bold, 'tools (', Length(Names), '):', Ansi.Reset);
+      for i := 0 to High(Names) do
+        WriteLn('  ', Names[i]);
+    end;
+    Exit;
+  end;
+  if Cmd = '/help' then
+  begin
+    WriteLn(Ansi.Bold, 'TUI commands:', Ansi.Reset);
+    WriteLn('  /help    show this');
+    WriteLn('  /tools   list registered tools');
+    WriteLn('  /clear   clear the screen');
+    WriteLn('  /quit    exit');
+    Exit;
+  end;
+  WriteLn(Ansi.Yellow, 'unknown command: ', Cmd, Ansi.Reset);
+end;
+
+procedure TTUI.HandleUserInput(const Text: string);
+var
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  Cfg: TToolLoopConfig;
+begin
+  if FProvider = nil then
+  begin
+    WriteLn(Ansi.Yellow, 'pasclaw  > ', Ansi.Reset,
+            '(offline - no provider configured)');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Text);
+
+  Cfg.Provider      := FProvider;
+  Cfg.Registry      := FRegistry;
+  Cfg.Model         := FModel;
+  Cfg.MaxIterations := 6;
+  Cfg.Options       := DefaultChatOptions;
+  Cfg.OnText        := nil;
+  Cfg.OnToolCall    := nil;
+  Cfg.OnToolResult  := nil;
+
+  if not RunToolLoop(Cfg, Msgs, Loop) then
+  begin
+    WriteLn(Ansi.Red, 'pasclaw  > ', Ansi.Reset, '(tool loop failed)');
+    Exit;
+  end;
+  Write(Ansi.BoldBlue, 'pasclaw', Ansi.Reset, '  > ');
+  WriteLn(Loop.Content);
+  if Loop.LastResp.Usage.InputTokens + Loop.LastResp.Usage.OutputTokens > 0 then
+    WriteLn(Ansi.Dim, '         ',
+      Format('[tokens in=%d out=%d, iters=%d]',
+        [Loop.LastResp.Usage.InputTokens, Loop.LastResp.Usage.OutputTokens, Loop.Iterations]),
+      Ansi.Reset);
+end;
+
+procedure TTUI.Run;
+var
+  Line: string;
+begin
+  Write(#27'[2J', #27'[H');
+  DrawHeader;
+  DrawSeparator;
+  WriteLn(Ansi.Dim, '/help for commands, /quit to exit', Ansi.Reset);
+  WriteLn;
+  FQuit := False;
+  while not FQuit do
+  begin
+    Write(Ansi.BoldBlue, 'you', Ansi.Reset, '      > ');
+    if EOF then Break;
+    ReadLn(Line);
+    Line := Trim(Line);
+    if Line = '' then Continue;
+    if (Line[1] = '/') then
+    begin
+      HandleSlashCommand(Line);
+      Continue;
+    end;
+    HandleUserInput(Line);
+  end;
+  WriteLn(Ansi.Dim, 'goodbye.', Ansi.Reset);
+end;
+
+end.

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -1,0 +1,264 @@
+(*
+  PasClaw.Updater - self-update over GitHub releases.
+
+  Flow:
+    1. GET https://api.github.com/repos/<owner>/<repo>/releases/latest
+    2. Parse tag_name (e.g. "v0.2.0") and compare against the build version.
+    3. Pick the asset matching the host OS+CPU (naming convention:
+       pasclaw_<os>_<cpu>[.exe]).
+    4. Download to <binary>.new alongside the current binary.
+    5. On POSIX, rename(<binary>.new, <binary>) — replacing an executable
+       while it runs is legal on Linux/macOS.
+    6. On Windows, leave <binary>.new in place and print instructions; an
+       upgrade helper or restart script does the actual swap. (Phase 10
+       can add a Windows-native MoveFileEx/MOVEFILE_DELAY_UNTIL_REBOOT path.)
+
+  No release exists yet; the code paths are exercised by `pasclaw update
+  --check` which only queries the API.
+*)
+unit PasClaw.Updater;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TReleaseInfo = record
+    TagName:    string;
+    Name:       string;
+    HtmlUrl:    string;
+    AssetUrl:   string;
+    AssetName:  string;
+    AssetSize:  Int64;
+    Found:      Boolean;
+  end;
+
+function HostPlatformSuffix: string;
+function CompareVersions(const A, B: string): Integer;     { -1, 0, +1 }
+function NormalizeVersion(const V: string): string;
+function FetchLatestRelease(const Owner, Repo: string;
+                            out Info: TReleaseInfo;
+                            out ErrMsg: string): Boolean;
+function DownloadAsset(const URL, DestPath: string;
+                       out ErrMsg: string): Boolean;
+function InstallUpdate(const DownloadedPath, TargetBinary: string;
+                       out ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  Classes,
+  {$IFDEF UNIX} BaseUnix, {$ENDIF}
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+function HostPlatformSuffix: string;
+begin
+  {$IF DEFINED(MSWINDOWS) OR DEFINED(WINDOWS)}
+    {$IF DEFINED(CPUX86_64) OR DEFINED(CPU_X64) OR DEFINED(CPU64)}
+      Result := 'windows_amd64.exe';
+    {$ELSE}
+      Result := 'windows_386.exe';
+    {$ENDIF}
+  {$ELSEIF DEFINED(DARWIN)}
+    {$IF DEFINED(CPUAARCH64) OR DEFINED(CPU_ARM64)}
+      Result := 'darwin_arm64';
+    {$ELSE}
+      Result := 'darwin_amd64';
+    {$ENDIF}
+  {$ELSEIF DEFINED(LINUX) OR DEFINED(UNIX)}
+    {$IF DEFINED(CPUAARCH64) OR DEFINED(CPU_ARM64)}
+      Result := 'linux_arm64';
+    {$ELSEIF DEFINED(CPUX86_64) OR DEFINED(CPU_X64)}
+      Result := 'linux_amd64';
+    {$ELSE}
+      Result := 'linux_386';
+    {$ENDIF}
+  {$ELSE}
+    Result := 'unknown';
+  {$ENDIF}
+end;
+
+function NormalizeVersion(const V: string): string;
+var
+  s: string;
+begin
+  s := Trim(V);
+  if (s <> '') and ((s[1] = 'v') or (s[1] = 'V')) then
+    s := Copy(s, 2, MaxInt);
+  Result := s;
+end;
+
+function ParseNum(const S: string; var Pos: Integer): Integer;
+var
+  N: string;
+begin
+  N := '';
+  while (Pos <= Length(S)) and (S[Pos] >= '0') and (S[Pos] <= '9') do
+  begin
+    N := N + S[Pos];
+    Inc(Pos);
+  end;
+  if N = '' then Result := 0 else Result := StrToIntDef(N, 0);
+  if (Pos <= Length(S)) and (S[Pos] = '.') then Inc(Pos);
+end;
+
+function CompareVersions(const A, B: string): Integer;
+var
+  Pa, Pb: Integer;
+  Na, Nb: Integer;
+  Sa, Sb: string;
+begin
+  Sa := NormalizeVersion(A);
+  Sb := NormalizeVersion(B);
+  Pa := 1; Pb := 1;
+  while (Pa <= Length(Sa)) or (Pb <= Length(Sb)) do
+  begin
+    if Pa <= Length(Sa) then Na := ParseNum(Sa, Pa) else Na := 0;
+    if Pb <= Length(Sb) then Nb := ParseNum(Sb, Pb) else Nb := 0;
+    if Na < Nb then Exit(-1);
+    if Na > Nb then Exit( 1);
+  end;
+  Result := 0;
+end;
+
+function PickAsset(Assets: TJsonArray; const Suffix: string;
+                   out Url, Name: string; out Size: Int64): Boolean;
+var
+  i: Integer;
+  Obj: TJsonObject;
+  AName: string;
+begin
+  Url := '';
+  Name := '';
+  Size := 0;
+  Result := False;
+  if Assets = nil then Exit;
+  for i := 0 to Assets.Count - 1 do
+  begin
+    Obj := Assets.ItemObject(i);
+    if Obj = nil then Continue;
+    try
+      AName := Obj.GetStr('name', '');
+      if (AName <> '') and (Pos(LowerCase(Suffix), LowerCase(AName)) > 0) then
+      begin
+        Name := AName;
+        Url  := Obj.GetStr('browser_download_url', '');
+        Size := Obj.GetInt('size', 0);
+        Exit(True);
+      end;
+    finally
+      Obj.Free;
+    end;
+  end;
+end;
+
+function FetchLatestRelease(const Owner, Repo: string;
+                            out Info: TReleaseInfo;
+                            out ErrMsg: string): Boolean;
+var
+  Url: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  Root: TJsonObject;
+  Assets: TJsonArray;
+  Suffix: string;
+begin
+  ErrMsg := '';
+  FillChar(Info, SizeOf(Info), 0);
+  SetLength(Headers, 2);
+  Headers[0] := MakeHeader('Accept',     'application/vnd.github+json');
+  Headers[1] := MakeHeader('X-GitHub-Api-Version', '2022-11-28');
+  Url := Format('https://api.github.com/repos/%s/%s/releases/latest', [Owner, Repo]);
+  Resp := GetJSONURL(Url, Headers, 30);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    ErrMsg := Format('github API status=%d', [Resp.StatusCode]);
+    Exit(False);
+  end;
+
+  Root := TJsonObject.Parse(Resp.Body);
+  if Root = nil then begin ErrMsg := 'bad JSON from github'; Exit(False); end;
+  try
+    Info.TagName := Root.GetStr('tag_name', '');
+    Info.Name    := Root.GetStr('name',     Info.TagName);
+    Info.HtmlUrl := Root.GetStr('html_url', '');
+    Info.Found   := Info.TagName <> '';
+    Suffix := HostPlatformSuffix;
+    Assets := Root.ChildArray('assets');
+    if Assets <> nil then
+    try
+      PickAsset(Assets, Suffix, Info.AssetUrl, Info.AssetName, Info.AssetSize);
+    finally
+      Assets.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+  Result := Info.Found;
+end;
+
+function DownloadAsset(const URL, DestPath: string;
+                       out ErrMsg: string): Boolean;
+var
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+  Strm: TFileStream;
+begin
+  ErrMsg := '';
+  SetLength(Empty, 0);
+  { GitHub redirects asset downloads to a signed CDN URL; Indy follows
+    redirects by default. The asset URL is a "browser_download_url" so a
+    plain GET is enough. }
+  Resp := GetJSONURL(URL, Empty, 120);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    ErrMsg := Format('download status=%d', [Resp.StatusCode]);
+    Exit(False);
+  end;
+  try
+    Strm := TFileStream.Create(DestPath, fmCreate);
+    try
+      if Resp.Body <> '' then
+        Strm.WriteBuffer(Resp.Body[1], Length(Resp.Body));
+    finally
+      Strm.Free;
+    end;
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'write failed: ' + E.Message;
+      Exit(False);
+    end;
+  end;
+  Result := True;
+end;
+
+function InstallUpdate(const DownloadedPath, TargetBinary: string;
+                       out ErrMsg: string): Boolean;
+begin
+  ErrMsg := '';
+  {$IFDEF MSWINDOWS}
+  { Windows can't replace a running .exe; leave the .new file in place. }
+  LogInfo('updater: new binary at %s — restart pasclaw and move it over.', [DownloadedPath]);
+  Result := True;
+  {$ELSE}
+  if not RenameFile(DownloadedPath, TargetBinary) then
+  begin
+    ErrMsg := 'rename failed (errno=' + IntToStr(GetLastOSError) + ')';
+    Exit(False);
+  end;
+  {$IFDEF UNIX}
+  { Best-effort chmod 0755; ignore errors. }
+  FpChmod(TargetBinary, &755);
+  {$ENDIF}
+  Result := True;
+  {$ENDIF}
+end;
+
+end.

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -1,0 +1,187 @@
+{
+  PasClaw.Utils - small helpers used across the codebase.
+  Mirrors pieces of pkg/utils in picoclaw.
+}
+unit PasClaw.Utils;
+
+{$MODE DELPHI}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes, DateUtils;
+
+function DupStr(const S: string; Count: Integer): string;
+function VisibleLength(const S: string): Integer;
+function HasPrefix(const S, Prefix: string): Boolean;
+function HasSuffix(const S, Suffix: string): Boolean;
+function TrimQuotes(const S: string): string;
+function EnsureDir(const Path: string): Boolean;
+function ExpandHome(const Path: string): string;
+function HomeDir: string;
+function JoinPath(const A, B: string): string;
+function FileExistsCI(const Path: string): Boolean;
+function ReadFileText(const Path: string): string;
+procedure WriteFileText(const Path, Content: string);
+function SplitToList(const S: string; Sep: Char): TStringList;
+function NowIsoUtc: string;
+
+implementation
+
+function DupStr(const S: string; Count: Integer): string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 1 to Count do Result := Result + S;
+end;
+
+function VisibleLength(const S: string): Integer;
+{ Strip ANSI escapes and count display columns; treats UTF-8 multi-byte runs
+  as one column each. This is approximate but adequate for box drawing. }
+var
+  i, n: Integer;
+  c: Byte;
+  inEsc: Boolean;
+begin
+  n := 0;
+  inEsc := False;
+  i := 1;
+  while i <= Length(S) do
+  begin
+    c := Byte(S[i]);
+    if inEsc then
+    begin
+      if c = Ord('m') then inEsc := False;
+      Inc(i);
+      Continue;
+    end;
+    if c = 27 then { ESC }
+    begin
+      inEsc := True;
+      Inc(i);
+      Continue;
+    end;
+    { Skip continuation bytes 10xxxxxx, count lead bytes only. }
+    if (c and $C0) <> $80 then
+      Inc(n);
+    Inc(i);
+  end;
+  Result := n;
+end;
+
+function HasPrefix(const S, Prefix: string): Boolean;
+begin
+  Result := (Length(S) >= Length(Prefix)) and
+            (Copy(S, 1, Length(Prefix)) = Prefix);
+end;
+
+function HasSuffix(const S, Suffix: string): Boolean;
+begin
+  Result := (Length(S) >= Length(Suffix)) and
+            (Copy(S, Length(S) - Length(Suffix) + 1, Length(Suffix)) = Suffix);
+end;
+
+function TrimQuotes(const S: string): string;
+begin
+  Result := S;
+  if (Length(Result) >= 2) and
+     (((Result[1] = '"') and (Result[Length(Result)] = '"')) or
+      ((Result[1] = '''') and (Result[Length(Result)] = ''''))) then
+    Result := Copy(Result, 2, Length(Result) - 2);
+end;
+
+function HomeDir: string;
+begin
+  Result := GetEnvironmentVariable('HOME');
+  if Result = '' then
+    Result := GetEnvironmentVariable('USERPROFILE');
+  if Result = '' then
+    Result := GetCurrentDir;
+end;
+
+function ExpandHome(const Path: string): string;
+begin
+  if (Path <> '') and (Path[1] = '~') then
+    Result := HomeDir + Copy(Path, 2, MaxInt)
+  else
+    Result := Path;
+end;
+
+function JoinPath(const A, B: string): string;
+begin
+  if A = '' then Exit(B);
+  if B = '' then Exit(A);
+  if (A[Length(A)] = PathDelim) or (A[Length(A)] = '/') then
+    Result := A + B
+  else
+    Result := A + PathDelim + B;
+end;
+
+function EnsureDir(const Path: string): Boolean;
+begin
+  if DirectoryExists(Path) then Exit(True);
+  Result := ForceDirectories(Path);
+end;
+
+function FileExistsCI(const Path: string): Boolean;
+begin
+  Result := FileExists(Path);
+end;
+
+function ReadFileText(const Path: string): string;
+var
+  Strm: TFileStream;
+  SS: TStringStream;
+begin
+  if not FileExists(Path) then Exit('');
+  Strm := TFileStream.Create(Path, fmOpenRead or fmShareDenyWrite);
+  try
+    SS := TStringStream.Create('');
+    try
+      SS.CopyFrom(Strm, 0);
+      Result := SS.DataString;
+    finally
+      SS.Free;
+    end;
+  finally
+    Strm.Free;
+  end;
+end;
+
+procedure WriteFileText(const Path, Content: string);
+var
+  Strm: TFileStream;
+begin
+  EnsureDir(ExtractFilePath(Path));
+  Strm := TFileStream.Create(Path, fmCreate);
+  try
+    if Content <> '' then
+      Strm.WriteBuffer(Pointer(Content)^, Length(Content));
+  finally
+    Strm.Free;
+  end;
+end;
+
+function SplitToList(const S: string; Sep: Char): TStringList;
+var
+  i, last: Integer;
+begin
+  Result := TStringList.Create;
+  last := 1;
+  for i := 1 to Length(S) do
+    if S[i] = Sep then
+    begin
+      Result.Add(Copy(S, last, i - last));
+      last := i + 1;
+    end;
+  Result.Add(Copy(S, last, MaxInt));
+end;
+
+function NowIsoUtc: string;
+begin
+  Result := FormatDateTime('yyyy"-"mm"-"dd"T"hh":"nn":"ss"Z"', LocalTimeToUniversal(Now));
+end;
+
+end.


### PR DESCRIPTION
## Summary

This is a complete port of [PicoClaw](https://github.com/sipeed/picoclaw) — Sipeed's ultra-lightweight personal AI agent — to Delphi Object Pascal. The port targets Free Pascal 3.2+ in `{$MODE DELPHI}` so sources build with both FPC and Delphi RAD Studio.

Phase 1 delivers the full command-tree skeleton and core infrastructure. Subsequent phases will implement real provider, MCP, gateway, cron, skills, and channel functionality.

## Key Changes

- **Complete CLI command structure**: All top-level commands (agent, auth, config, cron, gateway, mcp, migrate, model, onboard, skills, status, update, version) with argument parsing and help text
- **Provider abstraction layer**: Interface-based LLM provider system with Anthropic and OpenAI implementations (request building only; actual HTTP calls stubbed for Phase 2)
- **MCP (Model Context Protocol) support**: Full JSON-RPC 2.0 stdio client for spawning and communicating with MCP servers; tool registration bridge into the tools registry
- **Built-in tools**: Filesystem tools (fs_read, fs_write, fs_list) and shell_exec with basic safety checks
- **Tool loop infrastructure**: Core agent loop that dispatches tool calls, collects results, and iterates with the LLM
- **Configuration system**: TOML/JSON config loading/saving with support for providers, MCP servers, cron entries, and skills
- **CLI UI utilities**: ANSI color support, banner rendering, help/error panel formatting with terminal width detection
- **Logging framework**: Levelled logging (debug/info/warn/error) matching PicoClaw conventions
- **Build system**: Makefile with FPC compilation, unit path management, version injection from git tags

## Implementation Details

- All units follow the `PasClaw.*` namespace hierarchy mirroring the Go package structure
- JSON handling uses fpjson/jsonparser from FPC's standard library
- Process spawning and pipe I/O for MCP via TProcess (FPC's process unit)
- HTTP client stubs in place for provider implementations (full integration in Phase 2)
- Tool registry uses a slot-based handler dispatch system to work around Pascal's lack of closures
- Config paths respect `PASCLAW_HOME` and `PASCLAW_CONFIG` environment variables, with fallback to `~/.pasclaw`
- All command handlers follow a consistent pattern: parse args → load config → execute → save if needed

This foundation is ready for Phase 2 (real HTTP provider calls), Phase 3 (streaming), Phase 4 (gateway), and beyond.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon