### PR TITLE
Declare TStringArray locally in TToolRegistry under Delphi

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -13,11 +13,16 @@ interface
 
 uses
   SysUtils, Classes,
-  {$IFNDEF FPC}Types,{$ENDIF}
   PasClaw.Tools.Types,
   PasClaw.Providers.Types;
 
 type
+  {$IFNDEF FPC}
+  { Delphi's RTL doesn't declare TStringArray (FPC's SysUtils does); declare
+    it locally so the cross-compiler signature below resolves. }
+  TStringArray = array of string;
+  {$ENDIF}
+
   TToolRegistry = class
   private
     FTools: TToolList;


### PR DESCRIPTION
## Summary

PR #7 attempted to resolve `TStringArray` via `System.Types`, but Delphi's `System.Types` does **not** export `TStringArray` — that name only exists in FPC's `SysUtils`. Result: the original E2003 error came back.

Fix: drop the `Types` import and declare the alias locally:

```pascal
{$IFNDEF FPC}
TStringArray = array of string;
{$ENDIF}
```

FPC continues to use the `SysUtils` definition (same shape), so call sites are unchanged.

## Test plan

- [ ] Build under Delphi Win64/Linux64: no E2003/E2005/E2008 errors on `PasClaw.Tools.Registry.pas`
- [ ] Build under FPC 3.2+: no duplicate-type errors (the `{$IFNDEF FPC}` guard prevents it)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_