### PR TITLE
Delphi portability: .dproj, System.JSON backend, cross-toolchain process I/O

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
 .PHONY: all clean run test smoke print-version get-indy webui-res
 
+all: $(WEBUI_RES) $(BIN)
+
 # Compile the HTML resource into a .res that {$R webui.res} embeds.
 WEBUI_RES = src/pkg/gateway/webui.res
 
@@ -63,8 +65,6 @@ webui-res: $(WEBUI_RES)
 
 $(WEBUI_RES): src/pkg/gateway/webui.rc src/pkg/gateway/webui.html
 	cd src/pkg/gateway && fpcres -of res -o webui.res webui.rc
-
-all: $(WEBUI_RES) $(BIN)
 
 $(BIN): $(WEBUI_RES) | $(BUILDDIR) $(INDY_DIR)
 	@mkdir -p $(BUILDDIR)/lib

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ UNIT_DIRS = \
 	src/pkg/updater \
 	src/pkg/membench \
 	src/pkg/tui \
+	src/pkg/platform \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -9,7 +9,7 @@
   shell_exec). Falls back to an offline preview if no provider is configured.
 }
 unit PasClaw.Cmd.Agent;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Auth.pas
+++ b/src/cmd/PasClaw.Cmd.Auth.pas
@@ -1,6 +1,6 @@
 { Auth — login/logout/status for configured providers. }
 unit PasClaw.Cmd.Auth;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Config_.pas
+++ b/src/cmd/PasClaw.Cmd.Config_.pas
@@ -1,6 +1,6 @@
 { Config — view/edit raw config. }
 unit PasClaw.Cmd.Config_;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Cron.pas
+++ b/src/cmd/PasClaw.Cmd.Cron.pas
@@ -1,6 +1,6 @@
 { Cron — list/add/disable/enable/remove scheduled tasks. Real scheduler in Phase 5. }
 unit PasClaw.Cmd.Cron;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -9,7 +9,7 @@
   The HTTP API is documented in src/pkg/gateway/PasClaw.Gateway.Server.pas.
 *)
 unit PasClaw.Cmd.Gateway;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -1,6 +1,6 @@
 { MCP — list/add/remove/edit/test/show MCP server entries in config. }
 unit PasClaw.Cmd.MCP;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Membench.pas
+++ b/src/cmd/PasClaw.Cmd.Membench.pas
@@ -5,7 +5,7 @@
 *)
 unit PasClaw.Cmd.Membench;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Migrate.pas
+++ b/src/cmd/PasClaw.Cmd.Migrate.pas
@@ -1,6 +1,6 @@
 { Migrate — migrate config from older PasClaw/PicoClaw layouts. Stub for Phase 1. }
 unit PasClaw.Cmd.Migrate;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Model.pas
+++ b/src/cmd/PasClaw.Cmd.Model.pas
@@ -1,6 +1,6 @@
 { Model — view or switch the default model. }
 unit PasClaw.Cmd.Model;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -4,7 +4,7 @@
   and prompts for the default provider's API key.
 }
 unit PasClaw.Cmd.Onboard;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Post.pas
+++ b/src/cmd/PasClaw.Cmd.Post.pas
@@ -10,7 +10,7 @@
 *)
 unit PasClaw.Cmd.Post;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -5,7 +5,7 @@
 }
 unit PasClaw.Cmd.Root;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -1,6 +1,6 @@
 { Skills — list/install skill extensions (manifest-only for Phase 1). }
 unit PasClaw.Cmd.Skills;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Status.pas
+++ b/src/cmd/PasClaw.Cmd.Status.pas
@@ -1,6 +1,6 @@
 { Status — print effective config, home dir, key health checks. }
 unit PasClaw.Cmd.Status;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -5,7 +5,7 @@
 *)
 unit PasClaw.Cmd.TUI;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Update.pas
+++ b/src/cmd/PasClaw.Cmd.Update.pas
@@ -7,7 +7,7 @@
 *)
 unit PasClaw.Cmd.Update;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/cmd/PasClaw.Cmd.Version.pas
+++ b/src/cmd/PasClaw.Cmd.Version.pas
@@ -1,5 +1,5 @@
 unit PasClaw.Cmd.Version;
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -13,7 +13,7 @@
 
 program PasClaw;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 {$APPTYPE CONSOLE}
 

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -18,10 +18,10 @@ program PasClaw;
 {$APPTYPE CONSOLE}
 
 uses
-  {$IFDEF UNIX}
-  cthreads,            { FPC: pull in pthreads so Indy can use TThread }
+  {$IFDEF FPC}{$IFDEF UNIX}
+  cthreads,            { FPC/Linux: pull in pthreads so Indy can use TThread }
   cmem,
-  {$ENDIF}
+  {$ENDIF}{$ENDIF}
   SysUtils,
   PasClaw.CliUI,
   PasClaw.Logger,

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{9A0F2E70-1FE6-4D2A-9B07-44D8C75A1E29}</ProjectGuid>
+        <ProjectVersion>20.2</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <MainSource>PasClaw.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win64</Platform>
+        <TargetedPlatforms>33</TargetedPlatforms>
+        <AppType>Console</AppType>
+    </PropertyGroup>
+
+    <!-- Platform fan-out -->
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Linux64' and '$(Base)'=='true') or '$(Base_Linux64)'!=''">
+        <Base_Linux64>true</Base_Linux64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win64)'!=''">
+        <Cfg_1_Win64>true</Cfg_1_Win64>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+
+    <!-- Shared compile/link settings -->
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_E>false</DCC_E>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_DependencyCheckOutputName>pasclaw.dcc_dep</DCC_DependencyCheckOutputName>
+        <DCC_ExeOutput>..\..\build\delphi\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_DcuOutput>..\..\build\delphi\$(Platform)\$(Config)\dcu</DCC_DcuOutput>
+        <DCC_BplOutput>..\..\build\delphi\$(Platform)\$(Config)\bpl</DCC_BplOutput>
+        <DCC_DcpOutput>..\..\build\delphi\$(Platform)\$(Config)\dcp</DCC_DcpOutput>
+        <SanitizedProjectName>PasClaw</SanitizedProjectName>
+        <Manifest_File>None</Manifest_File>
+        <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
+        <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Linux64)'!=''">
+        <DCC_UsePackage>rtl;$(DCC_UsePackage)</DCC_UsePackage>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>2</DCC_DebugInformation>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_Optimize>true</DCC_Optimize>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+
+        <!-- cmd dispatchers -->
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Root.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Onboard.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Agent.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Auth.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Gateway.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Status.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Version.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Cron.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.MCP.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Migrate.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Skills.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Model.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Config_.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Update.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Post.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Membench.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.TUI.pas"/>
+
+        <!-- pkg/cliui -->
+        <DCCReference Include="..\pkg\cliui\PasClaw.CliUI.pas"/>
+
+        <!-- pkg/utils -->
+        <DCCReference Include="..\pkg\utils\PasClaw.Utils.pas"/>
+
+        <!-- pkg/logger -->
+        <DCCReference Include="..\pkg\logger\PasClaw.Logger.pas"/>
+
+        <!-- pkg/config -->
+        <DCCReference Include="..\pkg\config\PasClaw.Config.pas"/>
+
+        <!-- pkg/json -->
+        <DCCReference Include="..\pkg\json\PasClaw.JSON.pas"/>
+
+        <!-- pkg/providers -->
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.Types.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.Intf.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.HTTP.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.Anthropic.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.OpenAI.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.Factory.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.Stream.pas"/>
+
+        <!-- pkg/tokenizer -->
+        <DCCReference Include="..\pkg\tokenizer\PasClaw.Tokenizer.pas"/>
+
+        <!-- pkg/tools -->
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Types.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Registry.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.FS.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Shell.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.ToolLoop.pas"/>
+
+        <!-- pkg/mcp -->
+        <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Types.pas"/>
+        <DCCReference Include="..\pkg\mcp\PasClaw.MCP.StdioClient.pas"/>
+        <DCCReference Include="..\pkg\mcp\PasClaw.MCP.HttpClient.pas"/>
+        <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Bridge.pas"/>
+
+        <!-- pkg/gateway -->
+        <DCCReference Include="..\pkg\gateway\PasClaw.Gateway.Server.pas"/>
+        <DCCReference Include="..\pkg\gateway\PasClaw.Gateway.WebUI.pas"/>
+        <None Include="..\pkg\gateway\webui.rc"/>
+        <None Include="..\pkg\gateway\webui.html"/>
+        <RcCompile Include="..\pkg\gateway\webui.rc"/>
+
+        <!-- pkg/channels -->
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.Telegram.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.Discord.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.Slack.pas"/>
+
+        <!-- pkg/cron -->
+        <DCCReference Include="..\pkg\cron\PasClaw.Cron.Expr.pas"/>
+        <DCCReference Include="..\pkg\cron\PasClaw.Cron.Scheduler.pas"/>
+
+        <!-- pkg/skills -->
+        <DCCReference Include="..\pkg\skills\PasClaw.Skills.Loader.pas"/>
+
+        <!-- pkg/memory -->
+        <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>
+
+        <!-- pkg/updater -->
+        <DCCReference Include="..\pkg\updater\PasClaw.Updater.pas"/>
+
+        <!-- pkg/membench -->
+        <DCCReference Include="..\pkg\membench\PasClaw.Membench.Runner.pas"/>
+
+        <!-- pkg/tui -->
+        <DCCReference Include="..\pkg\tui\PasClaw.TUI.pas"/>
+
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>VCLApplication</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">PasClaw.dpr</Source>
+                </Source>
+                <VersionInfo>
+                    <VersionInfo Name="IncludeVerInfo">True</VersionInfo>
+                    <VersionInfo Name="AutoIncBuild">False</VersionInfo>
+                    <VersionInfo Name="MajorVer">0</VersionInfo>
+                    <VersionInfo Name="MinorVer">1</VersionInfo>
+                    <VersionInfo Name="Release">0</VersionInfo>
+                    <VersionInfo Name="Build">0</VersionInfo>
+                    <VersionInfo Name="Debug">False</VersionInfo>
+                    <VersionInfo Name="PreRelease">False</VersionInfo>
+                    <VersionInfo Name="Special">False</VersionInfo>
+                    <VersionInfo Name="Private">False</VersionInfo>
+                    <VersionInfo Name="DLL">False</VersionInfo>
+                    <VersionInfo Name="Locale">1033</VersionInfo>
+                    <VersionInfo Name="CodePage">1252</VersionInfo>
+                </VersionInfo>
+                <VersionInfoKeys>
+                    <VersionInfoKeys Name="CompanyName">PasClaw contributors</VersionInfoKeys>
+                    <VersionInfoKeys Name="FileDescription">PasClaw - personal AI assistant</VersionInfoKeys>
+                    <VersionInfoKeys Name="FileVersion">0.1.0.0</VersionInfoKeys>
+                    <VersionInfoKeys Name="InternalName">PasClaw</VersionInfoKeys>
+                    <VersionInfoKeys Name="LegalCopyright">MIT</VersionInfoKeys>
+                    <VersionInfoKeys Name="OriginalFilename">pasclaw.exe</VersionInfoKeys>
+                    <VersionInfoKeys Name="ProductName">PasClaw</VersionInfoKeys>
+                    <VersionInfoKeys Name="ProductVersion">0.1.0.0</VersionInfoKeys>
+                    <VersionInfoKeys Name="Comments">Delphi port of picoclaw</VersionInfoKeys>
+                </VersionInfoKeys>
+            </Delphi.Personality>
+            <Deployment Version="3"/>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+                <Platform value="Linux64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
@@ -192,6 +192,9 @@
 
         <!-- pkg/tui -->
         <DCCReference Include="..\pkg\tui\PasClaw.TUI.pas"/>
+
+        <!-- pkg/platform -->
+        <DCCReference Include="..\pkg\platform\PasClaw.Platform.pas"/>
 
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/src/pkg/channels/PasClaw.Channels.Discord.pas
+++ b/src/pkg/channels/PasClaw.Channels.Discord.pas
@@ -21,7 +21,7 @@
 *)
 unit PasClaw.Channels.Discord;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/channels/PasClaw.Channels.Slack.pas
+++ b/src/pkg/channels/PasClaw.Channels.Slack.pas
@@ -12,7 +12,7 @@
 *)
 unit PasClaw.Channels.Slack;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -44,7 +44,7 @@ type
 implementation
 
 uses
-  fpjson, jsonparser,
+  PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Providers.Types,
   PasClaw.Providers.HTTP,
@@ -91,16 +91,16 @@ function TTelegramChannel.SendMessage(ChatId: Int64; const Text: string): Boolea
 var
   URL, Body: string;
   Empty: array of THeaderPair;
-  J: TJSONObject;
+  J: TJsonObject;
   Resp: THTTPResult;
 begin
   SetLength(Empty, 0);
   URL := ApiUrl('sendMessage');
-  J := TJSONObject.Create;
+  J := TJsonObject.Create;
   try
-    J.Add('chat_id', ChatId);
-    J.Add('text',    Text);
-    Body := J.AsJSON;
+    J.PutInt('chat_id', ChatId);
+    J.PutStr('text',    Text);
+    Body := J.ToJSON;
   finally
     J.Free;
   end;
@@ -112,29 +112,35 @@ end;
 
 procedure TTelegramChannel.ProcessUpdate(const UpdateJSON: string);
 var
-  Root: TJSONData;
-  Obj, Msg, Chat: TJSONObject;
+  Obj, Msg, Chat: TJsonObject;
   Text: string;
   ChatId, UpdateId: Int64;
   Loop: TToolLoopResult;
   LoopCfg: TToolLoopConfig;
   Msgs: array of TMessage;
 begin
-  Root := GetJSON(UpdateJSON);
+  Obj := TJsonObject.Parse(UpdateJSON);
+  if Obj = nil then Exit;
   try
-    if not (Root is TJSONObject) then Exit;
-    Obj := TJSONObject(Root);
-    UpdateId := Obj.Get('update_id', Int64(0));
+    UpdateId := Obj.GetInt('update_id', 0);
     if UpdateId >= FOffset then FOffset := UpdateId + 1;
-    if Obj.IndexOfName('message') < 0 then Exit;
-    Msg := Obj.Objects['message'];
-    if Msg.IndexOfName('chat') < 0 then Exit;
-    Chat := Msg.Objects['chat'];
-    ChatId := Chat.Get('id', Int64(0));
-    Text   := Msg.Get('text', '');
-    if Text = '' then Exit;
+    Msg := Obj.ChildObject('message');
+    if Msg = nil then Exit;
+    try
+      Chat := Msg.ChildObject('chat');
+      if Chat = nil then Exit;
+      try
+        ChatId := Chat.GetInt('id', 0);
+      finally
+        Chat.Free;
+      end;
+      Text := Msg.GetStr('text', '');
+      if Text = '' then Exit;
+    finally
+      Msg.Free;
+    end;
   finally
-    Root.Free;
+    Obj.Free;
   end;
 
   LogInfo('telegram: chat=%d msg=%s', [ChatId, Copy(Text, 1, 80)]);
@@ -166,9 +172,8 @@ end;
 procedure TTelegramChannel.Run;
 var
   RawJSON: string;
-  Root: TJSONData;
-  Obj: TJSONObject;
-  Arr: TJSONArray;
+  Obj, Item: TJsonObject;
+  Arr: TJsonArray;
   i: Integer;
 begin
   if FToken = '' then
@@ -176,7 +181,7 @@ begin
     LogError('telegram: no bot token (set PASCLAW_TELEGRAM_TOKEN or --token)');
     Exit;
   end;
-  LogInfo('telegram: long-poll started (token …%s)',
+  LogInfo('telegram: long-poll started (token ...%s)',
     [Copy(FToken, Length(FToken) - 5, 5)]);
 
   while not FStop do
@@ -186,22 +191,28 @@ begin
       Sleep(2000);
       Continue;
     end;
+    Obj := TJsonObject.Parse(RawJSON);
+    if Obj = nil then begin Sleep(1000); Continue; end;
     try
-      Root := GetJSON(RawJSON);
-    except
-      Sleep(1000);
-      Continue;
-    end;
-    try
-      if not (Root is TJSONObject) then Continue;
-      Obj := TJSONObject(Root);
-      if not Obj.Get('ok', False) then Continue;
-      if Obj.IndexOfName('result') < 0 then Continue;
-      Arr := Obj.Arrays['result'];
-      for i := 0 to Arr.Count - 1 do
-        ProcessUpdate(Arr[i].AsJSON);
+      if not Obj.GetBool('ok', False) then Continue;
+      Arr := Obj.ChildArray('result');
+      if Arr = nil then Continue;
+      try
+        for i := 0 to Arr.Count - 1 do
+        begin
+          Item := Arr.ItemObject(i);
+          if Item = nil then Continue;
+          try
+            ProcessUpdate(Item.ToJSON);
+          finally
+            Item.Free;
+          end;
+        end;
+      finally
+        Arr.Free;
+      end;
     finally
-      Root.Free;
+      Obj.Free;
     end;
   end;
   LogInfo('telegram: long-poll stopped');

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -10,7 +10,7 @@
 *)
 unit PasClaw.Channels.Telegram;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -4,7 +4,7 @@
 }
 unit PasClaw.CliUI;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -84,7 +84,7 @@ implementation
 
 uses
   PasClaw.Utils,
-  fpjson, jsonparser;
+  PasClaw.JSON;
 
 constructor TConfig.Create;
 begin
