### PR TITLE
Upgrade Delphi TUI with vendored MVCFramework.Console (Apache 2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 vendor/
+!src/pkg/vendor/
 src/pkg/gateway/webui.res
 *.o
 *.ppu

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -206,6 +206,12 @@
 
         <!-- pkg/platform -->
         <DCCReference Include="..\pkg\platform\PasClaw.Platform.pas"/>
+
+        <!-- pkg/vendor/dmvcframework (Apache-2.0, Delphi-only) -->
+        <DCCReference Include="..\pkg\vendor\dmvcframework\LoggerPro.AnsiColors.pas"/>
+        <DCCReference Include="..\pkg\vendor\dmvcframework\MVCFramework.Console.pas"/>
+        <None Include="..\pkg\vendor\dmvcframework\dmvcframework.inc"/>
+        <None Include="..\pkg\vendor\dmvcframework\NOTICE"/>
 
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1,24 +1,20 @@
 (*
-  PasClaw.TUI - line-based ANSI terminal UI for `pasclaw tui`.
+  PasClaw.TUI - terminal UI for `pasclaw tui`.
 
-  Layout per turn:
-       PASCLAW                                       provider/model | tools:N
-       ---------------------------------------------------------------------
-       you      > <input>
-       pasclaw  > <streamed response, soft-wrapped to terminal width>
-       ---------------------------------------------------------------------
-       > _
+  Two implementations behind the same TTUI class shape:
 
-  We deliberately stay line-based (no raw key handling, no alt-screen) so
-  the same code runs in vt100, xterm, Windows Terminal, the GitHub Codespaces
-  web terminal, and tmux/screen scrollback all behave intuitively. A future
-  Phase can swap to a full-screen renderer (dmvc-tui or a curses-style)
-  without changing the command-dispatch surface.
+    {$IFNDEF FPC}  Delphi build: uses MVCFramework.Console (vendored in
+                   src/pkg/vendor/dmvcframework/, Apache-2.0) for
+                   themed headers, boxes, tables, themed colors, and a
+                   background-threaded spinner during the LLM round trip.
 
-  ANSI references:
-    CSI 2J        clear screen
-    CSI <n>m      SGR (colour)
-    \r            carriage return (overwrite current line)
+    {$IFDEF FPC}   FPC build: original line-based ANSI renderer. Works
+                   in any vt100-class terminal including tmux/screen
+                   scrollback. No external deps.
+
+  Both share the same loop: prompt, read line, slash-command vs.
+  user-input dispatch, run tool loop, print the answer. The differences
+  are purely visual.
 *)
 unit PasClaw.TUI;
 
@@ -40,8 +36,8 @@ type
     FModel:    string;
     FQuit:     Boolean;
     procedure DrawHeader;
-    procedure DrawSeparator;
-    function  TermWidth: Integer;
+    procedure ShowHelp;
+    procedure ShowTools;
     procedure HandleSlashCommand(const Cmd: string);
     procedure HandleUserInput(const Text: string);
   public
@@ -56,21 +52,11 @@ uses
   PasClaw.CliUI,
   PasClaw.Logger,
   PasClaw.Providers.Types,
-  PasClaw.Tools.ToolLoop;
-
-{$IFDEF FPC}{$IFDEF UNIX}
-{ Get terminal width via ioctl TIOCGWINSZ. Falls back to 80 if the call
-  fails (e.g. stdin is a pipe). FPC-only — Delphi cross-platform width
-  detection lands in a follow-up. }
-const
-  TIOCGWINSZ = $5413;
-type
-  Twinsize = record
-    ws_row, ws_col, ws_xpixel, ws_ypixel: Word;
-  end;
-function FpIoctl(fd: Integer; req: Cardinal; argp: Pointer): Integer; cdecl;
-  external 'c' name 'ioctl';
-{$ENDIF}{$ENDIF}
+  PasClaw.Tools.ToolLoop
+  {$IFNDEF FPC}
+  , MVCFramework.Console
+  {$ENDIF}
+  ;
 
 constructor TTUI.Create(Provider: ILLMProvider; Registry: TToolRegistry; const Model: string);
 begin
@@ -80,18 +66,185 @@ begin
   FModel    := Model;
 end;
 
-function TTUI.TermWidth: Integer;
-{$IFDEF FPC}{$IFDEF UNIX}
+function StatusLine(Provider: ILLMProvider; const Model: string;
+                    Registry: TToolRegistry): string;
+begin
+  if Provider <> nil then
+    Result := Provider.GetName + '/' + Model
+  else
+    Result := 'offline';
+  if Registry <> nil then
+    Result := Result + '  tools:' + IntToStr(Registry.Count);
+end;
+
+{ ============================== Delphi (rich) ============================== }
+{$IFNDEF FPC}
+
+procedure TTUI.DrawHeader;
+begin
+  ClrScr;
+  WriteHeader('PasClaw  ' + StatusLine(FProvider, FModel, FRegistry), 80, Cyan);
+end;
+
+procedure TTUI.ShowHelp;
+var
+  Lines: TStringArray;
+begin
+  SetLength(Lines, 4);
+  Lines[0] := '/help    show this panel';
+  Lines[1] := '/tools   list registered tools';
+  Lines[2] := '/clear   clear the screen';
+  Lines[3] := '/quit    exit';
+  Box('TUI commands', Lines, 60);
+end;
+
+procedure TTUI.ShowTools;
+var
+  Names: TStringArray;
+  Rows: TStringMatrix;
+  Headers: TStringArray;
+  i: Integer;
+begin
+  if FRegistry = nil then
+  begin
+    WriteWarning('no registry');
+    Exit;
+  end;
+  Names := FRegistry.Names;
+  if Length(Names) = 0 then
+  begin
+    WriteInfo('registry is empty');
+    Exit;
+  end;
+  SetLength(Headers, 2);
+  Headers[0] := '#';
+  Headers[1] := 'tool';
+  SetLength(Rows, Length(Names));
+  for i := 0 to High(Names) do
+  begin
+    SetLength(Rows[i], 2);
+    Rows[i][0] := IntToStr(i + 1);
+    Rows[i][1] := Names[i];
+  end;
+  Table(Headers, Rows, Format('tools (%d)', [Length(Names)]));
+end;
+
+procedure TTUI.HandleSlashCommand(const Cmd: string);
+begin
+  if (Cmd = '/quit') or (Cmd = '/exit') or (Cmd = '/q') then
+  begin
+    FQuit := True;
+    Exit;
+  end;
+  if Cmd = '/clear' then begin DrawHeader; Exit; end;
+  if Cmd = '/tools' then begin ShowTools; Exit; end;
+  if Cmd = '/help'  then begin ShowHelp;  Exit; end;
+  WriteWarning('unknown command: ' + Cmd);
+end;
+
+procedure TTUI.HandleUserInput(const Text: string);
+var
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  Cfg: TToolLoopConfig;
+  S: ISpinner;
+  Ok: Boolean;
+begin
+  if FProvider = nil then
+  begin
+    WriteWarning('offline - no provider configured');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Text);
+
+  Cfg.Provider      := FProvider;
+  Cfg.Registry      := FRegistry;
+  Cfg.Model         := FModel;
+  Cfg.MaxIterations := 6;
+  Cfg.Options       := DefaultChatOptions;
+  Cfg.OnText        := nil;
+  Cfg.OnToolCall    := nil;
+  Cfg.OnToolResult  := nil;
+
+  S := Spinner('thinking', ssDots, Cyan);
+  try
+    Ok := RunToolLoop(Cfg, Msgs, Loop);
+  finally
+    S.Hide;
+    S := nil;
+  end;
+
+  if not Ok then
+  begin
+    WriteError('tool loop failed');
+    Exit;
+  end;
+
+  WriteColoredText('pasclaw', Magenta);
+  WriteColoredText(' > ', DarkGray);
+  WriteLn(Loop.Content);
+  if Loop.LastResp.Usage.InputTokens + Loop.LastResp.Usage.OutputTokens > 0 then
+    WriteColoredText(Format('         [tokens in=%d out=%d, iters=%d]'#10,
+      [Loop.LastResp.Usage.InputTokens, Loop.LastResp.Usage.OutputTokens, Loop.Iterations]),
+      DarkGray);
+end;
+
+procedure TTUI.Run;
+var
+  Line: string;
+begin
+  EnableUTF8Console;
+  EnableANSIColorConsole;
+  DrawHeader;
+  WriteColoredText('/help for commands, /quit to exit'#10, DarkGray);
+  WriteLn;
+  FQuit := False;
+  while not FQuit do
+  begin
+    WriteColoredText('you', Cyan);
+    WriteColoredText(' > ', DarkGray);
+    if EOF then Break;
+    ReadLn(Line);
+    Line := Trim(Line);
+    if Line = '' then Continue;
+    if (Line[1] = '/') then
+    begin
+      HandleSlashCommand(Line);
+      Continue;
+    end;
+    HandleUserInput(Line);
+  end;
+  WriteColoredText('goodbye.'#10, DarkGray);
+end;
+
+{$ELSE}
+{ ============================= FPC (line-based) ============================ }
+
+{$IFDEF UNIX}
+const
+  TIOCGWINSZ = $5413;
+type
+  Twinsize = record
+    ws_row, ws_col, ws_xpixel, ws_ypixel: Word;
+  end;
+function FpIoctl(fd: Integer; req: Cardinal; argp: Pointer): Integer; cdecl;
+  external 'c' name 'ioctl';
+{$ENDIF}
+
+function TermWidth: Integer;
+{$IFDEF UNIX}
 var
   ws: Twinsize;
-{$ENDIF}{$ENDIF}
+{$ENDIF}
 begin
   Result := 80;
-  {$IFDEF FPC}{$IFDEF UNIX}
+  {$IFDEF UNIX}
   FillChar(ws, SizeOf(ws), 0);
   if FpIoctl(1, TIOCGWINSZ, @ws) = 0 then
     if ws.ws_col > 0 then Result := ws.ws_col;
-  {$ENDIF}{$ENDIF}
+  {$ENDIF}
 end;
 
 procedure TTUI.DrawHeader;
@@ -100,64 +253,45 @@ var
   Pad, W: Integer;
 begin
   Left  := Ansi.BoldBlue + 'PAS' + Ansi.BoldRed + 'CLAW' + Ansi.Reset;
-  if FProvider <> nil then
-    Right := Ansi.Dim + FProvider.GetName + '/' + FModel + Ansi.Reset
-  else
-    Right := Ansi.Yellow + 'offline' + Ansi.Reset;
-  if FRegistry <> nil then
-    Right := Right + Ansi.Dim + '  tools:' + IntToStr(FRegistry.Count) + Ansi.Reset;
-
+  Right := Ansi.Dim + StatusLine(FProvider, FModel, FRegistry) + Ansi.Reset;
   W := TermWidth;
-  Pad := W - 7 - 8 - 8;
+  Pad := W - 7 - Length(StatusLine(FProvider, FModel, FRegistry));
   if Pad < 2 then Pad := 2;
   WriteLn;
   WriteLn(Left, StringOfChar(' ', Pad), Right);
-end;
-
-procedure TTUI.DrawSeparator;
-begin
   WriteLn(Ansi.Dim, StringOfChar('-', TermWidth), Ansi.Reset);
 end;
 
-procedure TTUI.HandleSlashCommand(const Cmd: string);
+procedure TTUI.ShowHelp;
+begin
+  WriteLn(Ansi.Bold, 'TUI commands:', Ansi.Reset);
+  WriteLn('  /help    show this');
+  WriteLn('  /tools   list registered tools');
+  WriteLn('  /clear   clear the screen');
+  WriteLn('  /quit    exit');
+end;
+
+procedure TTUI.ShowTools;
 var
   i: Integer;
   Names: TStringArray;
 begin
-  if (Cmd = '/quit') or (Cmd = '/exit') or (Cmd = '/q') then
+  if FRegistry = nil then
   begin
-    FQuit := True;
+    WriteLn(Ansi.Dim, '(no registry)', Ansi.Reset);
     Exit;
   end;
-  if Cmd = '/clear' then
-  begin
-    Write(#27'[2J', #27'[H');
-    DrawHeader;
-    DrawSeparator;
-    Exit;
-  end;
-  if Cmd = '/tools' then
-  begin
-    if FRegistry = nil then
-      WriteLn(Ansi.Dim, '(no registry)', Ansi.Reset)
-    else
-    begin
-      Names := FRegistry.Names;
-      WriteLn(Ansi.Bold, 'tools (', Length(Names), '):', Ansi.Reset);
-      for i := 0 to High(Names) do
-        WriteLn('  ', Names[i]);
-    end;
-    Exit;
-  end;
-  if Cmd = '/help' then
-  begin
-    WriteLn(Ansi.Bold, 'TUI commands:', Ansi.Reset);
-    WriteLn('  /help    show this');
-    WriteLn('  /tools   list registered tools');
-    WriteLn('  /clear   clear the screen');
-    WriteLn('  /quit    exit');
-    Exit;
-  end;
+  Names := FRegistry.Names;
+  WriteLn(Ansi.Bold, 'tools (', Length(Names), '):', Ansi.Reset);
+  for i := 0 to High(Names) do WriteLn('  ', Names[i]);
+end;
+
+procedure TTUI.HandleSlashCommand(const Cmd: string);
+begin
+  if (Cmd = '/quit') or (Cmd = '/exit') or (Cmd = '/q') then begin FQuit := True; Exit; end;
+  if Cmd = '/clear' then begin Write(#27'[2J', #27'[H'); DrawHeader; Exit; end;
+  if Cmd = '/tools' then begin ShowTools; Exit; end;
+  if Cmd = '/help'  then begin ShowHelp;  Exit; end;
   WriteLn(Ansi.Yellow, 'unknown command: ', Cmd, Ansi.Reset);
 end;
 
@@ -206,7 +340,6 @@ var
 begin
   Write(#27'[2J', #27'[H');
   DrawHeader;
-  DrawSeparator;
   WriteLn(Ansi.Dim, '/help for commands, /quit to exit', Ansi.Reset);
   WriteLn;
   FQuit := False;
@@ -226,5 +359,7 @@ begin
   end;
   WriteLn(Ansi.Dim, 'goodbye.', Ansi.Reset);
 end;
+
+{$ENDIF}
 
 end.

--- a/src/pkg/vendor/dmvcframework/LoggerPro.AnsiColors.pas
+++ b/src/pkg/vendor/dmvcframework/LoggerPro.AnsiColors.pas
@@ -1,0 +1,252 @@
+// ***************************************************************************
+//
+// LoggerPro
+//
+// Copyright (c) 2010-2026 Daniele Teti
+//
+// https://github.com/danieleteti/loggerpro
+//
+// ***************************************************************************
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ***************************************************************************
+
+unit LoggerPro.AnsiColors;
+
+{ ANSI terminal color / style helpers for LoggerPro console rendering.
+  Self-contained: no dependencies on other LoggerPro units.
+  Safe to use on Windows 10+ (ENABLE_VIRTUAL_TERMINAL_PROCESSING), Linux, macOS. }
+
+interface
+
+const
+  ESC = #27;
+
+  { Foreground color escape sequences (bright variants where applicable) }
+  FORE_DEFAULT  = ESC + '[39m';
+  FORE_BLACK    = ESC + '[30m';
+  FORE_DARKRED  = ESC + '[31m';
+  FORE_DARKGREEN= ESC + '[32m';
+  FORE_DARKYELLOW= ESC + '[33m';
+  FORE_DARKBLUE = ESC + '[34m';
+  FORE_DARKMAGENTA= ESC + '[35m';
+  FORE_DARKCYAN = ESC + '[36m';
+  FORE_GRAY     = ESC + '[37m';
+  FORE_DARKGRAY = ESC + '[90m';
+  FORE_RED      = ESC + '[91m';
+  FORE_GREEN    = ESC + '[92m';
+  FORE_YELLOW   = ESC + '[93m';
+  FORE_BLUE     = ESC + '[94m';
+  FORE_MAGENTA  = ESC + '[95m';
+  FORE_CYAN     = ESC + '[96m';
+  FORE_WHITE    = ESC + '[97m';
+
+  { Background color escape sequences }
+  BACK_DEFAULT     = ESC + '[49m';
+  BACK_BLACK       = ESC + '[40m';
+  BACK_DARKRED     = ESC + '[41m';
+  BACK_DARKGREEN   = ESC + '[42m';
+  BACK_DARKYELLOW  = ESC + '[43m';
+  BACK_DARKBLUE    = ESC + '[44m';
+  BACK_DARKMAGENTA = ESC + '[45m';
+  BACK_DARKCYAN    = ESC + '[46m';
+  BACK_GRAY        = ESC + '[47m';
+  BACK_DARKGRAY    = ESC + '[100m';
+  BACK_RED         = ESC + '[101m';
+  BACK_GREEN       = ESC + '[102m';
+  BACK_YELLOW      = ESC + '[103m';
+  BACK_BLUE        = ESC + '[104m';
+  BACK_MAGENTA     = ESC + '[105m';
+  BACK_CYAN        = ESC + '[106m';
+  BACK_WHITE       = ESC + '[107m';
+
+  { Style escape sequences }
+  STYLE_BRIGHT        = ESC + '[1m';
+  STYLE_DIM           = ESC + '[2m';
+  STYLE_ITALIC        = ESC + '[3m';
+  STYLE_UNDERLINE     = ESC + '[4m';
+  STYLE_INVERSE       = ESC + '[7m';
+  STYLE_STRIKETHROUGH = ESC + '[9m';
+  STYLE_NORMAL        = ESC + '[22m';  // cancels Bold/Bright and Dim
+  STYLE_ITALICOFF     = ESC + '[23m';
+  STYLE_UNDERLINEOFF  = ESC + '[24m';
+  STYLE_INVERSEOFF    = ESC + '[27m';
+  STYLE_STRIKETHROUGHOFF = ESC + '[29m';
+  STYLE_RESETALL      = ESC + '[0m';
+
+type
+  /// <summary>
+  /// ANSI foreground color escape sequences. Colorama-style namespaced
+  /// access: Fore.Red, Fore.DarkGray, Fore.Reset, etc.
+  /// Usage: WriteLn(Fore.Red + 'error text' + Style.ResetAll);
+  /// Requires EnableANSIColorConsole on Windows 10+. No-op needed on Linux.
+  /// Values delegate to the flat FORE_* constants above so the escape
+  /// code literals live in one place only.
+  /// </summary>
+  Fore = record
+  const
+    Black       = FORE_BLACK;
+    DarkRed     = FORE_DARKRED;
+    DarkGreen   = FORE_DARKGREEN;
+    DarkYellow  = FORE_DARKYELLOW;
+    DarkBlue    = FORE_DARKBLUE;
+    DarkMagenta = FORE_DARKMAGENTA;
+    DarkCyan    = FORE_DARKCYAN;
+    Gray        = FORE_GRAY;
+    DarkGray    = FORE_DARKGRAY;
+    Red         = FORE_RED;
+    Green       = FORE_GREEN;
+    Yellow      = FORE_YELLOW;
+    Blue        = FORE_BLUE;
+    Magenta     = FORE_MAGENTA;
+    Cyan        = FORE_CYAN;
+    White       = FORE_WHITE;
+    Reset       = FORE_DEFAULT;
+  end;
+
+  /// <summary>
+  /// ANSI background color escape sequences.
+  /// Usage: WriteLn(Back.Red + 'highlighted' + Style.ResetAll);
+  /// </summary>
+  Back = record
+  const
+    Black       = BACK_BLACK;
+    DarkRed     = BACK_DARKRED;
+    DarkGreen   = BACK_DARKGREEN;
+    DarkYellow  = BACK_DARKYELLOW;
+    DarkBlue    = BACK_DARKBLUE;
+    DarkMagenta = BACK_DARKMAGENTA;
+    DarkCyan    = BACK_DARKCYAN;
+    Gray        = BACK_GRAY;
+    DarkGray    = BACK_DARKGRAY;
+    Red         = BACK_RED;
+    Green       = BACK_GREEN;
+    Yellow      = BACK_YELLOW;
+    Blue        = BACK_BLUE;
+    Magenta     = BACK_MAGENTA;
+    Cyan        = BACK_CYAN;
+    White       = BACK_WHITE;
+    Reset       = BACK_DEFAULT;
+  end;
+
+  /// <summary>
+  /// ANSI style escape sequences.
+  /// Bold and Bright are aliases for the same ESC[1m code.
+  /// Style.ResetAll resets all attributes (color + style) to terminal defaults.
+  /// </summary>
+  Style = record
+  const
+    Bright          = STYLE_BRIGHT;       // ESC[1m  (colorama: Style.BRIGHT)
+    Dim             = STYLE_DIM;          // ESC[2m
+    Italic          = STYLE_ITALIC;       // ESC[3m  (not all terminals)
+    Underline       = STYLE_UNDERLINE;    // ESC[4m
+    Inverse         = STYLE_INVERSE;      // ESC[7m  — swap fg/bg
+    StrikeThrough   = STYLE_STRIKETHROUGH;// ESC[9m  (not all terminals)
+    Normal          = STYLE_NORMAL;       // ESC[22m — cancel Bold/Dim
+    ItalicOff       = STYLE_ITALICOFF;    // ESC[23m
+    UnderlineOff    = STYLE_UNDERLINEOFF; // ESC[24m
+    InverseOff      = STYLE_INVERSEOFF;   // ESC[27m
+    StrikeThroughOff= STYLE_STRIKETHROUGHOFF; // ESC[29m
+    ResetAll        = STYLE_RESETALL;     // ESC[0m  — reset everything
+  end;
+
+{ Wrap aText in aColor + STYLE_RESETALL (colorama-style autoreset).
+  When aColor is empty, returns aText unchanged - so LogColorSchemes.Monochrome
+  passed through the renderer emits zero escape codes automatically. }
+function Colorize(const aText, aColor: string): string; inline;
+
+{ Enable ANSI virtual terminal processing on Windows 10+.
+  No-op on Linux / macOS (ANSI natively supported).
+  Idempotent: safe to call multiple times. }
+procedure EnableANSIColorConsole;
+
+{ True if EnableANSIColorConsole succeeded (Windows) or on Unix platforms. }
+function IsANSIColorConsoleEnabled: Boolean;
+
+{ True when stdout is an interactive terminal. False when redirected to
+  a file or piped to another process. Used to degrade colored output to
+  monochrome automatically, avoiding escape-code pollution in log files. }
+function IsStdoutTerminal: Boolean;
+
+implementation
+
+uses
+{$IFDEF MSWINDOWS}
+  Winapi.Windows
+{$ELSE}
+  Posix.Unistd
+{$ENDIF}
+  ;
+
+var
+  gANSIEnabled: Boolean = {$IFDEF MSWINDOWS}False{$ELSE}True{$ENDIF};
+
+function Colorize(const aText, aColor: string): string;
+begin
+  if aColor = '' then
+    Result := aText
+  else
+    Result := aColor + aText + STYLE_RESETALL;
+end;
+
+procedure EnableANSIColorConsole;
+{$IFDEF MSWINDOWS}
+const
+  ENABLE_VIRTUAL_TERMINAL_PROCESSING = $0004;
+var
+  hOut: THandle;
+  dwMode: DWORD;
+begin
+  if gANSIEnabled then
+    Exit;
+  hOut := GetStdHandle(STD_OUTPUT_HANDLE);
+  if hOut = INVALID_HANDLE_VALUE then
+    Exit;
+  dwMode := 0;
+  if not GetConsoleMode(hOut, dwMode) then
+    Exit;
+  if SetConsoleMode(hOut, dwMode or ENABLE_VIRTUAL_TERMINAL_PROCESSING) then
+    gANSIEnabled := True;
+end;
+{$ELSE}
+begin
+  // Unix terminals handle ANSI natively; nothing to turn on.
+end;
+{$ENDIF}
+
+function IsANSIColorConsoleEnabled: Boolean;
+begin
+  Result := gANSIEnabled;
+end;
+
+function IsStdoutTerminal: Boolean;
+{$IFDEF MSWINDOWS}
+var
+  hOut: THandle;
+  ft: DWORD;
+begin
+  hOut := GetStdHandle(STD_OUTPUT_HANDLE);
+  if hOut = INVALID_HANDLE_VALUE then
+    Exit(False);
+  ft := GetFileType(hOut);
+  // FILE_TYPE_CHAR = console / serial device. FILE_TYPE_DISK / _PIPE = redirect.
+  Result := ft = FILE_TYPE_CHAR;
+end;
+{$ELSE}
+begin
+  Result := isatty(STDOUT_FILENO) <> 0;
+end;
+{$ENDIF}
+
+end.

--- a/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
+++ b/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
@@ -1,0 +1,2299 @@
+// ***************************************************************************
+//
+// Delphi MVC Framework
+//
+// Copyright (c) 2010-2026 Daniele Teti and the DMVCFramework Team
+//
+// https://github.com/danieleteti/delphimvcframework
+//
+// ***************************************************************************
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ***************************************************************************
+//
+// Cross-platform console library:
+// - Colored text output
+// - Tables, boxes, progress bars, spinners, and interactive menus
+// - Keyboard input handling (arrows, special keys)
+// - Windows and Linux support
+//
+// *************************************************************************** }
+
+unit MVCFramework.Console;
+
+{$I dmvcframework.inc}
+{$WARN UNIT_PLATFORM OFF}
+
+interface
+
+uses
+  System.SysUtils,
+  System.SyncObjs,
+  System.Classes,
+  System.Character,
+  LoggerPro.AnsiColors
+{$IFDEF MSWINDOWS}
+  ,WinApi.Windows
+{$ENDIF}
+{$IFDEF LINUX}
+  ,Posix.Unistd,
+  Posix.Termios,
+  Posix.SysStat,
+  Posix.Fcntl,
+  Posix.SysSelect,
+  Posix.StrOpts,
+  Posix.Stdlib
+{$ENDIF}
+    ;
+
+const
+  KEY_UP    = 256 + 38;  // VK_UP
+  KEY_DOWN  = 256 + 40;  // VK_DOWN
+  KEY_LEFT  = 256 + 37;  // VK_LEFT
+  KEY_RIGHT = 256 + 39;  // VK_RIGHT
+  KEY_ESCAPE = 27;
+  KEY_ENTER = 13;
+  ESC = #27;
+
+type
+  TConsoleColor = (
+    Black = 0,
+    DarkBlue = 1,
+    DarkGreen = 2,
+    DarkCyan = 3,
+    DarkRed = 4,
+    DarkMagenta = 5,
+    DarkYellow = 6,
+    Gray = 7,
+    DarkGray = 8,
+    Blue = 9,
+    Green = 10,
+    Cyan = 11,
+    Red = 12,
+    Magenta = 13,
+    Yellow = 14,
+    White = 15,
+    UseDefault = 16
+    );
+
+  TBoxStyle = (bsSingle, bsDouble, bsRounded, bsThick, bsUseDefault);
+
+  TSpinnerStyle = (
+    ssLine,       // - \ | /
+    ssDots,       // Braille dots
+    ssBounce,     // Braille bounce
+    ssGrow,       // Block elements
+    ssArrow,      // Arrow rotation
+    ssCircle,     // Circle quarters
+    ssClock,      // Clock faces
+    ssEarth,      // Globe rotation
+    ssMoon,       // Moon phases
+    ssWeather     // Weather emoji
+  );
+
+  TProgressBarStyle = (pbsSimple, pbsBlocks, pbsArrows, pbsCircles);
+  TAlignment = (taLeft, taCenter, taRight);
+  TListStyle = (lsBullet, lsNumbered, lsDash, lsArrow);
+
+  EMVCConsole = class(Exception)
+  end;
+
+  TMVCConsoleSize = record
+    Columns: Word;
+    Rows: Word;
+  end;
+
+  TMVCConsolePoint = record
+    X: Word;
+    Y: Word;
+  end;
+
+  TConsoleColorStyle = record
+    Text:          string;         // default text style, e.g. Fore.Cyan
+    Draw:          string;         // borders/lines,       e.g. Fore.White
+    Symbols:       string;         // list prefixes,       e.g. Fore.Gray + Style.Dim
+    Highlight:     string;         // selected items,      e.g. Back.Blue + Fore.White + Style.Bright
+    HighlightText: string;         // headers/titles,      e.g. Fore.White + Style.Bright
+    Background:    TConsoleColor;  // whole-screen background fill (used by ClrScr + SetConsoleTheme)
+    BoxStyle:      TBoxStyle;
+  end;
+
+  TStringArray = array of string;
+  TStringMatrix = array of TStringArray;
+
+  /// <summary>
+  /// ANSI foreground, background and style escape sequences.
+  /// Pure type aliases to the canonical records in LoggerPro.AnsiColors.
+  /// No structure or values duplicated. User-facing API
+  /// (Fore.Red, Back.Red, Style.ResetAll, ...) unchanged.
+  /// </summary>
+  Fore  = LoggerPro.AnsiColors.Fore;
+  Back  = LoggerPro.AnsiColors.Back;
+  Style = LoggerPro.AnsiColors.Style;
+
+var
+  ConsoleTheme: TConsoleColorStyle = (
+    Text:          FORE_CYAN;
+    Draw:          FORE_WHITE;
+    Symbols:       FORE_GRAY;
+    Highlight:     BACK_CYAN + FORE_DARKBLUE + STYLE_BRIGHT;
+    HighlightText: FORE_BLUE + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsRounded;
+  );
+
+const
+  ConsoleThemeDefault: TConsoleColorStyle = (
+    Text:          FORE_CYAN;
+    Draw:          FORE_WHITE;
+    Symbols:       FORE_GRAY;
+    Highlight:     BACK_CYAN + FORE_DARKBLUE + STYLE_BRIGHT;
+    HighlightText: FORE_BLUE + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsRounded;
+  );
+
+  ConsoleThemeClassic: TConsoleColorStyle = (
+    Text:          FORE_WHITE;
+    Draw:          FORE_GRAY;
+    Symbols:       FORE_GRAY + STYLE_DIM;
+    Highlight:     BACK_BLUE + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_WHITE + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsSingle;
+  );
+
+  ConsoleThemeMatrix: TConsoleColorStyle = (
+    Text:          FORE_GREEN;
+    Draw:          FORE_DARKGREEN;
+    Symbols:       FORE_DARKGREEN + STYLE_DIM;
+    Highlight:     BACK_DARKGREEN + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_GREEN + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsSingle;
+  );
+
+  ConsoleThemeSunset: TConsoleColorStyle = (
+    Text:          FORE_YELLOW;
+    Draw:          FORE_RED;
+    Symbols:       FORE_DARKYELLOW + STYLE_DIM;
+    Highlight:     BACK_DARKRED + FORE_YELLOW + STYLE_BRIGHT;
+    HighlightText: FORE_YELLOW + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsRounded;
+  );
+
+  ConsoleThemeOcean: TConsoleColorStyle = (
+    Text:          FORE_CYAN;
+    Draw:          FORE_BLUE;
+    Symbols:       FORE_DARKCYAN + STYLE_DIM;
+    Highlight:     BACK_DARKBLUE + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_CYAN + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsThick;
+  );
+
+  ConsoleThemeMonochrome: TConsoleColorStyle = (
+    Text:          FORE_GRAY;
+    Draw:          FORE_DARKGRAY;
+    Symbols:       FORE_DARKGRAY + STYLE_DIM;
+    Highlight:     BACK_DARKGRAY + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_WHITE + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsThick;
+  );
+
+  ConsoleThemeMagenta: TConsoleColorStyle = (
+    Text:          FORE_MAGENTA;
+    Draw:          FORE_DARKMAGENTA;
+    Symbols:       FORE_DARKMAGENTA + STYLE_DIM;
+    Highlight:     BACK_DARKMAGENTA + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_MAGENTA + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsRounded;
+  );
+
+  ConsoleThemeAlert: TConsoleColorStyle = (
+    Text:          FORE_WHITE;
+    Draw:          FORE_GRAY;
+    Symbols:       FORE_DARKGRAY + STYLE_DIM;
+    Highlight:     BACK_RED + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_RED + STYLE_BRIGHT;
+    Background:    TConsoleColor.Black;
+    BoxStyle:      TBoxStyle.bsSingle;
+  );
+
+  // --- Themes with non-black backgrounds ---
+
+  // Navy: DarkBlue background — Turbo Pascal / classic IDE aesthetic
+  ConsoleThemeNavy: TConsoleColorStyle = (
+    Text:          FORE_WHITE;
+    Draw:          FORE_CYAN;
+    Symbols:       FORE_GRAY + STYLE_DIM;
+    Highlight:     BACK_CYAN + FORE_DARKBLUE + STYLE_BRIGHT;
+    HighlightText: FORE_YELLOW + STYLE_BRIGHT;
+    Background:    TConsoleColor.DarkBlue;
+    BoxStyle:      TBoxStyle.bsDouble;
+  );
+
+  // Forest: DarkGreen background — vintage terminal look
+  ConsoleThemeForest: TConsoleColorStyle = (
+    Text:          FORE_YELLOW;
+    Draw:          FORE_WHITE;
+    Symbols:       FORE_GRAY + STYLE_DIM;
+    Highlight:     BACK_DARKYELLOW + FORE_BLACK + STYLE_BRIGHT;
+    HighlightText: FORE_WHITE + STYLE_BRIGHT;
+    Background:    TConsoleColor.DarkGreen;
+    BoxStyle:      TBoxStyle.bsSingle;
+  );
+
+  // Slate: DarkGray background — softer dark mode
+  ConsoleThemeSlate: TConsoleColorStyle = (
+    Text:          FORE_WHITE;
+    Draw:          FORE_CYAN;
+    Symbols:       FORE_GRAY + STYLE_DIM;
+    Highlight:     BACK_BLUE + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_CYAN + STYLE_BRIGHT;
+    Background:    TConsoleColor.DarkGray;
+    BoxStyle:      TBoxStyle.bsRounded;
+  );
+
+  // Paper: Gray background — retro light terminal
+  ConsoleThemePaper: TConsoleColorStyle = (
+    Text:          FORE_DARKBLUE;
+    Draw:          FORE_DARKGREEN;
+    Symbols:       FORE_DARKGRAY;
+    Highlight:     BACK_DARKBLUE + FORE_WHITE + STYLE_BRIGHT;
+    HighlightText: FORE_DARKBLUE + STYLE_BRIGHT;
+    Background:    TConsoleColor.Gray;
+    BoxStyle:      TBoxStyle.bsSingle;
+  );
+
+  // Burgundy: DarkRed background — dramatic, high-contrast
+  ConsoleThemeBurgundy: TConsoleColorStyle = (
+    Text:          FORE_YELLOW;
+    Draw:          FORE_WHITE;
+    Symbols:       FORE_GRAY + STYLE_DIM;
+    Highlight:     BACK_DARKYELLOW + FORE_BLACK + STYLE_BRIGHT;
+    HighlightText: FORE_WHITE + STYLE_BRIGHT;
+    Background:    TConsoleColor.DarkRed;
+    BoxStyle:      TBoxStyle.bsThick;
+  );
+
+  // Midnight: DarkCyan background — teal terminal
+  ConsoleThemeMidnight: TConsoleColorStyle = (
+    Text:          FORE_WHITE;
+    Draw:          FORE_YELLOW;
+    Symbols:       FORE_GRAY + STYLE_DIM;
+    Highlight:     BACK_DARKCYAN + FORE_BLACK + STYLE_BRIGHT;
+    HighlightText: FORE_YELLOW + STYLE_BRIGHT;
+    Background:    TConsoleColor.DarkCyan;
+    BoxStyle:      TBoxStyle.bsRounded;
+  );
+
+
+// ============================================================================
+// CONSOLE THEME FUNCTIONS
+// ============================================================================
+
+procedure SetConsoleTheme(const Theme: TConsoleColorStyle);
+
+
+// ============================================================================
+// LOW-LEVEL CONSOLE FUNCTIONS
+// ============================================================================
+
+procedure ResetConsole;
+procedure TextColor(const Color: TConsoleColor);
+procedure TextBackground(const Color: TConsoleColor);
+procedure GotoXY(const X, Y: Word);
+function GetConsoleSize: TMVCConsoleSize;
+function GetConsoleBufferSize: TMVCConsoleSize;
+function GetCursorPosition: TMVCConsolePoint;
+procedure ClrScr;
+function GetCh: Char;
+function GetKey: Integer;
+function IsSpecialKey(KeyCode: Integer): Boolean; inline;
+procedure WaitForReturn;
+procedure SaveColors;
+procedure RestoreSavedColors;
+procedure SetDefaultColors;
+function ConsoleAttr: Integer;
+procedure SetConsoleAttr(const TextAttr: Integer);
+function TextAttr: Word;
+procedure SetTextAttr(const TextAttr: Word);
+function BackgroundAttr: Word;
+procedure SetBackgroundAttr(const BackgroundAttr: Word);
+procedure HideCursor;
+procedure ShowCursor;
+function KeyPressed: Boolean;
+procedure EnableUTF8Console;
+
+/// <summary>
+/// Enables ANSI virtual terminal processing on Windows 10+.
+/// No-op on Linux (ANSI is natively supported).
+/// Idempotent: safe to call multiple times.
+/// Called automatically by DMVC color console renderers.
+/// Call manually only if using Fore/Back/Style directly with WriteLn.
+/// </summary>
+procedure EnableANSIColorConsole;
+
+/// <summary>
+/// Returns True if ANSI escape sequences are supported by the current console.
+/// Always True on Linux. On Windows, True only after a successful EnableANSIColorConsole call.
+/// </summary>
+function IsANSIColorConsoleEnabled: Boolean;
+
+// ============================================================================
+// ANSI PRIMITIVES (low-level, theme-aware)
+// ============================================================================
+
+procedure WriteAnsiText(const AStyle, AText: string);
+procedure WriteAnsiLine(const AStyle, AText: string);
+
+// ============================================================================
+// TEXT OUTPUT
+// ============================================================================
+
+procedure WriteColoredText(const Text: string;
+  ForeColor: TConsoleColor = UseDefault;
+  BackColor: TConsoleColor = UseDefault);
+
+procedure WriteLine(const Text: string); overload;
+procedure WriteLine(const Text: string; ForeColor: TConsoleColor); overload;
+procedure WriteLine(const Text: string; ForeColor: TConsoleColor;
+  BackColor: TConsoleColor); overload;
+
+procedure WriteAlignedText(const Text: string; Width: Integer;
+  Alignment: TAlignment = taCenter; TextColor: TConsoleColor = UseDefault);
+procedure CenterInScreen(const Text: String);
+
+// ============================================================================
+// STATUS MESSAGES
+// ============================================================================
+
+procedure WriteHeader(const Text: string; Width: Integer = 80;
+  HeaderColor: TConsoleColor = UseDefault);
+procedure WriteSeparator(Width: Integer = 60; CharSymbol: Char = '-');
+procedure WriteSuccess(const Message: string);
+procedure WriteWarning(const Message: string);
+procedure WriteError(const Message: string);
+procedure WriteInfo(const Message: string);
+procedure WriteFormattedList(const Title: string; const Items: TStringArray;
+  ListStyle: TListStyle);
+
+// ============================================================================
+// DRAWING PRIMITIVES
+// ============================================================================
+
+procedure DrawBox(X, Y, Width, Height: Word; Style: TBoxStyle = bsRounded;
+  const Title: string = '');
+procedure DrawHorizontalLine(X, Y, Length: Word; Style: TBoxStyle = bsUseDefault);
+procedure DrawVerticalLine(X, Y, Length: Word; Style: TBoxStyle = bsUseDefault);
+procedure ClearRegion(X, Y, Width, Height: Word);
+procedure SaveCursorPosition;
+procedure RestoreCursorPosition;
+
+// ============================================================================
+// INFORMATION
+// ============================================================================
+
+function ColorName(const Color: TConsoleColor): String;
+function IsTerminalCapable: Boolean;
+function GetTerminalName: string;
+procedure Beep;
+procedure FlashScreen;
+
+// ============================================================================
+// HIGH-LEVEL API
+// ============================================================================
+
+type
+  ISpinner = interface
+    ['{A1B2C3D4-5E6F-7890-ABCD-EF1234567890}']
+    procedure Hide;
+  end;
+
+  IProgress = interface
+    ['{8F5E3C2A-1B4D-4E9F-A3C7-9D2E6F1B8A4C}']
+    procedure Update(Value: Integer);
+    procedure Increment(Amount: Integer = 1);
+    procedure SetMessage(const Msg: string);
+    procedure Complete;
+  end;
+
+/// <summary>
+/// Interactive menu with keyboard navigation. Returns selected index or -1 if cancelled.
+/// </summary>
+function Menu(const Items: TStringArray): Integer; overload;
+function Menu(const Title: string; const Items: TStringArray): Integer; overload;
+function Menu(const Title: string; const Items: TStringArray;
+  DefaultIndex: Integer): Integer; overload;
+
+/// <summary>
+/// Displays a formatted table with auto-sizing columns.
+/// </summary>
+procedure Table(const Headers: TStringArray; const Data: TStringMatrix); overload;
+procedure Table(const Headers: TStringArray; const Data: TStringMatrix;
+  const Title: string); overload;
+
+/// <summary>
+/// Interactive table with row selection. Returns selected row index or -1.
+/// </summary>
+function TableMenu(const Headers: TStringArray;
+  const Data: TStringMatrix): Integer; overload;
+function TableMenu(const Title: string; const Headers: TStringArray;
+  const Data: TStringMatrix): Integer; overload;
+function TableMenu(const Title: string; const Headers: TStringArray;
+  const Data: TStringMatrix; DefaultIndex: Integer): Integer; overload;
+
+/// <summary>
+/// Displays a box with optional title and content lines.
+/// </summary>
+procedure Box(const Content: TStringArray); overload;
+procedure Box(const Title: string; const Content: TStringArray); overload;
+procedure Box(const Title: string; const Content: TStringArray;
+  Width: Integer); overload;
+
+/// <summary>
+/// Progress bar with auto-cleanup. MaxValue > 0: determinate. MaxValue = 0: indeterminate.
+/// </summary>
+function Progress(const Title: string; MaxValue: Integer): IProgress; overload;
+function Progress(const Title: string): IProgress; overload;
+
+/// <summary>
+/// Yes/no confirmation prompt. Returns True if user confirms.
+/// </summary>
+function Confirm(const Question: string): Boolean; overload;
+function Confirm(const Question: string; DefaultYes: Boolean): Boolean; overload;
+
+/// <summary>
+/// Quick single-choice prompt. Returns selected index or -1.
+/// </summary>
+function Choose(const Question: string; const Options: TStringArray): Integer;
+
+/// <summary>
+/// Non-blocking background spinner. Call Hide or release the interface to stop.
+/// </summary>
+function Spinner(AStyle: TSpinnerStyle = ssLine;
+  AColor: TConsoleColor = DarkGray): ISpinner; overload;
+function Spinner(const AMessage: string; AStyle: TSpinnerStyle = ssLine;
+  AColor: TConsoleColor = DarkGray): ISpinner; overload;
+
+// ============================================================================
+// UTILITY
+// ============================================================================
+
+function PadRight(const S: string; Len: Integer): string;
+
+
+implementation
+
+uses
+  System.TypInfo,
+  System.Math;
+
+type
+  TBoxChars = record
+    TopLeft, TopRight, BottomLeft, BottomRight: Char;
+    Vertical, Horizontal: Char;
+    LeftJoin, RightJoin, TopJoin, BottomJoin, Cross: Char;
+  end;
+
+var
+  GForeGround, GSavedForeGround: Int16;
+  GBackGround, GSavedBackGround: Int16;
+  GThemeReset: string;
+  GOutHandle: THandle = INVALID_HANDLE_VALUE;
+  GInputHandle: THandle = INVALID_HANDLE_VALUE;
+  GIsConsoleAllocated: Boolean = False;
+  GLock: TObject = nil;
+  GSavedCursorX, GSavedCursorY: Word;
+{$IFDEF MSWINDOWS}
+  hConsoleInput: THandle;
+{$ENDIF}
+
+const
+  // Cross-platform ANSI escape sequences indexed by TConsoleColor.
+  // GBackGround is stored bit-shifted (Ord shl 4) for historical reasons;
+  // look up with ANSI_BG[TConsoleColor(GBackGround shr 4)].
+  ANSI_FG: array[TConsoleColor] of string = (
+    FORE_BLACK,       // Black
+    FORE_DARKBLUE,    // DarkBlue
+    FORE_DARKGREEN,   // DarkGreen
+    FORE_DARKCYAN,    // DarkCyan
+    FORE_DARKRED,     // DarkRed
+    FORE_DARKMAGENTA, // DarkMagenta
+    FORE_DARKYELLOW,  // DarkYellow
+    FORE_GRAY,        // Gray
+    FORE_DARKGRAY,    // DarkGray
+    FORE_BLUE,        // Blue
+    FORE_GREEN,       // Green
+    FORE_CYAN,        // Cyan
+    FORE_RED,         // Red
+    FORE_MAGENTA,     // Magenta
+    FORE_YELLOW,      // Yellow
+    FORE_WHITE,       // White
+    ''                // UseDefault — callers substitute ConsoleTheme.Text
+  );
+
+  ANSI_BG: array[TConsoleColor] of string = (
+    BACK_BLACK,       // Black
+    BACK_DARKBLUE,    // DarkBlue
+    BACK_DARKGREEN,   // DarkGreen
+    BACK_DARKCYAN,    // DarkCyan
+    BACK_DARKRED,     // DarkRed
+    BACK_DARKMAGENTA, // DarkMagenta
+    BACK_DARKYELLOW,  // DarkYellow
+    BACK_GRAY,        // Gray
+    BACK_DARKGRAY,    // DarkGray
+    BACK_BLUE,        // Blue
+    BACK_GREEN,       // Green
+    BACK_CYAN,        // Cyan
+    BACK_RED,         // Red
+    BACK_MAGENTA,     // Magenta
+    BACK_YELLOW,      // Yellow
+    BACK_WHITE,       // White
+    ''                // UseDefault — no background override
+  );
+
+{$IFDEF LINUX}
+type
+  TLinuxWinSize = record
+    ws_row: Word;
+    ws_col: Word;
+    ws_xpixel: Word;
+    ws_ypixel: Word;
+  end;
+
+  TLinuxTimeVal = record
+    tv_sec: Int64;
+    tv_usec: Int64;
+  end;
+
+const
+  TIOCGWINSZ = $5413;
+
+function __select(nfds: Integer; readfds, writefds, exceptfds: Pointer;
+  timeout: Pointer): Integer; cdecl; external 'libc.so.6' name 'select';
+
+var
+  GOriginalTermios: termios;
+  GTerminalSetup: Boolean = False;
+
+{$ENDIF}
+
+// ============================================================================
+// INTERNAL HELPERS
+// ============================================================================
+
+function GetBoxStyleOrDefault(BoxStyle: TBoxStyle): TBoxStyle;
+begin
+  Result := BoxStyle;
+  if Result = bsUseDefault then
+    Result := ConsoleTheme.BoxStyle;
+end;
+
+function GetBoxChars(Style: TBoxStyle): TBoxChars;
+begin
+  Style := GetBoxStyleOrDefault(Style);
+  case Style of
+    bsSingle: begin
+      Result.TopLeft := #$250C; Result.TopRight := #$2510;
+      Result.BottomLeft := #$2514; Result.BottomRight := #$2518;
+      Result.Vertical := #$2502; Result.Horizontal := #$2500;
+      Result.LeftJoin := #$251C; Result.RightJoin := #$2524;
+      Result.TopJoin := #$252C; Result.BottomJoin := #$2534;
+      Result.Cross := #$253C;
+    end;
+    bsDouble: begin
+      Result.TopLeft := #$2554; Result.TopRight := #$2557;
+      Result.BottomLeft := #$255A; Result.BottomRight := #$255D;
+      Result.Vertical := #$2551; Result.Horizontal := #$2550;
+      Result.LeftJoin := #$2560; Result.RightJoin := #$2563;
+      Result.TopJoin := #$2566; Result.BottomJoin := #$2569;
+      Result.Cross := #$256C;
+    end;
+    bsRounded: begin
+      Result.TopLeft := #$256D; Result.TopRight := #$256E;
+      Result.BottomLeft := #$2570; Result.BottomRight := #$256F;
+      Result.Vertical := #$2502; Result.Horizontal := #$2500;
+      Result.LeftJoin := #$251C; Result.RightJoin := #$2524;
+      Result.TopJoin := #$252C; Result.BottomJoin := #$2534;
+      Result.Cross := #$253C;
+    end;
+    bsThick: begin
+      Result.TopLeft := #$250F; Result.TopRight := #$2513;
+      Result.BottomLeft := #$2517; Result.BottomRight := #$251B;
+      Result.Vertical := #$2503; Result.Horizontal := #$2501;
+      Result.LeftJoin := #$2523; Result.RightJoin := #$252B;
+      Result.TopJoin := #$2533; Result.BottomJoin := #$253B;
+      Result.Cross := #$254B;
+    end;
+  end;
+end;
+
+procedure FlushOutput; inline;
+begin
+  Flush(Output);
+end;
+
+function CalcColumnWidths(const Headers: TStringArray; const Data: TStringMatrix): TArray<Integer>;
+var
+  I, J: Integer;
+begin
+  SetLength(Result, Length(Headers));
+  for I := 0 to High(Headers) do
+  begin
+    Result[I] := Length(Headers[I]);
+    for J := 0 to High(Data) do
+      if (I < Length(Data[J])) and (Length(Data[J][I]) > Result[I]) then
+        Result[I] := Length(Data[J][I]);
+    Inc(Result[I], 2); // padding
+  end;
+end;
+
+procedure WriteAnsiText(const AStyle, AText: string);
+begin
+  Write(AStyle + AText + GThemeReset);
+end;
+
+procedure WriteAnsiLine(const AStyle, AText: string);
+begin
+  WriteLn(AStyle + AText + GThemeReset);
+end;
+
+// ============================================================================
+// ANSI COLOR CONSOLE
+// ============================================================================
+
+function IsANSIColorConsoleEnabled: Boolean;
+begin
+  // Delegated to LoggerPro.AnsiColors - single source of truth, no
+  // duplicated state. Public API of this unit is unchanged.
+  Result := LoggerPro.AnsiColors.IsANSIColorConsoleEnabled;
+end;
+
+procedure EnableANSIColorConsole;
+begin
+  // Delegated to LoggerPro.AnsiColors - single source of truth. The
+  // underlying implementation is idempotent (safe to call multiple times)
+  // and enables Windows 10+ virtual terminal processing, no-op on Unix.
+  LoggerPro.AnsiColors.EnableANSIColorConsole;
+end;
+
+// ============================================================================
+// UTILITY
+// ============================================================================
+
+function PadRight(const S: string; Len: Integer): string;
+begin
+  Result := S;
+  if Length(Result) < Len then
+    Result := Result + StringOfChar(' ', Len - Length(Result))
+  else if Length(Result) > Len then
+    Result := Copy(Result, 1, Len);
+end;
+
+// ============================================================================
+// PLATFORM: LINUX
+// ============================================================================
+
+function ColorName(const Color: TConsoleColor): String;
+begin
+  case Color of
+    TConsoleColor.Black:       Result := 'Black';
+    TConsoleColor.DarkBlue:    Result := 'DarkBlue';
+    TConsoleColor.DarkGreen:   Result := 'DarkGreen';
+    TConsoleColor.DarkCyan:    Result := 'DarkCyan';
+    TConsoleColor.DarkRed:     Result := 'DarkRed';
+    TConsoleColor.DarkMagenta: Result := 'DarkMagenta';
+    TConsoleColor.DarkYellow:  Result := 'DarkYellow';
+    TConsoleColor.Gray:        Result := 'Gray';
+    TConsoleColor.DarkGray:    Result := 'DarkGray';
+    TConsoleColor.Blue:        Result := 'Blue';
+    TConsoleColor.Green:       Result := 'Green';
+    TConsoleColor.Cyan:        Result := 'Cyan';
+    TConsoleColor.Red:         Result := 'Red';
+    TConsoleColor.Magenta:     Result := 'Magenta';
+    TConsoleColor.Yellow:      Result := 'Yellow';
+    TConsoleColor.White:       Result := 'White';
+    TConsoleColor.UseDefault:  Result := 'UseDefault';
+  else
+    Result := 'Unknown';
+  end;
+end;
+
+{$IFDEF LINUX}
+
+procedure SetupTerminal;
+var
+  NewTermios: termios;
+begin
+  if not GTerminalSetup then
+  begin
+    tcgetattr(STDIN_FILENO, GOriginalTermios);
+    NewTermios := GOriginalTermios;
+    NewTermios.c_lflag := NewTermios.c_lflag and not (ICANON or ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, NewTermios);
+    GTerminalSetup := True;
+  end;
+end;
+
+procedure RestoreTerminal;
+begin
+  if GTerminalSetup then
+  begin
+    tcsetattr(STDIN_FILENO, TCSANOW, GOriginalTermios);
+    GTerminalSetup := False;
+  end;
+end;
+
+function KeyPressed: Boolean;
+var
+  FDSet: fd_set;
+  TimeVal: TLinuxTimeVal;
+begin
+  SetupTerminal;
+  __FD_ZERO(FDSet);
+  __FD_SET(STDIN_FILENO, FDSet);
+  TimeVal.tv_sec := 0;
+  TimeVal.tv_usec := 0;
+  Result := __select(STDIN_FILENO + 1, @FDSet, nil, nil, @TimeVal) > 0;
+end;
+
+procedure EnableUTF8Console;
+begin
+  WriteLn(ESC + '[?1049h');
+end;
+
+procedure HideCursor;
+begin
+  Write(ESC + '[?25l');
+end;
+
+procedure ShowCursor;
+begin
+  Write(ESC + '[?25h');
+end;
+
+procedure Init; inline;
+begin
+  SetupTerminal;
+end;
+
+procedure WaitForReturn;
+var
+  Ch: Char;
+begin
+  SetupTerminal;
+  repeat
+    Ch := GetCh;
+  until (Ch = #13) or (Ch = #10);
+end;
+
+procedure UpdateMode;
+begin
+  Write(ANSI_FG[TConsoleColor(GForeGround)] + ANSI_BG[TConsoleColor(GBackGround shr 4)]);
+end;
+
+function GetCh: Char;
+var
+  Buffer: array[0..0] of Char;
+begin
+  SetupTerminal;
+  if __read(STDIN_FILENO, @Buffer, 1) = 1 then
+    Result := Buffer[0]
+  else
+    Result := #0;
+end;
+
+procedure GotoXY(const X, Y: Word);
+begin
+  Write(ESC + '[' + IntToStr(Y + 1) + ';' + IntToStr(X + 1) + 'H');
+end;
+
+function GetConsoleSize: TMVCConsoleSize;
+var
+  WinSize: TLinuxWinSize;
+begin
+  if ioctl(STDOUT_FILENO, TIOCGWINSZ, @WinSize) = 0 then
+  begin
+    Result.Columns := WinSize.ws_col;
+    Result.Rows := WinSize.ws_row;
+  end
+  else
+  begin
+    Result.Columns := 80;
+    Result.Rows := 25;
+  end;
+end;
+
+function GetConsoleBufferSize: TMVCConsoleSize;
+begin
+  Result := GetConsoleSize;
+end;
+
+function GetCursorPosition: TMVCConsolePoint;
+var
+  Response: string;
+  Ch: Char;
+  I: Integer;
+  Numbers: array[0..1] of Integer;
+  NumberIndex: Integer;
+  CurrentNumber: string;
+begin
+  Write(ESC + '[6n');
+  Response := '';
+  NumberIndex := 0;
+  CurrentNumber := '';
+  repeat
+    Ch := GetCh;
+    Response := Response + Ch;
+  until (Ch = 'R') or (Length(Response) > 20);
+
+  for I := 1 to Length(Response) do
+  begin
+    Ch := Response[I];
+    if CharInSet(Ch, ['0'..'9']) then
+      CurrentNumber := CurrentNumber + Ch
+    else if (Ch = ';') or (Ch = 'R') then
+    begin
+      if CurrentNumber <> '' then
+      begin
+        Numbers[NumberIndex] := StrToIntDef(CurrentNumber, 1);
+        Inc(NumberIndex);
+        CurrentNumber := '';
+      end;
+    end;
+  end;
+
+  if NumberIndex >= 2 then
+  begin
+    Result.Y := Numbers[0] - 1;
+    Result.X := Numbers[1] - 1;
+  end
+  else
+  begin
+    Result.X := 0;
+    Result.Y := 0;
+  end;
+end;
+
+procedure ClrScr;
+begin
+  Write(ESC + '[2J');
+  Write(ESC + '[H');
+end;
+
+function GetKey: Integer;
+var
+  Buffer: array[0..0] of Char;
+  Ch: Char;
+begin
+  Result := 0;
+  SetupTerminal;
+  if __read(STDIN_FILENO, @Buffer, 1) = 1 then
+  begin
+    Ch := Buffer[0];
+    Result := Ord(Ch);
+    if Ch = #27 then
+    begin
+      if KeyPressed then
+      begin
+        if __read(STDIN_FILENO, @Buffer, 1) = 1 then
+        begin
+          if Buffer[0] = '[' then
+          begin
+            if __read(STDIN_FILENO, @Buffer, 1) = 1 then
+            begin
+              case Buffer[0] of
+                'A': Result := KEY_UP;
+                'B': Result := KEY_DOWN;
+                'C': Result := KEY_RIGHT;
+                'D': Result := KEY_LEFT;
+              end;
+            end;
+          end;
+        end;
+      end;
+    end;
+  end;
+end;
+
+{$ENDIF}
+
+// ============================================================================
+// PLATFORM: WINDOWS
+// ============================================================================
+
+{$IFDEF MSWINDOWS}
+
+const
+  ATTACH_PARENT_PROCESS = DWORD(-1);
+function AttachConsole(dwProcessId: DWORD): BOOL; stdcall; external kernel32 name 'AttachConsole';
+
+procedure EnableUTF8Console;
+begin
+  SetConsoleOutputCP(CP_UTF8);
+end;
+
+procedure KeyInit;
+var
+  mode: DWORD;
+begin
+  Reset(Input);
+  GInputHandle := TTextRec(Input).Handle;
+  hConsoleInput := GInputHandle;
+  SetActiveWindow(0);
+  GetConsoleMode(hConsoleInput, mode);
+  if (mode and ENABLE_MOUSE_INPUT) = ENABLE_MOUSE_INPUT then
+    SetConsoleMode(hConsoleInput, mode xor ENABLE_MOUSE_INPUT);
+end;
+
+procedure Init;
+begin
+  if not GIsConsoleAllocated then
+  begin
+    TMonitor.Enter(GLock);
+    try
+      KeyInit;
+      if not GIsConsoleAllocated then
+      begin
+        if not IsConsole then
+        begin
+          if not AttachConsole(ATTACH_PARENT_PROCESS) then
+            AllocConsole;
+        end;
+        GOutHandle := GetStdHandle(STD_OUTPUT_HANDLE);
+        if GOutHandle = INVALID_HANDLE_VALUE then
+          raise EMVCConsole.CreateFmt('Cannot Get STD_OUTPUT_HANDLE - GetLastError() = %d', [GetLastError]);
+        GIsConsoleAllocated := True;
+      end;
+    finally
+      TMonitor.Exit(GLock);
+    end;
+  end;
+end;
+
+function KeyPressed: Boolean;
+var
+  InputRecord: INPUT_RECORD;
+  NumRead: DWORD;
+begin
+  Result := False;
+  Init;
+  if PeekConsoleInput(GInputHandle, InputRecord, 1, NumRead) and (NumRead > 0) then
+  begin
+    if (InputRecord.EventType = KEY_EVENT) and InputRecord.Event.KeyEvent.bKeyDown then
+      Result := True
+    else
+      ReadConsoleInput(GInputHandle, InputRecord, 1, NumRead);
+  end;
+end;
+
+procedure InternalShowCursor(const AShowCursor: Boolean);
+var
+  info: CONSOLE_CURSOR_INFO;
+begin
+  Init;
+  GetConsoleCursorInfo(GOutHandle, info);
+  info.bVisible := AShowCursor;
+  SetConsoleCursorInfo(GOutHandle, info);
+end;
+
+procedure WaitForReturn;
+begin
+  Init;
+  while GetCh <> #13 do;
+end;
+
+procedure ClrScr;
+var
+  lSize: TMVCConsoleSize;
+  dwConSize: UInt32;
+  lStartCoord: _COORD;
+  lCharsWritten: UInt32;
+begin
+  Init;
+  lSize := GetConsoleBufferSize;
+  dwConSize := lSize.Columns * lSize.Rows;
+  lStartCoord.X := 0;
+  lStartCoord.Y := 0;
+  if not FillConsoleOutputCharacter(GOutHandle, ' ', dwConSize, lStartCoord, lCharsWritten) then
+    raise EMVCConsole.CreateFmt('Cannot fill console - GetLastError() = %d', [GetLastError]);
+  if not FillConsoleOutputAttribute(GOutHandle, GForeGround or GBackGround, dwConSize, lStartCoord,
+    lCharsWritten) then
+    raise EMVCConsole.CreateFmt('Cannot FillConsoleOutputAttribute - GetLastError() = %d', [GetLastError]);
+  GotoXY(0, 0);
+  // Sync the ANSI current attribute with the background we just painted.
+  // FillConsoleOutputAttribute sets stored cell attrs but does not update the
+  // terminal's "current" text attribute used by subsequent Write() calls.
+  Write(ANSI_BG[TConsoleColor(GBackGround shr 4)]);
+end;
+
+function GetConsoleSize: TMVCConsoleSize;
+var
+  lConsoleScreenBufferInfo: _CONSOLE_SCREEN_BUFFER_INFO;
+begin
+  if not GetConsoleScreenBufferInfo(GOutHandle, lConsoleScreenBufferInfo) then
+    raise EMVCConsole.CreateFmt('Cannot Get Console Size - GetLastError() = %d', [GetLastError]);
+  Result.Columns := lConsoleScreenBufferInfo.srWindow.Right - lConsoleScreenBufferInfo.srWindow.Left + 1;
+  Result.Rows := lConsoleScreenBufferInfo.srWindow.Bottom - lConsoleScreenBufferInfo.srWindow.Top + 1;
+end;
+
+function GetCursorPosition: TMVCConsolePoint;
+var
+  lConsoleScreenBufferInfo: _CONSOLE_SCREEN_BUFFER_INFO;
+begin
+  Init;
+  if not GetConsoleScreenBufferInfo(GOutHandle, lConsoleScreenBufferInfo) then
+    raise EMVCConsole.CreateFmt('Cannot Get Cursor Position - GetLastError() = %d', [GetLastError]);
+  Result.X := lConsoleScreenBufferInfo.dwCursorPosition.X;
+  Result.Y := lConsoleScreenBufferInfo.dwCursorPosition.Y;
+end;
+
+function GetCh: Char;
+var
+  Key: Integer;
+begin
+  Key := GetKey;
+  if Key < 256 then
+    Result := Chr(Key)
+  else
+    Result := #0;
+end;
+
+function GetKey: Integer;
+var
+  InputRecord: INPUT_RECORD;
+  NumRead: DWORD;
+  KeyEvent: KEY_EVENT_RECORD;
+begin
+  Init;
+  repeat
+    if ReadConsoleInput(GInputHandle, InputRecord, 1, NumRead) then
+    begin
+      if (InputRecord.EventType = KEY_EVENT) then
+      begin
+        KeyEvent := InputRecord.Event.KeyEvent;
+        if KeyEvent.bKeyDown then
+        begin
+          if KeyEvent.AsciiChar <> #0 then
+          begin
+            Result := Ord(KeyEvent.AsciiChar);
+            Exit;
+          end
+          else
+          begin
+            Result := 256 + KeyEvent.wVirtualKeyCode;
+            Exit;
+          end;
+        end;
+      end;
+    end;
+  until False;
+end;
+
+function GetConsoleBufferSize: TMVCConsoleSize;
+var
+  lConsoleScreenBufferInfo: _CONSOLE_SCREEN_BUFFER_INFO;
+begin
+  if not GetConsoleScreenBufferInfo(GOutHandle, lConsoleScreenBufferInfo) then
+    raise EMVCConsole.CreateFmt('Cannot Get Console Buffer Size - GetLastError() = %d', [GetLastError]);
+  Result.Columns := lConsoleScreenBufferInfo.dwSize.X;
+  Result.Rows := lConsoleScreenBufferInfo.dwSize.Y;
+end;
+
+procedure UpdateMode;
+begin
+  Init;
+  Write(ANSI_FG[TConsoleColor(GForeGround)] + ANSI_BG[TConsoleColor(GBackGround shr 4)]);
+end;
+
+procedure GotoXY(const X, Y: Word);
+var
+  lCoord: _COORD;
+begin
+  Init;
+  lCoord.X := X;
+  lCoord.Y := Y;
+  if not SetConsoleCursorPosition(GOutHandle, lCoord) then
+    raise EMVCConsole.Create('Invalid Coordinates');
+end;
+
+procedure HideCursor;
+begin
+  InternalShowCursor(False);
+end;
+
+procedure ShowCursor;
+begin
+  InternalShowCursor(True);
+end;
+
+{$ENDIF}
+
+// ============================================================================
+// CROSS-PLATFORM HIGH-LEVEL FUNCTIONS
+// ============================================================================
+
+procedure CenterInScreen(const Text: String);
+var
+  Size: TMVCConsoleSize;
+begin
+  Init;
+  Size := GetConsoleSize;
+  GotoXY(Size.Columns div 2 - Length(Text) div 2, Size.Rows div 2 - 1);
+  Write(Text);
+end;
+
+procedure ResetConsole;
+begin
+  Write(STYLE_RESETALL);
+  SetDefaultColors;
+end;
+
+procedure TextColor(const Color: TConsoleColor);
+begin
+  GForeGround := Ord(Color);
+  UpdateMode;
+end;
+
+procedure TextBackground(const Color: TConsoleColor);
+begin
+  GBackGround := Ord(Color) shl 4;
+  UpdateMode;
+end;
+
+procedure SetDefaultColors;
+begin
+  GForeGround := Ord(TConsoleColor.Gray);
+  GBackGround := Ord(TConsoleColor.Black);
+  UpdateMode;
+end;
+
+procedure SaveColors;
+begin
+  Init;
+  GSavedForeGround := GForeGround;
+  GSavedBackGround := GBackGround;
+end;
+
+procedure RestoreSavedColors;
+begin
+  GForeGround := GSavedForeGround;
+  GBackGround := GSavedBackGround;
+  UpdateMode;
+end;
+
+function ConsoleAttr: Integer;
+begin
+  Result := GForeGround;
+  Result := (Result shl 16) or GBackGround;
+end;
+
+procedure SetConsoleAttr(const TextAttr: Integer);
+var
+  lAttr: Integer;
+begin
+  lAttr := TextAttr;
+  GBackGround := lAttr and $0000FFFF;
+  GForeGround := lAttr shr 16;
+  UpdateMode;
+end;
+
+function TextAttr: Word;
+begin
+  Result := GForeGround;
+end;
+
+procedure SetTextAttr(const TextAttr: Word);
+begin
+  GForeGround := TextAttr;
+  UpdateMode;
+end;
+
+function BackgroundAttr: Word;
+begin
+  Result := GBackGround;
+end;
+
+procedure SetBackgroundAttr(const BackgroundAttr: Word);
+begin
+  GBackGround := BackgroundAttr;
+  UpdateMode;
+end;
+
+function IsSpecialKey(KeyCode: Integer): Boolean;
+begin
+  Result := KeyCode > 255;
+end;
+
+// ============================================================================
+// TEXT OUTPUT
+// ============================================================================
+
+procedure WriteColoredText(const Text: string; ForeColor: TConsoleColor;
+                          BackColor: TConsoleColor);
+var
+  LStyle: string;
+begin
+  if ForeColor = UseDefault then
+    LStyle := ConsoleTheme.Text
+  else
+    LStyle := ANSI_FG[ForeColor];
+  if BackColor <> UseDefault then
+    LStyle := LStyle + ANSI_BG[BackColor];
+  Write(LStyle + Text + GThemeReset);
+end;
+
+procedure WriteLine(const Text: string);
+begin
+  WriteLn(Text);
+end;
+
+procedure WriteLine(const Text: string; ForeColor: TConsoleColor);
+begin
+  WriteColoredText(Text, ForeColor, UseDefault);
+  WriteLn;
+end;
+
+procedure WriteLine(const Text: string; ForeColor: TConsoleColor; BackColor: TConsoleColor);
+begin
+  WriteColoredText(Text, ForeColor, BackColor);
+  WriteLn;
+end;
+
+procedure WriteAlignedText(const Text: string; Width: Integer; Alignment: TAlignment; TextColor: TConsoleColor);
+var
+  PaddingLeft, PaddingRight: Integer;
+  AlignedText: string;
+begin
+  if Length(Text) >= Width then
+  begin
+    WriteLine(Text, TextColor);
+    Exit;
+  end;
+  case Alignment of
+    taLeft:
+      AlignedText := Text + StringOfChar(' ', Width - Length(Text));
+    taRight:
+      AlignedText := StringOfChar(' ', Width - Length(Text)) + Text;
+    taCenter:
+    begin
+      PaddingLeft := (Width - Length(Text)) div 2;
+      PaddingRight := Width - Length(Text) - PaddingLeft;
+      AlignedText := StringOfChar(' ', PaddingLeft) + Text + StringOfChar(' ', PaddingRight);
+    end;
+  end;
+  WriteLine(AlignedText, TextColor);
+end;
+
+// ============================================================================
+// STATUS MESSAGES
+// ============================================================================
+
+procedure WriteHeader(const Text: string; Width: Integer; HeaderColor: TConsoleColor);
+var
+  Line: string;
+  PaddingSize: Integer;
+  CharSymbol: Char;
+  LHeaderStyle: string;
+begin
+  if HeaderColor = UseDefault then
+    LHeaderStyle := ConsoleTheme.HighlightText
+  else
+    LHeaderStyle := ANSI_FG[HeaderColor];
+  CharSymbol := GetBoxChars(ConsoleTheme.BoxStyle).Horizontal;
+  Line := StringOfChar(CharSymbol, Width);
+  WriteAnsiLine(ConsoleTheme.Draw, Line);
+
+  if Text <> '' then
+  begin
+    PaddingSize := (Width - Length(Text) - 2) div 2;
+    Line := StringOfChar(' ', PaddingSize) + ' ' + Text + ' ' +
+            StringOfChar(' ', Width - PaddingSize - Length(Text) - 2);
+    WriteAnsiLine(LHeaderStyle, Line);
+    Line := StringOfChar(CharSymbol, Width);
+    WriteAnsiLine(ConsoleTheme.Draw, Line);
+  end;
+end;
+
+procedure WriteSeparator(Width: Integer; CharSymbol: Char);
+begin
+  WriteAnsiLine(ConsoleTheme.Draw, StringOfChar(CharSymbol, Width));
+end;
+
+procedure WriteSuccess(const Message: string);
+begin
+  WriteColoredText('[SUCCESS]', Black, Green);
+  WriteAnsiLine(ConsoleTheme.Text, ' ' + Message);
+end;
+
+procedure WriteWarning(const Message: string);
+begin
+  WriteColoredText('[WARNING]', Black, Yellow);
+  WriteAnsiLine(ConsoleTheme.Text, ' ' + Message);
+end;
+
+procedure WriteError(const Message: string);
+begin
+  WriteColoredText('[ERROR]', White, Red);
+  WriteAnsiLine(ConsoleTheme.Text, ' ' + Message);
+end;
+
+procedure WriteInfo(const Message: string);
+begin
+  WriteColoredText('[INFO]', White, Blue);
+  WriteAnsiLine(ConsoleTheme.Text, ' ' + Message);
+end;
+
+procedure WriteFormattedList(const Title: string; const Items: TStringArray;
+  ListStyle: TListStyle);
+var
+  I: Integer;
+  Prefix: string;
+begin
+  if Title <> '' then
+    WriteAnsiLine(ConsoleTheme.Text, Title);
+  for I := 0 to High(Items) do
+  begin
+    case ListStyle of
+      lsBullet: Prefix := '  * ';
+      lsNumbered: Prefix := Format('%3d. ', [I + 1]);
+      lsDash: Prefix := '  - ';
+      lsArrow: Prefix := '  > ';
+    end;
+    WriteAnsiText(ConsoleTheme.Symbols, Prefix);
+    WriteAnsiLine(ConsoleTheme.Text, Items[I]);
+  end;
+end;
+
+// ============================================================================
+// DRAWING PRIMITIVES
+// ============================================================================
+
+procedure SaveCursorPosition;
+var
+  Pos: TMVCConsolePoint;
+begin
+  Pos := GetCursorPosition;
+  GSavedCursorX := Pos.X;
+  GSavedCursorY := Pos.Y;
+end;
+
+procedure RestoreCursorPosition;
+begin
+  GotoXY(GSavedCursorX, GSavedCursorY);
+end;
+
+procedure DrawBox(X, Y, Width, Height: Word; Style: TBoxStyle; const Title: string);
+var
+  I, J: Integer;
+  TitleStart: Integer;
+  BoxChars: TBoxChars;
+begin
+  BoxChars := GetBoxChars(Style);
+  GotoXY(X, Y);
+  Write(BoxChars.TopLeft);
+  TitleStart := (Width - Length(Title)) div 2;
+  J := 1;
+  while J <= Width - 2 do
+  begin
+    if (Title <> '') and (J = TitleStart) then
+    begin
+      Write(Title);
+      J := J + Length(Title);
+    end
+    else
+    begin
+      Write(BoxChars.Horizontal);
+      Inc(J);
+    end;
+  end;
+  Write(BoxChars.TopRight);
+
+  for I := 1 to Height - 2 do
+  begin
+    GotoXY(X, Y + I);
+    Write(BoxChars.Vertical);
+    GotoXY(X + Width - 1, Y + I);
+    Write(BoxChars.Vertical);
+  end;
+
+  GotoXY(X, Y + Height - 1);
+  Write(BoxChars.BottomLeft);
+  for I := 1 to Width - 2 do
+    Write(BoxChars.Horizontal);
+  Write(BoxChars.BottomRight);
+end;
+
+procedure DrawHorizontalLine(X, Y, Length: Word; Style: TBoxStyle);
+var
+  I: Integer;
+  BoxChars: TBoxChars;
+begin
+  BoxChars := GetBoxChars(Style);
+  GotoXY(X, Y);
+  for I := 0 to Length - 1 do
+    Write(BoxChars.Horizontal);
+end;
+
+procedure DrawVerticalLine(X, Y, Length: Word; Style: TBoxStyle);
+var
+  I: Integer;
+  BoxChars: TBoxChars;
+begin
+  BoxChars := GetBoxChars(Style);
+  for I := 0 to Length - 1 do
+  begin
+    GotoXY(X, Y + I);
+    Write(BoxChars.Vertical);
+  end;
+end;
+
+procedure ClearRegion(X, Y, Width, Height: Word);
+var
+  I: Integer;
+  Spaces: string;
+begin
+  Spaces := StringOfChar(' ', Width);
+  for I := 0 to Height - 1 do
+  begin
+    GotoXY(X, Y + I);
+    Write(Spaces);
+  end;
+end;
+
+// ============================================================================
+// INFORMATION
+// ============================================================================
+
+function IsTerminalCapable: Boolean;
+begin
+{$IFDEF LINUX}
+  Result := isatty(STDOUT_FILENO) = 1;
+{$ELSE}
+  Result := True;
+{$ENDIF}
+end;
+
+function GetTerminalName: string;
+{$IFDEF LINUX}
+var
+  TermVar: PAnsiChar;
+{$ENDIF}
+begin
+{$IFDEF LINUX}
+  TermVar := getenv('TERM');
+  if TermVar <> nil then
+    Result := string(TermVar)
+  else
+    Result := 'unknown';
+{$ELSE}
+  Result := 'Windows Console';
+{$ENDIF}
+end;
+
+procedure Beep;
+begin
+{$IFDEF LINUX}
+  Write(#7);
+{$ELSE}
+  WinApi.Windows.Beep(800, 200);
+{$ENDIF}
+end;
+
+procedure FlashScreen;
+begin
+{$IFDEF LINUX}
+  Write(ESC + '[?5h');
+  Sleep(100);
+  Write(ESC + '[?5l');
+{$ELSE}
+  SaveColors;
+  try
+    TextColor(Black);
+    TextBackground(White);
+    ClrScr;
+    Sleep(100);
+  finally
+    RestoreSavedColors;
+    ClrScr;
+  end;
+{$ENDIF}
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: TABLE
+// ============================================================================
+
+procedure InternalDrawTable(const Headers: TStringArray; const Data: TStringMatrix;
+  const ColWidths: TArray<Integer>; const lBoxChars: TBoxChars;
+  HighlightRow: Integer = -1);
+var
+  I, J: Integer;
+  Cell, Line: string;
+begin
+  // Top border
+  WriteAnsiText(ConsoleTheme.Draw, lBoxChars.TopLeft);
+  Line := '';
+  for I := 0 to High(ColWidths) do
+  begin
+    Line := Line + StringOfChar(lBoxChars.Horizontal, ColWidths[I]);
+    if I < High(ColWidths) then
+      Line := Line + lBoxChars.TopJoin
+    else
+      Line := Line + lBoxChars.TopRight;
+  end;
+  WriteAnsiLine(ConsoleTheme.Draw, Line);
+
+  // Headers
+  WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Vertical);
+  for I := 0 to High(Headers) do
+  begin
+    Cell := ' ' + PadRight(Headers[I], ColWidths[I] - 2) + ' ';
+    WriteAnsiText(ConsoleTheme.HighlightText, Cell);
+    WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Vertical);
+  end;
+  WriteLn;
+
+  // Header separator
+  WriteAnsiText(ConsoleTheme.Draw, lBoxChars.LeftJoin);
+  for I := 0 to High(ColWidths) do
+  begin
+    WriteAnsiText(ConsoleTheme.Draw, StringOfChar(lBoxChars.Horizontal, ColWidths[I]));
+    if I < High(ColWidths) then
+      WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Cross)
+    else
+      WriteAnsiText(ConsoleTheme.Draw, lBoxChars.RightJoin);
+  end;
+  WriteLn;
+
+  // Data rows
+  for I := 0 to High(Data) do
+  begin
+    WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Vertical);
+    for J := 0 to High(Headers) do
+    begin
+      if J < Length(Data[I]) then
+        Cell := ' ' + PadRight(Data[I][J], ColWidths[J] - 2) + ' '
+      else
+        Cell := StringOfChar(' ', ColWidths[J]);
+
+      if I = HighlightRow then
+        WriteAnsiText(ConsoleTheme.Highlight, Cell)
+      else
+        WriteAnsiText(ConsoleTheme.Text, Cell);
+
+      WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Vertical);
+    end;
+    WriteLn;
+  end;
+
+  // Bottom border
+  WriteAnsiText(ConsoleTheme.Draw, lBoxChars.BottomLeft);
+  Line := '';
+  for I := 0 to High(ColWidths) do
+  begin
+    Line := Line + StringOfChar(lBoxChars.Horizontal, ColWidths[I]);
+    if I < High(ColWidths) then
+      Line := Line + lBoxChars.BottomJoin
+    else
+      Line := Line + lBoxChars.BottomRight;
+  end;
+  WriteAnsiLine(ConsoleTheme.Draw, Line);
+end;
+
+procedure Table(const Headers: TStringArray; const Data: TStringMatrix);
+begin
+  Table(Headers, Data, '');
+end;
+
+procedure Table(const Headers: TStringArray; const Data: TStringMatrix; const Title: string);
+var
+  ColWidths: TArray<Integer>;
+begin
+  if Length(Headers) = 0 then Exit;
+
+  ColWidths := CalcColumnWidths(Headers, Data);
+
+  if Title <> '' then
+    WriteAnsiLine(ConsoleTheme.HighlightText, Title);
+
+  InternalDrawTable(Headers, Data, ColWidths, GetBoxChars(bsUseDefault));
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: TABLE MENU
+// ============================================================================
+
+function TableMenu(const Headers: TStringArray; const Data: TStringMatrix): Integer;
+begin
+  Result := TableMenu('', Headers, Data, 0);
+end;
+
+function TableMenu(const Title: string; const Headers: TStringArray; const Data: TStringMatrix): Integer;
+begin
+  Result := TableMenu(Title, Headers, Data, 0);
+end;
+
+function TableMenu(const Title: string; const Headers: TStringArray;
+  const Data: TStringMatrix; DefaultIndex: Integer): Integer;
+var
+  ColWidths: TArray<Integer>;
+  lBoxChars: TBoxChars;
+  SelectedIndex: Integer;
+  Key: Integer;
+  StartY: Integer;
+
+  procedure DrawTable;
+  begin
+    GotoXY(0, StartY);
+    if Title <> '' then
+      WriteAnsiLine(ConsoleTheme.HighlightText, Title);
+    InternalDrawTable(Headers, Data, ColWidths, lBoxChars, SelectedIndex);
+    WriteLine('Use arrows to navigate, Enter to select, ESC to cancel', DarkGray);
+  end;
+
+begin
+  if (Length(Data) = 0) or (Length(Headers) = 0) then Exit(-1);
+
+  lBoxChars := GetBoxChars(bsUseDefault);
+  ColWidths := CalcColumnWidths(Headers, Data);
+
+  ClrScr;
+  StartY := 0;
+  SelectedIndex := EnsureRange(DefaultIndex, 0, High(Data));
+
+  HideCursor;
+  try
+    repeat
+      DrawTable;
+      Key := GetKey;
+      case Key of
+        KEY_UP: if SelectedIndex > 0 then Dec(SelectedIndex);
+        KEY_DOWN: if SelectedIndex < High(Data) then Inc(SelectedIndex);
+        KEY_ENTER: Exit(SelectedIndex);
+        KEY_ESCAPE: Exit(-1);
+      end;
+    until False;
+  finally
+    ShowCursor;
+  end;
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: BOX
+// ============================================================================
+
+procedure Box(const Content: TStringArray);
+begin
+  Box('', Content, 60);
+end;
+
+procedure Box(const Title: string; const Content: TStringArray);
+begin
+  Box(Title, Content, 60);
+end;
+
+procedure Box(const Title: string; const Content: TStringArray; Width: Integer);
+var
+  I: Integer;
+  Line, ContentLine: string;
+  lBoxChars: TBoxChars;
+begin
+  lBoxChars := GetBoxChars(bsUseDefault);
+
+  // Top border
+  Line := lBoxChars.TopLeft + StringOfChar(lBoxChars.Horizontal, Width - 2) + lBoxChars.TopRight;
+  WriteAnsiLine(ConsoleTheme.Draw, Line);
+
+  // Title
+  if Title <> '' then
+  begin
+    ContentLine := ' ' + PadRight(Title, Width - 4) + ' ';
+    WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Vertical);
+    WriteAnsiText(ConsoleTheme.HighlightText, ContentLine);
+    WriteAnsiLine(ConsoleTheme.Draw, lBoxChars.Vertical);
+
+    Line := lBoxChars.LeftJoin + StringOfChar(lBoxChars.Horizontal, Width - 2) + lBoxChars.RightJoin;
+    WriteAnsiLine(ConsoleTheme.Draw, Line);
+  end;
+
+  // Content
+  for I := 0 to High(Content) do
+  begin
+    WriteAnsiText(ConsoleTheme.Draw, lBoxChars.Vertical);
+    ContentLine := ' ' + PadRight(Content[I], Width - 4) + ' ';
+    WriteAnsiText(ConsoleTheme.Text, ContentLine);
+    WriteAnsiLine(ConsoleTheme.Draw, lBoxChars.Vertical);
+  end;
+
+  // Bottom border
+  Line := lBoxChars.BottomLeft + StringOfChar(lBoxChars.Horizontal, Width - 2) + lBoxChars.BottomRight;
+  WriteAnsiLine(ConsoleTheme.Draw, Line);
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: MENU
+// ============================================================================
+
+function Menu(const Items: TStringArray): Integer;
+begin
+  Result := Menu('', Items, 0);
+end;
+
+function Menu(const Title: string; const Items: TStringArray): Integer;
+begin
+  Result := Menu(Title, Items, 0);
+end;
+
+function Menu(const Title: string; const Items: TStringArray; DefaultIndex: Integer): Integer;
+var
+  SelectedIndex: Integer;
+  Key: Integer;
+  Done: Boolean;
+  I: Integer;
+  MaxWidth: Integer;
+  StartX, StartY: Word;
+  CurPos: TMVCConsolePoint;
+  ConsSize: TMVCConsoleSize;
+  Line: string;
+  MenuHeight: Integer;
+  BoxChars: TBoxChars;
+  Hint: string;
+begin
+  Result := -1;
+  if Length(Items) = 0 then Exit;
+
+  Init;
+  Hint := 'Use arrows to navigate, Enter to select, ESC to cancel';
+
+  SelectedIndex := EnsureRange(DefaultIndex, 0, High(Items));
+
+  // Calculate max width (must also cover the hint line for proper clearing)
+  MaxWidth := Length(Hint);
+  if Length(Title) > MaxWidth then
+    MaxWidth := Length(Title);
+  for I := 0 to High(Items) do
+    if Length(Items[I]) + 6 > MaxWidth then
+      MaxWidth := Length(Items[I]) + 6;
+  Inc(MaxWidth, 4);
+
+  // top border + items + bottom border + hint = N + 3
+  // with title: + title + separator = N + 5
+  MenuHeight := Length(Items) + 3;
+  if Title <> '' then
+    Inc(MenuHeight, 2);
+  Inc(MenuHeight); // hint line
+
+  ConsSize := GetConsoleSize;
+  CurPos := GetCursorPosition;
+  StartX := CurPos.X;
+  StartY := CurPos.Y;
+
+  if StartY + MenuHeight > ConsSize.Rows then
+  begin
+    StartY := ConsSize.Rows - MenuHeight - 1;
+    GotoXY(StartX, StartY);
+  end;
+
+  HideCursor;
+  try
+    Done := False;
+    while not Done do
+    begin
+      GotoXY(StartX, StartY);
+      BoxChars := GetBoxChars(ConsoleTheme.BoxStyle);
+
+      // Top border
+      Line := BoxChars.TopLeft + StringOfChar(BoxChars.Horizontal, MaxWidth - 2) + BoxChars.TopRight;
+      WriteAnsiLine(ConsoleTheme.Draw, Line);
+
+      // Title
+      if Title <> '' then
+      begin
+        WriteAnsiText(ConsoleTheme.Draw, BoxChars.Vertical + ' ');
+        WriteAnsiText(ConsoleTheme.HighlightText, PadRight(Title, MaxWidth - 4));
+        WriteAnsiLine(ConsoleTheme.Draw, ' ' + BoxChars.Vertical);
+
+        Line := BoxChars.LeftJoin + StringOfChar(BoxChars.Horizontal, MaxWidth - 2) + BoxChars.RightJoin;
+        WriteAnsiLine(ConsoleTheme.Draw, Line);
+      end;
+
+      // Items
+      for I := 0 to High(Items) do
+      begin
+        WriteAnsiText(ConsoleTheme.Draw, BoxChars.Vertical + ' ');
+        if I = SelectedIndex then
+          WriteAnsiText(ConsoleTheme.Highlight, '> ' + PadRight(Items[I], MaxWidth - 6) + ' ')
+        else
+          WriteAnsiText(ConsoleTheme.Text, '  ' + PadRight(Items[I], MaxWidth - 6) + ' ');
+        WriteAnsiLine(ConsoleTheme.Draw, BoxChars.Vertical);
+      end;
+
+      // Bottom border
+      Line := BoxChars.BottomLeft + StringOfChar(BoxChars.Horizontal, MaxWidth - 2) + BoxChars.BottomRight;
+      WriteAnsiLine(ConsoleTheme.Draw, Line);
+
+      WriteAnsiLine(ConsoleTheme.Symbols, Hint);
+      FlushOutput;
+
+      Key := GetKey;
+      case Key of
+        KEY_UP:
+          begin
+            Dec(SelectedIndex);
+            if SelectedIndex < 0 then
+              SelectedIndex := High(Items);
+          end;
+        KEY_DOWN:
+          begin
+            Inc(SelectedIndex);
+            if SelectedIndex > High(Items) then
+              SelectedIndex := 0;
+          end;
+        KEY_ENTER:
+          begin
+            Done := True;
+            Result := SelectedIndex;
+          end;
+        KEY_ESCAPE:
+          begin
+            Done := True;
+            Result := -1;
+          end;
+      end;
+    end;
+
+    // Clear menu area
+    for I := 0 to MenuHeight - 1 do
+    begin
+      if StartY + I < ConsSize.Rows then
+      begin
+        GotoXY(StartX, StartY + I);
+        Write(StringOfChar(' ', Min(MaxWidth, ConsSize.Columns - StartX)));
+      end;
+    end;
+    if StartY < ConsSize.Rows then
+      GotoXY(StartX, StartY);
+
+  finally
+    ShowCursor;
+  end;
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: PROGRESS
+// ============================================================================
+
+type
+  TConsoleProgress = class(TInterfacedObject, IProgress)
+  private
+    FTitle: string;
+    FMaxValue: Integer;
+    FCurrent: Integer;
+    FStartX, FStartY: Integer;
+    FWidth: Integer;
+    FCompleted: Boolean;
+    FSpinnerIndex: Integer;
+    FSpinnerChars: string;
+    procedure DrawDeterminate;
+    procedure DrawIndeterminate;
+  public
+    constructor Create(const ATitle: string; AMaxValue: Integer; AWidth: Integer = 50);
+    destructor Destroy; override;
+    procedure Update(Value: Integer);
+    procedure Increment(Amount: Integer = 1);
+    procedure SetMessage(const Msg: string);
+    procedure Complete;
+  end;
+
+constructor TConsoleProgress.Create(const ATitle: string; AMaxValue: Integer; AWidth: Integer);
+begin
+  inherited Create;
+  FTitle := ATitle;
+  FMaxValue := AMaxValue;
+  FCurrent := 0;
+  FWidth := AWidth;
+  FCompleted := False;
+  FSpinnerIndex := 0;
+  FSpinnerChars := '|/-\';
+
+  FStartX := GetCursorPosition.X;
+  FStartY := GetCursorPosition.Y;
+
+  WriteAnsiLine(ConsoleTheme.Text, FTitle);
+  if FMaxValue > 0 then
+    DrawDeterminate
+  else
+    DrawIndeterminate;
+end;
+
+destructor TConsoleProgress.Destroy;
+begin
+  if not FCompleted then
+    Complete;
+  inherited;
+end;
+
+procedure TConsoleProgress.DrawDeterminate;
+var
+  Percent, FilledWidth: Integer;
+  Bar: string;
+begin
+  if FMaxValue = 0 then Exit;
+  Percent := (FCurrent * 100) div FMaxValue;
+  FilledWidth := (FCurrent * FWidth) div FMaxValue;
+  Bar := '[' + StringOfChar('=', FilledWidth) + StringOfChar(' ', FWidth - FilledWidth) + ']';
+  GotoXY(FStartX, FStartY + 1);
+  WriteAnsiText(ConsoleTheme.HighlightText, Bar);
+  WriteAnsiText(ConsoleTheme.Text, Format(' %3d%%', [Percent]));
+end;
+
+procedure TConsoleProgress.DrawIndeterminate;
+begin
+  GotoXY(FStartX, FStartY + 1);
+  WriteAnsiText(ConsoleTheme.Draw, '[');
+  WriteAnsiText(ConsoleTheme.HighlightText, FSpinnerChars[FSpinnerIndex + 1]);
+  WriteAnsiText(ConsoleTheme.Draw, ']');
+  WriteAnsiText(ConsoleTheme.Text, ' Processing...');
+  FSpinnerIndex := (FSpinnerIndex + 1) mod Length(FSpinnerChars);
+end;
+
+procedure TConsoleProgress.Update(Value: Integer);
+begin
+  if FCompleted then Exit;
+  FCurrent := Value;
+  if FMaxValue > 0 then
+    DrawDeterminate
+  else
+    DrawIndeterminate;
+end;
+
+procedure TConsoleProgress.Increment(Amount: Integer);
+begin
+  Update(FCurrent + Amount);
+end;
+
+procedure TConsoleProgress.SetMessage(const Msg: string);
+begin
+  GotoXY(FStartX, FStartY);
+  Write(Msg.PadRight(FWidth + 10));
+  FTitle := Msg;
+end;
+
+procedure TConsoleProgress.Complete;
+begin
+  if FCompleted then Exit;
+  FCompleted := True;
+  if FMaxValue > 0 then
+  begin
+    FCurrent := FMaxValue;
+    DrawDeterminate;
+  end;
+  GotoXY(FStartX, FStartY + 2);
+  WriteAnsiLine(ConsoleTheme.HighlightText, 'Done!');
+end;
+
+function Progress(const Title: string; MaxValue: Integer): IProgress;
+begin
+  Result := TConsoleProgress.Create(Title, MaxValue);
+end;
+
+function Progress(const Title: string): IProgress;
+begin
+  Result := TConsoleProgress.Create(Title, 0);
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: CONFIRM & CHOOSE
+// ============================================================================
+
+function Confirm(const Question: string): Boolean;
+begin
+  Result := Confirm(Question, True);
+end;
+
+function Confirm(const Question: string; DefaultYes: Boolean): Boolean;
+var
+  Response: string;
+begin
+  WriteAnsiText(ConsoleTheme.Text, Question + ' ');
+  if DefaultYes then
+    WriteAnsiText(ConsoleTheme.HighlightText, '[Y/n]: ')
+  else
+    WriteAnsiText(ConsoleTheme.HighlightText, '[y/N]: ');
+  ReadLn(Response);
+  Response := Trim(UpperCase(Response));
+  if Response = '' then
+    Result := DefaultYes
+  else
+    Result := (Response = 'Y') or (Response = 'YES');
+end;
+
+function Choose(const Question: string; const Options: TStringArray): Integer;
+var
+  I: Integer;
+  Response: string;
+  Choice: Integer;
+begin
+  WriteAnsiLine(ConsoleTheme.HighlightText, Question);
+  for I := 0 to High(Options) do
+  begin
+    WriteAnsiText(ConsoleTheme.Symbols, Format('  [%d] ', [I + 1]));
+    WriteAnsiLine(ConsoleTheme.Text, Options[I]);
+  end;
+  WriteAnsiText(ConsoleTheme.HighlightText, 'Your choice: ');
+  ReadLn(Response);
+  if TryStrToInt(Trim(Response), Choice) then
+  begin
+    if (Choice >= 1) and (Choice <= Length(Options)) then
+      Result := Choice - 1
+    else
+      Result := -1;
+  end
+  else
+    Result := -1;
+end;
+
+// ============================================================================
+// HIGH-LEVEL API: SPINNER (non-blocking, thread-based)
+// ============================================================================
+
+type
+  TSpinnerFrames = TArray<string>;
+
+  TConsoleSpinner = class(TInterfacedObject, ISpinner)
+  private
+    FFlag: Integer;
+    FThread: TThread;
+    FFrames: TSpinnerFrames;
+    FColor: TConsoleColor;
+    FMessage: string;
+    FInterval: Integer;
+    FSpinnerX, FSpinnerY: Word;
+    FMaxDisplayWidth: Integer;
+  public
+    constructor Create(const AMessage: string; AStyle: TSpinnerStyle; AColor: TConsoleColor);
+    destructor Destroy; override;
+    procedure Hide;
+  end;
+
+function GetSpinnerFrames(AStyle: TSpinnerStyle): TSpinnerFrames;
+begin
+  case AStyle of
+    ssLine:
+      Result := TSpinnerFrames.Create('-', '\', '|', '/');
+    ssDots:
+      Result := TSpinnerFrames.Create(
+        #$280B, #$2819, #$2839, #$2838, #$283C,
+        #$2834, #$2826, #$2827, #$2807, #$280F);
+    ssBounce:
+      Result := TSpinnerFrames.Create(
+        #$2801, #$2802, #$2804, #$2840,
+        #$2880, #$2820, #$2810, #$2808);
+    ssGrow:
+      Result := TSpinnerFrames.Create(
+        #$258F, #$258E, #$258D, #$258C,
+        #$258B, #$258A, #$2589, #$2588);
+    ssArrow:
+      Result := TSpinnerFrames.Create(
+        #$2190, #$2196, #$2191, #$2197,
+        #$2192, #$2198, #$2193, #$2199);
+    ssCircle:
+      Result := TSpinnerFrames.Create(#$25D0, #$25D3, #$25D1, #$25D2);
+    ssClock:
+      Result := TSpinnerFrames.Create(
+        #$D83D#$DD50, #$D83D#$DD51, #$D83D#$DD52, #$D83D#$DD53,
+        #$D83D#$DD54, #$D83D#$DD55, #$D83D#$DD56, #$D83D#$DD57,
+        #$D83D#$DD58, #$D83D#$DD59, #$D83D#$DD5A, #$D83D#$DD5B);
+    ssEarth:
+      Result := TSpinnerFrames.Create(
+        #$D83C#$DF0D, #$D83C#$DF0E, #$D83C#$DF0F);
+    ssMoon:
+      Result := TSpinnerFrames.Create(
+        #$D83C#$DF11, #$D83C#$DF12, #$D83C#$DF13, #$D83C#$DF14,
+        #$D83C#$DF15, #$D83C#$DF16, #$D83C#$DF17, #$D83C#$DF18);
+    ssWeather:
+      Result := TSpinnerFrames.Create(
+        #$D83C#$DF24, #$D83C#$DF27, #$26C8,
+        #$D83C#$DF29, #$D83C#$DF28, #$D83C#$DF2A);
+  else
+    Result := TSpinnerFrames.Create('-', '\', '|', '/');
+  end;
+end;
+
+function GetSpinnerInterval(AStyle: TSpinnerStyle): Integer;
+begin
+  case AStyle of
+    ssClock, ssEarth, ssMoon, ssWeather: Result := 200;
+    ssDots, ssBounce: Result := 80;
+    ssGrow: Result := 120;
+  else
+    Result := 100;
+  end;
+end;
+
+function DisplayWidth(const S: string): Integer;
+var
+  I: Integer;
+begin
+  Result := 0;
+  I := 1;
+  while I <= Length(S) do
+  begin
+    if (I < Length(S)) and Char.IsHighSurrogate(S, I - 1) then
+    begin
+      Inc(Result, 2);
+      Inc(I, 2);
+    end
+    else
+    begin
+      Inc(Result, 1);
+      Inc(I);
+    end;
+  end;
+end;
+
+constructor TConsoleSpinner.Create(const AMessage: string; AStyle: TSpinnerStyle; AColor: TConsoleColor);
+var
+  lFrames: TSpinnerFrames;
+  lInterval: Integer;
+  lColor: TConsoleColor;
+  lSpinnerX, lSpinnerY: Word;
+  lMaxWidth: Integer;
+  CurPos: TMVCConsolePoint;
+  lFrame: string;
+begin
+  inherited Create;
+  FFrames := GetSpinnerFrames(AStyle);
+  FColor := AColor;
+  FMessage := AMessage;
+  FInterval := GetSpinnerInterval(AStyle);
+  TInterlocked.Exchange(FFlag, 1);
+
+  if FMessage <> '' then
+  begin
+    TextColor(FColor);
+    Write(FMessage + ' ');
+  end;
+
+  HideCursor;
+
+  CurPos := GetCursorPosition;
+  FSpinnerX := CurPos.X;
+  FSpinnerY := CurPos.Y;
+
+  FMaxDisplayWidth := 0;
+  for lFrame in FFrames do
+  begin
+    lMaxWidth := DisplayWidth(lFrame);
+    if lMaxWidth > FMaxDisplayWidth then
+      FMaxDisplayWidth := lMaxWidth;
+  end;
+
+  lFrames := FFrames;
+  lInterval := FInterval;
+  lColor := FColor;
+  lSpinnerX := FSpinnerX;
+  lSpinnerY := FSpinnerY;
+  lMaxWidth := FMaxDisplayWidth;
+
+  FThread := TThread.CreateAnonymousThread(
+    procedure
+    var
+      I: Integer;
+      Frame: string;
+    begin
+      I := 0;
+      while TInterlocked.CompareExchange(FFlag, 1, 1) = 1 do
+      begin
+        Frame := lFrames[I mod Length(lFrames)];
+        GotoXY(lSpinnerX, lSpinnerY);
+        TextColor(lColor);
+        Write(Frame + StringOfChar(' ', lMaxWidth - DisplayWidth(Frame)));
+        Flush(Output);
+        Inc(I);
+        Sleep(lInterval);
+      end;
+    end
+  );
+  FThread.FreeOnTerminate := False;
+  FThread.Start;
+end;
+
+destructor TConsoleSpinner.Destroy;
+begin
+  Hide;
+  inherited;
+end;
+
+procedure TConsoleSpinner.Hide;
+begin
+  if TInterlocked.CompareExchange(FFlag, 0, 1) = 0 then
+    Exit;
+  if Assigned(FThread) then
+  begin
+    FThread.WaitFor;
+    FreeAndNil(FThread);
+  end;
+  GotoXY(FSpinnerX, FSpinnerY);
+  Write(StringOfChar(' ', FMaxDisplayWidth));
+  GotoXY(FSpinnerX, FSpinnerY);
+  ShowCursor;
+  Flush(Output);
+end;
+
+function Spinner(AStyle: TSpinnerStyle; AColor: TConsoleColor): ISpinner;
+begin
+  Result := TConsoleSpinner.Create('', AStyle, AColor);
+end;
+
+function Spinner(const AMessage: string; AStyle: TSpinnerStyle; AColor: TConsoleColor): ISpinner;
+begin
+  Result := TConsoleSpinner.Create(AMessage, AStyle, AColor);
+end;
+
+// ============================================================================
+// CONSOLE THEME FUNCTIONS
+// ============================================================================
+
+procedure SetConsoleTheme(const Theme: TConsoleColorStyle);
+begin
+  ConsoleTheme := Theme;
+  GThemeReset  := STYLE_RESETALL + ANSI_BG[Theme.Background];
+  TextBackground(Theme.Background);
+end;
+
+// ============================================================================
+
+initialization
+  GLock := TObject.Create;
+  GSavedCursorX := 0;
+  GSavedCursorY := 0;
+  GForeGround  := Ord(TConsoleColor.Gray);
+  GBackGround  := Ord(TConsoleColor.Black) shl 4;
+  GThemeReset  := STYLE_RESETALL + BACK_BLACK;
+  EnableANSIColorConsole;
+
+finalization
+{$IFDEF LINUX}
+  RestoreTerminal;
+{$ENDIF}
+  GLock.Free;
+
+end.

--- a/src/pkg/vendor/dmvcframework/NOTICE
+++ b/src/pkg/vendor/dmvcframework/NOTICE
@@ -1,0 +1,19 @@
+PasClaw vendors the following Apache-2.0 licensed source files in
+src/pkg/vendor/dmvcframework/:
+
+  MVCFramework.Console.pas
+  dmvcframework.inc
+      Copyright (c) 2010-2026 Daniele Teti and the DMVCFramework Team
+      https://github.com/danieleteti/delphimvcframework
+
+  LoggerPro.AnsiColors.pas
+      Copyright (c) 2010-2026 Daniele Teti
+      https://github.com/danieleteti/loggerpro
+
+Both projects are distributed under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0). The PasClaw build links
+these units verbatim under the Delphi build path (FPC builds use the
+fallback line-based TUI in PasClaw.TUI and do not require these files).
+
+No modifications were made to the upstream sources beyond placing them
+in this directory. Updates can be re-vendored from upstream.

--- a/src/pkg/vendor/dmvcframework/dmvcframework.inc
+++ b/src/pkg/vendor/dmvcframework/dmvcframework.inc
@@ -1,0 +1,122 @@
+// ***************************************************************************
+//
+// Delphi MVC Framework
+//
+// Copyright (c) 2010-2025 Daniele Teti and the DMVCFramework Team
+//
+// https://github.com/danieleteti/delphimvcframework
+//
+// ***************************************************************************
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *************************************************************************** }
+
+{
+  http://delphi.wikia.com/wiki/CompilerVersion_Constant
+}
+
+{ ---- Enable this if you are on DELPHI STARTED EDITION --------- }
+{ .$DEFINE STARTEREDITION }
+{ ------------ DO NOT CHANGE UNDER THIS LINE -------------------- }
+
+{$IFDEF STARTEREDITION}
+{$UNDEF USEFIREDAC}
+{$UNDEF USEDBX}
+{$ENDIF}
+
+{$IFDEF ANDROID OR IOS}
+{$DEFINE MOBILE}
+{$ENDIF}
+
+{$IF CompilerVersion <= 29} // XE8
+DelphiMVCFramework is compatible with Delphi 10.0 or better
+{$ENDIF}
+
+{$IF CompilerVersion >= 30} // 10.0 Seattle
+{$DEFINE SEATTLEORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 31} // 10.1 Berlin
+{$DEFINE BERLINORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 32} // 10.2 Tokyo
+{$DEFINE TOKYOORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 33} // 10.3 Rio
+{$DEFINE RIOORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 34} // 10.4 Sydney
+{$DEFINE SYDNEYORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 35} // 11 Alexandria
+{$DEFINE ALEXANDRIAORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 36} // 12 Athens
+{$DEFINE ATHENSORBETTER}
+{$ENDIF}
+
+{$IF CompilerVersion >= 37} // 13 Florence
+{$DEFINE FLORENCEORBETTER}
+{$ENDIF}
+
+{$IFDEF MOBILE}
+{$LEGACYIFEND OFF}
+{$ENDIF}
+
+{$IFDEF SEATTLEORBETTER}
+{$DEFINE JSONBOOL}
+{$ENDIF}
+
+{$IFDEF SEATTLEORBETTER}
+{$DEFINE SYSTEMNETENCODING}
+{$DEFINE TOJSON}
+{$ENDIF}
+
+{$DEFINE SYSTEMJSON}
+{$IFNDEF MOBILE}
+{$IFNDEF MACOS}
+{$DEFINE WEBAPACHEHTTP}
+{$ENDIF}
+{$ENDIF}
+{$DEFINE USEFIREDAC}
+
+{$IF Defined(SYDNEYORBETTER)}
+{$DEFINE CUSTOM_MANAGED_RECORDS}
+{$ENDIF}
+
+{$UNDEF WEBSTENCILS}
+{$IF Defined(ATHENSORBETTER)}
+{$IF declared(RTLVersion122) or (RTLVersion >= 37)}
+{$DEFINE WEBSTENCILS}
+{$ENDIF}
+{$ENDIF}
+
+{$UNDEF FASTCGI}
+{$IF Defined(FLORENCEORBETTER)}
+{$DEFINE FASTCGI}
+{$ENDIF}
+
+{ Streaming JSON serializer depends on System.JSON.Writers which was added
+  in 10.3 Rio. On older compilers the streaming path compiles as a stub
+  that returns False, making the framework fall back to the legacy
+  SerializeObject flow. }
+{$UNDEF MVC_HAS_STREAMING_JSON}
+{$IF Defined(RIOORBETTER)}
+{$DEFINE MVC_HAS_STREAMING_JSON}
+{$ENDIF}


### PR DESCRIPTION
## Summary

Adopts Daniele Teti's `MVCFramework.Console` (DMVCFramework) as the rich rendering layer for `pasclaw tui` on Delphi. FPC keeps the existing line-based ANSI renderer untouched — both implementations live in `PasClaw.TUI` behind `{$IFNDEF FPC}` / `{$IFDEF FPC}` guards and share the same `TTUI` class shape, slash-command surface, and tool-loop wiring. Nothing about command dispatch, config, providers, or tool registry changes.

### Vendored (Apache 2.0)

`src/pkg/vendor/dmvcframework/`:

| File | Lines | Purpose |
|------|------|---------|
| `MVCFramework.Console.pas` | 2299 | Themed boxes, tables, menus, spinners, progress bars, color primitives, cursor and console-size helpers |
| `LoggerPro.AnsiColors.pas`  | 252 | ANSI escape constants + `EnableANSIColorConsole` (the one external dep of MVCFramework.Console) |
| `dmvcframework.inc`        | 121 | Compiler-version sentinels |
| `NOTICE`                   |   – | Apache 2.0 attribution |

The vendored files are wired into `PasClaw.dproj` and the unit search path. FPC's Makefile has an explicit `UNIT_DIRS` list that doesn't include the vendor directory, so it never tries to compile the Delphi-only `WinApi.Windows` / `Posix.Termios` uses.

The repo-root `.gitignore` `vendor/` rule (for `make get-indy`'s Indy mirror) is narrowed with `!src/pkg/vendor/` so this intentional bundle is tracked.

### Rich TUI uses

- `WriteHeader('PasClaw  provider/model  tools:N', 80, Cyan)`
- `Box('TUI commands', [...])` — boxed `/help` panel
- `Table(['#','tool'], rows, 'tools (N)')` — boxed `/tools` listing
- `Spinner('thinking', ssDots, Cyan)` — runs in a background thread during `RunToolLoop`, hidden in a `finally` block so exceptions don't leave it spinning
- `WriteSuccess` / `WriteWarning` / `WriteError` / `WriteInfo` for status messages
- `WriteColoredText('you', Cyan)` + ` > ` prompts
- `EnableUTF8Console` + `EnableANSIColorConsole` at startup — both idempotent and safe to call after `CliUI_Init` already did the Windows variant

### On the `EnableUTF8Console` / `EnableANSIColorConsole` note from the article

> "On Windows, EnableUTF8Console calls SetConsoleOutputCP(CP_UTF8). On Linux it is a no-op since UTF-8 is the default. If you also plan to use the ANSI color primitives (Fore, Back, Style) directly with WriteLn, also call EnableANSIColorConsole. However, all high-level functions in this library call it internally, so most of the time you do not need to worry about it."

PR #23 already added our own `EnableUTF8Console` (with the extra `SetTextCodePage(Output, CP_UTF8)` Delphi needs). The vendored library's version is idempotent, so we call it again at TUI startup as belt-and-suspenders — the high-level functions (`Box`, `Table`, `WriteHeader`, etc.) also call `EnableANSIColorConsole` internally as the article promises, so we don't sprinkle that one through every call site.

## Test plan

- [ ] Delphi Win64 build: `pasclaw tui` shows a boxed cyan header, `/help` opens a styled box, `/tools` renders a bordered table, a dotted spinner animates during the LLM call
- [ ] Delphi Linux64 build: same rendering (Posix branch of MVCFramework.Console)
- [ ] FPC build: line-based TUI still works identically to before
- [ ] FPC build does not try to compile `MVCFramework.Console.pas` (no `WinApi.Windows`/`Posix.Termios` errors)
- [ ] Ctrl-C during a spinner doesn't leave the cursor hidden

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_