### PR TITLE
Fix TStringArray and Dispatch name clash in TToolRegistry under Delphi

### DIFF
--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -288,7 +288,7 @@ function RunSkill(Reg: TToolRegistry; const Name, ArgsJSON: string; out ErrMsg: 
 begin
   ErrMsg := '';
   if Reg = nil then begin ErrMsg := 'no registry'; Exit(''); end;
-  Result := Reg.Dispatch('skill_' + Name, ArgsJSON, ErrMsg);
+  Result := Reg.RunTool('skill_' + Name, ArgsJSON, ErrMsg);
 end;
 
 initialization

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -13,6 +13,7 @@ interface
 
 uses
   SysUtils, Classes,
+  {$IFNDEF FPC}Types,{$ENDIF}
   PasClaw.Tools.Types,
   PasClaw.Providers.Types;
 
@@ -27,7 +28,7 @@ type
     function  Names: TStringArray;
     function  Count: Integer;
     function  ToProviderDefs: TToolDefinitionArray;
-    function  Dispatch(const Name, ArgsJSON: string; out ErrMsg: string): string;
+    function  RunTool(const Name, ArgsJSON: string; out ErrMsg: string): string;
   end;
 
 implementation
@@ -91,7 +92,7 @@ begin
   end;
 end;
 
-function TToolRegistry.Dispatch(const Name, ArgsJSON: string; out ErrMsg: string): string;
+function TToolRegistry.RunTool(const Name, ArgsJSON: string; out ErrMsg: string): string;
 var
   T: TTool;
 begin

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -119,7 +119,7 @@ begin
       Err := '';
       ResultText := '';
       if Cfg.Registry <> nil then
-        ResultText := Cfg.Registry.Dispatch(Resp.ToolCalls[i].Func.Name,
+        ResultText := Cfg.Registry.RunTool(Resp.ToolCalls[i].Func.Name,
                                             Resp.ToolCalls[i].Func.Arguments,
                                             Err)
       else


### PR DESCRIPTION
## Summary

- **E2003 `TStringArray` undeclared**: added `{$IFNDEF FPC}Types,{$ENDIF}` to the uses clause so Delphi resolves it from `System.Types`; FPC already exposes `TStringArray` from `SysUtils`
- **W1010 `Dispatch` hides `TObject.Dispatch`**: renamed `TToolRegistry.Dispatch` → `RunTool` and updated both call sites (`PasClaw.Tools.ToolLoop`, `PasClaw.Skills.Loader`)

## Test plan

- [ ] Build under Delphi Win64/Linux64: no E2003/E2005/E2008 errors, no W1010 warning
- [ ] Build under FPC 3.2+: no regressions
- [ ] Tool dispatch (shell_exec, fs_read, skill tools) still works at runtime

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_