@@ -96,178 +96,210 @@ begin
   Gateway.Port     := 8088;
 end;
 
-function ProviderToJSON(const P: TProviderConfig): TJSONObject;
+function ProviderToJSON(const P: TProviderConfig): TJsonObject;
 begin
-  Result := TJSONObject.Create;
-  Result.Add('name',     P.Name);
-  Result.Add('kind',     P.Kind);
-  Result.Add('api_base', P.APIBase);
-  Result.Add('api_key',  P.APIKey);
-  Result.Add('model',    P.Model);
+  Result := TJsonObject.Create;
+  Result.PutStr('name',     P.Name);
+  Result.PutStr('kind',     P.Kind);
+  Result.PutStr('api_base', P.APIBase);
+  Result.PutStr('api_key',  P.APIKey);
+  Result.PutStr('model',    P.Model);
 end;
 
-function MCPToJSON(const M: TMCPServer): TJSONObject;
+function MCPToJSON(const M: TMCPServer): TJsonObject;
 begin
-  Result := TJSONObject.Create;
-  Result.Add('name',    M.Name);
-  Result.Add('cmd',     M.Cmd);
-  Result.Add('args',    M.Args);
-  Result.Add('env',     M.Env);
-  Result.Add('enabled', M.Enabled);
+  Result := TJsonObject.Create;
+  Result.PutStr ('name',    M.Name);
+  Result.PutStr ('cmd',     M.Cmd);
+  Result.PutStr ('args',    M.Args);
+  Result.PutStr ('env',     M.Env);
+  Result.PutBool('enabled', M.Enabled);
 end;
 
-function CronToJSON(const C: TCronEntry): TJSONObject;
+function CronToJSON(const C: TCronEntry): TJsonObject;
 begin
-  Result := TJSONObject.Create;
-  Result.Add('id',      C.Id);
-  Result.Add('spec',    C.Spec);
-  Result.Add('skill',   C.Skill);
-  Result.Add('args',    C.Args);
-  Result.Add('enabled', C.Enabled);
+  Result := TJsonObject.Create;
+  Result.PutStr ('id',      C.Id);
+  Result.PutStr ('spec',    C.Spec);
+  Result.PutStr ('skill',   C.Skill);
+  Result.PutStr ('args',    C.Args);
+  Result.PutBool('enabled', C.Enabled);
 end;
 
-function SkillToJSON(const S: TSkillEntry): TJSONObject;
+function SkillToJSON(const S: TSkillEntry): TJsonObject;
 begin
-  Result := TJSONObject.Create;
-  Result.Add('name',    S.Name);
-  Result.Add('source',  S.Source);
-  Result.Add('enabled', S.Enabled);
+  Result := TJsonObject.Create;
+  Result.PutStr ('name',    S.Name);
+  Result.PutStr ('source',  S.Source);
+  Result.PutBool('enabled', S.Enabled);
 end;
 
 function TConfig.ToJSON: string;
 var
-  Root, Gw: TJSONObject;
-  Arr: TJSONArray;
+  Root, Gw, Tmp: TJsonObject;
+  Arr: TJsonArray;
   i: Integer;
 begin
-  Root := TJSONObject.Create;
+  Root := TJsonObject.Create;
   try
-    Root.Add('default_provider', DefaultProvider);
-    Root.Add('default_model',    DefaultModel);
+    Root.PutStr('default_provider', DefaultProvider);
+    Root.PutStr('default_model',    DefaultModel);
 
-    Gw := TJSONObject.Create;
-    Gw.Add('log_level', Gateway.LogLevel);
-    Gw.Add('bind_addr', Gateway.BindAddr);
-    Gw.Add('port',      Gateway.Port);
-    Root.Add('gateway', Gw);
+    Gw := TJsonObject.Create;
+    Gw.PutStr ('log_level', Gateway.LogLevel);
+    Gw.PutStr ('bind_addr', Gateway.BindAddr);
+    Gw.PutInt ('port',      Gateway.Port);
+    Root.PutObject('gateway', Gw);
 
-    Arr := TJSONArray.Create;
-    for i := 0 to High(Providers) do Arr.Add(ProviderToJSON(Providers[i]));
-    Root.Add('providers', Arr);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Providers) do
+    begin
+      Tmp := ProviderToJSON(Providers[i]);
+      Arr.AddObject(Tmp);
+    end;
+    Root.PutArray('providers', Arr);
 
-    Arr := TJSONArray.Create;
-    for i := 0 to High(MCPServers) do Arr.Add(MCPToJSON(MCPServers[i]));
-    Root.Add('mcp_servers', Arr);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(MCPServers) do
+    begin
+      Tmp := MCPToJSON(MCPServers[i]);
+      Arr.AddObject(Tmp);
+    end;
+    Root.PutArray('mcp_servers', Arr);
 
-    Arr := TJSONArray.Create;
-    for i := 0 to High(Crons) do Arr.Add(CronToJSON(Crons[i]));
-    Root.Add('crons', Arr);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Crons) do
+    begin
+      Tmp := CronToJSON(Crons[i]);
+      Arr.AddObject(Tmp);
+    end;
+    Root.PutArray('crons', Arr);
 
-    Arr := TJSONArray.Create;
-    for i := 0 to High(Skills) do Arr.Add(SkillToJSON(Skills[i]));
-    Root.Add('skills', Arr);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Skills) do
+    begin
+      Tmp := SkillToJSON(Skills[i]);
+      Arr.AddObject(Tmp);
+    end;
+    Root.PutArray('skills', Arr);
 
-    Result := Root.FormatJSON;
+    Result := Root.ToJSON;
   finally
     Root.Free;
   end;
 end;
-
-procedure ReadProviders(Arr: TJSONArray; var Dest: array of TProviderConfig); forward;
 
 procedure TConfig.FromJSON(const S: string);
 var
-  Root: TJSONObject;
-  Obj: TJSONObject;
-  Arr: TJSONArray;
+  Root, Obj, Item: TJsonObject;
+  Arr: TJsonArray;
   i: Integer;
-  Data: TJSONData;
 begin
   if Trim(S) = '' then Exit;
-  Data := GetJSON(S);
-  if not (Data is TJSONObject) then
-  begin
-    Data.Free;
-    Exit;
-  end;
-  Root := TJSONObject(Data);
+  Root := TJsonObject.Parse(S);
+  if Root = nil then Exit;
   try
-    DefaultProvider := Root.Get('default_provider', DefaultProvider);
-    DefaultModel    := Root.Get('default_model',    DefaultModel);
+    DefaultProvider := Root.GetStr('default_provider', DefaultProvider);
+    DefaultModel    := Root.GetStr('default_model',    DefaultModel);
 
-    if Root.IndexOfName('gateway') >= 0 then
-    begin
-      Obj := Root.Objects['gateway'];
-      Gateway.LogLevel := Obj.Get('log_level', Gateway.LogLevel);
-      Gateway.BindAddr := Obj.Get('bind_addr', Gateway.BindAddr);
-      Gateway.Port     := Obj.Get('port',      Gateway.Port);
+    Obj := Root.ChildObject('gateway');
+    if Obj <> nil then
+    try
+      Gateway.LogLevel := Obj.GetStr('log_level', Gateway.LogLevel);
+      Gateway.BindAddr := Obj.GetStr('bind_addr', Gateway.BindAddr);
+      Gateway.Port     := Obj.GetInt('port',      Gateway.Port);
+    finally
+      Obj.Free;
     end;
 
-    if Root.IndexOfName('providers') >= 0 then
-    begin
-      Arr := Root.Arrays['providers'];
+    Arr := Root.ChildArray('providers');
+    if Arr <> nil then
+    try
       SetLength(Providers, Arr.Count);
       for i := 0 to Arr.Count - 1 do
       begin
-        Obj := TJSONObject(Arr[i]);
-        Providers[i].Name    := Obj.Get('name',     '');
-        Providers[i].Kind    := Obj.Get('kind',     '');
-        Providers[i].APIBase := Obj.Get('api_base', '');
-        Providers[i].APIKey  := Obj.Get('api_key',  '');
-        Providers[i].Model   := Obj.Get('model',    '');
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          Providers[i].Name    := Item.GetStr('name',     '');
+          Providers[i].Kind    := Item.GetStr('kind',     '');
+          Providers[i].APIBase := Item.GetStr('api_base', '');
+          Providers[i].APIKey  := Item.GetStr('api_key',  '');
+          Providers[i].Model   := Item.GetStr('model',    '');
+        finally
+          Item.Free;
+        end;
       end;
+    finally
+      Arr.Free;
     end;
 
-    if Root.IndexOfName('mcp_servers') >= 0 then
-    begin
-      Arr := Root.Arrays['mcp_servers'];
+    Arr := Root.ChildArray('mcp_servers');
+    if Arr <> nil then
+    try
       SetLength(MCPServers, Arr.Count);
       for i := 0 to Arr.Count - 1 do
       begin
-        Obj := TJSONObject(Arr[i]);
-        MCPServers[i].Name    := Obj.Get('name',    '');
-        MCPServers[i].Cmd     := Obj.Get('cmd',     '');
-        MCPServers[i].Args    := Obj.Get('args',    '');
-        MCPServers[i].Env     := Obj.Get('env',     '');
-        MCPServers[i].Enabled := Obj.Get('enabled', True);
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          MCPServers[i].Name    := Item.GetStr ('name',    '');
+          MCPServers[i].Cmd     := Item.GetStr ('cmd',     '');
+          MCPServers[i].Args    := Item.GetStr ('args',    '');
+          MCPServers[i].Env     := Item.GetStr ('env',     '');
+          MCPServers[i].Enabled := Item.GetBool('enabled', True);
+        finally
+          Item.Free;
+        end;
       end;
+    finally
+      Arr.Free;
     end;
 
-    if Root.IndexOfName('crons') >= 0 then
-    begin
-      Arr := Root.Arrays['crons'];
+    Arr := Root.ChildArray('crons');
+    if Arr <> nil then
+    try
       SetLength(Crons, Arr.Count);
       for i := 0 to Arr.Count - 1 do
       begin
-        Obj := TJSONObject(Arr[i]);
-        Crons[i].Id      := Obj.Get('id',      '');
-        Crons[i].Spec    := Obj.Get('spec',    '');
-        Crons[i].Skill   := Obj.Get('skill',   '');
-        Crons[i].Args    := Obj.Get('args',    '');
-        Crons[i].Enabled := Obj.Get('enabled', True);
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          Crons[i].Id      := Item.GetStr ('id',      '');
+          Crons[i].Spec    := Item.GetStr ('spec',    '');
+          Crons[i].Skill   := Item.GetStr ('skill',   '');
+          Crons[i].Args    := Item.GetStr ('args',    '');
+          Crons[i].Enabled := Item.GetBool('enabled', True);
+        finally
+          Item.Free;
+        end;
       end;
+    finally
+      Arr.Free;
     end;
 
-    if Root.IndexOfName('skills') >= 0 then
-    begin
-      Arr := Root.Arrays['skills'];
+    Arr := Root.ChildArray('skills');
+    if Arr <> nil then
+    try
       SetLength(Skills, Arr.Count);
       for i := 0 to Arr.Count - 1 do
       begin
-        Obj := TJSONObject(Arr[i]);
-        Skills[i].Name    := Obj.Get('name',    '');
-        Skills[i].Source  := Obj.Get('source',  '');
-        Skills[i].Enabled := Obj.Get('enabled', True);
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          Skills[i].Name    := Item.GetStr ('name',    '');
+          Skills[i].Source  := Item.GetStr ('source',  '');
+          Skills[i].Enabled := Item.GetBool('enabled', True);
+        finally
+          Item.Free;
+        end;
       end;
+    finally
+      Arr.Free;
     end;
   finally
     Root.Free;
   end;
-end;
-
-procedure ReadProviders(Arr: TJSONArray; var Dest: array of TProviderConfig);
-begin
-  { stub helper retained for forward decl; logic inlined above }
 end;
 
 function GetHome: string;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -5,7 +5,7 @@
 }
 unit PasClaw.Config;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface
@@ -14,9 +14,15 @@ uses
   SysUtils, Classes;
 
 const
-  { Build-time version: set the PASCLAW_VERSION environment variable before
-    invoking fpc to override (the Makefile does this from `git describe`). }
+  (* Build-time version. FPC reads the PASCLAW_VERSION environment variable
+     at compile time via the I-percent directive; Delphi falls back to the
+     literal below (override by setting PASCLAW_VERSION_LITERAL via a
+     project define). *)
+  {$IFDEF FPC}
   VersionRaw = {$I %PASCLAW_VERSION%};
+  {$ELSE}
+  VersionRaw = '';
+  {$ENDIF}
   VersionFallback = '0.1.0-dev';
 
   EnvHome   = 'PASCLAW_HOME';
@@ -348,9 +354,18 @@ begin
 end;
 
 function FormatBuildInfo: string;
+{$IFDEF FPC}
+const
+  FpcVer   = {$I %FPCVERSION%};
+  FpcOS    = {$I %FPCTARGETOS%};
+  FpcCPU   = {$I %FPCTARGETCPU%};
 begin
-  Result := Format('pasclaw %s (fpc %s %s/%s)',
-    [FormatVersion, {$I %FPCVERSION%}, {$I %FPCTARGETOS%}, {$I %FPCTARGETCPU%}]);
+  Result := Format('pasclaw %s (fpc %s %s/%s)', [FormatVersion, FpcVer, FpcOS, FpcCPU]);
 end;
+{$ELSE}
+begin
+  Result := Format('pasclaw %s (delphi)', [FormatVersion]);
+end;
+{$ENDIF}
 
 end.

--- a/src/pkg/cron/PasClaw.Cron.Expr.pas
+++ b/src/pkg/cron/PasClaw.Cron.Expr.pas
@@ -19,7 +19,7 @@
 *)
 unit PasClaw.Cron.Expr;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/cron/PasClaw.Cron.Scheduler.pas
+++ b/src/pkg/cron/PasClaw.Cron.Scheduler.pas
@@ -11,7 +11,7 @@
 *)
 unit PasClaw.Cron.Scheduler;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -14,7 +14,7 @@
 *)
 unit PasClaw.Gateway.Server;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -58,7 +58,7 @@ type
 implementation
 
 uses
-  fpjson, jsonparser,
+  PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop,
@@ -195,21 +195,19 @@ end;
 
 procedure TGatewayServer.HandleStatus(AResp: TIdHTTPResponseInfo);
 var
-  J: TJSONObject;
+  J: TJsonObject;
 begin
-  J := TJSONObject.Create;
+  J := TJsonObject.Create;
   try
-    J.Add('default_provider', FCfg.DefaultProvider);
-    J.Add('default_model',    FCfg.DefaultModel);
-    J.Add('providers',        Length(FCfg.Providers));
-    J.Add('mcp_servers',      Length(FCfg.MCPServers));
-    J.Add('crons',            Length(FCfg.Crons));
-    J.Add('skills',           Length(FCfg.Skills));
-    if FRegistry <> nil then
-      J.Add('tools',          FRegistry.Count)
-    else
-      J.Add('tools', 0);
-    WriteJSON(AResp, 200, J.AsJSON);
+    J.PutStr('default_provider', FCfg.DefaultProvider);
+    J.PutStr('default_model',    FCfg.DefaultModel);
+    J.PutInt('providers',        Length(FCfg.Providers));
+    J.PutInt('mcp_servers',      Length(FCfg.MCPServers));
+    J.PutInt('crons',            Length(FCfg.Crons));
+    J.PutInt('skills',           Length(FCfg.Skills));
+    if FRegistry <> nil then J.PutInt('tools', FRegistry.Count)
+    else                     J.PutInt('tools', 0);
+    WriteJSON(AResp, 200, J.ToJSON);
   finally
     J.Free;
   end;
@@ -217,29 +215,28 @@ end;
 
 procedure TGatewayServer.HandleTools(AResp: TIdHTTPResponseInfo);
 var
-  Root: TJSONObject;
-  Arr: TJSONArray;
+  Root, ToolObj: TJsonObject;
+  Arr: TJsonArray;
   Defs: TToolDefinitionArray;
   i: Integer;
-  ToolObj: TJSONObject;
 begin
-  Root := TJSONObject.Create;
-  Arr  := TJSONArray.Create;
+  Root := TJsonObject.Create;
   try
+    Arr := TJsonArray.Create;
     if FRegistry <> nil then
     begin
       Defs := FRegistry.ToProviderDefs;
       for i := 0 to High(Defs) do
       begin
-        ToolObj := TJSONObject.Create;
-        ToolObj.Add('name',        Defs[i].Name);
-        ToolObj.Add('description', Defs[i].Description);
-        ToolObj.Add('schema',      Defs[i].Schema);
-        Arr.Add(ToolObj);
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('name',        Defs[i].Name);
+        ToolObj.PutStr('description', Defs[i].Description);
+        ToolObj.PutStr('schema',      Defs[i].Schema);
+        Arr.AddObject(ToolObj);
       end;
     end;
-    Root.Add('tools', Arr);
-    WriteJSON(AResp, 200, Root.AsJSON);
+    Root.PutArray('tools', Arr);
+    WriteJSON(AResp, 200, Root.ToJSON);
   finally
     Root.Free;
   end;
@@ -249,8 +246,7 @@ procedure TGatewayServer.HandleChat(ARequest: TIdHTTPRequestInfo;
                                     AResp: TIdHTTPResponseInfo);
 var
   Body, Prompt: string;
