### PR TITLE
Finish UTF-8 console on Delphi and add `serve --debug` request logging

### DIFF
--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -5,6 +5,7 @@
     pasclaw serve --addr 0.0.0.0 --port 8088
     pasclaw serve --no-tools              # disable built-in tool registry
     pasclaw serve --no-mcp                # skip MCP server discovery
+    pasclaw serve --debug                 # log every request + response body
 
   Exposes POST /v1/chat/completions on the configured port. Any client
   that speaks the OpenAI Chat Completions API (openai-python, openai-node,
@@ -46,6 +47,7 @@ type
     Port:    Integer;
     NoMCP:   Boolean;
     NoTools: Boolean;
+    Debug:   Boolean;
   end;
 
 function ParseServe(const Argv: array of string; const Cfg: TConfig): TServeArgs;
@@ -56,6 +58,7 @@ begin
   Result.Port    := Cfg.Gateway.Port;
   Result.NoMCP   := False;
   Result.NoTools := False;
+  Result.Debug   := False;
   i := 0;
   while i <= High(Argv) do
   begin
@@ -63,6 +66,8 @@ begin
     if Argv[i] = '--port'     then begin if i < High(Argv) then Result.Port := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
     if Argv[i] = '--no-mcp'   then begin Result.NoMCP   := True; Inc(i); Continue; end;
     if Argv[i] = '--no-tools' then begin Result.NoTools := True; Inc(i); Continue; end;
+    if (Argv[i] = '--debug') or (Argv[i] = '-d') then
+                                  begin Result.Debug   := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -82,6 +87,12 @@ begin
   Cfg := LoadConfig;
   try
     Args := ParseServe(Argv, Cfg);
+
+    if Args.Debug then
+    begin
+      SetLogLevel(llDebug);
+      LogDebug('serve: --debug enabled (logging every request + body)');
+    end;
 
     Provider := nil;
     if Cfg.DefaultProvider <> '' then
@@ -105,6 +116,7 @@ begin
       MCPClients := ConnectMCPServers(Cfg, Reg);
 
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
+    Server.DebugIO := Args.Debug;
     try
       Server.Start(Args.Addr, Args.Port);
 

--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -49,9 +49,19 @@ var
 procedure EnableUTF8Console;
 begin
   { Force UTF-8 console code pages on Windows so Unicode banner/panel glyphs
-    (█, ╔, ┌, etc.) are not interpreted via legacy ANSI/OEM encodings. }
+    (█, ╔, ┌, etc.) are not interpreted via legacy ANSI/OEM encodings.
+    SetConsoleOutputCP alone tells the console how to interpret bytes;
+    under Delphi the RTL also caches a per-Text-file codepage that
+    converts UnicodeString → bytes before they reach the console, so we
+    need SetTextCodePage to point Output/ErrOutput at UTF-8 as well.
+    FPC's WriteLn already emits the UTF-8 bytes its AnsiString holds,
+    so it doesn't need the extra call. }
   SetConsoleCP(CP_UTF8);
   SetConsoleOutputCP(CP_UTF8);
+  {$IFNDEF FPC}
+  SetTextCodePage(Output,    CP_UTF8);
+  SetTextCodePage(ErrOutput, CP_UTF8);
+  {$ENDIF}
 end;
 {$ENDIF}
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -43,6 +43,7 @@ type
     FRegistry: TToolRegistry;
     FStarted:  Boolean;
     FStopFlag: TEvent;
+    FDebugIO:  Boolean;
     procedure OnCommandGet(AContext: TIdContext;
                            ARequest: TIdHTTPRequestInfo;
                            AResponse: TIdHTTPResponseInfo);
@@ -58,6 +59,10 @@ type
   public
     constructor Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
     destructor  Destroy; override;
+    { When True every request to /v1/chat/completions logs its full body
+      and the response body via LogDebug. Off by default; the `serve`
+      subcommand flips it on with --debug. }
+    property DebugIO: Boolean read FDebugIO write FDebugIO;
     procedure Start(const BindAddr: string; Port: Integer);
     procedure Stop;
     procedure WaitForStop;
@@ -463,8 +468,13 @@ begin
     end;
   end;
 
+  if FDebugIO then
+    LogDebug('chat/completions <- %d bytes from %s: %s',
+             [Length(Bytes), ARequest.RemoteIP, Body]);
+
   if Trim(Body) = '' then
   begin
+    if FDebugIO then LogDebug('chat/completions -> 400 (empty body)');
     WriteJSON(AResp, 400,
       '{"error":{"message":"empty request body","type":"invalid_request_error"}}');
     Exit;
@@ -473,6 +483,7 @@ begin
   Req := TJsonObject.Parse(Body);
   if Req = nil then
   begin
+    if FDebugIO then LogDebug('chat/completions -> 400 (invalid JSON)');
     WriteJSON(AResp, 400,
       '{"error":{"message":"invalid JSON","type":"invalid_request_error"}}');
     Exit;
@@ -481,6 +492,11 @@ begin
   try
     ReqModel    := Req.GetStr('model', FCfg.DefaultModel);
     WantsStream := Req.GetBool('stream', False);
+    if FDebugIO then
+      LogDebug('chat/completions: model=%s stream=%s temperature=%g max_tokens=%d',
+               [ReqModel, BoolToStr(WantsStream, True),
+                Req.GetFloat('temperature', 0),
+                Req.GetInt('max_tokens', 0)]);
 
     { Walk messages[] -> TMessageArray. We accept the OpenAI shape but
       pass the raw content string through; multimodal/image parts get
@@ -488,6 +504,7 @@ begin
     MsgArr := Req.ChildArray('messages');
     if (MsgArr = nil) or (MsgArr.Count = 0) then
     begin
+      if FDebugIO then LogDebug('chat/completions -> 400 (no messages[])');
       WriteJSON(AResp, 400,
         '{"error":{"message":"missing or empty messages[]","type":"invalid_request_error"}}');
       if MsgArr <> nil then MsgArr.Free;
@@ -512,6 +529,7 @@ begin
 
     if FProvider = nil then
     begin
+      if FDebugIO then LogDebug('chat/completions -> 503 (no provider configured)');
       WriteJSON(AResp, 503,
         '{"error":{"message":"no provider configured","type":"server_error"}}');
       Exit;
@@ -535,6 +553,7 @@ begin
 
     if not RunToolLoop(LoopCfg, Msgs, Loop) then
     begin
+      if FDebugIO then LogDebug('chat/completions -> 502 (tool loop failed)');
       WriteJSON(AResp, 502,
         '{"error":{"message":"tool loop failed","type":"server_error"}}');
       Exit;
@@ -546,11 +565,17 @@ begin
     else
       FinishReason := 'stop';
 
+    if FDebugIO then
+      LogDebug('chat/completions: tool loop done iterations=%d in=%d out=%d finish=%s content=%s',
+               [Loop.Iterations, Loop.LastResp.Usage.InputTokens,
+                Loop.LastResp.Usage.OutputTokens, FinishReason, Loop.Content]);
+
     if WantsStream then
     begin
       Buf := BuildOpenAIChunk(CompId, ReqModel, Loop.Content, '') +
              BuildOpenAIChunk(CompId, ReqModel, '', FinishReason) +
              'data: [DONE]' + #10#10;
+      if FDebugIO then LogDebug('chat/completions -> 200 SSE %d bytes', [Length(Buf)]);
       WriteSSE(AResp, Buf);
     end
     else
@@ -558,6 +583,7 @@ begin
       ReplyObj := BuildOpenAICompletion(CompId, ReqModel, Loop.Content,
                                          Loop.LastResp.Usage, FinishReason);
       try
+        if FDebugIO then LogDebug('chat/completions -> 200 JSON: %s', [ReplyObj.ToJSON]);
         WriteJSON(AResp, 200, ReplyObj.ToJSON);
       finally
         ReplyObj.Free;


### PR DESCRIPTION
## Summary

Two fixes:

### 1. UTF-8 console output under Delphi

`EnableUTF8Console` already called `SetConsoleCP`/`SetConsoleOutputCP(CP_UTF8)` but the Delphi build still rendered banner / panel glyphs as mojibake while FPC printed them cleanly. Root cause: Delphi's RTL caches a per-`Text`-file code page independently of the Win32 console output CP. The `UnicodeString → bytes` conversion in `WriteLn(Output, ...)` used the cached value (the system ANSI CP), so the bytes the console received were never UTF-8 even though it had been told to interpret them as such.

Add the missing pair under `{$IFNDEF FPC}`:

```pascal
SetTextCodePage(Output,    CP_UTF8);
SetTextCodePage(ErrOutput, CP_UTF8);
```

FPC's `WriteLn` emits the AnsiString-as-UTF-8 bytes verbatim, so the guards skip the Delphi-only step. Console banner, panel borders, and any other Unicode strings now render correctly in `cmd.exe`/PowerShell.

### 2. `pasclaw serve --debug` for diagnosing client integration

Adds a `--debug` / `-d` flag to `serve`:

```
pasclaw serve --debug
```

- Flips the log level to debug.
- Sets a new `DebugIO` property on `TGatewayServer`.

With `DebugIO` on, `/v1/chat/completions` logs:

- Incoming body (full JSON) + remote IP + byte count.
- Parsed request shape: `model`, `stream`, `temperature`, `max_tokens`.
- Tool-loop result summary: `iterations`, `input_tokens`, `output_tokens`, `finish_reason`, final `content`.
- Outgoing response body (200 JSON / SSE byte count) or status + reason on every early-return (400 empty body, 400 invalid JSON, 400 missing messages, 503 no provider, 502 tool loop failed).

The existing `gateway: METHOD PATH` debug line in `OnCommandGet` also lights up automatically once the level is at debug.

## Test plan

- [ ] On Windows under Delphi build: banner renders with `█`/`╔`/`╚` glyphs (not mojibake) in `cmd.exe`, PowerShell, Windows Terminal
- [ ] FPC/Windows still renders cleanly (no regression)
- [ ] FPC/Linux still renders cleanly (Posix branch untouched)
- [ ] `pasclaw serve --debug` boots; sending an OpenAI request prints body in/out
- [ ] `pasclaw serve` without `--debug` keeps the current quiet stdout
- [ ] An invalid request from a client surfaces a clear log line (e.g. `chat/completions -> 400 (invalid JSON)`)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_