### PR TITLE
Add hashline format + fs_edit_hashline + fs_grep built-in tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ UNIT_DIRS = \
 	src/pkg/membench \
 	src/pkg/tui \
 	src/pkg/platform \
+	src/pkg/hashline \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -42,6 +42,7 @@ type
     MaxIterations: Integer;
     NoTools:       Boolean;
     NoMCP:         Boolean;
+    NoHashline:    Boolean;
   end;
 
   TLoopHandlers = class
@@ -79,6 +80,7 @@ begin
   Result.MaxIterations := 8;
   Result.NoTools       := False;
   Result.NoMCP         := False;
+  Result.NoHashline    := False;
 end;
 
 function ParseArgs(const Argv: array of string; var A: TAgentArgs): Boolean;
@@ -101,8 +103,9 @@ begin
     if Argv[i] = '--thinking' then begin if i = High(Argv) then Exit(False); A.Thinking := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--max-tokens'     then begin if i = High(Argv) then Exit(False); A.MaxTokens     := StrToIntDef(Argv[i + 1], A.MaxTokens);     Inc(i, 2); Continue; end;
     if Argv[i] = '--max-iterations' then begin if i = High(Argv) then Exit(False); A.MaxIterations := StrToIntDef(Argv[i + 1], A.MaxIterations); Inc(i, 2); Continue; end;
-    if Argv[i] = '--no-tools' then begin A.NoTools := True; Inc(i); Continue; end;
-    if Argv[i] = '--no-mcp'   then begin A.NoMCP   := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-tools'    then begin A.NoTools    := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-mcp'      then begin A.NoMCP      := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-hashline' then begin A.NoHashline := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -121,12 +124,12 @@ begin
   Result := NewProviderFromConfig(Cfg, Name, Provider, Err);
 end;
 
-function NewBuiltinRegistry: TToolRegistry;
+function NewBuiltinRegistry(UseHashline: Boolean = True): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
   Result := TToolRegistry.Create;
-  RegisterFSTools(Result);
+  RegisterFSTools(Result, UseHashline);
   RegisterShellTool(Result);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(Result, Skills);
@@ -178,7 +181,7 @@ begin
   end;
 
   Reg := nil;
-  if not A.NoTools then Reg := NewBuiltinRegistry;
+  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Handlers := TLoopHandlers.Create;
   try
@@ -227,7 +230,7 @@ begin
 
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
   Reg := nil;
-  if not A.NoTools then Reg := NewBuiltinRegistry;
+  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Handlers := TLoopHandlers.Create;
   try

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -34,33 +34,36 @@ uses
 
 type
   TGwArgs = record
-    Addr:      string;
-    Port:      Integer;
-    Telegram:  Boolean;
-    Token:     string;
-    NoMCP:     Boolean;
-    NoTools:   Boolean;
+    Addr:        string;
+    Port:        Integer;
+    Telegram:    Boolean;
+    Token:       string;
+    NoMCP:       Boolean;
+    NoTools:     Boolean;
+    NoHashline:  Boolean;
   end;
 
 function ParseGw(const Argv: array of string; const Cfg: TConfig): TGwArgs;
 var
   i: Integer;
 begin
-  Result.Addr     := Cfg.Gateway.BindAddr;
-  Result.Port     := Cfg.Gateway.Port;
-  Result.Telegram := False;
-  Result.Token    := GetEnvironmentVariable('PASCLAW_TELEGRAM_TOKEN');
-  Result.NoMCP    := False;
-  Result.NoTools  := False;
+  Result.Addr       := Cfg.Gateway.BindAddr;
+  Result.Port       := Cfg.Gateway.Port;
+  Result.Telegram   := False;
+  Result.Token      := GetEnvironmentVariable('PASCLAW_TELEGRAM_TOKEN');
+  Result.NoMCP      := False;
+  Result.NoTools    := False;
+  Result.NoHashline := False;
   i := 0;
   while i <= High(Argv) do
   begin
-    if Argv[i] = '--addr'     then begin if i < High(Argv) then Result.Addr     := Argv[i + 1]; Inc(i, 2); Continue; end;
-    if Argv[i] = '--port'     then begin if i < High(Argv) then Result.Port     := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
-    if Argv[i] = '--telegram' then begin Result.Telegram := True; Inc(i); Continue; end;
-    if Argv[i] = '--token'    then begin if i < High(Argv) then Result.Token    := Argv[i + 1]; Inc(i, 2); Continue; end;
-    if Argv[i] = '--no-mcp'   then begin Result.NoMCP    := True; Inc(i); Continue; end;
-    if Argv[i] = '--no-tools' then begin Result.NoTools  := True; Inc(i); Continue; end;
+    if Argv[i] = '--addr'         then begin if i < High(Argv) then Result.Addr     := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--port'         then begin if i < High(Argv) then Result.Port     := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
+    if Argv[i] = '--telegram'     then begin Result.Telegram   := True; Inc(i); Continue; end;
+    if Argv[i] = '--token'        then begin if i < High(Argv) then Result.Token    := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-mcp'       then begin Result.NoMCP      := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-tools'     then begin Result.NoTools    := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -91,7 +94,7 @@ begin
     if not Args.NoTools then
     begin
       Reg := TToolRegistry.Create;
-      RegisterFSTools(Reg);
+      RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -7,6 +7,7 @@
     pasclaw serve --no-mcp                # skip MCP server discovery
     pasclaw serve --debug                 # log every request + response body
     pasclaw serve --max-iter 40           # raise the tool-loop cap (default 25)
