### PR TITLE
Preserve literal UNC backslashes in SplitArgs

### DIFF
--- a/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.StdioClient.pas
@@ -92,12 +92,13 @@ begin
 end;
 
 function SplitArgs(const S: string): TStringList;
-{ Shell-lite tokenizer: splits on unquoted whitespace, honors paired
-  single/double quotes, and recognizes \\ and \<quote> as escape
-  sequences (anywhere outside single quotes — single-quoted strings
-  stay literal, matching POSIX shell convention). Good enough for the
-  typical MCP `cmd args` line; for anything more complex, an array-form
-  config will eventually replace string parsing. }
+{ Tokenize a `cmd args...` string for direct-to-argv handoff to
+  TStdioProcess.Spawn (no shell is involved). Splits on unquoted
+  whitespace and honors paired single/double quotes; everything else,
+  including backslashes, is taken literally. That keeps Windows paths
+  intact — most importantly UNC roots like \\server\share — which a
+  POSIX-style \\-escape rule would mangle. When richer escaping is
+  needed, an array-form config will eventually replace this entirely. }
 var
   i, n: Integer;
   inQuote: Boolean;
@@ -114,25 +115,12 @@ begin
   begin
     if inQuote then
     begin
-      if (qc = '"') and (S[i] = '\') and (i < n) and
-         ((S[i + 1] = '"') or (S[i + 1] = '\')) then
-      begin
-        cur := cur + S[i + 1];
-        Inc(i);
-      end
-      else if S[i] = qc then inQuote := False
+      if S[i] = qc then inQuote := False
       else cur := cur + S[i];
     end
     else
     begin
-      if (S[i] = '\') and (i < n) and
-         ((S[i + 1] = '"') or (S[i + 1] = '''') or
-          (S[i + 1] = '\') or (S[i + 1] = ' ')) then
-      begin
-        cur := cur + S[i + 1];
-        Inc(i);
-      end
-      else if (S[i] = '"') or (S[i] = '''') then
+      if (S[i] = '"') or (S[i] = '''') then
       begin
         inQuote := True;
         qc := S[i];


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PR #17. The shell-style backslash escape rules I added to `SplitArgs` collapsed `\\` → `\` both inside and outside double-quoted args. `SplitArgs` hands its tokens straight to `TStdioProcess.Spawn` — no shell is interposed — so the doubled leading backslash in `--root=\\server\share` is part of the Windows UNC path and must be preserved. Collapsing it produced `--root=\server\share` and broke MCP servers configured with UNC roots.

The fix drops the escape branches entirely. `SplitArgs` does the bare minimum: split on unquoted whitespace, honor paired quotes, keep everything else (including backslashes) literal. When richer escaping is actually needed, an array-form config will eventually replace this.

## Test plan

- [ ] `cmd: server.exe`, `args: --root=\\\\server\\share --port=3000` (as encoded in JSON/YAML) splits to `[--root=\\server\share, --port=3000]` and `Spawn` receives them verbatim
- [ ] `args: "C:\Program Files\foo\bar.exe --quiet"` still splits to `[C:\Program Files\foo\bar.exe, --quiet]` via the quote grouping
- [ ] Plain `args: --foo --bar=baz` still tokenizes correctly

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_