### PR TITLE
Fix membench EFCreateError on Windows: build paths with native separators

### DIFF
--- a/src/pkg/membench/PasClaw.Membench.Runner.pas
+++ b/src/pkg/membench/PasClaw.Membench.Runner.pas
@@ -119,7 +119,8 @@ begin
 
   SessionId := 'membench-' + FormatDateTime('yyyymmdd-hhnnsszzz', Now);
   Log := NewMemoryLog(Home, SessionId);
-  Path := IncludeTrailingPathDelimiter(Home) + 'workspace/memory/' + SessionId + '.ndjson';
+  { Match the path NewMemoryLog actually wrote — native separators throughout. }
+  Path := JoinPath(JoinPath(JoinPath(Home, 'workspace'), 'memory'), SessionId + '.ndjson');
   Result.Path := Path;
 
   Payload := MakePayload(Opts.ContentSize);

--- a/src/pkg/memory/PasClaw.Memory.pas
+++ b/src/pkg/memory/PasClaw.Memory.pas
@@ -58,7 +58,11 @@ function NewMemoryLog(const HomeDir, SessionId: string): TMemoryLog;
 var
   Dir, Path: string;
 begin
-  Dir := JoinPath(HomeDir, 'workspace/memory');
+  { Build with two JoinPath calls so each separator uses the native
+    PathDelim. A literal 'workspace/memory' would leave a forward slash
+    inside an otherwise-backslash path on Windows, and ForceDirectories
+    fails to create the second segment in that case. }
+  Dir := JoinPath(JoinPath(HomeDir, 'workspace'), 'memory');
   EnsureDir(Dir);
   Path := JoinPath(Dir, SessionId + '.ndjson');
   Result := TMemoryLog.Create(Path, SessionId);


### PR DESCRIPTION
## Summary

Fixes the runtime crash on Windows:

```
Exception EFCreateError ... Cannot create file
"C:\Users\anony\AppData\Local\Temp\workspace\memory\membench-20260527-...ndjson".
The system cannot find the path specified.
```

`NewMemoryLog` was building the directory as `JoinPath(HomeDir, 'workspace/memory')`. On Windows that produces `...\Temp\workspace/memory` — a mixed-delimiter path. `ForceDirectories` walks segments by `PathDelim` (`\` on Windows) and never sees the `memory` segment, so only `workspace` gets created. `TFileStream.Create(..., fmCreate)` then fails because `memory\` doesn't exist.

Fix: use two `JoinPath` calls so each separator is `PathDelim`. Also fix the parallel `Path` construction in `Membench.Runner` so `Result.Path` agrees with the file the log actually wrote (used by `FileBytes` and the load pass).

## Test plan

- [ ] On Windows: `pasclaw membench` no longer raises `EFCreateError`; file appears under `%TEMP%\workspace\memory\`
- [ ] On Linux/macOS: still works (PathDelim is `/`, no behavioral change)
- [ ] Load pass reads back the same path; `RecordsLoaded` matches `RecordsWritten`

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_