+    pasclaw serve --no-hashline           # raw fs_read; skip fs_edit_hashline + fs_grep
 
   Exposes POST /v1/chat/completions on the configured port. Any client
   that speaks the OpenAI Chat Completions API (openai-python, openai-node,
@@ -44,34 +45,37 @@ uses
 
 type
   TServeArgs = record
-    Addr:    string;
-    Port:    Integer;
-    NoMCP:   Boolean;
-    NoTools: Boolean;
-    Debug:   Boolean;
-    MaxIter: Integer;
+    Addr:        string;
+    Port:        Integer;
+    NoMCP:       Boolean;
+    NoTools:     Boolean;
+    Debug:       Boolean;
+    MaxIter:     Integer;
+    NoHashline:  Boolean;
   end;
 
 function ParseServe(const Argv: array of string; const Cfg: TConfig): TServeArgs;
 var
   i: Integer;
 begin
-  Result.Addr    := Cfg.Gateway.BindAddr;
-  Result.Port    := Cfg.Gateway.Port;
-  Result.NoMCP   := False;
-  Result.NoTools := False;
-  Result.Debug   := False;
-  Result.MaxIter := 25;  { matches TGatewayServer.Create default }
+  Result.Addr       := Cfg.Gateway.BindAddr;
+  Result.Port       := Cfg.Gateway.Port;
+  Result.NoMCP      := False;
+  Result.NoTools    := False;
+  Result.Debug      := False;
+  Result.MaxIter    := 25;  { matches TGatewayServer.Create default }
+  Result.NoHashline := False;
   i := 0;
   while i <= High(Argv) do
   begin
-    if Argv[i] = '--addr'     then begin if i < High(Argv) then Result.Addr := Argv[i + 1]; Inc(i, 2); Continue; end;
-    if Argv[i] = '--port'     then begin if i < High(Argv) then Result.Port := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
-    if Argv[i] = '--no-mcp'   then begin Result.NoMCP   := True; Inc(i); Continue; end;
-    if Argv[i] = '--no-tools' then begin Result.NoTools := True; Inc(i); Continue; end;
+    if Argv[i] = '--addr'         then begin if i < High(Argv) then Result.Addr := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--port'         then begin if i < High(Argv) then Result.Port := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-mcp'       then begin Result.NoMCP      := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-tools'     then begin Result.NoTools    := True; Inc(i); Continue; end;
     if (Argv[i] = '--debug') or (Argv[i] = '-d') then
-                                  begin Result.Debug   := True; Inc(i); Continue; end;
-    if Argv[i] = '--max-iter' then begin if i < High(Argv) then Result.MaxIter := StrToIntDef(Argv[i + 1], Result.MaxIter); Inc(i, 2); Continue; end;
+                                      begin Result.Debug       := True; Inc(i); Continue; end;
+    if Argv[i] = '--max-iter'     then begin if i < High(Argv) then Result.MaxIter := StrToIntDef(Argv[i + 1], Result.MaxIter); Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
     Inc(i);
   end;
   if Result.MaxIter < 1 then Result.MaxIter := 1;
@@ -108,7 +112,7 @@ begin
     if not Args.NoTools then
     begin
       Reg := TToolRegistry.Create;
-      RegisterFSTools(Reg);
+      RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -30,10 +30,11 @@ uses
 
 type
   TTUIArgs = record
-    Model:    string;
-    Provider: string;
-    NoMCP:    Boolean;
-    NoTools:  Boolean;
+    Model:       string;
+    Provider:    string;
+    NoMCP:       Boolean;
+    NoTools:     Boolean;
+    NoHashline:  Boolean;
   end;
 
 function ParseArgs(const Argv: array of string; var A: TTUIArgs): Boolean;
@@ -41,14 +42,15 @@ var
   i: Integer;
 begin
   Result := True;
-  A.Model := ''; A.Provider := ''; A.NoMCP := False; A.NoTools := False;
+  A.Model := ''; A.Provider := ''; A.NoMCP := False; A.NoTools := False; A.NoHashline := False;
   i := 0;
   while i <= High(Argv) do
   begin
-    if Argv[i] = '--model'    then begin if i = High(Argv) then Exit(False); A.Model    := Argv[i + 1]; Inc(i, 2); Continue; end;
-    if Argv[i] = '--provider' then begin if i = High(Argv) then Exit(False); A.Provider := Argv[i + 1]; Inc(i, 2); Continue; end;
-    if Argv[i] = '--no-mcp'   then begin A.NoMCP   := True; Inc(i); Continue; end;
-    if Argv[i] = '--no-tools' then begin A.NoTools := True; Inc(i); Continue; end;
+    if Argv[i] = '--model'        then begin if i = High(Argv) then Exit(False); A.Model    := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--provider'     then begin if i = High(Argv) then Exit(False); A.Provider := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--no-mcp'       then begin A.NoMCP      := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-tools'     then begin A.NoTools    := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-hashline'  then begin A.NoHashline := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -78,7 +80,7 @@ begin
     if not A.NoTools then
     begin
       Reg := TToolRegistry.Create;
-      RegisterFSTools(Reg);
+      RegisterFSTools(Reg, not A.NoHashline);
       RegisterShellTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -206,6 +206,9 @@
 
         <!-- pkg/platform -->
         <DCCReference Include="..\pkg\platform\PasClaw.Platform.pas"/>
+
+        <!-- pkg/hashline -->
+        <DCCReference Include="..\pkg\hashline\PasClaw.Hashline.pas"/>
 
         <!-- pkg/vendor/dmvcframework (Apache-2.0, Delphi-only) -->
         <DCCReference Include="..\pkg\vendor\dmvcframework\LoggerPro.AnsiColors.pas"/>

--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -1,0 +1,762 @@
+(*
+  PasClaw.Hashline - hashline diff format port for built-in fs tools.
+
+  Hashline lets the model identify "which line to edit" by stable line-number
+  anchors instead of perfect-text reproduction (which fails ~half the time
+  with str_replace under spec compression). Pure-Pascal port of the format
+  primitives from oh-my-pi (Apache-2.0).
+
+  Read tool emits per file:
+      ¶path/to/file#abcd
+      1:first line
+      2:second line
+      ...
+
+  The "abcd" is xxHash32(normalized_content, 0) & 0xffff, hex-padded to 4
+  chars, so it's cheap, deterministic, and forwards-compatible with the
+  upstream TS hash if anyone ever wants to share patches between tools.
+
+  Edit tool accepts a patch shaped like:
+      ¶path/to/file#abcd
+      42:               <- anchor (a single line number or N-M range)
+      |new replacement line(s)
+      ↑a line inserted ABOVE the anchor
+      ↓a line inserted BELOW the anchor
+
+  The applier validates the header hash matches the file on disk so stale
+  edits abort instead of corrupting unrelated text.
+
+  Recovery heuristics (boundary-dup auto-absorb, structural-bracket fixups,
+  comment line skipping) from upstream are deliberately omitted in this port;
+  they only matter once production traffic surfaces the failure modes they
+  were written to handle. The format and the basic apply path are
+  faithful so we can add them incrementally.
+*)
+unit PasClaw.Hashline;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+const
+  { Use literal Unicode characters so each compiler stores them in its
+    native `string` form: Delphi UnicodeString = one WideChar per
+    codepoint, FPC {$MODE DELPHI} {$H+} = UTF-8 AnsiString = multi-byte
+    encoding. Length() and Copy() are unit-consistent per compiler
+    (chars in Delphi, bytes in FPC), so the same parsing code works
+    in both. }
+  HL_FILE_PREFIX     = '¶';
+  HL_FILE_HASH_SEP   = '#';
+  HL_LINE_BODY_SEP   = ':';
+  HL_OP_REPLACE      = ':';
+  HL_PAYLOAD_REPLACE = '|';
+  HL_PAYLOAD_ABOVE   = '↑';
+  HL_PAYLOAD_BELOW   = '↓';
+  HL_FILE_HASH_LEN   = 4;
+
+type
+  THLPayloadKind = (hpkReplace, hpkAbove, hpkBelow);
+
+  THLEditKind = (hekInsert, hekDelete);
+
+  THLAnchor = record
+    LineNum: Integer;       { 1-indexed }
+  end;
+
+  THLEdit = record
+    Kind:        THLEditKind;
+    Anchor:      THLAnchor; { for Delete; for Insert when Cursor is before/after }
+    Text:        string;    { for Insert }
+    PayloadKind: THLPayloadKind;
+    SourceLine:  Integer;   { line number in the patch text, for diagnostics }
+  end;
+
+  THLEditArray = array of THLEdit;
+
+  THLSection = record
+    Path:         string;
+    HasFileHash:  Boolean;
+    FileHash:     string;
+    Edits:        THLEditArray;
+  end;
+
+  THLSectionArray = array of THLSection;
+
+{ Low-level format helpers. }
+function ComputeFileHash(const Content: string): string;
+function FormatHashlineHeader(const FilePath, FileHash: string): string;
+function FormatNumberedLine(LineNumber: Integer; const LineText: string): string;
+function FormatNumberedLines(const Text: string; StartLine: Integer): string;
+function FormatHashlineRead(const FilePath, Content: string): string;
+
+{ Returns True if every non-empty content line in the input carries the
+  `LINENO:` prefix; in that case the prefixes are stripped in place.
+  Used by fs_write to defend against the model echoing read-output prefixes
+  back into a file body. }
+function StripHashlinePrefixes(var Lines: TStringList): Boolean;
+
+{ Patch parser + applier. The high-level entry point reads the file,
+  validates the header hash, applies the edits, and returns the new text.
+  ErrMsg carries any structural complaint; the file is never partially
+  written. }
+function ParseHashlinePatch(const PatchText: string;
+                            out Sections: THLSectionArray;
+                            out ErrMsg: string): Boolean;
+function ApplyHashlineEdits(const Original: string;
+                            const Edits: THLEditArray;
+                            out NewText: string;
+                            out ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  Math;
+
+{ ============================ xxHash32 =========================== }
+{ Lightweight 32-bit xxHash implementation matching upstream Bun.hash so
+  hashes are interchangeable. Operates on a TBytes buffer to avoid the
+  AnsiString/UnicodeString divergence between FPC and Delphi. }
+
+const
+  PRIME32_1 : Cardinal = 2654435761;
+  PRIME32_2 : Cardinal = 2246822519;
+  PRIME32_3 : Cardinal = 3266489917;
+  PRIME32_4 : Cardinal =  668265263;
+  PRIME32_5 : Cardinal =  374761393;
+
+function RotL32(X: Cardinal; N: Byte): Cardinal; inline;
+begin
+  Result := (X shl N) or (X shr (32 - N));
+end;
+
+function ReadLE32(const Data: TBytes; Pos: Integer): Cardinal; inline;
+begin
+  Result := Cardinal(Data[Pos])
+         or (Cardinal(Data[Pos + 1]) shl 8)
+         or (Cardinal(Data[Pos + 2]) shl 16)
+         or (Cardinal(Data[Pos + 3]) shl 24);
+end;
+
+function XXHash32(const Data: TBytes; Seed: Cardinal): Cardinal;
+var
+  v1, v2, v3, v4, h32: Cardinal;
+  len, p, limit: Integer;
+begin
+  len := Length(Data);
+  p := 0;
+  if len >= 16 then
+  begin
+    v1 := Seed + PRIME32_1 + PRIME32_2;
+    v2 := Seed + PRIME32_2;
+    v3 := Seed;
+    v4 := Seed - PRIME32_1;
+    limit := len - 16;
+    while p <= limit do
+    begin
+      v1 := v1 + ReadLE32(Data, p     ) * PRIME32_2; v1 := RotL32(v1, 13); v1 := v1 * PRIME32_1;
+      v2 := v2 + ReadLE32(Data, p +  4) * PRIME32_2; v2 := RotL32(v2, 13); v2 := v2 * PRIME32_1;
+      v3 := v3 + ReadLE32(Data, p +  8) * PRIME32_2; v3 := RotL32(v3, 13); v3 := v3 * PRIME32_1;
+      v4 := v4 + ReadLE32(Data, p + 12) * PRIME32_2; v4 := RotL32(v4, 13); v4 := v4 * PRIME32_1;
+      Inc(p, 16);
+    end;
+    h32 := RotL32(v1, 1) + RotL32(v2, 7) + RotL32(v3, 12) + RotL32(v4, 18);
+  end
+  else
+    h32 := Seed + PRIME32_5;
+
+  h32 := h32 + Cardinal(len);
+
+  while p + 4 <= len do
+  begin
+    h32 := h32 + ReadLE32(Data, p) * PRIME32_3;
+    h32 := RotL32(h32, 17) * PRIME32_4;
+    Inc(p, 4);
+  end;
+  while p < len do
+  begin
+    h32 := h32 + Cardinal(Data[p]) * PRIME32_5;
+    h32 := RotL32(h32, 11) * PRIME32_1;
+    Inc(p);
+  end;
+
+  h32 := h32 xor (h32 shr 15);
+  h32 := h32 * PRIME32_2;
+  h32 := h32 xor (h32 shr 13);
+  h32 := h32 * PRIME32_3;
+  h32 := h32 xor (h32 shr 16);
+
+  Result := h32;
+end;
+
+{ ====================== Normalization + hashing ====================== }
+
+function NormalizeForHash(const Text: string): string;
+{ Match upstream: strip CR, trim each line's trailing whitespace, rejoin
+  with LF. Keeps anchors stable across CRLF/LF mixes and editors that
+  trim on save. }
+var
+  Lines: TStringList;
+  i: Integer;
+  Tmp: string;
+begin
+  Tmp := StringReplace(Text, #13, '', [rfReplaceAll]);
+  Lines := TStringList.Create;
+  try
+    Lines.LineBreak := #10;
+    Lines.StrictDelimiter := True;
+    Lines.Text := Tmp;
+    for i := 0 to Lines.Count - 1 do
+      Lines[i] := TrimRight(Lines[i]);
+    Result := Lines.Text;
+    { TStringList.Text may append a trailing LF; trim it if Text didn't. }
+    if (Length(Tmp) = 0) or ((Tmp[Length(Tmp)] <> #10)) then
+      if (Length(Result) > 0) and (Result[Length(Result)] = #10) then
+        SetLength(Result, Length(Result) - 1);
+  finally
+    Lines.Free;
+  end;
+end;
+
+function ComputeFileHash(const Content: string): string;
+var
+  Norm: string;
+  Bytes: TBytes;
+  Hash: Cardinal;
+  Low16: Cardinal;
+begin
+  Norm := NormalizeForHash(Content);
+  Bytes := TEncoding.UTF8.GetBytes(Norm);
+  Hash := XXHash32(Bytes, 0);
+  Low16 := Hash and $FFFF;
+  Result := LowerCase(IntToHex(Integer(Low16), HL_FILE_HASH_LEN));
+end;
+
+{ ========================== Format helpers ========================== }
+
+function FormatHashlineHeader(const FilePath, FileHash: string): string;
+begin
+  Result := HL_FILE_PREFIX + FilePath + HL_FILE_HASH_SEP + FileHash;
+end;
+
+function FormatNumberedLine(LineNumber: Integer; const LineText: string): string;
+begin
+  Result := IntToStr(LineNumber) + HL_LINE_BODY_SEP + LineText;
+end;
+
+function FormatNumberedLines(const Text: string; StartLine: Integer): string;
+var
+  Lines: TStringList;
+  i: Integer;
+  Sb: TStringBuilder;
+begin
+  Lines := TStringList.Create;
+  Sb := TStringBuilder.Create;
+  try
+    Lines.LineBreak := #10;
+    Lines.StrictDelimiter := True;
+    Lines.Text := StringReplace(Text, #13, '', [rfReplaceAll]);
+    for i := 0 to Lines.Count - 1 do
+    begin
+      if i > 0 then Sb.Append(#10);
+      Sb.Append(FormatNumberedLine(StartLine + i, Lines[i]));
+    end;
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+    Lines.Free;
+  end;
+end;
+
+function FormatHashlineRead(const FilePath, Content: string): string;
+begin
+  Result := FormatHashlineHeader(FilePath, ComputeFileHash(Content)) + #10 +
+            FormatNumberedLines(Content, 1);
+end;
+
+{ ====================== Prefix stripping (defensive) ====================== }
+
+function LineLooksHashlinePrefixed(const Line: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  if Line = '' then Exit;
+  i := 1;
+  while (i <= Length(Line)) and (Line[i] = ' ') do Inc(i);
+  if (i > Length(Line)) or not ((Line[i] >= '0') and (Line[i] <= '9')) then Exit;
+  while (i <= Length(Line)) and (Line[i] >= '0') and (Line[i] <= '9') do Inc(i);
+  Result := (i <= Length(Line)) and (Line[i] = ':');
+end;
+
+function StripPrefixFromLine(const Line: string): string;
+var
+  i: Integer;
+begin
+  i := 1;
+  while (i <= Length(Line)) and (Line[i] = ' ') do Inc(i);
+  while (i <= Length(Line)) and (Line[i] >= '0') and (Line[i] <= '9') do Inc(i);
+  if (i <= Length(Line)) and (Line[i] = ':') then Inc(i);
+  Result := Copy(Line, i, MaxInt);
+end;
+
+function StripHashlinePrefixes(var Lines: TStringList): Boolean;
+var
+  i, NonEmpty, Prefixed: Integer;
+begin
+  Result := False;
+  NonEmpty := 0;
+  Prefixed := 0;
+  for i := 0 to Lines.Count - 1 do
+    if Trim(Lines[i]) <> '' then
+    begin
+      Inc(NonEmpty);
+      if LineLooksHashlinePrefixed(Lines[i]) then Inc(Prefixed);
+    end;
+  if (NonEmpty = 0) or (Prefixed < NonEmpty) then Exit;
+  for i := 0 to Lines.Count - 1 do
+    if LineLooksHashlinePrefixed(Lines[i]) then
+      Lines[i] := StripPrefixFromLine(Lines[i]);
+  Result := True;
+end;
+
+{ ============================ Patch parser ============================ }
+
+type
+  TPendingBlock = record
+    HasAnchor:   Boolean;
+    RangeStart:  Integer;
+    RangeEnd:    Integer;
+    SourceLine:  Integer;
+    Replaces:    array of string;
+    AboveLines:  array of string;
+    BelowLines:  array of string;
+  end;
+
+procedure ResetBlock(var B: TPendingBlock);
+begin
+  B.HasAnchor   := False;
+  B.RangeStart  := 0;
+  B.RangeEnd    := 0;
+  B.SourceLine  := 0;
+  SetLength(B.Replaces,   0);
+  SetLength(B.AboveLines, 0);
+  SetLength(B.BelowLines, 0);
+end;
+
+function StartsWith(const S, Prefix: string): Boolean; inline;
+begin
+  Result := (Length(S) >= Length(Prefix)) and
+            (Copy(S, 1, Length(Prefix)) = Prefix);
+end;
+
+function TryParseAnchor(const Line: string; out RangeStart, RangeEnd: Integer): Boolean;
+{ Anchor lines look like `42:` or `7-10:` (with optional decoration like
+  `>` or `*` that we ignore). Returns False for anything else. }
+var
+  i, n: Integer;
+  StartStr, EndStr: string;
+begin
+  Result := False;
+  RangeStart := 0;
+  RangeEnd := 0;
+  n := Length(Line);
+  i := 1;
+  while (i <= n) and ((Line[i] = ' ') or (Line[i] = #9) or
+                       (Line[i] = '>') or (Line[i] = '-') or (Line[i] = '*')) do Inc(i);
+  if (i > n) or not ((Line[i] >= '1') and (Line[i] <= '9')) then Exit;
+  StartStr := '';
+  while (i <= n) and (Line[i] >= '0') and (Line[i] <= '9') do
+  begin
+    StartStr := StartStr + Line[i];
+    Inc(i);
+  end;
+  if (i <= n) and (Line[i] = '-') then
+  begin
+    Inc(i);
+    EndStr := '';
+    while (i <= n) and (Line[i] >= '0') and (Line[i] <= '9') do
+    begin
+      EndStr := EndStr + Line[i];
+      Inc(i);
+    end;
+  end
+  else
+    EndStr := StartStr;
+  if (i > n) or (Line[i] <> ':') then Exit;
+  { trailing chars (we tolerate trailing spaces only) }
+  Inc(i);
+  while (i <= n) and (Line[i] = ' ') do Inc(i);
+  if i <= n then Exit;
+  RangeStart := StrToIntDef(StartStr, 0);
+  RangeEnd   := StrToIntDef(EndStr,   0);
+  Result := (RangeStart > 0) and (RangeEnd >= RangeStart);
+end;
+
+function TryParsePayload(const Line: string; out Kind: THLPayloadKind;
+                         out Body: string): Boolean;
+begin
+  Result := True;
+  if StartsWith(Line, HL_PAYLOAD_ABOVE) then
+  begin
+    Kind := hpkAbove;
+    Body := Copy(Line, Length(HL_PAYLOAD_ABOVE) + 1, MaxInt);
+  end
+  else if StartsWith(Line, HL_PAYLOAD_BELOW) then
+  begin
+    Kind := hpkBelow;
+    Body := Copy(Line, Length(HL_PAYLOAD_BELOW) + 1, MaxInt);
+  end
+  else if (Line <> '') and (Line[1] = HL_PAYLOAD_REPLACE) then
+  begin
+    Kind := hpkReplace;
+    Body := Copy(Line, 2, MaxInt);
+  end
+  else
+    Result := False;
+end;
+
+function TryParseHeader(const Line: string; out Path, Hash: string;
+                        out HasHash: Boolean): Boolean;
+{ Header looks like `¶path/to/file` or `¶path/to/file#abcd`. }
+var
+  Body: string;
+  Sep: Integer;
+begin
+  Result := False;
+  Path := '';
+  Hash := '';
+  HasHash := False;
+  if not StartsWith(Line, HL_FILE_PREFIX) then Exit;
+  Body := TrimRight(Copy(Line, Length(HL_FILE_PREFIX) + 1, MaxInt));
+  if Body = '' then Exit;
+  Sep := -1;
+  if Length(Body) > HL_FILE_HASH_LEN then
+    if Body[Length(Body) - HL_FILE_HASH_LEN] = HL_FILE_HASH_SEP then
+      Sep := Length(Body) - HL_FILE_HASH_LEN;
+  if Sep > 0 then
+  begin
+    Path := Copy(Body, 1, Sep - 1);
+    Hash := LowerCase(Copy(Body, Sep + 1, HL_FILE_HASH_LEN));
+    HasHash := True;
+  end
+  else
+    Path := Body;
+  Result := Path <> '';
+end;
+
+procedure FlushBlock(var B: TPendingBlock; var Edits: THLEditArray);
+var
+  i, Idx: Integer;
+begin
+  if not B.HasAnchor then Exit;
+  { Above-inserts go in front of the anchor. }
+  for i := 0 to High(B.AboveLines) do
+  begin
+    Idx := Length(Edits);
+    SetLength(Edits, Idx + 1);
+    Edits[Idx].Kind        := hekInsert;
+    Edits[Idx].Anchor.LineNum := B.RangeStart;
+    Edits[Idx].PayloadKind := hpkAbove;
+    Edits[Idx].Text        := B.AboveLines[i];
+    Edits[Idx].SourceLine  := B.SourceLine;
+  end;
+  { Replace = delete the anchored range + insert payloads in its place. }
+  if Length(B.Replaces) > 0 then
+  begin
+    for i := B.RangeStart to B.RangeEnd do
+    begin
+      Idx := Length(Edits);
+      SetLength(Edits, Idx + 1);
+      Edits[Idx].Kind        := hekDelete;
+      Edits[Idx].Anchor.LineNum := i;
+      Edits[Idx].PayloadKind := hpkReplace;
+      Edits[Idx].SourceLine  := B.SourceLine;
+    end;
+    for i := 0 to High(B.Replaces) do
+    begin
+      Idx := Length(Edits);
+      SetLength(Edits, Idx + 1);
+      Edits[Idx].Kind        := hekInsert;
+      Edits[Idx].Anchor.LineNum := B.RangeStart;
+      Edits[Idx].PayloadKind := hpkReplace;
+      Edits[Idx].Text        := B.Replaces[i];
+      Edits[Idx].SourceLine  := B.SourceLine;
+    end;
+  end;
+  { Below-inserts go after the last anchor line. }
+  for i := 0 to High(B.BelowLines) do
+  begin
+    Idx := Length(Edits);
+    SetLength(Edits, Idx + 1);
+    Edits[Idx].Kind        := hekInsert;
+    Edits[Idx].Anchor.LineNum := B.RangeEnd + 1;
+    Edits[Idx].PayloadKind := hpkBelow;
+    Edits[Idx].Text        := B.BelowLines[i];
+    Edits[Idx].SourceLine  := B.SourceLine;
+  end;
+  ResetBlock(B);
+end;
+
+function ParseHashlinePatch(const PatchText: string;
+                            out Sections: THLSectionArray;
+                            out ErrMsg: string): Boolean;
+var
+  Lines: TStringList;
+  i, SectionIdx: Integer;
+  Block: TPendingBlock;
+  CurEdits: THLEditArray;
+  Path, Hash, Body: string;
+  HasHash, Started: Boolean;
+  Kind: THLPayloadKind;
+  RangeStart, RangeEnd: Integer;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Sections, 0);
+  SectionIdx := -1;
+  Started := False;
+  ResetBlock(Block);
+  SetLength(CurEdits, 0);
+  Lines := TStringList.Create;
+  try
+    Lines.LineBreak := #10;
+    Lines.StrictDelimiter := True;
+    Lines.Text := StringReplace(PatchText, #13, '', [rfReplaceAll]);
+    for i := 0 to Lines.Count - 1 do
+    begin
+      if TryParseHeader(Lines[i], Path, Hash, HasHash) then
+      begin
+        if Started then
+        begin
+          FlushBlock(Block, CurEdits);
+          Sections[SectionIdx].Edits := CurEdits;
+          SetLength(CurEdits, 0);
+        end;
+        Inc(SectionIdx);
+        SetLength(Sections, SectionIdx + 1);
+        Sections[SectionIdx].Path        := Path;
+        Sections[SectionIdx].FileHash    := Hash;
+        Sections[SectionIdx].HasFileHash := HasHash;
+        Started := True;
+        Continue;
+      end;
+      if not Started then
+      begin
+        { Ignore leading whitespace/comment lines outside a section. }
+        if Trim(Lines[i]) = '' then Continue;
+        if (Lines[i] <> '') and (Lines[i][1] = '#') then Continue;
+        ErrMsg := Format('line %d: content before any %sPATH header', [i + 1, HL_FILE_PREFIX]);
+        Exit;
+      end;
+      if TryParseAnchor(Lines[i], RangeStart, RangeEnd) then
+      begin
+        FlushBlock(Block, CurEdits);
+        Block.HasAnchor  := True;
+        Block.RangeStart := RangeStart;
+        Block.RangeEnd   := RangeEnd;
+        Block.SourceLine := i + 1;
+        Continue;
+      end;
+      if TryParsePayload(Lines[i], Kind, Body) then
+      begin
+        if not Block.HasAnchor then
+        begin
+          ErrMsg := Format('line %d: payload without an anchor', [i + 1]);
+          Exit;
+        end;
+        case Kind of
+          hpkReplace:
+            begin
+              SetLength(Block.Replaces, Length(Block.Replaces) + 1);
+              Block.Replaces[High(Block.Replaces)] := Body;
+            end;
+          hpkAbove:
+            begin
+              SetLength(Block.AboveLines, Length(Block.AboveLines) + 1);
+              Block.AboveLines[High(Block.AboveLines)] := Body;
+            end;
+          hpkBelow:
+            begin
+              SetLength(Block.BelowLines, Length(Block.BelowLines) + 1);
+              Block.BelowLines[High(Block.BelowLines)] := Body;
+            end;
+        end;
+        Continue;
+      end;
+      if Trim(Lines[i]) = '' then Continue;
+      if (Lines[i] <> '') and (Lines[i][1] = '#') then Continue;
+      ErrMsg := Format('line %d: unrecognized content %s', [i + 1, QuotedStr(Lines[i])]);
+      Exit;
+    end;
+    if Started then
+    begin
+      FlushBlock(Block, CurEdits);
+      Sections[SectionIdx].Edits := CurEdits;
+    end;
+    Result := True;
+  finally
+    Lines.Free;
+  end;
+end;
+
+{ ============================ Patch applier ============================ }
+
+function ApplyHashlineEdits(const Original: string;
+                            const Edits: THLEditArray;
+                            out NewText: string;
+                            out ErrMsg: string): Boolean;
+{ Two-pass apply:
+    1. Walk edits in source order; mark deletes and bucket inserts by
+       (anchor-line, position-relative-to-anchor).
+    2. Rebuild output line-by-line: for each kept original line, emit
+       before-inserts -> the line itself -> after-inserts. Pure-insert
+       blocks at line N stash their payload into the same buckets. }
+var
+  Src: TStringList;
+  Deletes: array of Boolean;
+  Before:  array of TStringList;
+  After:   array of TStringList;
+  Sb: TStringBuilder;
+  Norm: string;
+  i, j, N: Integer;
+  E: THLEdit;
+  Idx: Integer;
+  HadTrailingNewline: Boolean;
+begin
+  Result := False;
+  ErrMsg := '';
+  Norm := StringReplace(Original, #13, '', [rfReplaceAll]);
+  HadTrailingNewline := (Norm <> '') and (Norm[Length(Norm)] = #10);
+
+  Src := TStringList.Create;
+  Sb  := nil;
+  try
+    Src.LineBreak := #10;
+    Src.StrictDelimiter := True;
+    Src.Text := Norm;
+    N := Src.Count;
+
+    SetLength(Deletes, N);
+    SetLength(Before,  N + 2);
+    SetLength(After,   N + 2);
+    for i := 0 to N - 1 do Deletes[i] := False;
+
+    for i := 0 to High(Edits) do
+    begin
+      E := Edits[i];
+      case E.Kind of
+        hekDelete:
+          begin
+            Idx := E.Anchor.LineNum - 1;
+            if (Idx < 0) or (Idx >= N) then
+            begin
+              ErrMsg := Format('patch line %d: delete anchor %d out of range (file has %d lines)',
+                               [E.SourceLine, E.Anchor.LineNum, N]);
+              Exit;
+            end;
+            Deletes[Idx] := True;
+          end;
+        hekInsert:
+          begin
+            Idx := E.Anchor.LineNum - 1;
+            case E.PayloadKind of
+              hpkAbove, hpkReplace:
+                begin
+                  if (Idx < 0) or (Idx >= N) then
+                  begin
+                    if Idx = N then { allow insert past end as "append" }
+                    begin
+                      if After[N] = nil then After[N] := TStringList.Create;
+                      After[N].Add(E.Text);
+                    end
+                    else
+                    begin
+                      ErrMsg := Format('patch line %d: insert anchor %d out of range (file has %d lines)',
+                                       [E.SourceLine, E.Anchor.LineNum, N]);
+                      Exit;
+                    end;
+                  end
+                  else
+                  begin
+                    if Before[Idx] = nil then Before[Idx] := TStringList.Create;
+                    Before[Idx].Add(E.Text);
+                  end;
+                end;
+              hpkBelow:
+                begin
+                  { Anchor.LineNum is RangeEnd+1; emit after the previous line. }
+                  if (Idx - 1 < 0) or (Idx - 1 >= N) then
+                  begin
+                    if Idx - 1 = N - 1 then
+                    begin
+                      if After[N - 1] = nil then After[N - 1] := TStringList.Create;
+                      After[N - 1].Add(E.Text);
+                    end
+                    else if Idx = N then
+                    begin
+                      if After[N - 1] = nil then After[N - 1] := TStringList.Create;
+                      After[N - 1].Add(E.Text);
+                    end
+                    else
+                    begin
+                      ErrMsg := Format('patch line %d: below-insert anchor %d out of range',
+                                       [E.SourceLine, E.Anchor.LineNum]);
+                      Exit;
+                    end;
+                  end
+                  else
+                  begin
+                    if After[Idx - 1] = nil then After[Idx - 1] := TStringList.Create;
+                    After[Idx - 1].Add(E.Text);
+                  end;
+                end;
+            end;
+          end;
+      end;
+    end;
+
+    Sb := TStringBuilder.Create;
+    for i := 0 to N - 1 do
+    begin
+      if (Before[i] <> nil) then
+        for j := 0 to Before[i].Count - 1 do
+        begin
+          if Sb.Length > 0 then Sb.Append(#10);
+          Sb.Append(Before[i][j]);
+        end;
+      if not Deletes[i] then
+      begin
+        if Sb.Length > 0 then Sb.Append(#10);
+        Sb.Append(Src[i]);
+      end;
+      if (After[i] <> nil) then
+        for j := 0 to After[i].Count - 1 do
+        begin
+          if Sb.Length > 0 then Sb.Append(#10);
+          Sb.Append(After[i][j]);
+        end;
+    end;
+    { Trailing After[N] catches pure-append inserts. }
+    if (After[N] <> nil) then
+      for j := 0 to After[N].Count - 1 do
+      begin
+        if Sb.Length > 0 then Sb.Append(#10);
+        Sb.Append(After[N][j]);
+      end;
+    NewText := Sb.ToString;
+    if HadTrailingNewline and ((NewText = '') or (NewText[Length(NewText)] <> #10)) then
+      NewText := NewText + #10;
+    Result := True;
+  finally
+    for i := 0 to High(Before) do if Before[i] <> nil then Before[i].Free;
+    for i := 0 to High(After)  do if After[i]  <> nil then After[i].Free;
+    if Sb <> nil then Sb.Free;
+    Src.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -140,11 +140,22 @@ end;
 function Tool_FSEditHashline(const ArgsJSON: string; out ErrMsg: string): string;
 { Apply a hashline-format patch to one or more files. The patch text carries
   its own ¶path#hash headers; we read each referenced file, validate the
-  header hash matches what's on disk, apply the edits, and write back. }
+  header hash matches what's on disk, apply the edits to an in-memory
+  buffer, and only write any file once every section has validated and
+  applied successfully. That keeps the stale-or-out-of-range abort path
+  truly all-or-nothing — a later section failing can't leave an earlier
+  section's file mutated. }
+type
+  TPlan = record
+    Path:      string;
+    NewBody:   string;
+    EditCount: Integer;
+  end;
 var
   Patch, ParseErr, ApplyErr, FileBody, NewBody, CurrentHash: string;
   Sections: THLSectionArray;
-  i, FilesWritten: Integer;
+  Plans: array of TPlan;
+  i: Integer;
   Sb: TStringBuilder;
 begin
   ErrMsg := '';
@@ -163,39 +174,52 @@ begin
     ErrMsg := 'patch contained no sections; expected one or more lines starting with ' + HL_FILE_PREFIX + 'path#hash';
     Exit('');
   end;
+
+  { Pass 1: validate every section and stage the new body in memory.
+    No writes happen during this pass, so a stale hash / missing file /
+    out-of-range anchor on any section leaves the disk untouched. }
+  SetLength(Plans, Length(Sections));
+  for i := 0 to High(Sections) do
+  begin
+    if not FileExists(Sections[i].Path) then
+    begin
+      ErrMsg := Format('section %d: no such file: %s', [i + 1, Sections[i].Path]);
+      Exit('');
+    end;
+    FileBody := ReadFileText(Sections[i].Path);
+    if Sections[i].HasFileHash then
+    begin
+      CurrentHash := ComputeFileHash(FileBody);
+      if CurrentHash <> Sections[i].FileHash then
+      begin
+        ErrMsg := Format('section %d: stale patch for %s (header hash %s, file hash %s) — re-read and rebase',
+                         [i + 1, Sections[i].Path, Sections[i].FileHash, CurrentHash]);
+        Exit('');
+      end;
+    end;
+    if not ApplyHashlineEdits(FileBody, Sections[i].Edits, NewBody, ApplyErr) then
+    begin
+      ErrMsg := Format('section %d (%s): %s', [i + 1, Sections[i].Path, ApplyErr]);
+      Exit('');
+    end;
+    Plans[i].Path      := Sections[i].Path;
+    Plans[i].NewBody   := NewBody;
+    Plans[i].EditCount := Length(Sections[i].Edits);
+  end;
+
+  { Pass 2: commit. By now every section is known to apply cleanly.
+    A disk-level write failure can still partially apply, but that's a
+    filesystem-atomicity concern beyond the hashline contract. }
   Sb := TStringBuilder.Create;
   try
-    FilesWritten := 0;
-    for i := 0 to High(Sections) do
+    for i := 0 to High(Plans) do
     begin
-      if not FileExists(Sections[i].Path) then
-      begin
-        ErrMsg := Format('section %d: no such file: %s', [i + 1, Sections[i].Path]);
-        Exit('');
-      end;
-      FileBody := ReadFileText(Sections[i].Path);
-      if Sections[i].HasFileHash then
-      begin
-        CurrentHash := ComputeFileHash(FileBody);
-        if CurrentHash <> Sections[i].FileHash then
-        begin
-          ErrMsg := Format('section %d: stale patch for %s (header hash %s, file hash %s) — re-read and rebase',
-                           [i + 1, Sections[i].Path, Sections[i].FileHash, CurrentHash]);
-          Exit('');
-        end;
-      end;
-      if not ApplyHashlineEdits(FileBody, Sections[i].Edits, NewBody, ApplyErr) then
-      begin
-        ErrMsg := Format('section %d (%s): %s', [i + 1, Sections[i].Path, ApplyErr]);
-        Exit('');
-      end;
-      WriteFileText(Sections[i].Path, NewBody);
-      Inc(FilesWritten);
+      WriteFileText(Plans[i].Path, Plans[i].NewBody);
       Sb.Append(Format('%s: wrote %d bytes (%d edits)',
-                       [Sections[i].Path, Length(NewBody), Length(Sections[i].Edits)]));
+                       [Plans[i].Path, Length(Plans[i].NewBody), Plans[i].EditCount]));
       Sb.Append(sLineBreak);
     end;
-    Result := Format('applied patch to %d file(s)'#10'%s', [FilesWritten, Sb.ToString]);
+    Result := Format('applied patch to %d file(s)'#10'%s', [Length(Plans), Sb.ToString]);
   finally
     Sb.Free;
   end;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -21,7 +21,10 @@ uses
   PasClaw.Tools.Types,
   PasClaw.Tools.Registry;
 
-procedure RegisterFSTools(R: TToolRegistry);
+{ UseHashline controls fs_read's default output format and whether the
+  hashline-only tools (fs_edit_hashline, fs_grep) get registered at all.
+  Default True. Set False from a command with --no-hashline. }
+procedure RegisterFSTools(R: TToolRegistry; UseHashline: Boolean = True);
 
 implementation
 
@@ -30,6 +33,9 @@ uses
   PasClaw.JSON,
   PasClaw.Utils,
   PasClaw.Hashline;
+
+var
+  GHashlineEnabled: Boolean = True;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
@@ -88,8 +94,15 @@ begin
     ErrMsg := 'no such file: ' + Path;
     Exit('');
   end;
-  Body  := ReadFileText(Path);
-  Plain := ParseBoolArg(ArgsJSON, 'plain', False);
+  Body := ReadFileText(Path);
+  { When hashline is disabled at register time, force plain regardless of
+    the per-call flag: there's no fs_edit_hashline registered to consume
+    a header, so emitting one would just confuse the model. The per-call
+    plain=true escape hatch still works in hashline-on mode. }
+  if not GHashlineEnabled then
+    Plain := True
+  else
+    Plain := ParseBoolArg(ArgsJSON, 'plain', False);
   if Plain then
     Result := Body
   else
@@ -415,24 +428,37 @@ begin
   end;
 end;
 
-procedure RegisterFSTools(R: TToolRegistry);
+procedure RegisterFSTools(R: TToolRegistry; UseHashline: Boolean);
 var
   T: TTool;
 begin
-  T.Name        := 'fs_read';
-  T.Description := 'Read a file. By default returns hashline format: a ' + HL_FILE_PREFIX +
-                   'path#hash header followed by LINENO:line per source line. Pass {"plain":true} for raw bytes.';
-  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"plain":{"type":"boolean","description":"Return raw file bytes instead of hashline-prefixed output."}},"required":["path"]}';
-  T.Handler     := Tool_FSRead;
-  T.IsCore      := True;
+  GHashlineEnabled := UseHashline;
+
+  T.Name := 'fs_read';
+  if UseHashline then
+  begin
+    T.Description := 'Read a file. Returns hashline format: a ' + HL_FILE_PREFIX +
+                     'path#hash header followed by LINENO:line per source line. Pass {"plain":true} for raw bytes.';
+    T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"plain":{"type":"boolean","description":"Return raw file bytes instead of hashline-prefixed output."}},"required":["path"]}';
+  end
+  else
+  begin
+    T.Description := 'Read the contents of a file from the local filesystem.';
+    T.Schema      := '{"type":"object","properties":{"path":{"type":"string","description":"Absolute or relative path to the file."}},"required":["path"]}';
+  end;
+  T.Handler := Tool_FSRead;
+  T.IsCore  := True;
   R.Register(T);
 
-  T.Name        := 'fs_write';
-  T.Description := 'Write a string to a file (overwrites). Creates parent dirs. ' +
-                   'Strips hashline LINENO: prefixes from `content` when every non-empty line carries one.';
-  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
-  T.Handler     := Tool_FSWrite;
-  T.IsCore      := True;
+  T.Name := 'fs_write';
+  if UseHashline then
+    T.Description := 'Write a string to a file (overwrites). Creates parent dirs. ' +
+                     'Strips hashline LINENO: prefixes from `content` when every non-empty line carries one.'
+  else
+    T.Description := 'Write a string to a file (overwrites). Creates parent dirs.';
+  T.Schema  := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
+  T.Handler := Tool_FSWrite;
+  T.IsCore  := True;
   R.Register(T);
 
   T.Name        := 'fs_list';
@@ -442,25 +468,31 @@ begin
   T.IsCore      := True;
   R.Register(T);
 
-  T.Name        := 'fs_edit_hashline';
-  T.Description := 'Apply a hashline-format patch. Patch begins with ' + HL_FILE_PREFIX +
-                   'path#hash; each block is an anchor like 42: or 7-10: followed by ' +
-                   '| (replace), ' + HL_PAYLOAD_ABOVE + ' (insert above), or ' +
-                   HL_PAYLOAD_BELOW + ' (insert below). The header hash must match the file on disk; ' +
-                   'stale patches abort without writing.';
-  T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
-  T.Handler     := Tool_FSEditHashline;
-  T.IsCore      := True;
-  R.Register(T);
+  { Hashline-only tools: skip registration entirely when UseHashline is False
+    so the model never sees them in the tool list and doesn't try to call
+    fs_edit_hashline with a hashless patch that we'd reject. }
+  if UseHashline then
+  begin
+    T.Name        := 'fs_edit_hashline';
+    T.Description := 'Apply a hashline-format patch. Patch begins with ' + HL_FILE_PREFIX +
+                     'path#hash; each block is an anchor like 42: or 7-10: followed by ' +
+                     '| (replace), ' + HL_PAYLOAD_ABOVE + ' (insert above), or ' +
+                     HL_PAYLOAD_BELOW + ' (insert below). The header hash must match the file on disk; ' +
+                     'stale patches abort without writing.';
+    T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
+    T.Handler     := Tool_FSEditHashline;
+    T.IsCore      := True;
+    R.Register(T);
 
-  T.Name        := 'fs_grep';
-  T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
-                   'Skips dotdirs. Returns hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
-                   'so you can paste anchors directly into fs_edit_hashline.';
-  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"pattern":{"type":"string"},"ignore_case":{"type":"boolean"},"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"}},"required":["path","pattern"]}';
-  T.Handler     := Tool_FSGrep;
-  T.IsCore      := True;
-  R.Register(T);
+    T.Name        := 'fs_grep';
+    T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
+                     'Skips dotdirs. Returns hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
+                     'so you can paste anchors directly into fs_edit_hashline.';
+    T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"pattern":{"type":"string"},"ignore_case":{"type":"boolean"},"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"}},"required":["path","pattern"]}';
+    T.Handler     := Tool_FSGrep;
+    T.IsCore      := True;
+    R.Register(T);
+  end;
 end;
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -181,21 +181,32 @@ begin
   SetLength(Plans, Length(Sections));
   for i := 0 to High(Sections) do
   begin
+    { Enforce the contract: every section header must carry a #hash so
+      we can verify the file hasn't drifted since the model read it.
+      ParseHashlinePatch accepts hashless ¶path headers for the format
+      library's other consumers (streaming previews, abbreviated diffs),
+      but at the tool layer we refuse them — applying line-anchored
+      edits without verifying the file version is exactly the silent
+      corruption hashline was designed to prevent. }
+    if not Sections[i].HasFileHash then
+    begin
+      ErrMsg := Format('section %d (%s): header is missing %shash; re-read the file with fs_read and use the returned %spath%shash header',
+                       [i + 1, Sections[i].Path,
+                        HL_FILE_HASH_SEP, HL_FILE_PREFIX, HL_FILE_HASH_SEP]);
+      Exit('');
+    end;
     if not FileExists(Sections[i].Path) then
     begin
       ErrMsg := Format('section %d: no such file: %s', [i + 1, Sections[i].Path]);
       Exit('');
     end;
     FileBody := ReadFileText(Sections[i].Path);
-    if Sections[i].HasFileHash then
+    CurrentHash := ComputeFileHash(FileBody);
+    if CurrentHash <> Sections[i].FileHash then
     begin
-      CurrentHash := ComputeFileHash(FileBody);
-      if CurrentHash <> Sections[i].FileHash then
-      begin
-        ErrMsg := Format('section %d: stale patch for %s (header hash %s, file hash %s) — re-read and rebase',
-                         [i + 1, Sections[i].Path, Sections[i].FileHash, CurrentHash]);
-        Exit('');
-      end;
+      ErrMsg := Format('section %d: stale patch for %s (header hash %s, file hash %s) — re-read and rebase',
+                       [i + 1, Sections[i].Path, Sections[i].FileHash, CurrentHash]);
+      Exit('');
     end;
     if not ApplyHashlineEdits(FileBody, Sections[i].Edits, NewBody, ApplyErr) then
     begin

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1,7 +1,13 @@
 {
-  PasClaw.Tools.FS - built-in filesystem tools: fs_read, fs_write, fs_list.
-  Mirrors a subset of pkg/tools/fs in picoclaw. Paths are not sandboxed by
-  default; the gateway will install a workspace-restricted variant in Phase 4.
+  PasClaw.Tools.FS - built-in filesystem tools: fs_read, fs_write, fs_list,
+  fs_edit_hashline, fs_grep. Paths are not sandboxed by default; the gateway
+  will install a workspace-restricted variant in Phase 4.
+
+  fs_read emits hashline-prefixed output by default — each file body is
+  preceded by a `¶path#hash` header and every line is prefixed with
+  `LINENO:`. That format is the input contract for fs_edit_hashline, which
+  applies anchored diff operations without needing the model to reproduce
+  the original text. Pass `{"plain": true}` to get raw bytes back instead.
 }
 unit PasClaw.Tools.FS;
 
@@ -20,8 +26,10 @@ procedure RegisterFSTools(R: TToolRegistry);
 implementation
 
 uses
+  Masks,
   PasClaw.JSON,
-  PasClaw.Utils;
+  PasClaw.Utils,
+  PasClaw.Hashline;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
@@ -45,9 +53,29 @@ begin
   end;
 end;
 
+function ParseBoolArg(const ArgsJSON, Field: string; Default: Boolean): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      if Obj.Has(Field) then Result := Obj.GetBool(Field, Default);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := Default;
+  end;
+end;
+
 function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
 var
-  Path: string;
+  Path, Body: string;
+  Plain: Boolean;
 begin
   ErrMsg := '';
   if not ParseStringArg(ArgsJSON, 'path', Path) then
@@ -60,12 +88,19 @@ begin
     ErrMsg := 'no such file: ' + Path;
     Exit('');
   end;
-  Result := ReadFileText(Path);
+  Body  := ReadFileText(Path);
+  Plain := ParseBoolArg(ArgsJSON, 'plain', False);
+  if Plain then
+    Result := Body
+  else
+    Result := FormatHashlineRead(Path, Body);
 end;
 
 function Tool_FSWrite(const ArgsJSON: string; out ErrMsg: string): string;
 var
   Path, Content: string;
+  Lines: TStringList;
+  Stripped: Boolean;
 begin
   ErrMsg := '';
   if not ParseStringArg(ArgsJSON, 'path', Path) then
@@ -74,15 +109,235 @@ begin
     Exit('');
   end;
   ParseStringArg(ArgsJSON, 'content', Content);
+  { Defensive: strip hashline LINE: prefixes if the model copied them
+    in from fs_read output. Only strips when every non-empty line has
+    one — so a real ratio like "42:00" won't be mangled. }
+  Lines := TStringList.Create;
+  try
+    Lines.LineBreak := #10;
+    Lines.StrictDelimiter := True;
+    Lines.Text := StringReplace(Content, #13, '', [rfReplaceAll]);
+    Stripped := StripHashlinePrefixes(Lines);
+    if Stripped then Content := Lines.Text;
+  finally
+    Lines.Free;
+  end;
   try
     WriteFileText(Path, Content);
-    Result := Format('wrote %d bytes to %s', [Length(Content), Path]);
+    if Stripped then
+      Result := Format('wrote %d bytes to %s (stripped hashline prefixes)', [Length(Content), Path])
+    else
+      Result := Format('wrote %d bytes to %s', [Length(Content), Path]);
   except
     on E: Exception do
     begin
       ErrMsg := E.Message;
       Result := '';
     end;
+  end;
+end;
+
+function Tool_FSEditHashline(const ArgsJSON: string; out ErrMsg: string): string;
+{ Apply a hashline-format patch to one or more files. The patch text carries
+  its own ¶path#hash headers; we read each referenced file, validate the
+  header hash matches what's on disk, apply the edits, and write back. }
+var
+  Patch, ParseErr, ApplyErr, FileBody, NewBody, CurrentHash: string;
+  Sections: THLSectionArray;
+  i, FilesWritten: Integer;
+  Sb: TStringBuilder;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'patch', Patch) then
+  begin
+    ErrMsg := 'missing required argument: patch';
+    Exit('');
+  end;
+  if not ParseHashlinePatch(Patch, Sections, ParseErr) then
+  begin
+    ErrMsg := 'patch parse: ' + ParseErr;
+    Exit('');
+  end;
+  if Length(Sections) = 0 then
+  begin
+    ErrMsg := 'patch contained no sections; expected one or more lines starting with ' + HL_FILE_PREFIX + 'path#hash';
+    Exit('');
+  end;
+  Sb := TStringBuilder.Create;
+  try
+    FilesWritten := 0;
+    for i := 0 to High(Sections) do
+    begin
+      if not FileExists(Sections[i].Path) then
+      begin
+        ErrMsg := Format('section %d: no such file: %s', [i + 1, Sections[i].Path]);
+        Exit('');
+      end;
+      FileBody := ReadFileText(Sections[i].Path);
+      if Sections[i].HasFileHash then
+      begin
+        CurrentHash := ComputeFileHash(FileBody);
+        if CurrentHash <> Sections[i].FileHash then
+        begin
+          ErrMsg := Format('section %d: stale patch for %s (header hash %s, file hash %s) — re-read and rebase',
+                           [i + 1, Sections[i].Path, Sections[i].FileHash, CurrentHash]);
+          Exit('');
+        end;
+      end;
+      if not ApplyHashlineEdits(FileBody, Sections[i].Edits, NewBody, ApplyErr) then
+      begin
+        ErrMsg := Format('section %d (%s): %s', [i + 1, Sections[i].Path, ApplyErr]);
+        Exit('');
+      end;
+      WriteFileText(Sections[i].Path, NewBody);
+      Inc(FilesWritten);
+      Sb.Append(Format('%s: wrote %d bytes (%d edits)',
+                       [Sections[i].Path, Length(NewBody), Length(Sections[i].Edits)]));
+      Sb.Append(sLineBreak);
+    end;
+    Result := Format('applied patch to %d file(s)'#10'%s', [FilesWritten, Sb.ToString]);
+  finally
+    Sb.Free;
+  end;
+end;
+
+function MatchesAny(const Name: string; Globs: TStringList): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  if (Globs = nil) or (Globs.Count = 0) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  for i := 0 to Globs.Count - 1 do
+    if MatchesMask(Name, Globs[i]) then Exit(True);
+end;
+
+function Tool_FSGrep(const ArgsJSON: string; out ErrMsg: string): string;
+{ Recursive line scan returning hashline-formatted matches. Output looks
+  like one section per matched file (¶path#hash header + N:line per
+  match), so a follow-up fs_edit_hashline call can paste anchors
+  verbatim. }
+var
+  Root, Pattern, IncludeGlob: string;
+  IgnoreCase: Boolean;
+  MaxMatches: Int64;
+  Globs: TStringList;
+  Sb: TStringBuilder;
+  TotalMatches: Integer;
+  PatLower: string;
+
+  procedure ScanFile(const Path: string);
+  var
+    Body, Header: string;
+    Lines: TStringList;
+    j, MatchCount: Integer;
+    Cmp: string;
+    Wrote: Boolean;
+  begin
+    if TotalMatches >= MaxMatches then Exit;
+    try
+      Body := ReadFileText(Path);
+    except
+      Exit;  { binary / permissions — skip silently to keep grep tractable }
+    end;
+    Header := FormatHashlineHeader(Path, ComputeFileHash(Body));
+    Lines := TStringList.Create;
+    try
+      Lines.LineBreak := #10;
+      Lines.StrictDelimiter := True;
+      Lines.Text := StringReplace(Body, #13, '', [rfReplaceAll]);
+      Wrote := False;
+      MatchCount := 0;
+      for j := 0 to Lines.Count - 1 do
+      begin
+        if TotalMatches >= MaxMatches then Break;
+        if IgnoreCase then Cmp := LowerCase(Lines[j]) else Cmp := Lines[j];
+        if Pos(PatLower, Cmp) > 0 then
+        begin
+          if not Wrote then
+          begin
+            if Sb.Length > 0 then Sb.Append(#10);
+            Sb.Append(Header).Append(#10);
+            Wrote := True;
+          end;
+          Sb.Append(FormatNumberedLine(j + 1, Lines[j])).Append(#10);
+          Inc(MatchCount);
+          Inc(TotalMatches);
+        end;
+      end;
+    finally
+      Lines.Free;
+    end;
+  end;
+
+  procedure Walk(const Dir: string);
+  var
+    SR: TSearchRec;
+    Full: string;
+  begin
+    if TotalMatches >= MaxMatches then Exit;
+    if FindFirst(JoinPath(Dir, '*'), faAnyFile, SR) = 0 then
+    begin
+      try
+        repeat
+          if (SR.Name = '.') or (SR.Name = '..') then Continue;
+          Full := JoinPath(Dir, SR.Name);
+          if (SR.Attr and faDirectory) <> 0 then
+          begin
+            if SR.Name <> '' then
+              if SR.Name[1] = '.' then Continue;  { skip dotdirs }
+            Walk(Full);
+          end
+          else if MatchesAny(SR.Name, Globs) then
+            ScanFile(Full);
+        until (FindNext(SR) <> 0) or (TotalMatches >= MaxMatches);
+      finally
+        FindClose(SR);
+      end;
+    end;
+  end;
+
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'path', Root) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not ParseStringArg(ArgsJSON, 'pattern', Pattern) then
+  begin
+    ErrMsg := 'missing required argument: pattern';
+    Exit('');
+  end;
+  IgnoreCase := ParseBoolArg(ArgsJSON, 'ignore_case', False);
+  if IgnoreCase then PatLower := LowerCase(Pattern) else PatLower := Pattern;
+  MaxMatches := 1000;
+  IncludeGlob := '';
+  ParseStringArg(ArgsJSON, 'include', IncludeGlob);
+  Globs := TStringList.Create;
+  Sb := TStringBuilder.Create;
+  try
+    if IncludeGlob <> '' then Globs.CommaText := IncludeGlob;
+    TotalMatches := 0;
+    if DirectoryExists(Root) then
+      Walk(Root)
+    else if FileExists(Root) then
+      ScanFile(Root)
+    else
+    begin
+      ErrMsg := 'no such path: ' + Root;
+      Exit('');
+    end;
+    if TotalMatches = 0 then
+      Result := '(no matches)'
+    else
+      Result := Sb.ToString;
+  finally
+    Sb.Free;
+    Globs.Free;
   end;
 end;
 
@@ -130,14 +385,16 @@ var
   T: TTool;
 begin
   T.Name        := 'fs_read';
-  T.Description := 'Read the contents of a file from the local filesystem.';
-  T.Schema      := '{"type":"object","properties":{"path":{"type":"string","description":"Absolute or relative path to the file."}},"required":["path"]}';
+  T.Description := 'Read a file. By default returns hashline format: a ' + HL_FILE_PREFIX +
+                   'path#hash header followed by LINENO:line per source line. Pass {"plain":true} for raw bytes.';
+  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"plain":{"type":"boolean","description":"Return raw file bytes instead of hashline-prefixed output."}},"required":["path"]}';
   T.Handler     := Tool_FSRead;
   T.IsCore      := True;
   R.Register(T);
 
   T.Name        := 'fs_write';
-  T.Description := 'Write a string to a file (overwrites). Creates parent dirs.';
+  T.Description := 'Write a string to a file (overwrites). Creates parent dirs. ' +
+                   'Strips hashline LINENO: prefixes from `content` when every non-empty line carries one.';
   T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
   T.Handler     := Tool_FSWrite;
   T.IsCore      := True;
@@ -147,6 +404,26 @@ begin
   T.Description := 'List entries in a directory. Returns "d name" or "- name  size" lines.';
   T.Schema      := '{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}';
   T.Handler     := Tool_FSList;
+  T.IsCore      := True;
+  R.Register(T);
+
+  T.Name        := 'fs_edit_hashline';
+  T.Description := 'Apply a hashline-format patch. Patch begins with ' + HL_FILE_PREFIX +
+                   'path#hash; each block is an anchor like 42: or 7-10: followed by ' +
+                   '| (replace), ' + HL_PAYLOAD_ABOVE + ' (insert above), or ' +
+                   HL_PAYLOAD_BELOW + ' (insert below). The header hash must match the file on disk; ' +
+                   'stale patches abort without writing.';
+  T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
+  T.Handler     := Tool_FSEditHashline;
+  T.IsCore      := True;
+  R.Register(T);
+
+  T.Name        := 'fs_grep';
+  T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
+                   'Skips dotdirs. Returns hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
+                   'so you can paste anchors directly into fs_edit_hashline.';
+  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"pattern":{"type":"string"},"ignore_case":{"type":"boolean"},"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"}},"required":["path","pattern"]}';
+  T.Handler     := Tool_FSGrep;
   T.IsCore      := True;
   R.Register(T);
 end;


### PR DESCRIPTION
## Summary

Adds **hashline** support — the line-anchored edit format from oh-my-pi that lets the model identify edits by stable line-number anchors instead of perfect-text reproduction (the same failure mode str_replace hits ~50% of the time on many models, per the blog post you linked).

**Not MCP.** Hashline is a format + tool integration pattern, so it lives as PasClaw built-in tools.

### What the model sees

`fs_read` now returns:
```
¶src/foo.pas#a3f1
1:unit Foo;
2:
3:interface
...
```

### What the model writes (new `fs_edit_hashline`)

```
¶src/foo.pas#a3f1
42:
|the new line 42 content
↑a line inserted above 42
↓a line inserted below 42
```

Sigils: `|` replace in place, `↑` insert above, `↓` insert below. Anchors can be a single line (`42:`) or a range (`7-10:`). The header hash must match the file on disk; stale patches abort without writing a single byte.

### New `fs_grep`

Recursive substring search whose output is itself hashline-formatted — the model can paste matched anchors straight into `fs_edit_hashline` without re-reading.

## What's in the PR

- **`src/pkg/hashline/PasClaw.Hashline.pas`** — format primitives:
  - `xxHash32` matching upstream `Bun.hash.xxHash32` so the 4-hex file hash is interchangeable
  - `ComputeFileHash` (CR-stripped + line-rtrimmed UTF-8 → xxHash32 → low16 → 4-hex)
  - `FormatHashlineRead` / `FormatNumberedLines` / `FormatHashlineHeader`
  - `StripHashlinePrefixes` (defensive, only strips when every non-empty line has a `LINENO:` prefix)
  - `ParseHashlinePatch` (multi-section tokenizer)
  - `ApplyHashlineEdits` (two-pass applier with before/after buckets per anchor; preserves trailing-newline shape)
- **`src/pkg/tools/PasClaw.Tools.FS.pas`** — `fs_read` emits hashline by default with `{"plain": true}` escape hatch; `fs_write` strips prefixes defensively; new `fs_edit_hashline` and `fs_grep` tools
- **Build wiring** for both `Makefile` (FPC) and `PasClaw.dproj` (Delphi)

Constants are declared as literal Unicode characters (`'¶'`, `'↑'`, `'↓'`), not raw `#$C2#$B6` byte sequences — that's the cross-compiler-correct way: Delphi `UnicodeString` stores one `WideChar` per codepoint and FPC `{$MODE DELPHI}` `{$H+}` `AnsiString` stores the UTF-8 bytes. `Length()`/`Copy()` are unit-consistent per compiler, so the same parser walks the string correctly in both.

Recovery heuristics from the upstream package (multi-line dup auto-absorb, structural-bracket boundary fixups, comment-line skipping inside payloads) are **deliberately omitted** — they only matter once production traffic surfaces the failure modes. Format and basic apply path are faithful so we can layer them incrementally.

## Test plan

- [ ] Delphi Win64 build: clean
- [ ] FPC 3.2+ build: clean
- [ ] `fs_read` against a small file: returns `¶path#hash` header + `1:line` per line
- [ ] `fs_read {"plain": true}`: returns raw bytes (no header, no prefixes)
- [ ] `fs_edit_hashline` with a single-line replace, an insert-above, an insert-below: writes the expected file
- [ ] `fs_edit_hashline` with a stale hash: aborts with `(header hash X, file hash Y) — re-read and rebase` and leaves file untouched
- [ ] `fs_grep src/pkg/hashline 'XXHash'`: returns one section, header + match lines
- [ ] Round-trip: agent reads a file, sends a 1-line edit patch, file changes correctly
- [ ] `fs_write` against content the model accidentally prefixed: succeeds and reports `(stripped hashline prefixes)`

## Future work (not in this PR)

- Recovery heuristics (auto-absorb duplicates, boundary fixups)
- LSP/diagnostic integration for edit feedback
- A `--no-hashline` config knob if specific models do worse with the format

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_