### PR TITLE
Fix F2613 'SysUtils not found' and Delphi/POSIX ABI issues

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -71,6 +71,16 @@
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
         <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <!--
+          DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
+          "Classes", "Windows") back to their fully qualified modern names
+          ("System.SysUtils", "System.Classes", "Winapi.Windows"). Without
+          this, Delphi emits F2613 Unit 'SysUtils' not found because the
+          RTL only ships System.SysUtils.dcu on modern Delphi.
+          Posix is included for the Delphi/Linux64 build; harmless on Windows.
+        -->
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UnitAlias>WinTypes=Winapi.Windows;WinProcs=Winapi.Windows;$(DCC_UnitAlias)</DCC_UnitAlias>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -266,4 +266,14 @@
 
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+
+    <!--
+      Post-import override.  CodeGear.Delphi.Targets may reset DCC_Namespace
+      with its own defaults; re-assert ours here so bare unit names like
+      "SysUtils" or "Classes" always resolve to their qualified counterparts
+      ("System.SysUtils", "System.Classes") regardless of IDE version.
+    -->
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix</DCC_Namespace>
+    </PropertyGroup>
 </Project>

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -246,6 +246,7 @@ procedure TGatewayServer.HandleChat(ARequest: TIdHTTPRequestInfo;
                                     AResp: TIdHTTPResponseInfo);
 var
   Body, Prompt: string;
+  Bytes: TBytes;
   Req, RespJ: TJsonObject;
   Msgs: array of TMessage;
   Loop: TToolLoopResult;
@@ -255,9 +256,14 @@ begin
   if ARequest.PostStream <> nil then
   begin
     ARequest.PostStream.Position := 0;
-    SetLength(Body, ARequest.PostStream.Size);
+    SetLength(Bytes, ARequest.PostStream.Size);
     if ARequest.PostStream.Size > 0 then
-      ARequest.PostStream.ReadBuffer(Body[1], ARequest.PostStream.Size);
+    begin
+      ARequest.PostStream.ReadBuffer(Bytes[0], ARequest.PostStream.Size);
+      { Bodies are JSON, by convention UTF-8. Decoding here means the
+        Delphi build sees the same string the FPC build does. }
+      Body := TEncoding.UTF8.GetString(Bytes);
+    end;
   end;
 
   if Trim(Body) = '' then

--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -37,7 +37,10 @@ type
     FProcess: TStdioProcess;
     FCmd, FArgs, FName: string;
     FNextId:  Integer;