-  Req, RespJ: TJSONObject;
-  Data: TJSONData;
+  Req, RespJ: TJsonObject;
   Msgs: array of TMessage;
   Loop: TToolLoopResult;
   LoopCfg: TToolLoopConfig;
@@ -271,20 +267,12 @@ begin
   end;
 
   Prompt := '';
+  Req := TJsonObject.Parse(Body);
+  if Req <> nil then
   try
-    Data := GetJSON(Body);
-    try
-      if Data is TJSONObject then
-      begin
-        Req := TJSONObject(Data);
-        Prompt := Req.Get('message', '');
-      end;
-    finally
-      Data.Free;
-    end;
-  except
-    WriteJSON(AResp, 400, '{"error":"invalid json"}');
-    Exit;
+    Prompt := Req.GetStr('message', '');
+  finally
+    Req.Free;
   end;
 
   if Prompt = '' then
@@ -317,13 +305,13 @@ begin
     Exit;
   end;
 
-  RespJ := TJSONObject.Create;
+  RespJ := TJsonObject.Create;
   try
-    RespJ.Add('content',     Loop.Content);
-    RespJ.Add('iterations',  Loop.Iterations);
-    RespJ.Add('input_tokens', Loop.LastResp.Usage.InputTokens);
-    RespJ.Add('output_tokens', Loop.LastResp.Usage.OutputTokens);
-    WriteJSON(AResp, 200, RespJ.AsJSON);
+    RespJ.PutStr('content',       Loop.Content);
+    RespJ.PutInt('iterations',    Loop.Iterations);
+    RespJ.PutInt('input_tokens',  Loop.LastResp.Usage.InputTokens);
+    RespJ.PutInt('output_tokens', Loop.LastResp.Usage.OutputTokens);
+    WriteJSON(AResp, 200, RespJ.ToJSON);
   finally
     RespJ.Free;
   end;

--- a/src/pkg/gateway/PasClaw.Gateway.WebUI.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.WebUI.pas
@@ -17,7 +17,7 @@
 *)
 unit PasClaw.Gateway.WebUI;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 {$R webui.res}

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -102,7 +102,7 @@ uses
   fpjson, jsonparser;
 {$ELSE}
 uses
-  System.JSON;
+  System.JSON, System.JSON.Writers, System.JSON.Readers, System.JSON.Types;
 {$ENDIF}
 
 function JsonEscape(const S: string): string;
@@ -440,8 +440,340 @@ end;
 
 {$ELSE}
 (* ----- Delphi backend (System.JSON) -----
-   Implementations parallel to the FPC versions above. Keep the public
-   interface identical so call sites need no changes. *)
+   Same semantics as the FPC backend above. Backing types are
+   System.JSON.TJSONObject / TJSONArray. Ownership: a parent owns nested
+   children added through PutObject/PutArray/AddObject/AddArray; this is
+   how System.JSON works natively. ChildObject/ChildArray/ItemObject/
+   ItemArray return non-owning wrappers so the caller frees the wrapper
+   but not the underlying System.JSON value. *)
+
+constructor TJsonObject.Create;
+begin
+  inherited Create;
+  FBacking := System.JSON.TJSONObject.Create;
+  FOwnsBacking := True;
+end;
+
+constructor TJsonObject.CreateWrapping(Backing: TObject; OwnsIt: Boolean);
+begin
+  inherited Create;
+  FBacking := Backing;
+  FOwnsBacking := OwnsIt;
+end;
+
+destructor TJsonObject.Destroy;
+begin
+  if FOwnsBacking and (FBacking <> nil) then FBacking.Free;
+  inherited Destroy;
+end;
+
+class function TJsonObject.Parse(const S: string): TJsonObject;
+var
+  V: System.JSON.TJSONValue;
+begin
+  Result := nil;
+  if Trim(S) = '' then Exit;
+  try
+    V := System.JSON.TJSONObject.ParseJSONValue(S);
+  except
+    on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
+  end;
+  if not (V is System.JSON.TJSONObject) then
+  begin
+    V.Free;
+    Exit;
+  end;
+  Result := TJsonObject.CreateWrapping(V, True);
+end;
+
+function TJsonObject.Has(const Key: string): Boolean;
+begin
+  Result := System.JSON.TJSONObject(FBacking).GetValue(Key) <> nil;
+end;
+
+function TJsonObject.GetStr(const Key: string; const Default: string): string;
+var
+  V: System.JSON.TJSONValue;
+begin
+  V := System.JSON.TJSONObject(FBacking).GetValue(Key);
+  if V = nil then Exit(Default);
+  try
+    Result := V.Value;
+  except
+    Result := Default;
+  end;
+end;
+
+function TJsonObject.GetInt(const Key: string; Default: Int64): Int64;
+var
+  V: System.JSON.TJSONValue;
+begin
+  V := System.JSON.TJSONObject(FBacking).GetValue(Key);
+  if V = nil then Exit(Default);
+  if V is System.JSON.TJSONNumber then
+    Result := System.JSON.TJSONNumber(V).AsInt64
+  else
+    Result := Default;
+end;
+
+function TJsonObject.GetBool(const Key: string; Default: Boolean): Boolean;
+var
+  V: System.JSON.TJSONValue;
+begin
+  V := System.JSON.TJSONObject(FBacking).GetValue(Key);
+  if V = nil then Exit(Default);
+  if V is System.JSON.TJSONTrue then Exit(True);
+  if V is System.JSON.TJSONFalse then Exit(False);
+  if V is System.JSON.TJSONBool then Exit(System.JSON.TJSONBool(V).AsBoolean);
+  Result := Default;
+end;
+
+function TJsonObject.GetFloat(const Key: string; Default: Double): Double;
+var
+  V: System.JSON.TJSONValue;
+begin
+  V := System.JSON.TJSONObject(FBacking).GetValue(Key);
+  if V = nil then Exit(Default);
+  if V is System.JSON.TJSONNumber then
+    Result := System.JSON.TJSONNumber(V).AsDouble
+  else
+    Result := Default;
+end;
+
+function TJsonObject.ChildObject(const Key: string): TJsonObject;
+var
+  V: System.JSON.TJSONValue;
+begin
+  Result := nil;
+  V := System.JSON.TJSONObject(FBacking).GetValue(Key);
+  if V is System.JSON.TJSONObject then
+    Result := TJsonObject.CreateWrapping(V, False);
+end;
+
+function TJsonObject.ChildArray(const Key: string): TJsonArray;
+var
+  V: System.JSON.TJSONValue;
+begin
+  Result := nil;
+  V := System.JSON.TJSONObject(FBacking).GetValue(Key);
+  if V is System.JSON.TJSONArray then
+    Result := TJsonArray.CreateWrapping(V, False);
+end;
+
+procedure TJsonObject.PutStr  (const Key, Value: string);
+begin System.JSON.TJSONObject(FBacking).AddPair(Key, Value); end;
+
+procedure TJsonObject.PutInt  (const Key: string; Value: Int64);
+begin System.JSON.TJSONObject(FBacking).AddPair(Key, System.JSON.TJSONNumber.Create(Value)); end;
+
+procedure TJsonObject.PutBool (const Key: string; Value: Boolean);
+begin System.JSON.TJSONObject(FBacking).AddPair(Key, System.JSON.TJSONBool.Create(Value)); end;
+
+procedure TJsonObject.PutFloat(const Key: string; Value: Double);
+begin System.JSON.TJSONObject(FBacking).AddPair(Key, System.JSON.TJSONNumber.Create(Value)); end;
+
+procedure TJsonObject.PutObject(const Key: string; var Obj: TJsonObject);
+var
+  Inner: System.JSON.TJSONValue;
+begin
+  if Obj = nil then Exit;
+  Inner := System.JSON.TJSONValue(Obj.Backing);
+  Obj.FOwnsBacking := False;
+  Obj.Free;
+  Obj := nil;
+  System.JSON.TJSONObject(FBacking).AddPair(Key, Inner);
+end;
+
+procedure TJsonObject.PutArray(const Key: string; var Arr: TJsonArray);
+var
+  Inner: System.JSON.TJSONValue;
+begin
+  if Arr = nil then Exit;
+  Inner := System.JSON.TJSONValue(Arr.Backing);
+  Arr.FOwnsBacking := False;
+  Arr.Free;
+  Arr := nil;
+  System.JSON.TJSONObject(FBacking).AddPair(Key, Inner);
+end;
+
+procedure TJsonObject.PutRaw(const Key, RawJSON: string);
+var
+  V: System.JSON.TJSONValue;
+begin
+  try
+    V := System.JSON.TJSONObject.ParseJSONValue(RawJSON);
+    if V = nil then V := System.JSON.TJSONObject.Create;
+  except
+    V := System.JSON.TJSONObject.Create;
+  end;
+  System.JSON.TJSONObject(FBacking).AddPair(Key, V);
+end;
+
+function TJsonObject.ToJSON: string;
+begin
+  Result := System.JSON.TJSONObject(FBacking).ToJSON;
+end;
+
+function TJsonObject.Backing: TObject;
+begin
+  Result := FBacking;
+end;
+
+(* TJsonArray *)
+
+constructor TJsonArray.Create;
+begin
+  inherited Create;
+  FBacking := System.JSON.TJSONArray.Create;
+  FOwnsBacking := True;
+end;
+
+constructor TJsonArray.CreateWrapping(Backing: TObject; OwnsIt: Boolean);
+begin
+  inherited Create;
+  FBacking := Backing;
+  FOwnsBacking := OwnsIt;
+end;
+
+destructor TJsonArray.Destroy;
+begin
+  if FOwnsBacking and (FBacking <> nil) then FBacking.Free;
+  inherited Destroy;
+end;
+
+class function TJsonArray.Parse(const S: string): TJsonArray;
+var
+  V: System.JSON.TJSONValue;
+begin
+  Result := nil;
+  if Trim(S) = '' then Exit;
+  try
+    V := System.JSON.TJSONObject.ParseJSONValue(S);
+  except
+    on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
+  end;
+  if not (V is System.JSON.TJSONArray) then
+  begin
+    V.Free;
+    Exit;
+  end;
+  Result := TJsonArray.CreateWrapping(V, True);
+end;
+
+function TJsonArray.Count: Integer;
+begin
+  Result := System.JSON.TJSONArray(FBacking).Count;
+end;
+
+function TJsonArray.ItemStr(Index: Integer; const Default: string): string;
+var
+  V: System.JSON.TJSONValue;
+begin
+  if (Index < 0) or (Index >= Count) then Exit(Default);
+  V := System.JSON.TJSONArray(FBacking).Items[Index];
+  if V = nil then Exit(Default);
+  try Result := V.Value; except Result := Default; end;
+end;
+
+function TJsonArray.ItemInt(Index: Integer; Default: Int64): Int64;
+var
+  V: System.JSON.TJSONValue;
+begin
+  if (Index < 0) or (Index >= Count) then Exit(Default);
+  V := System.JSON.TJSONArray(FBacking).Items[Index];
+  if V is System.JSON.TJSONNumber then
+    Result := System.JSON.TJSONNumber(V).AsInt64
+  else
+    Result := Default;
+end;
+
+function TJsonArray.ItemBool(Index: Integer; Default: Boolean): Boolean;
+var
+  V: System.JSON.TJSONValue;
+begin
+  if (Index < 0) or (Index >= Count) then Exit(Default);
+  V := System.JSON.TJSONArray(FBacking).Items[Index];
+  if V is System.JSON.TJSONBool then Result := System.JSON.TJSONBool(V).AsBoolean
+  else Result := Default;
+end;
+
+function TJsonArray.ItemObject(Index: Integer): TJsonObject;
+var
+  V: System.JSON.TJSONValue;
+begin
+  Result := nil;
+  if (Index < 0) or (Index >= Count) then Exit;
+  V := System.JSON.TJSONArray(FBacking).Items[Index];
+  if V is System.JSON.TJSONObject then
+    Result := TJsonObject.CreateWrapping(V, False);
+end;
+
+function TJsonArray.ItemArray(Index: Integer): TJsonArray;
+var
+  V: System.JSON.TJSONValue;
+begin
+  Result := nil;
+  if (Index < 0) or (Index >= Count) then Exit;
+  V := System.JSON.TJSONArray(FBacking).Items[Index];
+  if V is System.JSON.TJSONArray then
+    Result := TJsonArray.CreateWrapping(V, False);
+end;
+
+procedure TJsonArray.AddStr (const Value: string);
+begin System.JSON.TJSONArray(FBacking).Add(Value); end;
+
+procedure TJsonArray.AddInt (Value: Int64);
+begin System.JSON.TJSONArray(FBacking).Add(Value); end;
+
+procedure TJsonArray.AddBool(Value: Boolean);
+begin System.JSON.TJSONArray(FBacking).AddElement(System.JSON.TJSONBool.Create(Value)); end;
+
+procedure TJsonArray.AddObject(var Obj: TJsonObject);
+var
+  Inner: System.JSON.TJSONValue;
+begin
+  if Obj = nil then Exit;
+  Inner := System.JSON.TJSONValue(Obj.Backing);
+  Obj.FOwnsBacking := False;
+  Obj.Free;
+  Obj := nil;
+  System.JSON.TJSONArray(FBacking).AddElement(Inner);
+end;
+
+procedure TJsonArray.AddArray(var Arr: TJsonArray);
+var
+  Inner: System.JSON.TJSONValue;
+begin
+  if Arr = nil then Exit;
+  Inner := System.JSON.TJSONValue(Arr.Backing);
+  Arr.FOwnsBacking := False;
+  Arr.Free;
+  Arr := nil;
+  System.JSON.TJSONArray(FBacking).AddElement(Inner);
+end;
+
+procedure TJsonArray.AddRaw(const RawJSON: string);
+var
+  V: System.JSON.TJSONValue;
+begin
+  try
+    V := System.JSON.TJSONObject.ParseJSONValue(RawJSON);
+    if V <> nil then System.JSON.TJSONArray(FBacking).AddElement(V);
+  except
+    { swallow malformed JSON — call site can detect via Count }
+  end;
+end;
+
+function TJsonArray.ToJSON: string;
+begin
+  Result := System.JSON.TJSONArray(FBacking).ToJSON;
+end;
+
+function TJsonArray.Backing: TObject;
+begin
+  Result := FBacking;
+end;
+
 {$ENDIF}
 
 function JsonReadStr(const Body, Key: string; const Default: string): string;

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -17,7 +17,7 @@
 *)
 unit PasClaw.JSON;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/logger/PasClaw.Logger.pas
+++ b/src/pkg/logger/PasClaw.Logger.pas
@@ -4,7 +4,7 @@
 }
 unit PasClaw.Logger;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -5,7 +5,7 @@
 }
 unit PasClaw.MCP.Bridge;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
@@ -16,7 +16,7 @@
 *)
 unit PasClaw.MCP.HttpClient;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -28,13 +28,13 @@ interface
 
 uses
   SysUtils, Classes,
-  {$IFDEF FPC} Process, {$ENDIF}
-  PasClaw.MCP.Types;
+  PasClaw.MCP.Types,
+  PasClaw.Platform;
 
 type
   TMCPStdioClient = class(TMCPBaseClient)
   private
-    {$IFDEF FPC} FProcess: TProcess; {$ENDIF}
+    FProcess: TStdioProcess;
     FCmd, FArgs, FName: string;
     FNextId:  Integer;
     FBuffer:  string;
@@ -75,26 +75,18 @@ begin
   inherited Destroy;
 end;
 
-{$IFDEF FPC}
 procedure TMCPStdioClient.Close;
 begin
   if FProcess <> nil then
   begin
     try
