### PR TITLE
Raise tool-loop cap and synthesize fallback when /v1/chat/completions returns empty content

### DIFF
--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -6,6 +6,7 @@
     pasclaw serve --no-tools              # disable built-in tool registry
     pasclaw serve --no-mcp                # skip MCP server discovery
     pasclaw serve --debug                 # log every request + response body
+    pasclaw serve --max-iter 40           # raise the tool-loop cap (default 25)
 
   Exposes POST /v1/chat/completions on the configured port. Any client
   that speaks the OpenAI Chat Completions API (openai-python, openai-node,
@@ -48,6 +49,7 @@ type
     NoMCP:   Boolean;
     NoTools: Boolean;
     Debug:   Boolean;
+    MaxIter: Integer;
   end;
 
 function ParseServe(const Argv: array of string; const Cfg: TConfig): TServeArgs;
@@ -59,6 +61,7 @@ begin
   Result.NoMCP   := False;
   Result.NoTools := False;
   Result.Debug   := False;
+  Result.MaxIter := 25;  { matches TGatewayServer.Create default }
   i := 0;
   while i <= High(Argv) do
   begin
@@ -68,8 +71,10 @@ begin
     if Argv[i] = '--no-tools' then begin Result.NoTools := True; Inc(i); Continue; end;
     if (Argv[i] = '--debug') or (Argv[i] = '-d') then
                                   begin Result.Debug   := True; Inc(i); Continue; end;
+    if Argv[i] = '--max-iter' then begin if i < High(Argv) then Result.MaxIter := StrToIntDef(Argv[i + 1], Result.MaxIter); Inc(i, 2); Continue; end;
     Inc(i);
   end;
+  if Result.MaxIter < 1 then Result.MaxIter := 1;
 end;
 
 function Cmd_Serve_Run(const Argv: array of string): Integer;
@@ -117,6 +122,7 @@ begin
 
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
     Server.DebugIO := Args.Debug;
+    Server.MaxIter := Args.MaxIter;
     try
       Server.Start(Args.Addr, Args.Port);
 
@@ -124,6 +130,7 @@ begin
       WriteLn(Ansi.Bold, 'OpenAI-compatible server up.', Ansi.Reset);
       WriteLn('  base_url: ', BaseURL);
       WriteLn('  model:    ', Cfg.DefaultModel);
+      WriteLn('  max-iter: ', Args.MaxIter);
       WriteLn;
       WriteLn(Ansi.Dim, '  Example (openai-python):', Ansi.Reset);
       WriteLn('    client = OpenAI(base_url="', BaseURL, '", api_key="sk-pasclaw")');

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -571,27 +571,36 @@ begin
     else
       FinishReason := 'stop';
 
-    { Synthesize a message when the loop exhausted MaxIterations on a
-      tool-use turn — Loop.Content is empty in that case because the
-      final assistant turn was tool calls, not text. Without this the
-      SSE stream goes out with an empty delta and clients (correctly)
-      report "stream ended without any text deltas." Surface the cap
-      hit as visible content + a synthetic finish_reason so the client
-      knows why it didn't get a real answer. }
-    if (Loop.Content = '') and (Loop.Iterations >= FMaxIter) then
+    { Tag cap-exhausted turns regardless of whether the model produced
+      pre-tool narration. The discriminator is the presence of pending
+      tool calls in the last response: RunToolLoop only exits via the
+      cap when the last turn had ToolCalls (otherwise it early-returns
+      cleanly). Iterations >= FMaxIter alone is ambiguous since a clean
+      completion on the very last allowed turn also reports that count.
+
+      When the cap is hit:
+        - empty Content -> the cap note is the whole message
+        - non-empty Content (model said "Let me check..." then called a
+          tool) -> keep the partial text and append the cap note. Set
+          finish_reason=length so clients don't treat a truncated tool
+          loop as a completed answer. }
+    if Length(Loop.LastResp.ToolCalls) > 0 then
     begin
-      Loop.Content := Format(
+      Loop.Content := Trim(Loop.Content);
+      if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
+      Loop.Content := Loop.Content + Format(
         '(reached MaxIterations=%d while the model was still calling tools; '+
-        'last finish_reason=%s — raise the --max-iter cap on `pasclaw serve` '+
-        'or reduce the task scope.)',
-        [FMaxIter, FinishReason]);
+        'last finish_reason=%s, %d pending tool call(s) — raise the --max-iter '+
+        'cap on `pasclaw serve` or reduce the task scope.)',
+        [FMaxIter, FinishReason, Length(Loop.LastResp.ToolCalls)]);
       FinishReason := 'length';
-      LogWarn('chat/completions: tool loop hit MaxIterations=%d with no final text', [FMaxIter]);
+      LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
+              [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
     end
     else if Loop.Content = '' then
     begin
-      { Empty content for any other reason still confuses streaming clients;
-        give them something so they can decide what to do. }
+      { Loop exited normally with no pending tool calls but the model
+        produced no text. Some streaming clients can't represent that. }
       Loop.Content := Format('(no content returned by the model; finish_reason=%s)',
                               [FinishReason]);
       LogWarn('chat/completions: empty content with finish=%s iterations=%d',

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -44,6 +44,7 @@ type
     FStarted:  Boolean;
     FStopFlag: TEvent;
     FDebugIO:  Boolean;
+    FMaxIter:  Integer;
     procedure OnCommandGet(AContext: TIdContext;
                            ARequest: TIdHTTPRequestInfo;
                            AResponse: TIdHTTPResponseInfo);
@@ -63,6 +64,10 @@ type
       and the response body via LogDebug. Off by default; the `serve`
       subcommand flips it on with --debug. }
     property DebugIO: Boolean read FDebugIO write FDebugIO;
+    { Cap on tool-loop iterations for /v1/chat/completions. Defaults to 25
+      to match what typical code agents need for read-debug-edit cycles;
+      legacy /v1/chat keeps its 8-iteration cap unchanged. }
+    property MaxIter: Integer read FMaxIter write FMaxIter;
     procedure Start(const BindAddr: string; Port: Integer);
     procedure Stop;
     procedure WaitForStop;
@@ -84,6 +89,7 @@ begin
   FCfg      := Cfg;
   FProvider := Provider;
   FRegistry := Registry;
+  FMaxIter  := 25;
   FStopFlag := TEvent.Create(nil, True, False, '');
   FHTTP := TIdHTTPServer.Create(nil);
   FHTTP.OnCommandGet := OnCommandGet;
@@ -538,7 +544,7 @@ begin
     LoopCfg.Provider      := FProvider;
     LoopCfg.Registry      := FRegistry;
     LoopCfg.Model         := ReqModel;
-    LoopCfg.MaxIterations := 8;
+    LoopCfg.MaxIterations := FMaxIter;
     LoopCfg.Options       := DefaultChatOptions;
     { Temperature: only forward if the client actually set it (>0). Avoids
       the deprecated-field 400 from newer Claude models when the OpenAI
@@ -564,6 +570,33 @@ begin
       FinishReason := Loop.LastResp.FinishReason
     else
       FinishReason := 'stop';
+
+    { Synthesize a message when the loop exhausted MaxIterations on a
+      tool-use turn — Loop.Content is empty in that case because the
+      final assistant turn was tool calls, not text. Without this the
+      SSE stream goes out with an empty delta and clients (correctly)
+      report "stream ended without any text deltas." Surface the cap
+      hit as visible content + a synthetic finish_reason so the client
+      knows why it didn't get a real answer. }
+    if (Loop.Content = '') and (Loop.Iterations >= FMaxIter) then
+    begin
+      Loop.Content := Format(
+        '(reached MaxIterations=%d while the model was still calling tools; '+
+        'last finish_reason=%s — raise the --max-iter cap on `pasclaw serve` '+
+        'or reduce the task scope.)',
+        [FMaxIter, FinishReason]);
+      FinishReason := 'length';
+      LogWarn('chat/completions: tool loop hit MaxIterations=%d with no final text', [FMaxIter]);
+    end
+    else if Loop.Content = '' then
+    begin
+      { Empty content for any other reason still confuses streaming clients;
+        give them something so they can decide what to do. }
+      Loop.Content := Format('(no content returned by the model; finish_reason=%s)',
+                              [FinishReason]);
+      LogWarn('chat/completions: empty content with finish=%s iterations=%d',
+              [FinishReason, Loop.Iterations]);
+    end;
 
     if FDebugIO then
       LogDebug('chat/completions: tool loop done iterations=%d in=%d out=%d finish=%s content=%s',

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -88,7 +88,12 @@ end;
 
 procedure TTUI.ShowHelp;
 var
-  Lines: TStringArray;
+  { Disambiguate: TStringArray is declared by both MVCFramework.Console
+    and PasClaw.Tools.Registry. Without the qualifier dcc64 picks the
+    last-imported (the MVC one) for locals but rejects the assignment
+    from FRegistry.Names below with E2010. Qualify each local with the
+    unit whose API consumes it. }
+  Lines: MVCFramework.Console.TStringArray;
 begin
   SetLength(Lines, 4);
   Lines[0] := '/help    show this panel';
@@ -100,9 +105,9 @@ end;
 
 procedure TTUI.ShowTools;
 var
-  Names: TStringArray;
-  Rows: TStringMatrix;
-  Headers: TStringArray;
+  Names: PasClaw.Tools.Registry.TStringArray;
+  Rows:  MVCFramework.Console.TStringMatrix;
+  Headers: MVCFramework.Console.TStringArray;
   i: Integer;
 begin
   if FRegistry = nil then


### PR DESCRIPTION
## Summary

Fixes the "stream ended without any text deltas" error your nanobot-style client reported. From your debug log:

```
[debug] chat/completions: tool loop done iterations=8 in=8124 out=86 finish=tool_use content=
[debug] chat/completions -> 200 SSE 371 bytes
```

`iterations=8` is the cap, `content=` is empty, `finish=tool_use` means the model was still calling tools when we hit the wall. The SSE stream went out with an empty `delta`, so the client correctly reported no text deltas.

Two compounding causes, both addressed:

### 1. MaxIterations was 8 (too tight for code-agent flows)

Your log showed 6 of 8 iterations were a single shell call each — normal for a build-debug-edit cycle. Bump the default to **25**, and expose it as a knob:

```
pasclaw serve --max-iter 40
```

Wired via a new `TGatewayServer.MaxIter` property. The legacy `/v1/chat` endpoint keeps its old 8-iter cap unchanged.

### 2. Empty-content fallback

When the cap is reached on a `tool_use` turn, `Loop.Content` is `''` because the last assistant turn carried tool_calls instead of text. We were shipping that empty string straight to the SSE stream. Now we synthesize a message:

```
(reached MaxIterations=25 while the model was still calling tools; last
finish_reason=tool_use — raise the --max-iter cap on `pasclaw serve` or
reduce the task scope.)
```

…and set `finish_reason=length` so OpenAI-style clients can recognize the truncation. Also covers the "model returned no content for some other reason" path with a parallel fallback.

`pasclaw serve` now prints the active cap on startup:

```
OpenAI-compatible server up.
  base_url: http://127.0.0.1:8088/v1
  model:    claude-opus-4-7
  max-iter: 25
```

## Test plan

- [ ] Same task that previously truncated at 8 iterations now completes within 25
- [ ] If a task still exceeds the cap, the client sees the synthetic message instead of empty content
- [ ] `pasclaw serve --max-iter 40` raises the cap and prints it in the startup banner
- [ ] `pasclaw serve --max-iter 0` clamps to 1 (sanity guard)
- [ ] Non-streaming (`stream:false`) requests get the same fallback content in the OpenAI `chat.completion` response

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_