### PR TITLE
Delphi UTF-8 / byte-buffer fixes (stacks on PR #2)

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -246,6 +246,7 @@ procedure TGatewayServer.HandleChat(ARequest: TIdHTTPRequestInfo;
                                     AResp: TIdHTTPResponseInfo);
 var
   Body, Prompt: string;
+  Bytes: TBytes;
   Req, RespJ: TJsonObject;
   Msgs: array of TMessage;
   Loop: TToolLoopResult;
@@ -255,9 +256,14 @@ begin
   if ARequest.PostStream <> nil then
   begin
     ARequest.PostStream.Position := 0;
-    SetLength(Body, ARequest.PostStream.Size);
+    SetLength(Bytes, ARequest.PostStream.Size);
     if ARequest.PostStream.Size > 0 then
-      ARequest.PostStream.ReadBuffer(Body[1], ARequest.PostStream.Size);
+    begin
+      ARequest.PostStream.ReadBuffer(Bytes[0], ARequest.PostStream.Size);
+      { Bodies are JSON, by convention UTF-8. Decoding here means the
+        Delphi build sees the same string the FPC build does. }
+      Body := TEncoding.UTF8.GetString(Bytes);
+    end;
   end;
 
   if Trim(Body) = '' then

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -37,7 +37,10 @@ type
     FProcess: TStdioProcess;
     FCmd, FArgs, FName: string;
     FNextId:  Integer;
-    FBuffer:  string;
+    { FBuffer is a UTF8String (1-byte-per-char in both FPC and Delphi) so
+      byte-level accumulation from the child's stdout works regardless of
+      whether `string` is AnsiString (FPC) or UnicodeString (Delphi). }
+    FBuffer:  UTF8String;
     function  ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
     function  WriteLine(const S: string): Boolean;
     function  RoundTrip(const Method, ParamsJSON: string;
@@ -137,25 +140,27 @@ function TMCPStdioClient.ReadLine(out Line: string; TimeoutMs: Integer): Boolean
 var
   Buf: array[0..4095] of Byte;
   N, Waited, NLPos: Integer;
-  Chunk: string;
+  Chunk, LineUTF8: UTF8String;
 begin
   Line := '';
   Waited := 0;
   if FProcess = nil then Exit(False);
   while True do
   begin
-    NLPos := Pos(#10, FBuffer);
+    NLPos := Pos(UTF8String(#10), FBuffer);
     if NLPos > 0 then
     begin
-      Line    := Copy(FBuffer, 1, NLPos - 1);
-      FBuffer := Copy(FBuffer, NLPos + 1, MaxInt);
+      LineUTF8 := Copy(FBuffer, 1, NLPos - 1);
+      FBuffer  := Copy(FBuffer, NLPos + 1, MaxInt);
+      { UTF8String -> string: AnsiString-identity under FPC, UTF-8 decode under Delphi. }
+      Line := string(LineUTF8);
       Exit(True);
     end;
     N := FProcess.ReadAvailable(Buf, SizeOf(Buf));
     if N > 0 then
     begin
       SetLength(Chunk, N);
-      Move(Buf[0], Chunk[1], N);
+      Move(Buf[0], Chunk[1], N);   { safe: UTF8String is 1 byte per char }
       FBuffer := FBuffer + Chunk;
       Continue;
     end;

--- a/src/pkg/memory/PasClaw.Memory.pas
+++ b/src/pkg/memory/PasClaw.Memory.pas
@@ -84,11 +84,15 @@ end;
 
 procedure TMemoryLog.WriteLine(const S: string);
 var
-  Line: string;
+  Bytes: TBytes;
 begin
   if FStream = nil then Exit;
-  Line := S + #10;
-  FStream.WriteBuffer(Line[1], Length(Line));
+  { Encode UTF-8 bytes explicitly. Writing `Line[1]` directly worked under
+    FPC (1-byte AnsiString) but wrote half the bytes under Delphi
+    (2-byte UnicodeString). }
+  Bytes := TEncoding.UTF8.GetBytes(S + #10);
+  if Length(Bytes) > 0 then
+    FStream.WriteBuffer(Bytes[0], Length(Bytes));
 end;
 
 procedure TMemoryLog.Append(Role: TMsgRole; const Content, ToolName: string);

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -67,7 +67,11 @@ begin
   Result.StatusCode := 0;
   Result.Body := '';
   Result.ErrorMsg := '';
-  Resp := TStringStream.Create('');
+  { Force UTF-8 on the response stream. Under Delphi modern, TStringStream
+    defaults to TEncoding.Default (the system codepage), which mangles
+    non-ASCII bytes in JSON responses. Under FPC the encoding arg is
+    accepted and behaves the same. }
+  Resp := TStringStream.Create('', TEncoding.UTF8);
   try
     try
       if IsPost then
@@ -121,7 +125,9 @@ var
   Req: TStringStream;
 begin
   Http := NewClient(TimeoutSeconds, MakeHTTPS(URL));
-  Req  := TStringStream.Create(JSON);
+  { UTF-8 encode the request body; default codepage would corrupt non-ASCII
+    JSON values (user names, system prompts, content blocks). }
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
   try
     Http.Request.ContentType    := 'application/json';
     Http.Request.ContentEncoding := 'utf-8';

--- a/src/pkg/providers/PasClaw.Providers.Stream.pas
+++ b/src/pkg/providers/PasClaw.Providers.Stream.pas
@@ -71,8 +71,10 @@ begin
   StatusCode := 0;
 
   Http := TIdHTTP.Create(nil);
-  Req  := TStringStream.Create(JSON);
-  Resp := TStringStream.Create('');
+  { Explicit UTF-8 — Delphi's TStringStream defaults to ANSI which would
+    mangle the SSE response body and the JSON request body. }
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
+  Resp := TStringStream.Create('', TEncoding.UTF8);
   SSL  := nil;
   try
     Http.ConnectTimeout := TimeoutSeconds * 1000;

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -133,18 +133,18 @@ end;
 function ReadFileText(const Path: string): string;
 var
   Strm: TFileStream;
-  SS: TStringStream;
+  Bytes: TBytes;
 begin
-  if not FileExists(Path) then Exit('');
+  Result := '';
+  if not FileExists(Path) then Exit;
   Strm := TFileStream.Create(Path, fmOpenRead or fmShareDenyWrite);
   try
-    SS := TStringStream.Create('');
-    try
-      SS.CopyFrom(Strm, 0);
-      Result := SS.DataString;
-    finally
-      SS.Free;
-    end;
+    SetLength(Bytes, Strm.Size);
+    if Strm.Size > 0 then Strm.ReadBuffer(Bytes[0], Strm.Size);
+    { TEncoding.UTF8.GetString round-trips correctly in both FPC and Delphi:
+      under FPC the result is AnsiString-UTF8; under Delphi it's UnicodeString
+      decoded from the UTF-8 bytes. }
+    Result := TEncoding.UTF8.GetString(Bytes);
   finally
     Strm.Free;
   end;
@@ -153,12 +153,16 @@ end;
 procedure WriteFileText(const Path, Content: string);
 var
   Strm: TFileStream;
+  Bytes: TBytes;
 begin
   EnsureDir(ExtractFilePath(Path));
   Strm := TFileStream.Create(Path, fmCreate);
   try
     if Content <> '' then
-      Strm.WriteBuffer(Pointer(Content)^, Length(Content));
+    begin
+      Bytes := TEncoding.UTF8.GetBytes(Content);
+      Strm.WriteBuffer(Bytes[0], Length(Bytes));
+    end;
   finally
     Strm.Free;
   end;


### PR DESCRIPTION
## Summary

Stacks on top of PR #2. The `DCC_Namespace` fix in PR #2 unblocked parsing under Delphi, but exposed a deeper portability bug that I'd missed: anywhere I treated a `string` as a raw byte buffer, the code silently produces half the bytes (plus embedded zeros) under Delphi because `string` = UTF-16 `UnicodeString` in Delphi vs UTF-8 `AnsiString` in FPC mode Delphi.

This PR walks every byte/string boundary in the project and routes it through explicit `TEncoding.UTF8` or `UTF8String` so the bytes on the wire / on disk are identical in both compilers.

## What was broken in Delphi (and silent in FPC)

| Pattern | Worked in FPC because… | Broke in Delphi because… |
|---|---|---|
| `Strm.WriteBuffer(S[1], Length(S))` | `string` = AnsiString, `S[1]` is a byte, `Length` returns bytes | `string` = UnicodeString, `S[1]` is a 2-byte WideChar, `Length` returns code units, so we write half the bytes |
| `Pointer(S)^` cast as bytes | PChar = PAnsiChar | PChar = PWideChar, bytes are 16-bit |
| `Move(Buf, S[1], N)` to fill a string | direct byte copy | writes N bytes into N WideChar slots; half garbage |
| `TStringStream.Create(s)` | UTF-8 string | uses TEncoding.Default = system codepage; mangles non-ASCII JSON |
| `SetLength(Body, n)` + `ReadBuffer(Body[1], n)` | n bytes into n char slots | n bytes into n*2-byte UnicodeString; half-length, half-garbage |

## Fixes (file by file)

**`src/pkg/utils/PasClaw.Utils.pas`** — `ReadFileText` reads into `TBytes` then decodes with `TEncoding.UTF8.GetString`. `WriteFileText` encodes with `TEncoding.UTF8.GetBytes` before `WriteBuffer`. Drops the `TStringStream.DataString` trick which was ANSI-default in Delphi.

**`src/pkg/memory/PasClaw.Memory.pas`** — `WriteLine` calls `TEncoding.UTF8.GetBytes(S + #10)` before writing. The NDJSON log is now byte-identical between toolchains.

**`src/pkg/mcp/PasClaw.MCP.StdioClient.pas`** — `FBuffer` and `Chunk` are now `UTF8String` (1 byte per char in both FPC and Delphi). The `Move(Buf[0], Chunk[1], N)` accumulator is safe again; when a complete `#10`-terminated line is extracted, the assignment to `Line: string` triggers UTF-8 decode under Delphi automatically.

**`src/pkg/gateway/PasClaw.Gateway.Server.pas`** — `HandleChat` reads the POST body into `TBytes` and decodes UTF-8 to a string. Previously `SetLength(Body, n) + ReadBuffer(Body[1], n)` produced a half-length corrupted `UnicodeString` under Delphi.

**`src/pkg/providers/PasClaw.Providers.HTTP.pas`** — both `TStringStream` constructors pin `TEncoding.UTF8` so JSON bodies (request and response) round-trip non-ASCII correctly. Delphi's default ANSI codepage was the bug.

**`src/pkg/providers/PasClaw.Providers.Stream.pas`** — same fix for the SSE streaming path's `Req` and `Resp` streams.

## Audit method

`grep -rn` for the five patterns above; reviewed every hit. The remaining `Length(S)`/`S[i]` usages are pure ASCII parsing (cron field splitter, slash-command detection, template `{{ }}` scanner) where character vs byte semantics happen to coincide.

## Test plan

- [x] FPC build clean (`make`) — 268k lines, 0 errors
- [x] `make smoke` — all 11 commands OK
- [x] MCP stdio handshake against fake Python server (verifies UTF8String FBuffer accumulator)
- [x] Config write+read round-trip with a 2-server config (verifies UTF-8 file I/O)
- [ ] Open `PasClaw.dproj` in Delphi 11/12 — Build for Win64
- [ ] Confirm `pasclaw mcp test` against a stdio MCP server works under Delphi
- [ ] Confirm `pasclaw agent` POST to `/v1/chat` body decodes correctly under Delphi

## Commits

- `b86bde7` Delphi string-as-bytes fixes: explicit UTF-8 at every byte boundary


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_