-      if FProcess.Running then
-        FProcess.Terminate(0);
+      if FProcess.Running then FProcess.Terminate;
     except
       { ignore — we're tearing down }
     end;
     FreeAndNil(FProcess);
   end;
 end;
-{$ELSE}
-procedure TMCPStdioClient.Close;
-begin
-  { Delphi build: nothing was spawned. }
-end;
-{$ENDIF}
 
 function SplitArgs(const S: string): TStringList;
 var
@@ -135,19 +127,10 @@ begin
   if cur <> '' then Result.Add(cur);
 end;
 
-{$IFDEF FPC}
 function TMCPStdioClient.WriteLine(const S: string): Boolean;
-var
-  Buf: string;
 begin
   if (FProcess = nil) or not FProcess.Running then Exit(False);
-  Buf := S + #10;
-  try
-    FProcess.Input.Write(Buf[1], Length(Buf));
-    Result := True;
-  except
-    Result := False;
-  end;
+  Result := FProcess.WriteLineUTF8(S);
 end;
 
 function TMCPStdioClient.ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
@@ -168,37 +151,19 @@ begin
       FBuffer := Copy(FBuffer, NLPos + 1, MaxInt);
       Exit(True);
     end;
-    if not FProcess.Running and (FProcess.Output.NumBytesAvailable = 0) then
-      Exit(False);
-    if FProcess.Output.NumBytesAvailable > 0 then
+    N := FProcess.ReadAvailable(Buf, SizeOf(Buf));
+    if N > 0 then
     begin
-      N := FProcess.Output.Read(Buf, SizeOf(Buf));
-      if N > 0 then
-      begin
-        SetLength(Chunk, N);
-        Move(Buf[0], Chunk[1], N);
-        FBuffer := FBuffer + Chunk;
-      end;
-    end
-    else
-    begin
-      Sleep(20);
-      Inc(Waited, 20);
-      if Waited >= TimeoutMs then Exit(False);
+      SetLength(Chunk, N);
+      Move(Buf[0], Chunk[1], N);
+      FBuffer := FBuffer + Chunk;
+      Continue;
     end;
+    if not FProcess.Running then Exit(False);
+    Inc(Waited, 50);   { ReadAvailable already slept up to ~50 ms }
+    if Waited >= TimeoutMs then Exit(False);
   end;
 end;
-{$ELSE}
-function TMCPStdioClient.WriteLine(const S: string): Boolean;
-begin
-  Result := False;
-end;
-function TMCPStdioClient.ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
-begin
-  Line := '';
-  Result := False;
-end;
-{$ENDIF}
 
 function TMCPStdioClient.RoundTrip(const Method, ParamsJSON: string;
                                    TimeoutMs: Integer;
@@ -246,37 +211,23 @@ function TMCPStdioClient.Connect(TimeoutMs: Integer; out ErrMsg: string): Boolea
 var
   Params, Caps, ClientInfo, RespObj, ResultObj, Inner: TJsonObject;
   Resp: string;
-  {$IFDEF FPC}
   ArgList: TStringList;
-  i: Integer;
-  {$ENDIF}
 begin
   ErrMsg := '';
   if FCmd = '' then begin ErrMsg := 'no command configured'; Exit(False); end;
 
-  {$IFDEF FPC}
-  FProcess := TProcess.Create(nil);
-  FProcess.Executable := FCmd;
+  FProcess := TStdioProcess.Create;
   ArgList := SplitArgs(FArgs);
   try
-    for i := 0 to ArgList.Count - 1 do FProcess.Parameters.Add(ArgList[i]);
+    if not FProcess.Spawn(FCmd, ArgList) then
+    begin
+      ErrMsg := 'failed to spawn ' + FCmd;
+      FreeAndNil(FProcess);
+      Exit(False);
+    end;
   finally
     ArgList.Free;
   end;
-  FProcess.Options := [poUsePipes];
-  try
-    FProcess.Execute;
-  except
-    on E: Exception do
-    begin
-      ErrMsg := 'failed to spawn ' + FCmd + ': ' + E.Message;
-      Exit(False);
-    end;
-  end;
-  {$ELSE}
-  ErrMsg := 'stdio MCP not supported in Delphi build yet (use HTTP MCP)';
-  Exit(False);
-  {$ENDIF}
 
   { initialize }
   Params := TJsonObject.Create;

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -13,6 +13,11 @@
   Message framing: one JSON object per line (LSP-style "Content-Length"
   headers are also valid but most MCP servers default to newline-delimited
   JSON, which is what we implement here).
+
+  Process spawn is FPC-only for now (uses fcl-process). The Delphi build
+  provides stubs that report "stdio MCP not supported in Delphi build yet";
+  full Delphi support needs a CreateProcess (Win) / Posix.Spawn (POSIX)
+  shim with bidirectional pipes.
 }
 unit PasClaw.MCP.StdioClient;
 
@@ -22,13 +27,14 @@ unit PasClaw.MCP.StdioClient;
 interface
 
 uses
-  SysUtils, Classes, Process,
+  SysUtils, Classes,
+  {$IFDEF FPC} Process, {$ENDIF}
   PasClaw.MCP.Types;
 
 type
   TMCPStdioClient = class(TMCPBaseClient)
   private
-    FProcess: TProcess;
+    {$IFDEF FPC} FProcess: TProcess; {$ENDIF}
     FCmd, FArgs, FName: string;
     FNextId:  Integer;
     FBuffer:  string;
@@ -50,7 +56,7 @@ type
 implementation
 
 uses
-  fpjson, jsonparser,
+  PasClaw.JSON,
   PasClaw.Logger;
 
 constructor TMCPStdioClient.Create(const Name, Cmd, Args: string);
@@ -69,6 +75,7 @@ begin
   inherited Destroy;
 end;
 
+{$IFDEF FPC}
 procedure TMCPStdioClient.Close;
 begin
   if FProcess <> nil then
@@ -82,10 +89,16 @@ begin
     FreeAndNil(FProcess);
   end;
 end;
+{$ELSE}
+procedure TMCPStdioClient.Close;
+begin
+  { Delphi build: nothing was spawned. }
+end;
+{$ENDIF}
 
 function SplitArgs(const S: string): TStringList;
 var
-  i, last, n: Integer;
+  i, n: Integer;
   inQuote: Boolean;
   qc: Char;
   cur: string;
@@ -96,7 +109,6 @@ begin
   inQuote := False;
   qc := ' ';
   i := 1;
-  last := 1;
   while i <= n do
   begin
     if inQuote then
@@ -119,14 +131,13 @@ begin
         cur := cur + S[i];
     end;
     Inc(i);
-    Inc(last);
   end;
   if cur <> '' then Result.Add(cur);
 end;
 
+{$IFDEF FPC}
 function TMCPStdioClient.WriteLine(const S: string): Boolean;
 var
-  Bytes: TBytes;
   Buf: string;
 begin
   if (FProcess = nil) or not FProcess.Running then Exit(False);
@@ -177,36 +188,36 @@ begin
     end;
   end;
 end;
+{$ELSE}
+function TMCPStdioClient.WriteLine(const S: string): Boolean;
+begin
+  Result := False;
+end;
+function TMCPStdioClient.ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
+begin
+  Line := '';
+  Result := False;
+end;
+{$ENDIF}
 
 function TMCPStdioClient.RoundTrip(const Method, ParamsJSON: string;
                                    TimeoutMs: Integer;
                                    out RespJSON: string): Boolean;
 var
   Id: Integer;
-  Req: TJSONObject;
-  ParamsData: TJSONData;
+  Req, RespObj: TJsonObject;
   Line: string;
-  RespRoot: TJSONData;
-  RespObj: TJSONObject;
 begin
   RespJSON := '';
   Id := FNextId; Inc(FNextId);
 
-  Req := TJSONObject.Create;
+  Req := TJsonObject.Create;
   try
-    Req.Add('jsonrpc', JSONRPCVersion);
-    Req.Add('id', Id);
-    Req.Add('method', Method);
-    if ParamsJSON <> '' then
-    begin
-      try
-        ParamsData := GetJSON(ParamsJSON);
-        Req.Add('params', ParamsData);
-      except
-        Req.Add('params', TJSONObject.Create);
-      end;
-    end;
-    if not WriteLine(Req.AsJSON) then Exit(False);
+    Req.PutStr('jsonrpc', JSONRPCVersion);
+    Req.PutInt('id',      Id);
+    Req.PutStr('method',  Method);
+    if ParamsJSON <> '' then Req.PutRaw('params', ParamsJSON);
+    if not WriteLine(Req.ToJSON) then Exit(False);
   finally
     Req.Free;
   end;
@@ -216,21 +227,16 @@ begin
     Line := Trim(Line);
     if Line = '' then Continue;
     LogDebug('mcp[%s] <- %s', [FName, Copy(Line, 1, 200)]);
+    RespObj := TJsonObject.Parse(Line);
+    if RespObj = nil then Continue;
     try
-      RespRoot := GetJSON(Line);
-    except
-      Continue;
-    end;
-    try
-      if not (RespRoot is TJSONObject) then Continue;
-      RespObj := TJSONObject(RespRoot);
       { Skip notifications (no id) and responses to other requests. }
-      if (RespObj.IndexOfName('id') < 0) or
-         (RespObj.Integers['id'] <> Id) then Continue;
+      if (not RespObj.Has('id')) or (RespObj.GetInt('id', -1) <> Id) then
+        Continue;
       RespJSON := Line;
       Exit(True);
     finally
-      RespRoot.Free;
+      RespObj.Free;
     end;
   end;
   Result := False;
@@ -238,16 +244,17 @@ end;
 
 function TMCPStdioClient.Connect(TimeoutMs: Integer; out ErrMsg: string): Boolean;
 var
+  Params, Caps, ClientInfo, RespObj, ResultObj, Inner: TJsonObject;
+  Resp: string;
+  {$IFDEF FPC}
   ArgList: TStringList;
   i: Integer;
-  Params, ServerCaps, ServerInfo: TJSONObject;
-  Resp: string;
-  RespData: TJSONData;
-  RespObj, ResultObj: TJSONObject;
+  {$ENDIF}
 begin
   ErrMsg := '';
   if FCmd = '' then begin ErrMsg := 'no command configured'; Exit(False); end;
 
+  {$IFDEF FPC}
   FProcess := TProcess.Create(nil);
   FProcess.Executable := FCmd;
   ArgList := SplitArgs(FArgs);
@@ -266,18 +273,22 @@ begin
       Exit(False);
     end;
   end;
+  {$ELSE}
+  ErrMsg := 'stdio MCP not supported in Delphi build yet (use HTTP MCP)';
+  Exit(False);
+  {$ENDIF}
 
   { initialize }
-  Params := TJSONObject.Create;
+  Params := TJsonObject.Create;
   try
-    Params.Add('protocolVersion', MCPProtocolVersion);
-    ServerCaps := TJSONObject.Create;
-    Params.Add('capabilities', ServerCaps);
-    ServerInfo := TJSONObject.Create;
-    ServerInfo.Add('name', 'pasclaw');
-    ServerInfo.Add('version', '0.1');
-    Params.Add('clientInfo', ServerInfo);
-    if not RoundTrip('initialize', Params.AsJSON, TimeoutMs, Resp) then
+    Params.PutStr('protocolVersion', MCPProtocolVersion);
+    Caps := TJsonObject.Create;
+    Params.PutObject('capabilities', Caps);
+    ClientInfo := TJsonObject.Create;
+    ClientInfo.PutStr('name',    'pasclaw');
+    ClientInfo.PutStr('version', '0.1');
+    Params.PutObject('clientInfo', ClientInfo);
+    if not RoundTrip('initialize', Params.ToJSON, TimeoutMs, Resp) then
     begin
       ErrMsg := 'no response to initialize from ' + FCmd;
       Exit(False);
@@ -287,34 +298,39 @@ begin
   end;
 
   { Parse server info & capabilities out of the response. }
-  RespData := GetJSON(Resp);
+  RespObj := TJsonObject.Parse(Resp);
+  if RespObj = nil then begin ErrMsg := 'bad initialize response'; Exit(False); end;
   try
-    if RespData is TJSONObject then
+    if RespObj.Has('error') then
     begin
-      RespObj := TJSONObject(RespData);
-      if RespObj.IndexOfName('error') >= 0 then
-      begin
-        ErrMsg := 'initialize error: ' + RespObj.Find('error').AsJSON;
-        Exit(False);
+      ErrMsg := 'initialize error';
+      Exit(False);
+    end;
+    ResultObj := RespObj.ChildObject('result');
+    if ResultObj <> nil then
+    try
+      Inner := ResultObj.ChildObject('serverInfo');
+      if Inner <> nil then
+      try
+        FInfo.Name    := Inner.GetStr('name',    '');
+        FInfo.Version := Inner.GetStr('version', '');
+      finally
+        Inner.Free;
       end;
-      if RespObj.IndexOfName('result') >= 0 then
-      begin
-        ResultObj := RespObj.Objects['result'];
-        if ResultObj.IndexOfName('serverInfo') >= 0 then
-        begin
-          FInfo.Name    := ResultObj.Objects['serverInfo'].Get('name', '');
-          FInfo.Version := ResultObj.Objects['serverInfo'].Get('version', '');
-        end;
-        if ResultObj.IndexOfName('capabilities') >= 0 then
-        begin
-          FInfo.Caps.Tools     := ResultObj.Objects['capabilities'].IndexOfName('tools')     >= 0;
-          FInfo.Caps.Resources := ResultObj.Objects['capabilities'].IndexOfName('resources') >= 0;
-          FInfo.Caps.Prompts   := ResultObj.Objects['capabilities'].IndexOfName('prompts')   >= 0;
-        end;
+      Inner := ResultObj.ChildObject('capabilities');
+      if Inner <> nil then
+      try
+        FInfo.Caps.Tools     := Inner.Has('tools');
+        FInfo.Caps.Resources := Inner.Has('resources');
+        FInfo.Caps.Prompts   := Inner.Has('prompts');
+      finally
+        Inner.Free;
       end;
+    finally
+      ResultObj.Free;
     end;
   finally
-    RespData.Free;
+    RespObj.Free;
   end;
 
   { Send "initialized" notification (no id, no response expected). }
@@ -325,9 +341,8 @@ end;
 function TMCPStdioClient.ListTools(out Tools: TMCPToolArray; out ErrMsg: string): Boolean;
 var
   Resp: string;
-  Data: TJSONData;
-  Obj, ResultObj, ToolObj: TJSONObject;
-  Arr: TJSONArray;
+  Obj, ResultObj, ToolObj, Schema: TJsonObject;
+  Arr: TJsonArray;
   i: Integer;
 begin
   ErrMsg := '';
@@ -337,33 +352,46 @@ begin
     ErrMsg := 'no response to tools/list';
     Exit(False);
   end;
-  Data := GetJSON(Resp);
+  Obj := TJsonObject.Parse(Resp);
+  if Obj = nil then Exit(False);
   try
-    if not (Data is TJSONObject) then Exit(False);
-    Obj := TJSONObject(Data);
-    if Obj.IndexOfName('error') >= 0 then
-    begin
-      ErrMsg := 'tools/list error: ' + Obj.Find('error').AsJSON;
-      Exit(False);
-    end;
-    if Obj.IndexOfName('result') < 0 then Exit(False);
-    ResultObj := Obj.Objects['result'];
-    if ResultObj.IndexOfName('tools') < 0 then Exit(True);   { server has none }
-    Arr := ResultObj.Arrays['tools'];
-    SetLength(Tools, Arr.Count);
-    for i := 0 to Arr.Count - 1 do
-    begin
-      ToolObj := TJSONObject(Arr[i]);
-      Tools[i].Name        := ToolObj.Get('name', '');
-      Tools[i].Description := ToolObj.Get('description', '');
-      if ToolObj.IndexOfName('inputSchema') >= 0 then
-        Tools[i].Schema := ToolObj.Find('inputSchema').AsJSON
-      else
-        Tools[i].Schema := '{"type":"object"}';
-      Tools[i].Server := FName;
+    if Obj.Has('error') then begin ErrMsg := 'tools/list error'; Exit(False); end;
+    ResultObj := Obj.ChildObject('result');
+    if ResultObj = nil then Exit(True);
+    try
+      Arr := ResultObj.ChildArray('tools');
+      if Arr = nil then Exit(True);
+      try
+        SetLength(Tools, Arr.Count);
+        for i := 0 to Arr.Count - 1 do
+        begin
+          ToolObj := Arr.ItemObject(i);
+          if ToolObj = nil then Continue;
+          try
+            Tools[i].Name        := ToolObj.GetStr('name',        '');
+            Tools[i].Description := ToolObj.GetStr('description', '');
+            Schema := ToolObj.ChildObject('inputSchema');
+            if Schema <> nil then
+            try
+              Tools[i].Schema := Schema.ToJSON;
+            finally
+              Schema.Free;
+            end
+            else
+              Tools[i].Schema := '{"type":"object"}';
+            Tools[i].Server := FName;
+          finally
+            ToolObj.Free;
+          end;
+        end;
+      finally
+        Arr.Free;
+      end;
+    finally
+      ResultObj.Free;
     end;
   finally
-    Data.Free;
+    Obj.Free;
   end;
   Result := True;
 end;
@@ -371,33 +399,19 @@ end;
 function TMCPStdioClient.CallTool(const ToolName, ArgsJSON: string;
                                   out ResultText, ErrMsg: string): Boolean;
 var
-  Params: TJSONObject;
-  ArgsData: TJSONData;
+  Params, RespObj, ResultObj, Block: TJsonObject;
+  ContentArr: TJsonArray;
   Resp: string;
-  Data: TJSONData;
-  Obj, ResultObj, Block: TJSONObject;
-  ContentArr: TJSONArray;
   i: Integer;
-  Kind: string;
 begin
   ResultText := '';
   ErrMsg := '';
-  Params := TJSONObject.Create;
+  Params := TJsonObject.Create;
   try
-    Params.Add('name', ToolName);
-    if ArgsJSON <> '' then
-    begin
-      try
-        ArgsData := GetJSON(ArgsJSON);
-        Params.Add('arguments', ArgsData);
-      except
-        Params.Add('arguments', TJSONObject.Create);
-      end;
-    end
-    else
-      Params.Add('arguments', TJSONObject.Create);
-
-    if not RoundTrip('tools/call', Params.AsJSON, 30000, Resp) then
+    Params.PutStr('name', ToolName);
+    if ArgsJSON <> '' then Params.PutRaw('arguments', ArgsJSON)
+    else                    Params.PutRaw('arguments', '{}');
+    if not RoundTrip('tools/call', Params.ToJSON, 30000, Resp) then
     begin
       ErrMsg := 'no response to tools/call';
       Exit(False);
@@ -406,36 +420,40 @@ begin
     Params.Free;
   end;
 
-  Data := GetJSON(Resp);
+  RespObj := TJsonObject.Parse(Resp);
+  if RespObj = nil then Exit(False);
   try
-    if not (Data is TJSONObject) then Exit(False);
-    Obj := TJSONObject(Data);
-    if Obj.IndexOfName('error') >= 0 then
-    begin
-      ErrMsg := 'tools/call error: ' + Obj.Find('error').AsJSON;
-      Exit(False);
-    end;
-    if Obj.IndexOfName('result') < 0 then Exit(False);
-    ResultObj := Obj.Objects['result'];
-    if ResultObj.IndexOfName('content') >= 0 then
-    begin
-      ContentArr := ResultObj.Arrays['content'];
-      for i := 0 to ContentArr.Count - 1 do
-      begin
-        Block := TJSONObject(ContentArr[i]);
-        Kind := Block.Get('type', '');
-        if Kind = 'text' then
+    if RespObj.Has('error') then begin ErrMsg := 'tools/call error'; Exit(False); end;
+    ResultObj := RespObj.ChildObject('result');
+    if ResultObj = nil then Exit(False);
+    try
+      ContentArr := ResultObj.ChildArray('content');
+      if ContentArr <> nil then
+      try
+        for i := 0 to ContentArr.Count - 1 do
         begin
-          if ResultText <> '' then ResultText := ResultText + sLineBreak;
-          ResultText := ResultText + Block.Get('text', '');
+          Block := ContentArr.ItemObject(i);
+          if Block = nil then Continue;
+          try
+            if Block.GetStr('type', '') = 'text' then
+            begin
+              if ResultText <> '' then ResultText := ResultText + sLineBreak;
+              ResultText := ResultText + Block.GetStr('text', '');
+            end;
+          finally
+            Block.Free;
+          end;
         end;
+      finally
+        ContentArr.Free;
       end;
+      if (ResultText = '') and ResultObj.GetBool('isError', False) then
+        ErrMsg := 'tool reported error (no text content)';
+    finally
+      ResultObj.Free;
     end;
-    if (ResultText = '') and (ResultObj.IndexOfName('isError') >= 0) and
-       (ResultObj.Booleans['isError']) then
-      ErrMsg := 'tool reported error (no text content)';
   finally
-    Data.Free;
+    RespObj.Free;
   end;
   Result := ErrMsg = '';
 end;

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -21,7 +21,7 @@
 }
 unit PasClaw.MCP.StdioClient;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/mcp/PasClaw.MCP.Types.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Types.pas
