### PR TITLE
Fix NowIsoUtc: use TTimeZone.Local.ToUniversalTime under Delphi

### DIFF
--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -184,8 +184,15 @@ begin
 end;
 
 function NowIsoUtc: string;
+var
+  DT: TDateTime;
 begin
-  Result := FormatDateTime('yyyy"-"mm"-"dd"T"hh":"nn":"ss"Z"', LocalTimeToUniversal(Now));
+  {$IFDEF FPC}
+  DT := LocalTimeToUniversal(Now);
+  {$ELSE}
+  DT := TTimeZone.Local.ToUniversalTime(Now);
+  {$ENDIF}
+  Result := FormatDateTime('yyyy"-"mm"-"dd"T"hh":"nn":"ss"Z"', DT);
 end;
 
 end.


### PR DESCRIPTION
## Summary

- `LocalTimeToUniversal` is FPC-only (`DateUtils` unit); calling it under Delphi produces `E2003 Undeclared identifier: 'LocalTimeToUniversal'`
- Guard with `{$IFDEF FPC}` / `{$ELSE}`: FPC keeps `LocalTimeToUniversal(Now)`; Delphi uses `TTimeZone.Local.ToUniversalTime(Now)` from `System.DateUtils` (already in scope via the `DateUtils` import + `DCC_Namespace`)

## Test plan

- [ ] Build under FPC 3.2+: `NowIsoUtc` compiles and returns correct UTC ISO-8601 string
- [ ] Build under Delphi Win64 / Linux64: no `E2003` error; `TTimeZone.Local.ToUniversalTime` resolves correctly

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_