### PR TITLE
Default ChatOptions.Temperature to 0 so newer Claude models accept the request

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -113,7 +113,13 @@ end;
 
 function DefaultChatOptions: TChatOptions;
 begin
-  Result.Temperature   := 0.7;
+  { Temperature defaults to 0 ("not set"). The Anthropic and OpenAI
+    request builders only emit the `temperature` field when this is
+    > 0, so a caller that never picks a value lets the provider use
+    its server-side default. This avoids hitting Anthropic's
+    "`temperature` is deprecated for this model" 400 on the newer
+    Claude models, which reject the field outright. }
+  Result.Temperature   := 0;
   Result.MaxTokens     := 4096;
   Result.Stream        := False;
   Result.SystemPrompt  := '';


### PR DESCRIPTION
## Summary

Fixes the runtime error from `pasclaw agent`:

```
anthropic error 400: {"type":"error","error":{"type":"invalid_request_error",
"message":"`temperature` is deprecated for this model."}}
```

Anthropic deprecated the `temperature` field for newer Claude models — Opus 4.7 now returns 400 even with a perfectly valid value. The default of `0.7` in `DefaultChatOptions` meant the field was always emitted, even when no caller had explicitly picked a value.

Both the Anthropic and OpenAI request builders already gate the field on `Options.Temperature > 0`:
- `PasClaw.Providers.Anthropic.pas:108`
- `PasClaw.Providers.OpenAI.pas:79`

So changing the default to `0` ("not set") silently omits the field. Callers who want a specific temperature still set it via `Options` or config; otherwise providers fall back to their server-side default, which is what most users implicitly assumed they were getting from `0.7`.

## Test plan

- [ ] `pasclaw agent` with Claude Opus 4.7 model: no more 400; reply streams normally
- [ ] OpenAI provider still works (still gates on `>0`, no behavior change unless a caller relied on the implicit 0.7)
- [ ] Explicit `Options.Temperature := 0.7` before calling `Chat()` still sends the field

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_