### PR TITLE
Sanitize SSE comments and surface streaming errors properly

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -461,6 +461,7 @@ type
     procedure WriteRaw(const Data: string);
     procedure WriteChunk(const DeltaContent, FinishReason: string);
     procedure WriteComment(const Note: string);
+    procedure WriteError(const Msg: string);
     procedure NoteToolCall(const Name, ArgsJSON: string);
     procedure NoteToolResult(const Name, ResultText, Err: string);
     procedure Finalize(const Content, FinishReason: string);
@@ -500,12 +501,45 @@ begin
 end;
 
 procedure TSSEStreamer.WriteComment(const Note: string);
+var
+  Clean: string;
 begin
-  { Lines starting with `:` are SSE comments per the spec — every
-    compliant client (and openai-python, anthropic-sdk, langchain,
-    autogen) skips them silently. Useful for keepalive without
-    polluting visible content. }
-  WriteRaw(': ' + Note + #10#10);
+  (* Lines starting with `:` are SSE comments per the spec — every
+     compliant client (openai-python, anthropic-sdk, langchain,
+     autogen) skips them silently.
+
+     IMPORTANT: callers pass arbitrary content here (tool argsJSON,
+     tool result text). If the body contains a newline followed by
+     `data: ...` or another SSE field, a naive `: ' + Note + #10#10`
+     would let that line be parsed as a real event, terminating or
+     corrupting the stream. Strip CR and prefix EVERY line of the
+     body with `: ` so the whole thing stays inside the comment, then
+     append the empty-line terminator. *)
+  Clean := StringReplace(Note, #13, '', [rfReplaceAll]);
+  Clean := StringReplace(Clean, #10, #10': ', [rfReplaceAll]);
+  WriteRaw(': ' + Clean + #10#10);
+end;
+
+procedure TSSEStreamer.WriteError(const Msg: string);
+var
+  Root, Err: TJsonObject;
+begin
+  (* Stream-mode error after headers are already on the wire. We can't
+     change the status, but we can send an OpenAI-style error frame
+     followed by [DONE] so clients that recognize streaming errors
+     surface them properly instead of treating an assistant turn that
+     says "tool loop failed" as a normal completion. *)
+  Root := TJsonObject.Create;
+  try
+    Err := TJsonObject.Create;
+    Err.PutStr('message', Msg);
+    Err.PutStr('type',    'server_error');
+    Root.PutObject('error', Err);
+    WriteRaw('data: ' + Root.ToJSON + #10#10);
+  finally
+    Root.Free;
+  end;
+  WriteRaw('data: [DONE]'#10#10);
 end;
 
 procedure TSSEStreamer.NoteToolCall(const Name, ArgsJSON: string);
@@ -690,7 +724,10 @@ begin
     begin
       if FDebugIO then LogDebug('chat/completions -> 502 (tool loop failed)');
       if WantsStream then
-        Streamer.Finalize('(tool loop failed)', 'stop')
+        { Headers already went out as 200 OK; send an OpenAI-style
+          error frame + [DONE] rather than disguising the failure as
+          a normal assistant completion. }
+        Streamer.WriteError('tool loop failed')
       else
         WriteJSON(AResp, 502,
           '{"error":{"message":"tool loop failed","type":"server_error"}}');


### PR DESCRIPTION
## Summary

Two correctness fixes in the SSE streaming layer landed by PR #29.

### 1. SSE comment injection (security/correctness)

`TSSEStreamer.WriteComment` emitted `': ' + Note + #10#10` verbatim. `NoteToolCall` and `NoteToolResult` pass the tool's `argsJSON` and the tool's `ResultText` (or its 200-char preview) straight into the comment body. Any newline in that payload followed by `data: ...` or another SSE field caused the client to parse the rest as a real event — terminating the stream early or feeding bogus deltas into the chat. A shell tool that ran `printf '\ndata: [DONE]\n'` was enough to silently end the stream from a client's perspective.

Fix: strip CR, then prefix every newline in the body with `: ` so the entire payload stays inside comment-line mode, then append the empty-line event terminator. Single-line common case unchanged; multi-line and adversarial payloads are now safe.

### 2. Streaming RunToolLoop failure was misreported as success

The stream-path branch called `Streamer.Finalize('(tool loop failed)', 'stop')`, writing that string as an assistant content delta with `finish_reason: stop`. Headers had already gone out as `200 OK`, so the OpenAI-compatible client saw a perfectly normal completion containing the literal text `"(tool loop failed)"` and could feed that back into the next turn. Meanwhile the non-streaming path correctly returned HTTP 502.

Fix: new `Streamer.WriteError(Msg)` writes an OpenAI-style `data: {"error":{"message":...,"type":"server_error"}}` frame followed by `data: [DONE]`. Stream clients that recognize the error shape surface a real error; clients that don't at least don't see a fake assistant turn. Non-streaming 502 path is unchanged.

## Test plan

- [ ] Tool that emits output containing `\ndata: [DONE]\n` no longer terminates the stream prematurely; the bytes appear as comment lines and the stream continues normally
- [ ] `pasclaw serve` with no provider configured + a stream:true request: client receives an `error` frame followed by `[DONE]` rather than an assistant turn containing the failure text
- [ ] Non-streaming failure still returns HTTP 502 with the existing error JSON
- [ ] Normal streaming flow with multi-line tool outputs renders correctly (tool results don't visibly leak into the assistant response)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_