-    FBuffer:  string;
+    { FBuffer is a UTF8String (1-byte-per-char in both FPC and Delphi) so
+      byte-level accumulation from the child's stdout works regardless of
+      whether `string` is AnsiString (FPC) or UnicodeString (Delphi). }
+    FBuffer:  UTF8String;
     function  ReadLine(out Line: string; TimeoutMs: Integer): Boolean;
     function  WriteLine(const S: string): Boolean;
     function  RoundTrip(const Method, ParamsJSON: string;
@@ -137,25 +140,27 @@ function TMCPStdioClient.ReadLine(out Line: string; TimeoutMs: Integer): Boolean
 var
   Buf: array[0..4095] of Byte;
   N, Waited, NLPos: Integer;
-  Chunk: string;
+  Chunk, LineUTF8: UTF8String;
 begin
   Line := '';
   Waited := 0;
   if FProcess = nil then Exit(False);
   while True do
   begin
-    NLPos := Pos(#10, FBuffer);
+    NLPos := Pos(UTF8String(#10), FBuffer);
     if NLPos > 0 then
     begin
-      Line    := Copy(FBuffer, 1, NLPos - 1);
-      FBuffer := Copy(FBuffer, NLPos + 1, MaxInt);
+      LineUTF8 := Copy(FBuffer, 1, NLPos - 1);
+      FBuffer  := Copy(FBuffer, NLPos + 1, MaxInt);
+      { UTF8String -> string: AnsiString-identity under FPC, UTF-8 decode under Delphi. }
+      Line := string(LineUTF8);
       Exit(True);
     end;
     N := FProcess.ReadAvailable(Buf, SizeOf(Buf));
     if N > 0 then
     begin
       SetLength(Chunk, N);
-      Move(Buf[0], Chunk[1], N);
+      Move(Buf[0], Chunk[1], N);   { safe: UTF8String is 1 byte per char }
       FBuffer := FBuffer + Chunk;
       Continue;
     end;

--- a/src/pkg/memory/PasClaw.Memory.pas
+++ b/src/pkg/memory/PasClaw.Memory.pas
@@ -84,11 +84,15 @@ end;
 
 procedure TMemoryLog.WriteLine(const S: string);
 var
-  Line: string;
+  Bytes: TBytes;
 begin
   if FStream = nil then Exit;
-  Line := S + #10;
-  FStream.WriteBuffer(Line[1], Length(Line));
+  { Encode UTF-8 bytes explicitly. Writing `Line[1]` directly worked under
+    FPC (1-byte AnsiString) but wrote half the bytes under Delphi
+    (2-byte UnicodeString). }
+  Bytes := TEncoding.UTF8.GetBytes(S + #10);
+  if Length(Bytes) > 0 then
+    FStream.WriteBuffer(Bytes[0], Length(Bytes));
 end;
 
 procedure TMemoryLog.Append(Role: TMsgRole; const Content, ToolName: string);

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -93,7 +93,7 @@ uses
     Winapi.Windows
   {$ELSE}
     Posix.Base, Posix.Unistd, Posix.Stdlib, Posix.SysWait,
-    Posix.Fcntl, Posix.Signal, Posix.SysTypes
+    Posix.Fcntl, Posix.Signal, Posix.SysTypes, Posix.SysSelect
   {$ENDIF}{$ENDIF};
 
 {$IFDEF FPC}
@@ -394,6 +394,7 @@ var
   Buf: array[0..ReadBufferSize - 1] of Byte;
   Total, N: Integer;
   Acc: TMemoryStream;
+  Bytes: TBytes;
 begin
   Result := -1;
   Output := '';
@@ -418,8 +419,13 @@ begin
     WaitForSingleObject(P.FProcHandle, INFINITE);
     P.Running;   { latches ExitCode via the side effect }
     Result := P.ExitCode;
-    SetLength(Output, Acc.Size);
-    if Acc.Size > 0 then begin Acc.Position := 0; Acc.ReadBuffer(Output[1], Acc.Size); end;
+    if Acc.Size > 0 then
+    begin
+      SetLength(Bytes, Acc.Size);
+      Acc.Position := 0;
+      Acc.ReadBuffer(Bytes[0], Acc.Size);
+      Output := TEncoding.UTF8.GetString(Bytes);
+    end;
   finally
     Acc.Free;
     Args.Free;
@@ -435,7 +441,12 @@ const
   STDOUT_FILENO = 1;
   STDERR_FILENO = 2;
 
-function pipe(fildes: array of Integer): Integer; cdecl;
+type
+  { Fixed-size pipe fd pair; pass by var so the C ABI receives a bare pointer,
+    not the (High,Ptr) pair that Delphi's open-array convention would send. }
+  TPipeFDs = array[0..1] of Integer;
+
+function pipe(var pipefds: TPipeFDs): Integer; cdecl;
   external libc name _PU + 'pipe';
 function execvp(const path: PAnsiChar; const argv: PPAnsiChar): Integer; cdecl;
   external libc name _PU + 'execvp';
@@ -458,11 +469,11 @@ end;
 
 function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
 var
-  StdinPipe, StdoutPipe: array[0..1] of Integer;
+  StdinPipe, StdoutPipe: TPipeFDs;
   Pid: pid_t;
   i: Integer;
   Argv: array of Pointer;
-  Argv0, ArgsI: TArray<RawByteString>;
+  ArgsI: array of RawByteString;
   Path: AnsiString;
 begin
   if FStarted then Exit(False);
@@ -576,6 +587,7 @@ var
   Buf: array[0..ReadBufferSize - 1] of Byte;
   Total, N, Status: Integer;
   Acc: TMemoryStream;
+  Bytes: TBytes;
 begin
   Result := -1;
   Output := '';
@@ -599,8 +611,13 @@ begin
     end;
     waitpid(P.FPid, Status, 0);
     if WIFEXITED(Status) then Result := WEXITSTATUS(Status) else Result := -1;
-    SetLength(Output, Acc.Size);
-    if Acc.Size > 0 then begin Acc.Position := 0; Acc.ReadBuffer(Output[1], Acc.Size); end;
+    if Acc.Size > 0 then
+    begin
+      SetLength(Bytes, Acc.Size);
+      Acc.Position := 0;
+      Acc.ReadBuffer(Bytes[0], Acc.Size);
+      Output := TEncoding.UTF8.GetString(Bytes);
+    end;
   finally
     Acc.Free;
     Args.Free;

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -67,7 +67,11 @@ begin
   Result.StatusCode := 0;
   Result.Body := '';
   Result.ErrorMsg := '';
-  Resp := TStringStream.Create('');
+  { Force UTF-8 on the response stream. Under Delphi modern, TStringStream
+    defaults to TEncoding.Default (the system codepage), which mangles
+    non-ASCII bytes in JSON responses. Under FPC the encoding arg is
+    accepted and behaves the same. }
+  Resp := TStringStream.Create('', TEncoding.UTF8);
   try
     try
       if IsPost then
@@ -121,7 +125,9 @@ var
   Req: TStringStream;
 begin
   Http := NewClient(TimeoutSeconds, MakeHTTPS(URL));
-  Req  := TStringStream.Create(JSON);
+  { UTF-8 encode the request body; default codepage would corrupt non-ASCII
+    JSON values (user names, system prompts, content blocks). }
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
   try
     Http.Request.ContentType    := 'application/json';
     Http.Request.ContentEncoding := 'utf-8';

--- a/src/pkg/providers/PasClaw.Providers.Stream.pas
+++ b/src/pkg/providers/PasClaw.Providers.Stream.pas
@@ -71,8 +71,10 @@ begin
   StatusCode := 0;
 
   Http := TIdHTTP.Create(nil);
-  Req  := TStringStream.Create(JSON);
-  Resp := TStringStream.Create('');
+  { Explicit UTF-8 — Delphi's TStringStream defaults to ANSI which would
+    mangle the SSE response body and the JSON request body. }
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
+  Resp := TStringStream.Create('', TEncoding.UTF8);
   SSL  := nil;
   try
     Http.ConnectTimeout := TimeoutSeconds * 1000;

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -210,6 +210,7 @@ var
   Empty: array of THeaderPair;
   Resp: THTTPResult;
   Strm: TFileStream;
+  Bytes: TBytes;
 begin
   ErrMsg := '';
   SetLength(Empty, 0);
@@ -226,7 +227,11 @@ begin
     Strm := TFileStream.Create(DestPath, fmCreate);
     try
       if Resp.Body <> '' then
-        Strm.WriteBuffer(Resp.Body[1], Length(Resp.Body));
+      begin
+        Bytes := TEncoding.UTF8.GetBytes(Resp.Body);
+        if Length(Bytes) > 0 then
+          Strm.WriteBuffer(Bytes[0], Length(Bytes));
+      end;
     finally
       Strm.Free;
     end;

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -133,18 +133,18 @@ end;
 function ReadFileText(const Path: string): string;
 var
   Strm: TFileStream;
-  SS: TStringStream;
+  Bytes: TBytes;
 begin
-  if not FileExists(Path) then Exit('');
+  Result := '';
+  if not FileExists(Path) then Exit;
   Strm := TFileStream.Create(Path, fmOpenRead or fmShareDenyWrite);
   try
-    SS := TStringStream.Create('');
-    try
-      SS.CopyFrom(Strm, 0);
-      Result := SS.DataString;
-    finally
-      SS.Free;
-    end;
+    SetLength(Bytes, Strm.Size);
+    if Strm.Size > 0 then Strm.ReadBuffer(Bytes[0], Strm.Size);
+    { TEncoding.UTF8.GetString round-trips correctly in both FPC and Delphi:
+      under FPC the result is AnsiString-UTF8; under Delphi it's UnicodeString
+      decoded from the UTF-8 bytes. }
+    Result := TEncoding.UTF8.GetString(Bytes);
   finally
     Strm.Free;
   end;
@@ -153,12 +153,16 @@ end;
 procedure WriteFileText(const Path, Content: string);
 var
   Strm: TFileStream;
+  Bytes: TBytes;
 begin
   EnsureDir(ExtractFilePath(Path));
   Strm := TFileStream.Create(Path, fmCreate);
   try
     if Content <> '' then
-      Strm.WriteBuffer(Pointer(Content)^, Length(Content));
+    begin
+      Bytes := TEncoding.UTF8.GetBytes(Content);
+      Strm.WriteBuffer(Bytes[0], Length(Bytes));
+    end;
   finally
     Strm.Free;
   end;


### PR DESCRIPTION
## Summary

- DCC_Namespace post-import override in `.dproj` so bare unit names compile on all Delphi versions
- `Posix.SysSelect` added; `pipe` C-ABI fixed; string/bytes fixed in Delphi `RunOneShot` paths
- `DownloadAsset` in `PasClaw.Updater` fixed to use `TBytes` instead of `string` direct buffer write

## What changed

### `src/pasclaw/PasClaw.dproj`

Added a second `<PropertyGroup>` block **after** the `<Import>` of `CodeGear.Delphi.Targets` that re-asserts `DCC_Namespace`:

```xml
<PropertyGroup Condition="'$(Base)'!=''">
    <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix</DCC_Namespace>
</PropertyGroup>
```

The existing pre-import setting was being silently reset by the targets file in some Delphi IDE versions, which is why `[dcc64 Fatal Error] PasClaw.CliUI.pas(13): F2613 Unit 'SysUtils' not found` kept appearing even after PR #3's fix. The post-import group is evaluated last and always wins.

### `src/pkg/platform/PasClaw.Platform.pas`

Three Delphi-specific bugs fixed, all inside `{$IFNDEF FPC}` guards:

| Bug | Fix |
|---|---|
| `Posix.SysSelect` missing — `TFDSet`, `select`, `FD_SET`, `timeval` undeclared | Added `Posix.SysSelect` to the POSIX `uses` clause |
| `pipe` declared as `array of Integer` (open-array ABI passes `(High, Ptr)`, C expects bare `Ptr`) | New `TPipeFDs = array[0..1] of Integer`; `pipe(var pipefds: TPipeFDs)` |
| `RunOneShot` (Win + POSIX) wrote bytes directly into a `UnicodeString` buffer | Accumulate into `TBytes`, decode with `TEncoding.UTF8.GetString` |

### `src/pkg/updater/PasClaw.Updater.pas`

`DownloadAsset` was calling `WriteBuffer(Resp.Body[1], Length(Resp.Body))`. Under Delphi, `Body[1]` is a 2-byte `WideChar` and `Length` returns character count, so this wrote half the bytes. Fixed with `TEncoding.UTF8.GetBytes` + `WriteBuffer(Bytes[0], …)`.

## Test plan

- [ ] Open `PasClaw.dproj` in Delphi 11/12 — Build for Win64; confirm no F2613
- [ ] Run `pasclaw version` under the Delphi Win64 build
- [ ] `pasclaw update --check` — exercises `DownloadAsset` path
- [ ] `pasclaw mcp test <server>` — exercises `PasClaw.Platform` POSIX spawn path on Linux64

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_