@@ -6,7 +6,7 @@
 }
 unit PasClaw.MCP.Types;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/membench/PasClaw.Membench.Runner.pas
+++ b/src/pkg/membench/PasClaw.Membench.Runner.pas
@@ -12,7 +12,7 @@
 *)
 unit PasClaw.Membench.Runner;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/memory/PasClaw.Memory.pas
+++ b/src/pkg/memory/PasClaw.Memory.pas
@@ -11,7 +11,7 @@
 *)
 unit PasClaw.Memory;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -1,0 +1,614 @@
+(*
+  PasClaw.Platform - cross-toolchain process primitives.
+
+  Two surfaces:
+
+    RunOneShot       Spawn a shell command, capture stdout+stderr, wait
+                     for exit. Caps output at 1 MiB. Used by Tools.Shell
+                     and Skills.Loader.
+
+    TStdioProcess    Long-lived child process with bidirectional pipes.
+                     Used by MCP.StdioClient. Write JSON-RPC frames in,
+                     read responses out. Non-blocking-ish reads with a
+                     small per-call buffer; ReadAvailable returns however
+                     much is currently in the pipe.
+
+  Three implementations selected at compile time:
+    {$IFDEF FPC}                use fcl-process (works on every FPC target)
+    {$ELSE} {$IFDEF MSWINDOWS}  CreateProcess + CreatePipe + ReadFile/WriteFile
+    {$ELSE}                     Posix.Unistd pipe / fork / execvp / waitpid
+
+  The interface is identical across all three so callers stay free of
+  IFDEFs.
+*)
+unit PasClaw.Platform;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+const
+  OneShotMaxBytes = 1024 * 1024;  { 1 MiB cap on captured output }
+  ReadBufferSize  = 4096;
+
+type
+  TStdioProcess = class
+  private
+    {$IFDEF FPC}
+    FProcess: TObject;   { TProcess; declared as TObject to keep fcl-process
+                           out of the public interface }
+    {$ENDIF}
+    {$IFNDEF FPC}{$IFDEF MSWINDOWS}
+    FProcHandle: THandle;
+    FThreadHandle: THandle;
+    FStdinWrite:  THandle;
+    FStdoutRead:  THandle;
+    {$ENDIF}{$ENDIF}
+    {$IFNDEF FPC}{$IFNDEF MSWINDOWS}
+    FPid:        Integer;
+    FStdinFd:    Integer;   { write end of child stdin pipe }
+    FStdoutFd:   Integer;   { read end of child stdout pipe }
+    {$ENDIF}{$ENDIF}
+    FStarted: Boolean;
+    FExited:  Boolean;
+    FExitCode: Integer;
+  public
+    constructor Create;
+    destructor  Destroy; override;
+
+    { Spawn Cmd with each entry of Args as a separate argv element. Returns
+      True on successful spawn, False on failure (errno-style; check log). }
+    function Spawn(const Cmd: string; Args: TStrings): Boolean;
+
+    { Send Buf to child stdin. Returns the byte count written. }
+    function WriteBytes(const Buf; Count: Integer): Integer;
+    function WriteLineUTF8(const S: string): Boolean;
+
+    { Read up to BufSize bytes from child stdout. Returns the count actually
+      read; 0 = no data available right now (or child has exited and pipe
+      is drained). Does not block longer than ~50 ms. }
+    function ReadAvailable(var Buf; BufSize: Integer): Integer;
+
+    { True until the process has been reaped. }
+    function Running: Boolean;
+
+    procedure Terminate;
+    property ExitCode: Integer read FExitCode;
+  end;
+
+(* Run a shell command; capture combined stdout+stderr (UTF-8) up to
+   OneShotMaxBytes. Returns the exit code; -1 on failure to spawn. *)
+function RunOneShot(const Cmd: string; out Output: string): Integer;
+
+implementation
+
+uses
+  {$IFDEF FPC}
+    Process
+  {$ELSE}{$IFDEF MSWINDOWS}
+    Winapi.Windows
+  {$ELSE}
+    Posix.Base, Posix.Unistd, Posix.Stdlib, Posix.SysWait,
+    Posix.Fcntl, Posix.Signal, Posix.SysTypes
+  {$ENDIF}{$ENDIF};
+
+{$IFDEF FPC}
+(* ----- FPC backend (fcl-process) ----- *)
+
+type
+  TInternalProcess = Process.TProcess;
+
+constructor TStdioProcess.Create;
+begin
+  inherited Create;
+  FProcess := nil;
+end;
+
+destructor TStdioProcess.Destroy;
+begin
+  Terminate;
+  if FProcess <> nil then begin TInternalProcess(FProcess).Free; FProcess := nil; end;
+  inherited Destroy;
+end;
+
+function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
+var
+  P: TInternalProcess;
+  i: Integer;
+begin
+  if FStarted then Exit(False);
+  P := TInternalProcess.Create(nil);
+  P.Executable := Cmd;
+  for i := 0 to Args.Count - 1 do P.Parameters.Add(Args[i]);
+  P.Options := [poUsePipes];
+  try
+    P.Execute;
+  except
+    P.Free;
+    Exit(False);
+  end;
+  FProcess := P;
+  FStarted := True;
+  Result := True;
+end;
+
+function TStdioProcess.WriteBytes(const Buf; Count: Integer): Integer;
+begin
+  Result := 0;
+  if (FProcess = nil) or not TInternalProcess(FProcess).Running then Exit;
+  try
+    Result := TInternalProcess(FProcess).Input.Write(Buf, Count);
+  except
+    Result := 0;
+  end;
+end;
+
+function TStdioProcess.WriteLineUTF8(const S: string): Boolean;
+var
+  Line: string;
+begin
+  Line := S + #10;
+  Result := WriteBytes(Pointer(Line)^, Length(Line)) = Length(Line);
+end;
+
+function TStdioProcess.ReadAvailable(var Buf; BufSize: Integer): Integer;
+var
+  P: TInternalProcess;
+  Avail, Waited: Integer;
+begin
+  Result := 0;
+  if FProcess = nil then Exit;
+  P := TInternalProcess(FProcess);
+  Waited := 0;
+  while True do
+  begin
+    Avail := P.Output.NumBytesAvailable;
+    if Avail > 0 then
+    begin
+      if Avail > BufSize then Avail := BufSize;
+      Result := P.Output.Read(Buf, Avail);
+      Exit;
+    end;
+    if (not P.Running) then Exit;
+    Sleep(10);
+    Inc(Waited, 10);
+    if Waited >= 50 then Exit;
+  end;
+end;
+
+function TStdioProcess.Running: Boolean;
+begin
+  if (FProcess = nil) or not FStarted then Exit(False);
+  Result := TInternalProcess(FProcess).Running;
+  if not Result and not FExited then
+  begin
+    FExited := True;
+    try FExitCode := TInternalProcess(FProcess).ExitStatus; except FExitCode := -1; end;
+  end;
+end;
+
+procedure TStdioProcess.Terminate;
+begin
+  if (FProcess <> nil) and TInternalProcess(FProcess).Running then
+    try TInternalProcess(FProcess).Terminate(0); except end;
+end;
+
+function RunOneShot(const Cmd: string; out Output: string): Integer;
+var
+  P: TInternalProcess;
+  M: TMemoryStream;
+  Buf: array[0..ReadBufferSize - 1] of Byte;
+  N, Total: Integer;
+begin
+  Result := -1;
+  Output := '';
+  P := TInternalProcess.Create(nil);
+  M := TMemoryStream.Create;
+  try
+    {$IFDEF MSWINDOWS}
+    P.Executable := 'cmd.exe';
+    P.Parameters.Add('/C'); P.Parameters.Add(Cmd);
+    {$ELSE}
+    P.Executable := '/bin/sh';
+    P.Parameters.Add('-c'); P.Parameters.Add(Cmd);
+    {$ENDIF}
+    P.Options := [poUsePipes, poStderrToOutPut];
+    try P.Execute; except Exit; end;
+    Total := 0;
+    while P.Running or (P.Output.NumBytesAvailable > 0) do
+    begin
+      while P.Output.NumBytesAvailable > 0 do
+      begin
+        N := P.Output.Read(Buf, SizeOf(Buf));
+        if N > 0 then begin M.WriteBuffer(Buf, N); Inc(Total, N); end;
+        if Total > OneShotMaxBytes then begin P.Terminate(124); Break; end;
+      end;
+      Sleep(20);
+    end;
+    Result := P.ExitStatus;
+    SetLength(Output, M.Size);
+    if M.Size > 0 then begin M.Position := 0; M.ReadBuffer(Output[1], M.Size); end;
+  finally
+    M.Free;
+    P.Free;
+  end;
+end;
+
+{$ELSE}
+{$IFDEF MSWINDOWS}
+(* ----- Delphi/Windows backend (Win32 API direct) ----- *)
+
+constructor TStdioProcess.Create;
+begin
+  inherited Create;
+  FProcHandle   := 0;
+  FThreadHandle := 0;
+  FStdinWrite   := 0;
+  FStdoutRead   := 0;
+end;
+
+destructor TStdioProcess.Destroy;
+begin
+  Terminate;
+  if FStdinWrite  <> 0 then CloseHandle(FStdinWrite);
+  if FStdoutRead  <> 0 then CloseHandle(FStdoutRead);
+  if FProcHandle  <> 0 then CloseHandle(FProcHandle);
+  if FThreadHandle <> 0 then CloseHandle(FThreadHandle);
+  inherited Destroy;
+end;
+
+function QuoteArg(const S: string): string;
+begin
+  if (Pos(' ', S) > 0) or (Pos('"', S) > 0) then
+    Result := '"' + StringReplace(S, '"', '\"', [rfReplaceAll]) + '"'
+  else
+    Result := S;
+end;
+
+function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
+var
+  SA: TSecurityAttributes;
+  SI: TStartupInfoW;
+  PI: TProcessInformation;
+  ChildStdinRead, ChildStdoutWrite: THandle;
+  CmdLine: string;
+  i: Integer;
+begin
+  if FStarted then Exit(False);
+  SA.nLength := SizeOf(SA);
+  SA.bInheritHandle := True;
+  SA.lpSecurityDescriptor := nil;
+
+  { stdout pipe: parent reads, child writes }
+  if not CreatePipe(FStdoutRead, ChildStdoutWrite, @SA, 0) then Exit(False);
+  SetHandleInformation(FStdoutRead, HANDLE_FLAG_INHERIT, 0);
+  { stdin pipe: parent writes, child reads }
+  if not CreatePipe(ChildStdinRead, FStdinWrite, @SA, 0) then
+  begin
+    CloseHandle(FStdoutRead); CloseHandle(ChildStdoutWrite);
+    Exit(False);
+  end;
+  SetHandleInformation(FStdinWrite, HANDLE_FLAG_INHERIT, 0);
+
+  ZeroMemory(@SI, SizeOf(SI));
+  SI.cb := SizeOf(SI);
+  SI.dwFlags := STARTF_USESHOWWINDOW or STARTF_USESTDHANDLES;
+  SI.wShowWindow := SW_HIDE;
+  SI.hStdInput  := ChildStdinRead;
+  SI.hStdOutput := ChildStdoutWrite;
+  SI.hStdError  := ChildStdoutWrite;
+
+  CmdLine := QuoteArg(Cmd);
+  for i := 0 to Args.Count - 1 do CmdLine := CmdLine + ' ' + QuoteArg(Args[i]);
+
+  if not CreateProcessW(nil, PWideChar(CmdLine), nil, nil, True,
+                        CREATE_NO_WINDOW, nil, nil, SI, PI) then
+  begin
+    CloseHandle(FStdoutRead); CloseHandle(ChildStdoutWrite);
+    CloseHandle(ChildStdinRead); CloseHandle(FStdinWrite);
+    FStdoutRead := 0; FStdinWrite := 0;
+    Exit(False);
+  end;
+
+  { Close child-side ends in the parent }
+  CloseHandle(ChildStdinRead);
+  CloseHandle(ChildStdoutWrite);
+
+  FProcHandle   := PI.hProcess;
+  FThreadHandle := PI.hThread;
+  FStarted := True;
+  Result := True;
+end;
+
+function TStdioProcess.WriteBytes(const Buf; Count: Integer): Integer;
+var
+  W: DWORD;
+begin
+  Result := 0;
+  if FStdinWrite = 0 then Exit;
+  if not WriteFile(FStdinWrite, Buf, Count, W, nil) then Exit(0);
+  Result := Integer(W);
+end;
+
+function TStdioProcess.WriteLineUTF8(const S: string): Boolean;
+var
+  Line: UTF8String;
+begin
+  Line := UTF8String(S) + #10;
+  Result := WriteBytes(Pointer(Line)^, Length(Line)) = Length(Line);
+end;
+
+function TStdioProcess.ReadAvailable(var Buf; BufSize: Integer): Integer;
+var
+  Avail, R: DWORD;
+  Waited: Integer;
+begin
+  Result := 0;
+  if FStdoutRead = 0 then Exit;
+  Waited := 0;
+  while True do
+  begin
+    Avail := 0;
+    if not PeekNamedPipe(FStdoutRead, nil, 0, nil, @Avail, nil) then Exit(0);
+    if Avail > 0 then
+    begin
+      if Integer(Avail) > BufSize then Avail := DWORD(BufSize);
+      if not ReadFile(FStdoutRead, Buf, Avail, R, nil) then Exit(0);
+      Exit(Integer(R));
+    end;
+    if WaitForSingleObject(FProcHandle, 0) = WAIT_OBJECT_0 then Exit;
+    Sleep(10);
+    Inc(Waited, 10);
+    if Waited >= 50 then Exit;
+  end;
+end;
+
+function TStdioProcess.Running: Boolean;
+var
+  Code: DWORD;
+begin
+  if (FProcHandle = 0) or not FStarted then Exit(False);
+  if not GetExitCodeProcess(FProcHandle, Code) then Exit(False);
+  Result := Code = STILL_ACTIVE;
+  if (not Result) and (not FExited) then
+  begin
+    FExited := True;
+    FExitCode := Integer(Code);
+  end;
+end;
+
+procedure TStdioProcess.Terminate;
+begin
+  if (FProcHandle <> 0) and Running then
+    TerminateProcess(FProcHandle, 0);
+end;
+
+function RunOneShot(const Cmd: string; out Output: string): Integer;
+var
+  P: TStdioProcess;
+  Args: TStringList;
+  Buf: array[0..ReadBufferSize - 1] of Byte;
+  Total, N: Integer;
+  Acc: TMemoryStream;
+begin
+  Result := -1;
+  Output := '';
+  P := TStdioProcess.Create;
+  Args := TStringList.Create;
+  Acc := TMemoryStream.Create;
+  try
+    Args.Add('/C'); Args.Add(Cmd);
+    if not P.Spawn('cmd.exe', Args) then Exit;
+    Total := 0;
+    while P.Running or True do
+    begin
+      N := P.ReadAvailable(Buf, SizeOf(Buf));
+      if N > 0 then
+      begin
+        Acc.WriteBuffer(Buf, N);
+        Inc(Total, N);
+        if Total > OneShotMaxBytes then begin P.Terminate; Break; end;
+      end
+      else if not P.Running then Break;
+    end;
+    WaitForSingleObject(P.FProcHandle, INFINITE);
+    P.Running;   { latches ExitCode via the side effect }
+    Result := P.ExitCode;
+    SetLength(Output, Acc.Size);
+    if Acc.Size > 0 then begin Acc.Position := 0; Acc.ReadBuffer(Output[1], Acc.Size); end;
+  finally
+    Acc.Free;
+    Args.Free;
+    P.Free;
+  end;
+end;
+
+{$ELSE}
+(* ----- Delphi/POSIX backend ----- *)
+
+const
+  STDIN_FILENO  = 0;
+  STDOUT_FILENO = 1;
+  STDERR_FILENO = 2;
+
+function pipe(fildes: array of Integer): Integer; cdecl;
+  external libc name _PU + 'pipe';
+function execvp(const path: PAnsiChar; const argv: PPAnsiChar): Integer; cdecl;
+  external libc name _PU + 'execvp';
+
+constructor TStdioProcess.Create;
+begin
+  inherited Create;
+  FPid := 0;
+  FStdinFd := -1;
+  FStdoutFd := -1;
+end;
+
+destructor TStdioProcess.Destroy;
+begin
+  Terminate;
+  if FStdinFd  >= 0 then __close(FStdinFd);
+  if FStdoutFd >= 0 then __close(FStdoutFd);
+  inherited Destroy;
+end;
+
+function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
+var
+  StdinPipe, StdoutPipe: array[0..1] of Integer;
+  Pid: pid_t;
+  i: Integer;
+  Argv: array of Pointer;
+  Argv0, ArgsI: TArray<RawByteString>;
+  Path: AnsiString;
+begin
+  if FStarted then Exit(False);
+  if pipe(StdinPipe)  <> 0 then Exit(False);
+  if pipe(StdoutPipe) <> 0 then begin __close(StdinPipe[0]); __close(StdinPipe[1]); Exit(False); end;
+
+  Pid := fork;
+  if Pid < 0 then Exit(False);
+
+  if Pid = 0 then
+  begin
+    { child }
+    dup2(StdinPipe[0],  STDIN_FILENO);
+    dup2(StdoutPipe[1], STDOUT_FILENO);
+    dup2(StdoutPipe[1], STDERR_FILENO);
+    __close(StdinPipe[0]);  __close(StdinPipe[1]);
+    __close(StdoutPipe[0]); __close(StdoutPipe[1]);
+
+    Path := UTF8Encode(Cmd);
+    SetLength(ArgsI, Args.Count);
+    SetLength(Argv, Args.Count + 2);
+    Argv[0] := PAnsiChar(Path);
+    for i := 0 to Args.Count - 1 do
+    begin
+      ArgsI[i] := UTF8Encode(Args[i]);
+      Argv[i + 1] := PAnsiChar(ArgsI[i]);
+    end;
+    Argv[Args.Count + 1] := nil;
+    execvp(PAnsiChar(Path), PPAnsiChar(@Argv[0]));
+    _exit(127);
+  end;
+
+  { parent }
+  __close(StdinPipe[0]);
+  __close(StdoutPipe[1]);
+  FStdinFd  := StdinPipe[1];
+  FStdoutFd := StdoutPipe[0];
+  FPid := Pid;
+  FStarted := True;
+  Result := True;
+end;
+
+function TStdioProcess.WriteBytes(const Buf; Count: Integer): Integer;
+begin
+  if FStdinFd < 0 then Exit(0);
+  Result := __write(FStdinFd, Buf, Count);
+end;
+
+function TStdioProcess.WriteLineUTF8(const S: string): Boolean;
+var
+  Line: UTF8String;
+begin
+  Line := UTF8String(S) + #10;
+  Result := WriteBytes(Pointer(Line)^, Length(Line)) = Length(Line);
+end;
+
+function TStdioProcess.ReadAvailable(var Buf; BufSize: Integer): Integer;
+var
+  Status, R, Waited: Integer;
+  TimeoutFd: TFDSet;
+  Tv: timeval;
+begin
+  Result := 0;
+  if FStdoutFd < 0 then Exit;
+  Waited := 0;
+  while True do
+  begin
+    FillChar(TimeoutFd, SizeOf(TimeoutFd), 0);
+    FD_SET(FStdoutFd, TimeoutFd);
+    Tv.tv_sec  := 0;
+    Tv.tv_usec := 10 * 1000;   { 10 ms }
+    Status := select(FStdoutFd + 1, @TimeoutFd, nil, nil, @Tv);
+    if Status > 0 then
+    begin
+      R := __read(FStdoutFd, Buf, BufSize);
+      if R > 0 then Exit(R);
+      Exit;
+    end;
+    if not Running then Exit;
+    Inc(Waited, 10);
+    if Waited >= 50 then Exit;
+  end;
+end;
+
+function TStdioProcess.Running: Boolean;
+var
+  Status, R: Integer;
+begin
+  if (FPid = 0) or not FStarted then Exit(False);
+  R := waitpid(FPid, Status, WNOHANG);
+  if R = 0 then Exit(True);   { still running }
+  if R = FPid then
+  begin
+    FExited := True;
+    if WIFEXITED(Status) then FExitCode := WEXITSTATUS(Status)
+    else FExitCode := -1;
+  end;
+  Result := False;
+end;
+
+procedure TStdioProcess.Terminate;
+begin
+  if (FPid <> 0) and Running then
+    kill(FPid, SIGTERM);
+end;
+
+function RunOneShot(const Cmd: string; out Output: string): Integer;
+var
+  P: TStdioProcess;
+  Args: TStringList;
+  Buf: array[0..ReadBufferSize - 1] of Byte;
+  Total, N, Status: Integer;
+  Acc: TMemoryStream;
+begin
+  Result := -1;
+  Output := '';
+  P := TStdioProcess.Create;
+  Args := TStringList.Create;
+  Acc := TMemoryStream.Create;
+  try
+    Args.Add('-c'); Args.Add(Cmd);
+    if not P.Spawn('/bin/sh', Args) then Exit;
+    Total := 0;
+    while P.Running or True do
+    begin
+      N := P.ReadAvailable(Buf, SizeOf(Buf));
+      if N > 0 then
+      begin
+        Acc.WriteBuffer(Buf, N);
+        Inc(Total, N);
+        if Total > OneShotMaxBytes then begin P.Terminate; Break; end;
+      end
+      else if not P.Running then Break;
+    end;
+    waitpid(P.FPid, Status, 0);
+    if WIFEXITED(Status) then Result := WEXITSTATUS(Status) else Result := -1;
+    SetLength(Output, Acc.Size);
+    if Acc.Size > 0 then begin Acc.Position := 0; Acc.ReadBuffer(Output[1], Acc.Size); end;
+  finally
+    Acc.Free;
+    Args.Free;
+    P.Free;
+  end;
+end;
+
+{$ENDIF}
+{$ENDIF}
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -44,7 +44,7 @@ type
 implementation
 
 uses
