### PR TITLE
Use TToolDefinitionArray for Tools local in RunToolLoop

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -68,7 +68,7 @@ function RunToolLoop(const Cfg: TToolLoopConfig;
                      out Loop: TToolLoopResult): Boolean;
 var
   Iter, i: Integer;
-  Tools: array of TToolDefinition;
+  Tools: TToolDefinitionArray;
   Resp: TLLMResponse;
   Hist: array of TMessage;
   ResultText, Err: string;


### PR DESCRIPTION
## Summary

Fixes `[dcc64 Error] PasClaw.Tools.ToolLoop.pas(87): E2010 Incompatible types: 'Dynamic array' and 'TToolDefinitionArray'`.

The local `Tools` was declared as the anonymous `array of TToolDefinition`; Delphi treats anonymous dynamic-array types as distinct from the named alias `TToolDefinitionArray` returned by `TToolRegistry.ToProviderDefs`. FPC's `{$MODE DELPHI}` is more lenient and accepted the assignment. Using the named alias makes both compilers agree.

## Test plan

- [ ] Build under Delphi Win64/Linux64: no E2010 on ToolLoop.pas
- [ ] Build under FPC 3.2+: still compiles
- [ ] Tool dispatch path runs end-to-end (agent calls a tool, sees result)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_