### PR TITLE
Guard FPC-only $MACRO block in MCP.Bridge for Delphi

### DIFF
--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -53,7 +53,9 @@ var
 function FindBinding(const RegisteredName: string; out Idx: Integer): Boolean; forward;
 
 { Per-slot handlers. We can't generate these dynamically in Pascal, so we
-  hand-roll one per slot and use the slot index to look up the binding. }
+  hand-roll one per slot and use the slot index to look up the binding.
+  The macro template below is FPC-only and documentary — Delphi ignores it. }
+{$IFDEF FPC}
 {$MACRO ON}
 {$DEFINE MAKE_HANDLER :=
 function H_NUM(const ArgsJSON: string; out ErrMsg: string): string;
@@ -72,6 +74,7 @@ begin
   if not Done and (ErrMsg = '') then ErrMsg := 'mcp call failed';
 end;
 }
+{$ENDIF}
 
 { Slot handlers: we emit one per index so the function table is fixed at
   compile time. If you raise MaxBindings, extend this block to match. }


### PR DESCRIPTION
## Summary

Fixes `[dcc64 Error] PasClaw.MCP.Bridge.pas(57): E1030 Invalid compiler directive: 'MACRO'`.

`{$MACRO ON}` and `{$DEFINE name := ...}` are FPC-only directives — Delphi rejects them with E1030. The `MAKE_HANDLER` macro template is never actually expanded anyway; the H_0..H_31 functions below it are hand-written. Wrapping the block in `{$IFDEF FPC}` keeps it as documentary reference for FPC builds and hides it from Delphi.

## Test plan

- [ ] Build under Delphi Win64/Linux64: no E1030 on MCP.Bridge.pas
- [ ] Build under FPC 3.2+: still compiles; macro block parses (even though unused)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_