### PR TITLE
Delphi compatibility fixes: DCC_Namespace, UTF-8 byte handling, NowIsoUtc

### DIFF
--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -184,8 +184,15 @@ begin
 end;
 
 function NowIsoUtc: string;
+var
+  DT: TDateTime;
 begin
-  Result := FormatDateTime('yyyy"-"mm"-"dd"T"hh":"nn":"ss"Z"', LocalTimeToUniversal(Now));
+  {$IFDEF FPC}
+  DT := LocalTimeToUniversal(Now);
+  {$ELSE}
+  DT := TTimeZone.Local.ToUniversalTime(Now);
+  {$ENDIF}
+  Result := FormatDateTime('yyyy"-"mm"-"dd"T"hh":"nn":"ss"Z"', DT);
 end;
 
 end.


### PR DESCRIPTION
## Summary

- **DCC_Namespace**: Added post-import `<PropertyGroup>` in `.dproj` so bare unit names (`SysUtils`, `Classes`, etc.) always resolve under Delphi regardless of what `CodeGear.Delphi.Targets` does during MSBuild evaluation
- **PasClaw.Platform**: Fixed `pipe` C-ABI declaration (open-array → `var TPipeFDs`), added `Posix.SysSelect` for `TFDSet`/`select`, fixed `RunOneShot` string/bytes via `TBytes` + `TEncoding.UTF8.GetString`
- **PasClaw.Updater**: Fixed `DownloadAsset` to use `TEncoding.UTF8.GetBytes` so byte count is correct under Delphi's UnicodeString
- **PasClaw.Utils**: Fixed `NowIsoUtc` — `LocalTimeToUniversal` is FPC-only; Delphi now uses `TTimeZone.Local.ToUniversalTime`

## Test plan

- [ ] Build under FPC 3.2+ (`fpc -dFPC`): no regressions
- [ ] Build under Delphi Win64: no F2613/E2003 errors
- [ ] Build under Delphi Linux64: `Posix.SysSelect` resolves, `pipe` ABI correct
- [ ] `pasclaw update --check` exercises the updater path; `NowIsoUtc` returns correct UTC timestamp

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_