### PR TITLE
Fix PasClaw.Hashline const-block comment that broke Delphi compilation

### DIFF
--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -43,12 +43,11 @@ uses
   SysUtils, Classes;
 
 const
-  { Use literal Unicode characters so each compiler stores them in its
-    native `string` form: Delphi UnicodeString = one WideChar per
-    codepoint, FPC {$MODE DELPHI} {$H+} = UTF-8 AnsiString = multi-byte
-    encoding. Length() and Copy() are unit-consistent per compiler
-    (chars in Delphi, bytes in FPC), so the same parsing code works
-    in both. }
+  (* Use literal Unicode characters so each compiler stores them in its
+     native string form: Delphi UnicodeString = one WideChar per
+     codepoint, FPC mode-delphi UTF-8 AnsiString = multi-byte encoding.
+     Length() and Copy() are unit-consistent per compiler (chars in
+     Delphi, bytes in FPC), so the same parsing code works in both. *)
   HL_FILE_PREFIX     = '¶';
   HL_FILE_HASH_SEP   = '#';
   HL_LINE_BODY_SEP   = ':';


### PR DESCRIPTION
## Summary

Fixes `[dcc64 Error] PasClaw.Hashline.pas(48): E2029 Identifier expected but '=' found`.

The `HL_*` const-block comment used `{ ... }` delimiters and contained the literal compiler-directive examples `{$MODE DELPHI} {$H+}`. Pascal `{ ... }` comments don't nest, so the first inner `}` closed the outer comment early. The remaining text (`= UTF-8 AnsiString = multi-byte`) was then parsed inside the still-open `const` block, where Delphi expected an identifier and found `=`.

Same failure shape as PR #21 (Gateway.Server) and PR #27 (Tools.FS). Third strike — going to start defaulting new doc comments to `(* ... *)` unless I'm sure they contain no braces.

Switch this one comment to `(* ... *)` and prose-describe the directive names so a future paste-back can't bring it back. Every other comment in `PasClaw.Hashline` is already brace-free.

## Test plan

- [ ] Build under Delphi Win64: no E2029 on `PasClaw.Hashline.pas`
- [ ] Build under FPC: still compiles
- [ ] `fs_read` / `fs_edit_hashline` / `fs_grep` unchanged behaviorally

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_