### PR TITLE
Avoid writing JSON after streaming /v1/chat/completions response started

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -55,7 +55,9 @@ type
     procedure HandleChat(ARequest: TIdHTTPRequestInfo; AResp: TIdHTTPResponseInfo);
     procedure HandleChatCompletions(AContext: TIdContext;
                                     ARequest: TIdHTTPRequestInfo;
-                                    AResp: TIdHTTPResponseInfo);
+                                    AResp: TIdHTTPResponseInfo;
+                                    out AWasStreamingRequest: Boolean;
+                                    out AResponseStarted: Boolean);
     procedure HandleModels(AResp: TIdHTTPResponseInfo);
     procedure WriteJSON(AResp: TIdHTTPResponseInfo; Code: Integer; const Body: string);
     procedure WriteSSE(AResp: TIdHTTPResponseInfo; const Body: string);
@@ -180,8 +182,12 @@ procedure TGatewayServer.OnCommandGet(AContext: TIdContext;
                                      AResponse: TIdHTTPResponseInfo);
 var
   Doc: string;
+  IsChatCompletionsStream: Boolean;
+  ResponseStarted: Boolean;
 begin
   Doc := ARequest.Document;
+  IsChatCompletionsStream := False;
+  ResponseStarted := False;
   LogDebug('gateway: %s %s', [ARequest.Command, Doc]);
 
   try
@@ -190,7 +196,8 @@ begin
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/status')  then HandleStatus(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/tools')   then HandleTools(AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/chat')    then HandleChat(ARequest, AResponse)
-    else if (ARequest.Command = 'POST') and (Doc = '/v1/chat/completions') then HandleChatCompletions(AContext, ARequest, AResponse)
+    else if (ARequest.Command = 'POST') and (Doc = '/v1/chat/completions') then
+      HandleChatCompletions(AContext, ARequest, AResponse, IsChatCompletionsStream, ResponseStarted)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/models')  then HandleModels(AResponse)
     else if Doc = '/' then
     begin
@@ -212,7 +219,20 @@ begin
     on E: Exception do
     begin
       LogError('gateway: handler crashed: %s', [E.Message]);
-      if not AResponse.HeaderHasBeenWritten then
+      if IsChatCompletionsStream and (ResponseStarted or AResponse.HeaderHasBeenWritten) then
+      begin
+        LogWarn('gateway: streaming response already started; closing connection');
+        if (AContext <> nil) and (AContext.Connection <> nil) then
+        begin
+          try
+            AContext.Connection.Disconnect;
+          except
+            on EDisconnect: Exception do
+              LogWarn('gateway: failed to close streaming connection: %s', [EDisconnect.Message]);
+          end;
+        end;
+      end
+      else if not AResponse.HeaderHasBeenWritten then
         WriteJSON(AResponse, 500, '{"error":"internal","message":"' + E.Message + '"}')
       else if (AContext <> nil) and (AContext.Connection <> nil) then
         AContext.Connection.Disconnect;
@@ -653,7 +673,9 @@ end;
 
 procedure TGatewayServer.HandleChatCompletions(AContext: TIdContext;
                                                 ARequest: TIdHTTPRequestInfo;
-                                                AResp: TIdHTTPResponseInfo);
+                                                AResp: TIdHTTPResponseInfo;
+                                                out AWasStreamingRequest: Boolean;
+                                                out AResponseStarted: Boolean);
 (* OpenAI Chat Completions API. Accepts the standard request shape
    (model, messages array of role/content objects, optional temperature,
    max_tokens, stream, tools) and routes through the existing tool loop.
@@ -690,6 +712,8 @@ begin
   Streamer := nil;
   StreamStarted := False;
   StreamClosed := False;
+  AWasStreamingRequest := False;
+  AResponseStarted := False;
   Body := '';
   if ARequest.PostStream <> nil then
   begin
@@ -726,6 +750,7 @@ begin
   try
     ReqModel    := Req.GetStr('model', FCfg.DefaultModel);
     WantsStream := Req.GetBool('stream', False);
+    AWasStreamingRequest := WantsStream;
     if FDebugIO then
       LogDebug('chat/completions: model=%s stream=%s temperature=%g max_tokens=%d',
                [ReqModel, BoolToStr(WantsStream, True),
@@ -820,6 +845,7 @@ begin
         writes (and would double-chunk ours). }
       AResp.WriteHeader;
       StreamStarted := True;
+      AResponseStarted := True;
       { Drain every nested write buffer so headers AND subsequent body
         writes go straight to the socket. TIdHTTPServer opens a
         connection-level buffer per request to compute Content-Length;


### PR DESCRIPTION
### Motivation
- Prevent writing a JSON error body into an already-started SSE stream for `/v1/chat/completions` requests. 
- Provide a reliable, explicit per-request signal to indicate streaming requests and whether response headers have been flushed instead of brittle heuristics. 

### Description
- Added `out AWasStreamingRequest: Boolean` and `out AResponseStarted: Boolean` to `HandleChatCompletions` so the handler propagates whether the request asked for streaming and whether headers were emitted. 
- Introduced local flags `IsChatCompletionsStream` and `ResponseStarted` in `OnCommandGet` and pass them into `HandleChatCompletions`. 
- Initialized `AWasStreamingRequest := False` and `AResponseStarted := False` in `HandleChatCompletions`, set `AWasStreamingRequest` from the parsed `stream` field, and set `AResponseStarted := True` immediately after `AResp.WriteHeader` on the SSE path. 
- Updated the top-level exception handler in `OnCommandGet` to avoid calling `WriteJSON` when a streaming `/v1/chat/completions` response has already started, instead logging a warning and best-effort disconnecting the connection; preserved existing JSON-500 behavior when the response had not started. 

### Testing
- Ran `rg -n "procedure TGatewayServer.HandleChatCompletions|stream|HeaderHasBeenWritten|OnCommandGet" src/pkg/gateway/PasClaw.Gateway.Server.pas` to verify symbol changes, and it succeeded. 
- Inspected the modified file with `sed -n '1,260p' src/pkg/gateway/PasClaw.Gateway.Server.pas` and `sed -n '620,980p' src/pkg/gateway/PasClaw.Gateway.Server.pas` to confirm inserted flags and updated exception handling, and both succeeded. 
- Listed annotated lines with `nl -ba src/pkg/gateway/PasClaw.Gateway.Server.pas | sed -n '44,90p;176,245p;664,865p'` to review the integrated changes, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17ce10d150832e97242f8f880bcf0b)