### PR TITLE
Fix PasClaw.Tools.FS unit-header comment that broke Delphi compilation

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1,14 +1,15 @@
-{
+(*
   PasClaw.Tools.FS - built-in filesystem tools: fs_read, fs_write, fs_list,
   fs_edit_hashline, fs_grep. Paths are not sandboxed by default; the gateway
   will install a workspace-restricted variant in Phase 4.
 
   fs_read emits hashline-prefixed output by default — each file body is
-  preceded by a `¶path#hash` header and every line is prefixed with
-  `LINENO:`. That format is the input contract for fs_edit_hashline, which
+  preceded by a ¶path#hash header and every line is prefixed with
+  LINENO:. That format is the input contract for fs_edit_hashline, which
   applies anchored diff operations without needing the model to reproduce
-  the original text. Pass `{"plain": true}` to get raw bytes back instead.
-}
+  the original text. Pass plain=true in the JSON args to get raw bytes
+  back instead.
+*)
 unit PasClaw.Tools.FS;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}


### PR DESCRIPTION
## Summary

Fixes Delphi compile errors landed by PR #26:

```
[dcc64 Error] PasClaw.Tools.FS.pas(10): E2038 Illegal character in input file: '`' (#$60)
[dcc64 Error] PasClaw.Tools.FS.pas(11): E2038 Illegal character in input file: '}' (#$7D)
[dcc64 Error] PasClaw.Tools.FS.pas(27): E2003 Undeclared identifier: 'TToolRegistry'
```

The unit-header comment used `{ ... }` delimiters and contained the literal JSON example `` `{"plain": true}` ``. Pascal `{ ... }` comments don't nest, so the first inner `}` closed the outer comment early — leaving the trailing backticks and the real closing `}` as illegal tokens at file scope, which then made every later type reference (`TToolRegistry`, etc.) unresolved.

Same failure shape as PR #21 in `Gateway.Server`. Switch to `(* ... *)` delimiters and drop the braces from the JSON example in the prose so a paste-back can't re-introduce the bug. The other `{ ... }` comments in the file are already brace-free and were unaffected.

## Test plan

- [ ] Build under Delphi Win64: no E2038/E2003 on `PasClaw.Tools.FS.pas`
- [ ] Build under FPC: still compiles (FPC tolerated the braces but accepts `(* ... *)` equally)
- [ ] `fs_read` / `fs_edit_hashline` / `fs_grep` still register and behave the same

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_