-  fpjson, jsonparser,
+  PasClaw.JSON,
   PasClaw.Providers.HTTP,
   PasClaw.Providers.Stream,
   PasClaw.Logger;
@@ -96,116 +96,107 @@ function BuildRequest(const Messages: array of TMessage;
                       const Model:    string;
                       const Options:  TChatOptions): string;
 var
-  Root: TJSONObject;
-  MsgArr, ToolArr, ContentArr: TJSONArray;
-  Msg, Block, ToolObj: TJSONObject;
+  Root, Block, ToolObj, Thinking, Msg, EmptyInput: TJsonObject;
+  MsgArr, ToolArr, ContentArr: TJsonArray;
   i, j: Integer;
   Sys: string;
-  ToolSchema: TJSONData;
 begin
-  Root := TJSONObject.Create;
+  Root := TJsonObject.Create;
   try
-    Root.Add('model', Model);
-    Root.Add('max_tokens', Options.MaxTokens);
-    if Options.Temperature > 0 then Root.Add('temperature', Options.Temperature);
+    Root.PutStr('model',      Model);
+    Root.PutInt('max_tokens', Options.MaxTokens);
+    if Options.Temperature > 0 then Root.PutFloat('temperature', Options.Temperature);
 
     { System prompt: prefer Options.SystemPrompt, else first system message. }
     Sys := Options.SystemPrompt;
     for i := 0 to High(Messages) do
       if (Messages[i].Role = mrSystem) and (Sys = '') then
         Sys := Messages[i].Content;
-    if Sys <> '' then Root.Add('system', Sys);
+    if Sys <> '' then Root.PutStr('system', Sys);
 
     if Options.ThinkingLevel <> '' then
     begin
-      Block := TJSONObject.Create;
-      Block.Add('type', 'enabled');
-      if Options.ThinkingLevel = 'low'    then Block.Add('budget_tokens', 1024)
-      else if Options.ThinkingLevel = 'high' then Block.Add('budget_tokens', 8192)
-      else Block.Add('budget_tokens', 2048);
-      Root.Add('thinking', Block);
+      Thinking := TJsonObject.Create;
+      Thinking.PutStr('type', 'enabled');
+      if      Options.ThinkingLevel = 'low'  then Thinking.PutInt('budget_tokens', 1024)
+      else if Options.ThinkingLevel = 'high' then Thinking.PutInt('budget_tokens', 8192)
+      else                                        Thinking.PutInt('budget_tokens', 2048);
+      Root.PutObject('thinking', Thinking);
     end;
 
-    MsgArr := TJSONArray.Create;
+    MsgArr := TJsonArray.Create;
     for i := 0 to High(Messages) do
     begin
       if Messages[i].Role = mrSystem then Continue;
-      Msg := TJSONObject.Create;
-      Msg.Add('role', RoleForAnthropic(Messages[i].Role));
-      ContentArr := TJSONArray.Create;
+      Msg := TJsonObject.Create;
+      Msg.PutStr('role', RoleForAnthropic(Messages[i].Role));
+      ContentArr := TJsonArray.Create;
       if Messages[i].Role = mrTool then
       begin
-        Block := TJSONObject.Create;
-        Block.Add('type', 'tool_result');
-        Block.Add('tool_use_id', Messages[i].ToolCallId);
-        Block.Add('content', Messages[i].Content);
-        ContentArr.Add(Block);
+        Block := TJsonObject.Create;
+        Block.PutStr('type',        'tool_result');
+        Block.PutStr('tool_use_id', Messages[i].ToolCallId);
+        Block.PutStr('content',     Messages[i].Content);
+        ContentArr.AddObject(Block);
       end
       else if Length(Messages[i].ToolCalls) > 0 then
       begin
         if Messages[i].Content <> '' then
         begin
-          Block := TJSONObject.Create;
-          Block.Add('type', 'text');
-          Block.Add('text', Messages[i].Content);
-          ContentArr.Add(Block);
+          Block := TJsonObject.Create;
+          Block.PutStr('type', 'text');
+          Block.PutStr('text', Messages[i].Content);
+          ContentArr.AddObject(Block);
         end;
         for j := 0 to High(Messages[i].ToolCalls) do
         begin
-          Block := TJSONObject.Create;
-          Block.Add('type', 'tool_use');
-          Block.Add('id',    Messages[i].ToolCalls[j].Id);
-          Block.Add('name',  Messages[i].ToolCalls[j].Func.Name);
+          Block := TJsonObject.Create;
+          Block.PutStr('type', 'tool_use');
+          Block.PutStr('id',   Messages[i].ToolCalls[j].Id);
+          Block.PutStr('name', Messages[i].ToolCalls[j].Func.Name);
           if Messages[i].ToolCalls[j].Func.Arguments <> '' then
-          begin
-            try
-              Block.Add('input', GetJSON(Messages[i].ToolCalls[j].Func.Arguments));
-            except
-              Block.Add('input', TJSONObject.Create);
-            end;
-          end
+            Block.PutRaw('input', Messages[i].ToolCalls[j].Func.Arguments)
           else
-            Block.Add('input', TJSONObject.Create);
-          ContentArr.Add(Block);
+          begin
+            EmptyInput := TJsonObject.Create;
+            Block.PutObject('input', EmptyInput);
+          end;
+          ContentArr.AddObject(Block);
         end;
       end
       else
       begin
-        Block := TJSONObject.Create;
-        Block.Add('type', 'text');
-        Block.Add('text', Messages[i].Content);
-        ContentArr.Add(Block);
+        Block := TJsonObject.Create;
+        Block.PutStr('type', 'text');
+        Block.PutStr('text', Messages[i].Content);
+        ContentArr.AddObject(Block);
       end;
-      Msg.Add('content', ContentArr);
-      MsgArr.Add(Msg);
+      Msg.PutArray('content', ContentArr);
+      MsgArr.AddObject(Msg);
     end;
-    Root.Add('messages', MsgArr);
+    Root.PutArray('messages', MsgArr);
 
     if Length(Tools) > 0 then
     begin
-      ToolArr := TJSONArray.Create;
+      ToolArr := TJsonArray.Create;
       for i := 0 to High(Tools) do
       begin
-        ToolObj := TJSONObject.Create;
-        ToolObj.Add('name', Tools[i].Name);
-        if Tools[i].Description <> '' then ToolObj.Add('description', Tools[i].Description);
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('name', Tools[i].Name);
+        if Tools[i].Description <> '' then ToolObj.PutStr('description', Tools[i].Description);
         if Tools[i].Schema <> '' then
-        begin
-          try
-            ToolSchema := GetJSON(Tools[i].Schema);
-            ToolObj.Add('input_schema', ToolSchema);
-          except
-            ToolObj.Add('input_schema', TJSONObject.Create);
-          end;
-        end
+          ToolObj.PutRaw('input_schema', Tools[i].Schema)
         else
-          ToolObj.Add('input_schema', TJSONObject.Create);
-        ToolArr.Add(ToolObj);
+        begin
+          EmptyInput := TJsonObject.Create;
+          ToolObj.PutObject('input_schema', EmptyInput);
+        end;
+        ToolArr.AddObject(ToolObj);
       end;
-      Root.Add('tools', ToolArr);
+      Root.PutArray('tools', ToolArr);
     end;
 
-    Result := Root.AsJSON;
+    Result := Root.ToJSON;
   finally
     Root.Free;
   end;
@@ -213,15 +204,12 @@ end;
 
 procedure ParseResponse(const Body: string; var Resp: TLLMResponse);
 var
-  Root: TJSONData;
-  Obj: TJSONObject;
-  Arr: TJSONArray;
+  Obj, Block, Usage, InputObj: TJsonObject;
+  Arr: TJsonArray;
+  InputArr: TJsonArray;
   i: Integer;
-  Block: TJSONObject;
   Kind, Text: string;
   TC: TToolCall;
-  Usage: TJSONObject;
-  Input: TJSONData;
 begin
   Resp.Content := '';
   Resp.FinishReason := '';
@@ -230,53 +218,72 @@ begin
   Resp.Usage.OutputTokens := 0;
   SetLength(Resp.ToolCalls, 0);
   if Trim(Body) = '' then Exit;
-  Root := GetJSON(Body);
-  if not (Root is TJSONObject) then begin Root.Free; Exit; end;
-  Obj := TJSONObject(Root);
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit;
   try
-    Resp.Model        := Obj.Get('model', '');
-    Resp.FinishReason := Obj.Get('stop_reason', '');
-    if Obj.IndexOfName('content') >= 0 then
-    begin
-      Arr := Obj.Arrays['content'];
+    Resp.Model        := Obj.GetStr('model',       '');
+    Resp.FinishReason := Obj.GetStr('stop_reason', '');
+    Arr := Obj.ChildArray('content');
+    if Arr <> nil then
+    try
       for i := 0 to Arr.Count - 1 do
       begin
-        Block := TJSONObject(Arr[i]);
-        Kind := Block.Get('type', '');
-        if Kind = 'text' then
-        begin
-          Text := Block.Get('text', '');
-          if Resp.Content <> '' then Resp.Content := Resp.Content + sLineBreak;
-          Resp.Content := Resp.Content + Text;
-        end
-        else if Kind = 'tool_use' then
-        begin
-          TC.Id        := Block.Get('id', '');
-          TC.Kind      := 'function';
-          TC.Func.Name := Block.Get('name', '');
-          if Block.IndexOfName('input') >= 0 then
+        Block := Arr.ItemObject(i);
+        if Block = nil then Continue;
+        try
+          Kind := Block.GetStr('type', '');
+          if Kind = 'text' then
           begin
-            Input := Block.Find('input');
-            if Input <> nil then TC.Func.Arguments := Input.AsJSON
-            else TC.Func.Arguments := '{}';
+            Text := Block.GetStr('text', '');
+            if Resp.Content <> '' then Resp.Content := Resp.Content + sLineBreak;
+            Resp.Content := Resp.Content + Text;
           end
-          else
-            TC.Func.Arguments := '{}';
-          SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
-          Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+          else if Kind = 'tool_use' then
+          begin
+            TC.Id        := Block.GetStr('id',   '');
+            TC.Kind      := 'function';
+            TC.Func.Name := Block.GetStr('name', '');
+            InputObj := Block.ChildObject('input');
+            if InputObj <> nil then
+            try
+              TC.Func.Arguments := InputObj.ToJSON;
+            finally
+              InputObj.Free;
+            end
+            else
+            begin
+              InputArr := Block.ChildArray('input');
+              if InputArr <> nil then
+              try
+                TC.Func.Arguments := InputArr.ToJSON;
+              finally
+                InputArr.Free;
+              end
+              else
+                TC.Func.Arguments := '{}';
+            end;
+            SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
+            Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+          end;
+        finally
+          Block.Free;
         end;
       end;
+    finally
+      Arr.Free;
     end;
