### PR TITLE
Add SystemTempDir wrapper for cross-compiler temp-path lookup

### DIFF
--- a/src/pkg/membench/PasClaw.Membench.Runner.pas
+++ b/src/pkg/membench/PasClaw.Membench.Runner.pas
@@ -44,9 +44,19 @@ implementation
 
 uses
   Classes, DateUtils,
+  {$IFNDEF FPC}IOUtils,{$ENDIF}
   PasClaw.Memory,
   PasClaw.Providers.Types,
   PasClaw.Utils;
+
+function SystemTempDir: string;
+begin
+  {$IFDEF FPC}
+  Result := GetTempDir;
+  {$ELSE}
+  Result := TPath.GetTempPath;
+  {$ENDIF}
+end;
 
 function DefaultMembenchOpts: TMembenchOpts;
 begin
@@ -105,7 +115,7 @@ begin
   Result.LoadSeconds    := 0;
 
   if Opts.OutDir <> '' then Home := Opts.OutDir
-  else                      Home := GetTempDir;
+  else                      Home := SystemTempDir;
 
   SessionId := 'membench-' + FormatDateTime('yyyymmdd-hhnnsszzz', Now);
   Log := NewMemoryLog(Home, SessionId);


### PR DESCRIPTION
## Summary

Fixes `[dcc64 Error] PasClaw.Membench.Runner.pas(108): E2003 Undeclared identifier: 'GetTempDir'`.

`GetTempDir` is FPC-only (defined in FPC's `SysUtils`). Delphi's cross-platform equivalent is `TPath.GetTempPath` in `System.IOUtils`. Added a small `SystemTempDir` wrapper that picks the right call with `{$IFDEF FPC}` and replaced the direct `GetTempDir` reference with it.

## Test plan

- [ ] Build under Delphi Win64/Linux64: no E2003; `SystemTempDir` resolves
- [ ] Build under FPC 3.2+: still compiles via the existing `GetTempDir` path
- [ ] `pasclaw membench` (with no `--out-dir`) writes to the system temp directory on both platforms

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_