### PR TITLE
Fix HandleChatCompletions doc comment that broke Delphi compilation

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -429,18 +429,18 @@ end;
 
 procedure TGatewayServer.HandleChatCompletions(ARequest: TIdHTTPRequestInfo;
                                                 AResp: TIdHTTPResponseInfo);
-{ OpenAI Chat Completions API. Accepts the standard request shape:
-    {model, messages: [{role, content, ...}], temperature?, max_tokens?,
-     stream?, tools?}.
-  Routes through the existing tool loop. When stream:true is set we emit
-  the completed content as a single SSE chunk + [DONE]; the tool loop
-  runs server-side first, so clients see the same final text as in the
-  non-streaming response — just framed for an SSE-aware client (chatgpt.js,
-  LangChain, autogen, openai-python with stream=True, etc.). }
+(* OpenAI Chat Completions API. Accepts the standard request shape
+   (model, messages array of role/content objects, optional temperature,
+   max_tokens, stream, tools) and routes through the existing tool loop.
+   When stream:true is set we emit the completed content as a single SSE
+   chunk followed by [DONE]; the tool loop runs server-side first, so
+   clients see the same final text as in the non-streaming response —
+   just framed for an SSE-aware client (chatgpt.js, LangChain, autogen,
+   openai-python with stream=True, etc.). *)
 var
   Body, ReqModel, FinishReason, CompId: string;
   Bytes: TBytes;
-  Req, MsgObj, ErrObj, ErrInner: TJsonObject;
+  Req, MsgObj: TJsonObject;
   MsgArr: TJsonArray;
   Msgs: array of TMessage;
   i: Integer;


### PR DESCRIPTION
## Summary

Fixes Delphi compile errors introduced in PR #20:

```
[dcc64 Error] PasClaw.Gateway.Server.pas(433): E2029 Declaration expected but ']' found
[dcc64 Error] PasClaw.Gateway.Server.pas(433): E2038 Illegal character: '?'
[dcc64 Error] PasClaw.Gateway.Server.pas(434): E2038 Illegal character: '?'
[dcc64 Error] PasClaw.Gateway.Server.pas(439): E2038 Illegal character: '}'
```

The `HandleChatCompletions` doc comment used `{ ... }` delimiters and illustrated the OpenAI request shape literally as JSON (`{model, messages: [{role, content, ...}], ...}`). Pascal `{ ... }` comments don't nest, so the first inner `}` closed the comment early — leaving `]`, `?`, and the trailing `}` as illegal tokens at file scope.

Switch the comment to `(* ... *)` delimiters and describe the shape in prose so braces and brackets in the explanation can't break the parser again. Also dropped two unused locals (`ErrObj`, `ErrInner`) that crept in but the implementation didn't need.

## Test plan

- [ ] Build under Delphi Win64: no E2029/E2038 on `PasClaw.Gateway.Server.pas`
- [ ] Build under FPC: still compiles (FPC tolerates the braces but the `(* ... *)` form is equally valid)
- [ ] `POST /v1/chat/completions` still returns OpenAI-formatted JSON

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_