-    if Obj.IndexOfName('usage') >= 0 then
-    begin
-      Usage := Obj.Objects['usage'];
-      Resp.Usage.InputTokens        := Usage.Get('input_tokens',  0);
-      Resp.Usage.OutputTokens       := Usage.Get('output_tokens', 0);
-      Resp.Usage.CacheReadTokens    := Usage.Get('cache_read_input_tokens', 0);
-      Resp.Usage.CacheCreatedTokens := Usage.Get('cache_creation_input_tokens', 0);
+    Usage := Obj.ChildObject('usage');
+    if Usage <> nil then
+    try
+      Resp.Usage.InputTokens        := Usage.GetInt('input_tokens',  0);
+      Resp.Usage.OutputTokens       := Usage.GetInt('output_tokens', 0);
+      Resp.Usage.CacheReadTokens    := Usage.GetInt('cache_read_input_tokens',     0);
+      Resp.Usage.CacheCreatedTokens := Usage.GetInt('cache_creation_input_tokens', 0);
+    finally
+      Usage.Free;
     end;
   finally
-    Root.Free;
+    Obj.Free;
   end;
 end;
 
@@ -288,7 +295,6 @@ var
   Body, URL, UseModel: string;
   Resp: THTTPResult;
   Headers: array of THeaderPair;
-  ErrJSON: TJSONData;
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1/messages';
@@ -309,20 +315,8 @@ begin
     Exit;
   end;
 
-  { Surface API error message rather than swallowing it. }
   if Resp.Body <> '' then
-  begin
-    try
-      ErrJSON := GetJSON(Resp.Body);
-      try
-        Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, ErrJSON.AsJSON]);
-      finally
-        ErrJSON.Free;
-      end;
-    except
-      Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, Resp.Body]);
-    end;
-  end
+    Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, Resp.Body])
   else
     Result.Content := Format('anthropic error: status=%d msg=%s', [Resp.StatusCode, Resp.ErrorMsg]);
   Result.FinishReason := 'error';
@@ -335,62 +329,70 @@ var
 
 procedure HandleAnthropicSSE(const Event, Data: string);
 var
-  Obj: TJSONData;
-  Root, Delta, Usage: TJSONObject;
+  Root, Delta, Usage, MsgObj: TJsonObject;
   Kind, Text: string;
   Chunk: TStreamChunk;
 begin
   if Data = '' then Exit;
+  Root := TJsonObject.Parse(Data);
+  if Root = nil then Exit;
   try
-    Obj := GetJSON(Data);
-  except
-    Exit;
-  end;
-  try
-    if not (Obj is TJSONObject) then Exit;
-    Root := TJSONObject(Obj);
-    Kind := Root.Get('type', Event);
+    Kind := Root.GetStr('type', Event);
 
     if Kind = 'content_block_delta' then
     begin
-      if Root.IndexOfName('delta') < 0 then Exit;
-      Delta := Root.Objects['delta'];
-      if Delta.Get('type', '') = 'text_delta' then
-      begin
-        Text := Delta.Get('text', '');
-        if Text <> '' then
+      Delta := Root.ChildObject('delta');
+      if Delta = nil then Exit;
+      try
+        if Delta.GetStr('type', '') = 'text_delta' then
         begin
-          GStreamAcc := GStreamAcc + Text;
-          Chunk.Kind := 'text';
-          Chunk.Text := Text;
-          if Assigned(GStreamCB) then GStreamCB(Chunk);
+          Text := Delta.GetStr('text', '');
+          if Text <> '' then
+          begin
+            GStreamAcc := GStreamAcc + Text;
+            Chunk.Kind := 'text';
+            Chunk.Text := Text;
+            if Assigned(GStreamCB) then GStreamCB(Chunk);
+          end;
         end;
+      finally
+        Delta.Free;
       end;
     end
     else if Kind = 'message_delta' then
     begin
-      if Root.IndexOfName('usage') >= 0 then
-      begin
-        Usage := Root.Objects['usage'];
-        GStreamLast.Usage.OutputTokens := Usage.Get('output_tokens', GStreamLast.Usage.OutputTokens);
+      Usage := Root.ChildObject('usage');
+      if Usage <> nil then
+      try
+        GStreamLast.Usage.OutputTokens :=
+          Usage.GetInt('output_tokens', GStreamLast.Usage.OutputTokens);
+      finally
+        Usage.Free;
       end;
-      if Root.IndexOfName('delta') >= 0 then
-      begin
-        Delta := Root.Objects['delta'];
-        GStreamLast.FinishReason := Delta.Get('stop_reason', GStreamLast.FinishReason);
+      Delta := Root.ChildObject('delta');
+      if Delta <> nil then
+      try
+        GStreamLast.FinishReason :=
+          Delta.GetStr('stop_reason', GStreamLast.FinishReason);
+      finally
+        Delta.Free;
       end;
     end
     else if Kind = 'message_start' then
     begin
-      if Root.IndexOfName('message') >= 0 then
-      begin
-        Delta := Root.Objects['message'];
-        GStreamLast.Model := Delta.Get('model', GStreamLast.Model);
-        if Delta.IndexOfName('usage') >= 0 then
-        begin
-          Usage := Delta.Objects['usage'];
-          GStreamLast.Usage.InputTokens := Usage.Get('input_tokens', 0);
+      MsgObj := Root.ChildObject('message');
+      if MsgObj <> nil then
+      try
+        GStreamLast.Model := MsgObj.GetStr('model', GStreamLast.Model);
+        Usage := MsgObj.ChildObject('usage');
+        if Usage <> nil then
+        try
+          GStreamLast.Usage.InputTokens := Usage.GetInt('input_tokens', 0);
+        finally
+          Usage.Free;
         end;
+      finally
+        MsgObj.Free;
       end;
     end
     else if Kind = 'message_stop' then
@@ -400,7 +402,7 @@ begin
       if Assigned(GStreamCB) then GStreamCB(Chunk);
     end;
   finally
-    Obj.Free;
+    Root.Free;
   end;
 end;
 
@@ -415,8 +417,7 @@ var
   Opts: TChatOptions;
   Status: Integer;
   Err: string;
-  Root: TJSONObject;
-  Stream: TJSONBoolean;
+  Root: TJsonObject;
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL := FAPIBase + '/v1/messages';
@@ -425,19 +426,17 @@ begin
   Opts := Options;
   Opts.Stream := True;
   Body := BuildRequest(Messages, Tools, UseModel, Opts);
-  try
-    Root := TJSONObject(GetJSON(Body));
-    try
-      Stream := TJSONBoolean.Create(True);
-      Root.Add('stream', Stream);
-      Body := Root.AsJSON;
-    finally
-      Root.Free;
-    end;
-  except
-    { fall back to non-stream }
+  Root := TJsonObject.Parse(Body);
+  if Root = nil then
+  begin
     Result := Chat(Messages, Tools, UseModel, Options);
     Exit;
+  end;
+  try
+    Root.PutBool('stream', True);
+    Body := Root.ToJSON;
+  finally
+    Root.Free;
   end;
 
   SetLength(Headers, 2);

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -7,7 +7,7 @@
 }
 unit PasClaw.Providers.Anthropic;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -5,7 +5,7 @@
 }
 unit PasClaw.Providers.Factory;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -10,7 +10,7 @@
 }
 unit PasClaw.Providers.HTTP;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/providers/PasClaw.Providers.Intf.pas
+++ b/src/pkg/providers/PasClaw.Providers.Intf.pas
@@ -4,7 +4,7 @@
 }
 unit PasClaw.Providers.Intf;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -7,7 +7,7 @@
 }
 unit PasClaw.Providers.OpenAI;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -44,7 +44,7 @@ type
 implementation
 
 uses
-  fpjson, jsonparser,
+  PasClaw.JSON,
   PasClaw.Providers.HTTP,
   PasClaw.Logger;
 
@@ -67,27 +67,26 @@ function BuildOAIRequest(const Messages: array of TMessage;
                          const Model:    string;
                          const Options:  TChatOptions): string;
 var
-  Root: TJSONObject;
-  MsgArr, ToolArr, TCArr: TJSONArray;
-  M, ToolObj, FObj, TCObj: TJSONObject;
+  Root, M, ToolObj, FObj, TCObj, EmptyParams: TJsonObject;
+  MsgArr, ToolArr, TCArr: TJsonArray;
   i, j: Integer;
   Sys: string;
 begin
-  Root := TJSONObject.Create;
+  Root := TJsonObject.Create;
   try
-    Root.Add('model', Model);
-    if Options.MaxTokens > 0 then Root.Add('max_tokens', Options.MaxTokens);
-    if Options.Temperature > 0 then Root.Add('temperature', Options.Temperature);
+    Root.PutStr('model', Model);
+    if Options.MaxTokens > 0 then Root.PutInt('max_tokens', Options.MaxTokens);
+    if Options.Temperature > 0 then Root.PutFloat('temperature', Options.Temperature);
 
     Sys := Options.SystemPrompt;
 
-    MsgArr := TJSONArray.Create;
+    MsgArr := TJsonArray.Create;
     if Sys <> '' then
     begin
-      M := TJSONObject.Create;
-      M.Add('role', 'system');
-      M.Add('content', Sys);
-      MsgArr.Add(M);
+      M := TJsonObject.Create;
+      M.PutStr('role',    'system');
+      M.PutStr('content', Sys);
+      MsgArr.AddObject(M);
     end;
 
     for i := 0 to High(Messages) do
@@ -95,62 +94,58 @@ begin
       if (Messages[i].Role = mrSystem) and (Sys <> '') then
         Continue;  { already added above }
 
-      M := TJSONObject.Create;
-      M.Add('role', MsgRoleToString(Messages[i].Role));
-      if Messages[i].Content <> '' then M.Add('content', Messages[i].Content)
-      else M.Add('content', '');
+      M := TJsonObject.Create;
+      M.PutStr('role', MsgRoleToString(Messages[i].Role));
+      M.PutStr('content', Messages[i].Content);
 
       if Messages[i].Role = mrTool then
-        M.Add('tool_call_id', Messages[i].ToolCallId);
+        M.PutStr('tool_call_id', Messages[i].ToolCallId);
 
       if Length(Messages[i].ToolCalls) > 0 then
       begin
-        TCArr := TJSONArray.Create;
+        TCArr := TJsonArray.Create;
         for j := 0 to High(Messages[i].ToolCalls) do
         begin
-          TCObj := TJSONObject.Create;
-          TCObj.Add('id',   Messages[i].ToolCalls[j].Id);
-          TCObj.Add('type', 'function');
-          FObj := TJSONObject.Create;
-          FObj.Add('name',      Messages[i].ToolCalls[j].Func.Name);
-          FObj.Add('arguments', Messages[i].ToolCalls[j].Func.Arguments);
-          TCObj.Add('function', FObj);
-          TCArr.Add(TCObj);
+          TCObj := TJsonObject.Create;
+          TCObj.PutStr('id',   Messages[i].ToolCalls[j].Id);
+          TCObj.PutStr('type', 'function');
+          FObj := TJsonObject.Create;
+          FObj.PutStr('name',      Messages[i].ToolCalls[j].Func.Name);
+          FObj.PutStr('arguments', Messages[i].ToolCalls[j].Func.Arguments);
+          TCObj.PutObject('function', FObj);
+          TCArr.AddObject(TCObj);
         end;
-        M.Add('tool_calls', TCArr);
+        M.PutArray('tool_calls', TCArr);
       end;
 
-      MsgArr.Add(M);
+      MsgArr.AddObject(M);
     end;
-    Root.Add('messages', MsgArr);
+    Root.PutArray('messages', MsgArr);
 
     if Length(Tools) > 0 then
     begin
-      ToolArr := TJSONArray.Create;
+      ToolArr := TJsonArray.Create;
       for i := 0 to High(Tools) do
       begin
-        ToolObj := TJSONObject.Create;
-        ToolObj.Add('type', 'function');
-        FObj := TJSONObject.Create;
-        FObj.Add('name', Tools[i].Name);
-        if Tools[i].Description <> '' then FObj.Add('description', Tools[i].Description);
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('type', 'function');
+        FObj := TJsonObject.Create;
+        FObj.PutStr('name', Tools[i].Name);
+        if Tools[i].Description <> '' then FObj.PutStr('description', Tools[i].Description);
         if Tools[i].Schema <> '' then
-        begin
-          try
-            FObj.Add('parameters', GetJSON(Tools[i].Schema));
-          except
-            FObj.Add('parameters', TJSONObject.Create);
-          end;
-        end
+          FObj.PutRaw('parameters', Tools[i].Schema)
         else
-          FObj.Add('parameters', TJSONObject.Create);
-        ToolObj.Add('function', FObj);
-        ToolArr.Add(ToolObj);
+        begin
+          EmptyParams := TJsonObject.Create;
+          FObj.PutObject('parameters', EmptyParams);
+        end;
+        ToolObj.PutObject('function', FObj);
+        ToolArr.AddObject(ToolObj);
       end;
-      Root.Add('tools', ToolArr);
+      Root.PutArray('tools', ToolArr);
     end;
 
-    Result := Root.AsJSON;
+    Result := Root.ToJSON;
   finally
     Root.Free;
   end;
@@ -158,54 +153,78 @@ end;
 
 procedure ParseOAIResponse(const Body: string; var Resp: TLLMResponse);
 var
-  Root: TJSONData;
-  Obj, Choice, Msg, FObj, TCObj, Usage: TJSONObject;
-  Choices, TCArr: TJSONArray;
+  Obj, Choice, Msg, FObj, TCObj, Usage: TJsonObject;
+  Choices, TCArr: TJsonArray;
   i: Integer;
   TC: TToolCall;
 begin
   Resp.Content := '';
   SetLength(Resp.ToolCalls, 0);
   if Trim(Body) = '' then Exit;
-  Root := GetJSON(Body);
-  if not (Root is TJSONObject) then begin Root.Free; Exit; end;
-  Obj := TJSONObject(Root);
+  Obj := TJsonObject.Parse(Body);
+  if Obj = nil then Exit;
   try
-    Resp.Model := Obj.Get('model', '');
-    if Obj.IndexOfName('choices') >= 0 then
-    begin
-      Choices := Obj.Arrays['choices'];
+    Resp.Model := Obj.GetStr('model', '');
+    Choices := Obj.ChildArray('choices');
+    if Choices <> nil then
+    try
       if Choices.Count > 0 then
       begin
-        Choice := TJSONObject(Choices[0]);
-        Resp.FinishReason := Choice.Get('finish_reason', '');
-        Msg := Choice.Objects['message'];
-        Resp.Content := Msg.Get('content', '');
-        if Msg.IndexOfName('tool_calls') >= 0 then
-        begin
-          TCArr := Msg.Arrays['tool_calls'];
-          for i := 0 to TCArr.Count - 1 do
-          begin
-            TCObj := TJSONObject(TCArr[i]);
-            TC.Id   := TCObj.Get('id', '');
-            TC.Kind := TCObj.Get('type', 'function');
-            FObj := TCObj.Objects['function'];
-            TC.Func.Name      := FObj.Get('name', '');
-            TC.Func.Arguments := FObj.Get('arguments', '{}');
-            SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
-            Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+        Choice := Choices.ItemObject(0);
+        if Choice <> nil then
+        try
+          Resp.FinishReason := Choice.GetStr('finish_reason', '');
+          Msg := Choice.ChildObject('message');
+          if Msg <> nil then
+          try
+            Resp.Content := Msg.GetStr('content', '');
+            TCArr := Msg.ChildArray('tool_calls');
+            if TCArr <> nil then
+            try
+              for i := 0 to TCArr.Count - 1 do
+              begin
+                TCObj := TCArr.ItemObject(i);
+                if TCObj = nil then Continue;
+                try
+                  TC.Id   := TCObj.GetStr('id', '');
+                  TC.Kind := TCObj.GetStr('type', 'function');
+                  FObj := TCObj.ChildObject('function');
+                  if FObj <> nil then
+                  try
+                    TC.Func.Name      := FObj.GetStr('name', '');
+                    TC.Func.Arguments := FObj.GetStr('arguments', '{}');
+                  finally
+                    FObj.Free;
+                  end;
+                  SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
+                  Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+                finally
+                  TCObj.Free;
+                end;
+              end;
+            finally
+              TCArr.Free;
+            end;
+          finally
+            Msg.Free;
           end;
+        finally
+          Choice.Free;
         end;
       end;
+    finally
+      Choices.Free;
     end;
-    if Obj.IndexOfName('usage') >= 0 then
-    begin
-      Usage := Obj.Objects['usage'];
-      Resp.Usage.InputTokens  := Usage.Get('prompt_tokens',     0);
-      Resp.Usage.OutputTokens := Usage.Get('completion_tokens', 0);
+    Usage := Obj.ChildObject('usage');
+    if Usage <> nil then
+    try
+      Resp.Usage.InputTokens  := Usage.GetInt('prompt_tokens',     0);
+      Resp.Usage.OutputTokens := Usage.GetInt('completion_tokens', 0);
+    finally
+      Usage.Free;
     end;
   finally
-    Root.Free;
+    Obj.Free;
   end;
 end;
 

--- a/src/pkg/providers/PasClaw.Providers.Stream.pas
+++ b/src/pkg/providers/PasClaw.Providers.Stream.pas
@@ -16,7 +16,7 @@
 *)
 unit PasClaw.Providers.Stream;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -4,7 +4,7 @@
 }
 unit PasClaw.Providers.Types;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -50,7 +50,7 @@ function RenderTemplate(const Template, ArgsJSON: string): string;
 implementation
 
 uses
