### PR TITLE
Enable UTF-8 console on Windows in PasClaw CLI

### DIFF
--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -36,10 +36,24 @@ function  RenderCommandHelp(const Use, Short, Long, Example: string;
 implementation
 
 uses
-  PasClaw.Utils;
+  PasClaw.Utils
+  {$IFDEF MSWINDOWS}
+  , {$IFDEF FPC}Windows{$ELSE}Winapi.Windows{$ENDIF}
+  {$ENDIF}
+  ;
 
 var
   GNoColor: Boolean = False;
+
+{$IFDEF MSWINDOWS}
+procedure EnableUTF8Console;
+begin
+  { Force UTF-8 console code pages on Windows so Unicode banner/panel glyphs
+    (█, ╔, ┌, etc.) are not interpreted via legacy ANSI/OEM encodings. }
+  SetConsoleCP(CP_UTF8);
+  SetConsoleOutputCP(CP_UTF8);
+end;
+{$ENDIF}
 
 procedure SetAnsi(Disabled: Boolean);
 begin
@@ -77,6 +91,9 @@ end;
 
 procedure CliUI_Init(NoColor: Boolean);
 begin
+  {$IFDEF MSWINDOWS}
+  EnableUTF8Console;
+  {$ENDIF}
   GNoColor := NoColor;
   SetAnsi(NoColor);
 end;


### PR DESCRIPTION
### Motivation
- Ensure Unicode box-drawing glyphs and banner characters render correctly on Windows consoles by forcing UTF-8 code pages at CLI initialization.

### Description
- Add Windows-specific `EnableUTF8Console` that calls `SetConsoleCP(CP_UTF8)` and `SetConsoleOutputCP(CP_UTF8)`, include the appropriate Windows unit in `uses`, and invoke it from `CliUI_Init` under `MSWINDOWS`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f628e970832e97cc655ebfff183f)