### PR TITLE
Replace 3-arg BoolToStr with StrUtils.IfThen in auth status

### DIFF
--- a/src/cmd/PasClaw.Cmd.Auth.pas
+++ b/src/cmd/PasClaw.Cmd.Auth.pas
@@ -10,7 +10,7 @@ function Cmd_Auth_Run(const Argv: array of string): Integer;
 implementation
 
 uses
-  SysUtils, PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger;
+  SysUtils, StrUtils, PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger;
 
 procedure Help;
 begin
@@ -31,7 +31,7 @@ begin
     end;
     for i := 0 to High(Cfg.Providers) do
       WriteLn(Cfg.Providers[i].Name:14, '  key: ',
-        BoolToStr(Cfg.Providers[i].APIKey <> '', 'present', 'missing'));
+        IfThen(Cfg.Providers[i].APIKey <> '', 'present', 'missing'));
     Result := 0;
   finally
     Cfg.Free;


### PR DESCRIPTION
## Summary

Fixes `[dcc64 Error] PasClaw.Cmd.Auth.pas(34): E2010 Incompatible types: 'Boolean' and 'string'`.

Delphi's `BoolToStr` only has two overloads: `(B: Boolean)` and `(B: Boolean; UseBoolStrs: Boolean)`. FPC additionally has `BoolToStr(B: Boolean; const TrueS, FalseS: string)`, which is what `DoStatus` was relying on. Delphi tries to match against the 2-arg overload and fails on the string args.

Swap to `StrUtils.IfThen(Condition, TrueStr, FalseStr)` — same signature on both compilers, same result.

## Test plan

- [ ] Build under Delphi Win64/Linux64: no E2010 on Cmd.Auth.pas
- [ ] Build under FPC 3.2+: still compiles
- [ ] `pasclaw auth status` prints `present` / `missing` per provider

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_