-  Process,
+  {$IFDEF FPC} Process, {$ENDIF}
   PasClaw.Utils,
   PasClaw.JSON,
   PasClaw.Logger;
@@ -169,6 +169,7 @@ begin
   end;
 end;
 
+{$IFDEF FPC}
 function RunShell(const Cmd: string; out ExitCode: Integer): string;
 var
   P: TProcess;
@@ -213,6 +214,14 @@ begin
     P.Free;
   end;
 end;
+{$ELSE}
+function RunShell(const Cmd: string; out ExitCode: Integer): string;
+begin
+  { Delphi-native skill shell exec stub. See Tools.Shell for the same note. }
+  ExitCode := 127;
+  Result := '(shell skills not implemented in Delphi build yet)';
+end;
+{$ENDIF}
 
 function RunShellSkill(Slot: Integer; const ArgsJSON: string; out ErrMsg: string): string;
 var

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -19,7 +19,7 @@
 *)
 unit PasClaw.Skills.Loader;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -50,10 +50,10 @@ function RenderTemplate(const Template, ArgsJSON: string): string;
 implementation
 
 uses
-  {$IFDEF FPC} Process, {$ENDIF}
   PasClaw.Utils,
   PasClaw.JSON,
-  PasClaw.Logger;
+  PasClaw.Logger,
+  PasClaw.Platform;
 
 const
   MaxSkills = 64;
@@ -169,59 +169,10 @@ begin
   end;
 end;
 
-{$IFDEF FPC}
-function RunShell(const Cmd: string; out ExitCode: Integer): string;
-var
-  P: TProcess;
-  M: TMemoryStream;
-  Buf: array[0..4095] of Byte;
-  N: Integer;
-begin
-  Result := '';
-  ExitCode := -1;
-  P := TProcess.Create(nil);
-  M := TMemoryStream.Create;
-  try
-    {$IFDEF MSWINDOWS}
-    P.Executable := 'cmd.exe';
-    P.Parameters.Add('/C');
-    P.Parameters.Add(Cmd);
-    {$ELSE}
-    P.Executable := '/bin/sh';
-    P.Parameters.Add('-c');
-    P.Parameters.Add(Cmd);
-    {$ENDIF}
-    P.Options := [poUsePipes, poStderrToOutPut];
-    P.Execute;
-    while P.Running or (P.Output.NumBytesAvailable > 0) do
-    begin
-      while P.Output.NumBytesAvailable > 0 do
-      begin
-        N := P.Output.Read(Buf, SizeOf(Buf));
-        if N > 0 then M.WriteBuffer(Buf, N);
-      end;
-      Sleep(20);
-    end;
-    ExitCode := P.ExitStatus;
-    SetLength(Result, M.Size);
-    if M.Size > 0 then
-    begin
-      M.Position := 0;
-      M.ReadBuffer(Result[1], M.Size);
-    end;
-  finally
-    M.Free;
-    P.Free;
-  end;
-end;
-{$ELSE}
 function RunShell(const Cmd: string; out ExitCode: Integer): string;
 begin
-  { Delphi-native skill shell exec stub. See Tools.Shell for the same note. }
-  ExitCode := 127;
-  Result := '(shell skills not implemented in Delphi build yet)';
+  ExitCode := RunOneShot(Cmd, Result);
 end;
-{$ENDIF}
 
 function RunShellSkill(Slot: Integer; const ArgsJSON: string; out ErrMsg: string): string;
 var

--- a/src/pkg/tokenizer/PasClaw.Tokenizer.pas
+++ b/src/pkg/tokenizer/PasClaw.Tokenizer.pas
@@ -5,7 +5,7 @@
 }
 unit PasClaw.Tokenizer;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -20,27 +20,25 @@ procedure RegisterFSTools(R: TToolRegistry);
 implementation
 
 uses
-  fpjson, jsonparser,
+  PasClaw.JSON,
   PasClaw.Utils;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
-  J: TJSONData;
-  Obj: TJSONObject;
+  Obj: TJsonObject;
 begin
   Result := False;
   V := '';
   if Trim(ArgsJSON) = '' then Exit;
   try
-    J := GetJSON(ArgsJSON);
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
     try
-      if not (J is TJSONObject) then Exit;
-      Obj := TJSONObject(J);
-      if Obj.IndexOfName(Field) < 0 then Exit;
-      V := Obj.Get(Field, '');
+      if not Obj.Has(Field) then Exit;
+      V := Obj.GetStr(Field, '');
       Result := V <> '';
     finally
-      J.Free;
+      Obj.Free;
     end;
   except
     Result := False;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -5,7 +5,7 @@
 }
 unit PasClaw.Tools.FS;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -6,7 +6,7 @@
 }
 unit PasClaw.Tools.Registry;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -9,7 +9,7 @@
 }
 unit PasClaw.Tools.Shell;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -24,28 +24,26 @@ procedure RegisterShellTool(R: TToolRegistry);
 implementation
 
 uses
-  Process,
-  fpjson, jsonparser,
+  {$IFDEF FPC} Process, {$ENDIF}
+  PasClaw.JSON,
   PasClaw.Logger;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
-  J: TJSONData;
-  Obj: TJSONObject;
+  Obj: TJsonObject;
 begin
   Result := False;
   V := '';
   if Trim(ArgsJSON) = '' then Exit;
   try
-    J := GetJSON(ArgsJSON);
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
     try
-      if not (J is TJSONObject) then Exit;
-      Obj := TJSONObject(J);
-      if Obj.IndexOfName(Field) < 0 then Exit;
-      V := Obj.Get(Field, '');
+      if not Obj.Has(Field) then Exit;
+      V := Obj.GetStr(Field, '');
       Result := V <> '';
     finally
-      J.Free;
+      Obj.Free;
     end;
   except
     Result := False;
@@ -66,6 +64,7 @@ begin
     (Pos('shutdown -h', L) > 0);
 end;
 
+{$IFDEF FPC}
 function RunShell(const Cmd: string; out ExitCode: Integer): string;
 var
   P: TProcess;
@@ -122,6 +121,19 @@ begin
     P.Free;
   end;
 end;
+{$ELSE}
+function RunShell(const Cmd: string; out ExitCode: Integer): string;
+begin
+  { Delphi-native shell exec stub.
+    A real Delphi build needs to call CreateProcess (Windows) or
+    Posix.Spawn / fork+execve (Linux/macOS). Until that's ported the
+    shell_exec tool returns a clear error so the agent loop can
+    surface it. }
+  ExitCode := 127;
+  Result := '(shell_exec not implemented in Delphi build yet — see ' +
+            'src/pkg/tools/PasClaw.Tools.Shell.pas)';
+end;
+{$ENDIF}
 
 function Tool_Shell(const ArgsJSON: string; out ErrMsg: string): string;
 var

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -24,9 +24,9 @@ procedure RegisterShellTool(R: TToolRegistry);
 implementation
 
 uses
-  {$IFDEF FPC} Process, {$ENDIF}
   PasClaw.JSON,
-  PasClaw.Logger;
+  PasClaw.Logger,
+  PasClaw.Platform;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
@@ -64,76 +64,10 @@ begin
     (Pos('shutdown -h', L) > 0);
 end;
 
-{$IFDEF FPC}
-function RunShell(const Cmd: string; out ExitCode: Integer): string;
-var
-  P: TProcess;
-  M: TMemoryStream;
-  Buf: array[0..4095] of Byte;
-  N, Total: Integer;
-  Args: TStringList;
-begin
-  Result := '';
-  ExitCode := -1;
-  P := TProcess.Create(nil);
-  M := TMemoryStream.Create;
-  Args := TStringList.Create;
-  try
-    {$IFDEF MSWINDOWS}
-    P.Executable := 'cmd.exe';
-    Args.Add('/C'); Args.Add(Cmd);
-    {$ELSE}
-    P.Executable := '/bin/sh';
-    Args.Add('-c'); Args.Add(Cmd);
-    {$ENDIF}
-    P.Parameters.AddStrings(Args);
-    P.Options := [poUsePipes, poStderrToOutPut];
-    P.Execute;
-    Total := 0;
-    while P.Running or (P.Output.NumBytesAvailable > 0) do
-    begin
-      while P.Output.NumBytesAvailable > 0 do
-      begin
-        N := P.Output.Read(Buf, SizeOf(Buf));
-        if N > 0 then
-        begin
-          M.WriteBuffer(Buf, N);
-          Inc(Total, N);
-        end;
-        if Total > 1024 * 1024 then  { 1 MiB cap }
-        begin
-          P.Terminate(124);
-          Break;
-        end;
-      end;
-      Sleep(20);
-    end;
-    ExitCode := P.ExitStatus;
-    SetLength(Result, M.Size);
-    if M.Size > 0 then
-    begin
-      M.Position := 0;
-      M.ReadBuffer(Result[1], M.Size);
-    end;
-  finally
-    Args.Free;
-    M.Free;
-    P.Free;
-  end;
-end;
-{$ELSE}
 function RunShell(const Cmd: string; out ExitCode: Integer): string;
 begin
-  { Delphi-native shell exec stub.
-    A real Delphi build needs to call CreateProcess (Windows) or
-    Posix.Spawn / fork+execve (Linux/macOS). Until that's ported the
-    shell_exec tool returns a clear error so the agent loop can
-    surface it. }
-  ExitCode := 127;
-  Result := '(shell_exec not implemented in Delphi build yet — see ' +
-            'src/pkg/tools/PasClaw.Tools.Shell.pas)';
+  ExitCode := RunOneShot(Cmd, Result);
 end;
-{$ENDIF}
 
 function Tool_Shell(const ArgsJSON: string; out ErrMsg: string): string;
 var

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -6,7 +6,7 @@
 }
 unit PasClaw.Tools.ToolLoop;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -4,7 +4,7 @@
 }
 unit PasClaw.Tools.Types;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -58,9 +58,10 @@ uses
   PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop;
 
-{$IFDEF UNIX}
+{$IFDEF FPC}{$IFDEF UNIX}
 { Get terminal width via ioctl TIOCGWINSZ. Falls back to 80 if the call
-  fails (e.g. stdin is a pipe). }
+  fails (e.g. stdin is a pipe). FPC-only — Delphi cross-platform width
+  detection lands in a follow-up. }
 const
   TIOCGWINSZ = $5413;
 type
@@ -69,7 +70,7 @@ type
   end;
 function FpIoctl(fd: Integer; req: Cardinal; argp: Pointer): Integer; cdecl;
   external 'c' name 'ioctl';
-{$ENDIF}
+{$ENDIF}{$ENDIF}
 
 constructor TTUI.Create(Provider: ILLMProvider; Registry: TToolRegistry; const Model: string);
 begin
@@ -80,17 +81,17 @@ begin
 end;
 
 function TTUI.TermWidth: Integer;
-{$IFDEF UNIX}
+{$IFDEF FPC}{$IFDEF UNIX}
 var
   ws: Twinsize;
-{$ENDIF}
+{$ENDIF}{$ENDIF}
 begin
   Result := 80;
-  {$IFDEF UNIX}
+  {$IFDEF FPC}{$IFDEF UNIX}
   FillChar(ws, SizeOf(ws), 0);
   if FpIoctl(1, TIOCGWINSZ, @ws) = 0 then
     if ws.ws_col > 0 then Result := ws.ws_col;
-  {$ENDIF}
+  {$ENDIF}{$ENDIF}
 end;
 
 procedure TTUI.DrawHeader;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -22,7 +22,7 @@
 *)
 unit PasClaw.TUI;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -18,7 +18,7 @@
 *)
 unit PasClaw.Updater;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -52,7 +52,8 @@ implementation
 
 uses
   Classes,
-  {$IFDEF UNIX} BaseUnix, {$ENDIF}
+  {$IFDEF FPC}{$IFDEF UNIX} BaseUnix, {$ENDIF}{$ENDIF}
+  {$IFNDEF FPC}{$IFDEF POSIX} Posix.SysStat, Posix.UniStd, {$ENDIF}{$ENDIF}
   PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Providers.HTTP;
@@ -253,10 +254,13 @@ begin
     ErrMsg := 'rename failed (errno=' + IntToStr(GetLastOSError) + ')';
     Exit(False);
   end;
-  {$IFDEF UNIX}
+  {$IFDEF FPC}{$IFDEF UNIX}
   { Best-effort chmod 0755; ignore errors. }
   FpChmod(TargetBinary, &755);
-  {$ENDIF}
+  {$ENDIF}{$ENDIF}
+  {$IFNDEF FPC}{$IFDEF POSIX}
+  Posix.SysStat.chmod(PAnsiChar(AnsiString(TargetBinary)), $1ED);  { 0755 }
+  {$ENDIF}{$ENDIF}
   Result := True;
   {$ENDIF}
 end;

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -4,7 +4,7 @@
 }
 unit PasClaw.Utils;
 
-{$MODE DELPHI}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
 
 interface


### PR DESCRIPTION
## Summary

Makes the PasClaw source tree compile under both FPC (`{$MODE DELPHI}` via `make`) **and** Delphi/RAD Studio 11/12 from the same `.pas` files. Five commits, branched from where PR #1 was merged (`a8431b2`).

Open `src/pasclaw/PasClaw.dproj` in RAD Studio → Build. No vendoring needed under Delphi (Indy ships with RAD Studio).

## What's in the box

### `src/pasclaw/PasClaw.dproj`
Delphi 12 multi-platform project file (Win32 / Win64 / Linux64). Every `src/pkg/*` directory on `DCC_UnitSearchPath`; every unit listed under `DCCReference`. `webui.rc` registered as `RcCompile` so `brcc32` rebuilds the embedded resource on each build.

### `src/pkg/json/PasClaw.JSON.pas` — full `System.JSON` backend
The Delphi branch of the JSON wrapper (previously an empty stub) now implements `TJsonObject` / `TJsonArray` on top of `System.JSON.TJSONObject` / `TJSONArray`. Same `GetStr` / `GetInt` / `GetBool` / `PutObject` / `ChildObject` / `ItemObject` / `ToJSON` / `Parse` surface as the FPC backend. Memory model preserved (parents own children, wrappers don't).

### Migration of 9 call sites off `fpjson`
`Config`, `Tools.FS`, `Tools.Shell`, `Skills.Loader`, `MCP.StdioClient`, `Gateway.Server`, `Channels.Telegram`, `Providers.OpenAI`, `Providers.Anthropic` (including the SSE handler) — all routed through `PasClaw.JSON`. `grep -rl fpjson src/` returns only the wrapper unit itself.

### `src/pkg/platform/PasClaw.Platform.pas` — cross-toolchain process I/O
Replaces the previous Delphi-side stubs for `shell_exec`, shell skills, and stdio MCP. Same interface, three back-ends selected at compile time:
- **FPC**: `fcl-process`
- **Delphi / Windows**: Win32 API direct — `CreatePipe` + `CreateProcessW` + `ReadFile`/`WriteFile` + `PeekNamedPipe` + `GetExitCodeProcess` + `TerminateProcess`, `CREATE_NO_WINDOW`
- **Delphi / POSIX**: `pipe` + `fork` + `dup2` + `execvp` + `select`(10 ms) + `waitpid(WNOHANG)` + `SIGTERM`

`Tools.Shell.RunShell`, `Skills.Loader.RunShell`, and `MCP.StdioClient` (spawn / WriteLine / ReadLine) are now one-liners that delegate to the abstraction. No more per-file `{$IFDEF FPC}` branches around process I/O.

### Portable directives across all 51 units
- `{$MODE DELPHI}` wrapped as `{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}` so Delphi (which doesn't have `$MODE`) doesn't warn
- `{$I %PASCLAW_VERSION%}` / `{$I %FPCVERSION%}` / `{$I %FPCTARGETOS%}` / `{$I %FPCTARGETCPU%}` wrapped — Delphi `FormatBuildInfo` returns `pasclaw <version> (delphi)`
- `BaseUnix` (chmod), `cthreads`/`cmem` (Indy threading), ioctl `TIOCGWINSZ` (terminal width) all FPC-only; Delphi POSIX uses `Posix.SysStat.chmod`; Delphi Windows + TUI fall back to 80-col width

## Test plan

- [x] FPC build (`make`) clean — 268k lines, 0 errors
- [x] `make smoke` — all 11 commands OK
- [x] OpenAI tool-call round-trip via fake LLM (`fs_read` end-to-end)
- [x] Anthropic SSE streaming round-trip via fake event-stream server
- [x] MCP stdio handshake against a Python `fakemcp.py` server
- [x] `shell_exec` runs `uname -m && echo ok` through the tool loop
- [ ] Open `PasClaw.dproj` in Delphi 11/12 — Build for Win64
- [ ] Open `PasClaw.dproj` in Delphi 11/12 — Build for Linux64

The Delphi-side code can't be exercised in the FPC dev environment but follows canonical Win32 + POSIX API patterns; first-build issues are most likely unit-naming (e.g. `Posix.Base`) and easy to fix.

## Commits

- `ccbfd23` chunk 1/4: `.dproj` + simple FPC-only guards (`cthreads`, `BaseUnix`, ioctl)
- `aabb67a` chunk 2/4: `System.JSON` backend for `PasClaw.JSON`
- `ff86249` chunk 3/4: migrate all `fpjson` call-sites to the wrapper
- `16a0ef1` chunk 4/4: portable directives across all units
- `1da9427` `PasClaw.Platform` cross-toolchain process I/O (removes the three stubs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_