### PR TITLE
Add TPasClawAgent + TPasClawServer components for embedding the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ UNIT_DIRS = \
 	src/pkg/tui \
 	src/pkg/platform \
 	src/pkg/hashline \
+	src/pkg/component \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).

--- a/samples/component-console/SampleConsole.dpr
+++ b/samples/component-console/SampleConsole.dpr
@@ -1,0 +1,42 @@
+(*
+  SampleConsole - shows how to embed PasClaw inside a standalone Delphi
+  / FPC console program via TPasClawAgent. Build either compiler:
+
+    Delphi:  drop the .dpr into a console project that has the PasClaw
+             unit search path (..\..\src\cmd, ..\..\src\pkg\*) wired in.
+    FPC:     fpc -Fu../../src/cmd -Fu../../src/pkg/... SampleConsole.dpr
+
+  The agent inherits config from ~/.pasclaw/config.json (same as the CLI),
+  so set up `pasclaw auth login` once first. The Execute() call mirrors
+  `pasclaw version`; Chat() round-trips a single prompt through the
+  configured provider and prints the assistant's reply.
+*)
+program SampleConsole;
+
+{$APPTYPE CONSOLE}
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Component;
+
+var
+  PC:        TPasClawAgent;
+  Reply, Err: string;
+begin
+  PC := TPasClawAgent.Create(nil);
+  try
+    WriteLn('--- pasclaw version ---');
+    PC.Execute('version', []);
+
+    WriteLn;
+    WriteLn('--- chat ---');
+    if PC.Chat('Say hi in three words.', Reply, Err) then
+      WriteLn('reply: ', Reply)
+    else
+      WriteLn('error: ', Err);
+  finally
+    PC.Free;
+  end;
+end.

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -10,6 +10,14 @@ unit PasClaw.Cmd.Root;
 
 interface
 
+{ Returns the exit code that would have been returned by the CLI for the
+  same `pasclaw Cmd Argv...` invocation. Pure dispatch — does not touch
+  ParamStr, the log level, or any global init — so embedding callers
+  (TPasClawAgent.Execute, tests) can use it without re-reading the host
+  process's command line. RunRootCommand below handles CLI-only concerns
+  (argv parsing, --no-color stripping, config-driven log level) then
+  forwards to DispatchCommand. }
+function DispatchCommand(const Cmd: string; const Argv: array of string): Integer;
 function RunRootCommand: Integer;
 
 implementation
@@ -116,10 +124,36 @@ begin
   Write(RenderCommandHelp(Use, Short, Long, Example, Sub, Fl));
 end;
 
+function DispatchCommand(const Cmd: string; const Argv: array of string): Integer;
+begin
+  if      Cmd = 'config'   then Result := Cmd_Config_Run(Argv)
+  else if Cmd = 'onboard'  then Result := Cmd_Onboard_Run(Argv)
+  else if Cmd = 'agent'    then Result := Cmd_Agent_Run(Argv)
+  else if Cmd = 'auth'     then Result := Cmd_Auth_Run(Argv)
+  else if Cmd = 'gateway'  then Result := Cmd_Gateway_Run(Argv)
+  else if Cmd = 'serve'    then Result := Cmd_Serve_Run(Argv)
+  else if Cmd = 'status'   then Result := Cmd_Status_Run(Argv)
+  else if Cmd = 'cron'     then Result := Cmd_Cron_Run(Argv)
+  else if Cmd = 'mcp'      then Result := Cmd_MCP_Run(Argv)
+  else if Cmd = 'migrate'  then Result := Cmd_Migrate_Run(Argv)
+  else if Cmd = 'skills'   then Result := Cmd_Skills_Run(Argv)
+  else if Cmd = 'model'    then Result := Cmd_Model_Run(Argv)
+  else if Cmd = 'post'     then Result := Cmd_Post_Run(Argv)
+  else if Cmd = 'membench' then Result := Cmd_Membench_Run(Argv)
+  else if Cmd = 'tui'      then Result := Cmd_TUI_Run(Argv)
+  else if Cmd = 'update'   then Result := Cmd_Update_Run(Argv)
+  else if Cmd = 'version'  then Result := Cmd_Version_Run(Argv)
+  else
+  begin
+    Write(ErrOutput, FormatCLIError('unknown command: ' + Cmd, 'pasclaw'));
+    Result := 1;
+  end;
+end;
+
 function RunRootCommand: Integer;
 var
   Args: TStringList;
-  Cmd, Last: string;
+  Cmd: string;
   ArgArr: TArray<string>;
   Cfg: TConfig;
 begin
@@ -144,30 +178,7 @@ begin
 
     Cmd := Args[0];
     ArgArr := ToArray(Args, 1);
-    Last := 'pasclaw ' + Cmd;
-
-    if      Cmd = 'config'   then Result := Cmd_Config_Run(ArgArr)
-    else if Cmd = 'onboard'  then Result := Cmd_Onboard_Run(ArgArr)
-    else if Cmd = 'agent'    then Result := Cmd_Agent_Run(ArgArr)
-    else if Cmd = 'auth'     then Result := Cmd_Auth_Run(ArgArr)
-    else if Cmd = 'gateway'  then Result := Cmd_Gateway_Run(ArgArr)
-    else if Cmd = 'serve'    then Result := Cmd_Serve_Run(ArgArr)
-    else if Cmd = 'status'   then Result := Cmd_Status_Run(ArgArr)
-    else if Cmd = 'cron'     then Result := Cmd_Cron_Run(ArgArr)
-    else if Cmd = 'mcp'      then Result := Cmd_MCP_Run(ArgArr)
-    else if Cmd = 'migrate'  then Result := Cmd_Migrate_Run(ArgArr)
-    else if Cmd = 'skills'   then Result := Cmd_Skills_Run(ArgArr)
-    else if Cmd = 'model'    then Result := Cmd_Model_Run(ArgArr)
-    else if Cmd = 'post'     then Result := Cmd_Post_Run(ArgArr)
-    else if Cmd = 'membench' then Result := Cmd_Membench_Run(ArgArr)
-    else if Cmd = 'tui'      then Result := Cmd_TUI_Run(ArgArr)
-    else if Cmd = 'update'   then Result := Cmd_Update_Run(ArgArr)
-    else if Cmd = 'version'  then Result := Cmd_Version_Run(ArgArr)
-    else
-    begin
-      Write(ErrOutput, FormatCLIError('unknown command: ' + Cmd, 'pasclaw'));
-      Result := 1;
-    end;
+    Result := DispatchCommand(Cmd, ArgArr);
   finally
     Args.Free;
   end;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -209,6 +209,9 @@
 
         <!-- pkg/hashline -->
         <DCCReference Include="..\pkg\hashline\PasClaw.Hashline.pas"/>
+
+        <!-- pkg/component -->
+        <DCCReference Include="..\pkg\component\PasClaw.Component.pas"/>
 
         <!-- pkg/vendor/dmvcframework (Apache-2.0, Delphi-only) -->
         <DCCReference Include="..\pkg\vendor\dmvcframework\LoggerPro.AnsiColors.pas"/>

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -1,0 +1,460 @@
+(*
+  PasClaw.Component - drop-in TComponent wrappers for embedding PasClaw
+  inside other Delphi/FPC applications without shelling out to the CLI.
+
+    TPasClawAgent  - chat/agent surface: Chat(), ChatHistory(), and a
+                     pass-through Execute(cmd, args) that mirrors every
+                     `pasclaw <cmd>` subcommand. OnText/OnToolCall/
+                     OnToolResult/OnError events surface activity.
+    TPasClawServer - hosts the same HTTP API as `pasclaw serve` inside
+                     the calling process. Start/Stop manage a background
+                     listener thread; OnStarted/OnStopped/OnError fire on
+                     lifecycle transitions.
+
+  Both compose the same building blocks the CLI uses (LoadConfig,
+  NewProviderFromConfig, TToolRegistry, RegisterFSTools/Shell, MCP
+  bridge, TGatewayServer, RunToolLoop) — no business logic is
+  duplicated, only adapted to TComponent property/event idioms.
+
+  Single-instance contract: PasClaw.MCP.Bridge and PasClaw.Skills.Loader
+  hold their state in compile-time fixed module-level arrays, so only
+  one live TPasClawAgent and one live TPasClawServer are supported per
+  process. Constructing a second instance of either while the first is
+  still alive raises EPasClawInstance; freeing the first then creating
+  another works. Lifting that restriction is a larger refactor of those
+  two units' handler-slot tables.
+
+  Register installs both components onto the `PasClaw` palette tab when
+  this unit is included in a design-time package.
+*)
+unit PasClaw.Component;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.Gateway.Server,
+  PasClaw.MCP.Bridge;
+
+type
+  EPasClawInstance = class(Exception);
+
+  TPasClawTextEvent       = procedure(Sender: TObject; const Text: string) of object;
+  TPasClawToolEvent       = procedure(Sender: TObject; const Name, ArgsJSON: string) of object;
+  TPasClawToolResultEvent = procedure(Sender: TObject; const Name, ResultText, Err: string) of object;
+  TPasClawErrorEvent      = procedure(Sender: TObject; const Msg: string) of object;
+
+  TPasClawAgent = class(TComponent)
+  private
+    FConfig:         TConfig;
+    FProvider:       ILLMProvider;
+    FRegistry:       TToolRegistry;
+    FMCPClients:     TMCPClientList;
+    FProviderName:   string;
+    FModel:          string;
+    FSystemPrompt:   string;
+    FMaxIterations:  Integer;
+    FUseTools:       Boolean;
+    FUseMCP:         Boolean;
+    FUseHashline:    Boolean;
+    FOnText:         TPasClawTextEvent;
+    FOnToolCall:     TPasClawToolEvent;
+    FOnToolResult:   TPasClawToolResultEvent;
+    FOnError:        TPasClawErrorEvent;
+    procedure EnsureConfig;
+    procedure EnsureProvider;
+    procedure EnsureRegistry;
+    procedure ForwardText      (const S: string);
+    procedure ForwardToolCall  (const Name, ArgsJSON: string);
+    procedure ForwardToolResult(const Name, ResultText, Err: string);
+    procedure RaiseError(const Msg: string);
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor  Destroy; override;
+    function Chat(const Prompt: string; out Reply, ErrMsg: string): Boolean;
+    function ChatHistory(const History: array of TMessage;
+                         out Reply, ErrMsg: string): Boolean;
+    function Execute(const Command: string; const Args: array of string): Integer;
+    property Provider: ILLMProvider  read FProvider;
+    property Registry: TToolRegistry read FRegistry;
+    property Config:   TConfig       read FConfig;
+  published
+    property ProviderName:  string  read FProviderName  write FProviderName;
+    property Model:         string  read FModel         write FModel;
+    property SystemPrompt:  string  read FSystemPrompt  write FSystemPrompt;
+    property MaxIterations: Integer read FMaxIterations write FMaxIterations default 8;
+    property UseTools:      Boolean read FUseTools      write FUseTools      default True;
+    property UseMCP:        Boolean read FUseMCP        write FUseMCP        default True;
+    property UseHashline:   Boolean read FUseHashline   write FUseHashline   default True;
+    property OnText:        TPasClawTextEvent       read FOnText       write FOnText;
+    property OnToolCall:    TPasClawToolEvent       read FOnToolCall   write FOnToolCall;
+    property OnToolResult:  TPasClawToolResultEvent read FOnToolResult write FOnToolResult;
+    property OnError:       TPasClawErrorEvent      read FOnError      write FOnError;
+  end;
+
+  TPasClawServer = class(TComponent)
+  private
+    FConfig:         TConfig;
+    FProvider:       ILLMProvider;
+    FRegistry:       TToolRegistry;
+    FMCPClients:     TMCPClientList;
+    FServer:         TGatewayServer;
+    FThread:         TThread;
+    FBindAddr:       string;
+    FPort:           Integer;
+    FMaxIter:        Integer;
+    FDebug:          Boolean;
+    FEnableTools:    Boolean;
+    FEnableMCP:      Boolean;
+    FEnableHashline: Boolean;
+    FProviderName:   string;
+    FModel:          string;
+    FOnStarted:      TNotifyEvent;
+    FOnStopped:      TNotifyEvent;
+    FOnError:        TPasClawErrorEvent;
+    procedure RaiseError(const Msg: string);
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor  Destroy; override;
+    function  Start: Boolean;
+    procedure Stop;
+    function  IsRunning: Boolean;
+    property Server: TGatewayServer read FServer;
+  published
+    property BindAddr:       string  read FBindAddr       write FBindAddr;
+    property Port:           Integer read FPort           write FPort           default 8088;
+    property MaxIter:        Integer read FMaxIter        write FMaxIter        default 25;
+    property Debug:          Boolean read FDebug          write FDebug          default False;
+    property EnableTools:    Boolean read FEnableTools    write FEnableTools    default True;
+    property EnableMCP:      Boolean read FEnableMCP      write FEnableMCP      default True;
+    property EnableHashline: Boolean read FEnableHashline write FEnableHashline default True;
+    property ProviderName:   string  read FProviderName   write FProviderName;
+    property Model:          string  read FModel          write FModel;
+    property OnStarted:      TNotifyEvent       read FOnStarted write FOnStarted;
+    property OnStopped:      TNotifyEvent       read FOnStopped write FOnStopped;
+    property OnError:        TPasClawErrorEvent read FOnError   write FOnError;
+  end;
+
+procedure Register;
+
+implementation
+
+uses
+  PasClaw.Cmd.Root,
+  PasClaw.Providers.Factory,
+  PasClaw.Tools.FS,
+  PasClaw.Tools.Shell,
+  PasClaw.Skills.Loader,
+  PasClaw.Tools.ToolLoop;
+
+var
+  { Tracks the live instance of each component class. Set in the
+    constructor, cleared in the destructor. A second create attempt
+    while one is live raises EPasClawInstance — see unit-header comment
+    on the MCP/Skills global-state limitation. }
+  GAgentInstance:  TPasClawAgent  = nil;
+  GServerInstance: TPasClawServer = nil;
+
+{ ============================== TPasClawAgent ============================== }
+
+constructor TPasClawAgent.Create(AOwner: TComponent);
+begin
+  if GAgentInstance <> nil then
+    raise EPasClawInstance.Create(
+      'Only one TPasClawAgent can be live per process — PasClaw.MCP.Bridge ' +
+      'and PasClaw.Skills.Loader hold their state in module-level arrays. ' +
+      'Free the existing instance before creating another.');
+  inherited Create(AOwner);
+  FMaxIterations := 8;
+  FUseTools      := True;
+  FUseMCP        := True;
+  FUseHashline   := True;
+  GAgentInstance := Self;
+end;
+
+destructor TPasClawAgent.Destroy;
+begin
+  FreeMCPClients(FMCPClients);
+  FreeAndNil(FRegistry);
+  FProvider := nil;
+  FreeAndNil(FConfig);
+  if GAgentInstance = Self then GAgentInstance := nil;
+  inherited Destroy;
+end;
+
+procedure TPasClawAgent.EnsureConfig;
+begin
+  if FConfig = nil then FConfig := LoadConfig;
+end;
+
+procedure TPasClawAgent.EnsureProvider;
+var
+  Name, Err: string;
+begin
+  if FProvider <> nil then Exit;
+  EnsureConfig;
+  if FProviderName <> '' then Name := FProviderName else Name := FConfig.DefaultProvider;
+  if Name = '' then
+  begin
+    RaiseError('no provider configured (run `pasclaw onboard` or set ProviderName)');
+    Exit;
+  end;
+  if not NewProviderFromConfig(FConfig, Name, FProvider, Err) then
+  begin
+    FProvider := nil;
+    RaiseError('provider unavailable: ' + Err);
+  end;
+end;
+
+procedure TPasClawAgent.EnsureRegistry;
+var
+  Skills: TSkillSpecArray;
+begin
+  if FRegistry <> nil then Exit;
+  if not FUseTools then Exit;
+  EnsureConfig;
+  FRegistry := TToolRegistry.Create;
+  RegisterFSTools(FRegistry, FUseHashline);
+  RegisterShellTool(FRegistry);
+  Skills := LoadSkillManifests(GetHome);
+  RegisterSkills(FRegistry, Skills);
+  if FUseMCP then
+    FMCPClients := ConnectMCPServers(FConfig, FRegistry);
+end;
+
+procedure TPasClawAgent.ForwardText(const S: string);
+begin
+  if Assigned(FOnText) then FOnText(Self, S);
+end;
+
+procedure TPasClawAgent.ForwardToolCall(const Name, ArgsJSON: string);
+begin
+  if Assigned(FOnToolCall) then FOnToolCall(Self, Name, ArgsJSON);
+end;
+
+procedure TPasClawAgent.ForwardToolResult(const Name, ResultText, Err: string);
+begin
+  if Assigned(FOnToolResult) then FOnToolResult(Self, Name, ResultText, Err);
+end;
+
+procedure TPasClawAgent.RaiseError(const Msg: string);
+begin
+  if Assigned(FOnError) then FOnError(Self, Msg);
+end;
+
+function TPasClawAgent.Chat(const Prompt: string; out Reply, ErrMsg: string): Boolean;
+var
+  Msgs: array of TMessage;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Prompt);
+  Result := ChatHistory(Msgs, Reply, ErrMsg);
+end;
+
+function TPasClawAgent.ChatHistory(const History: array of TMessage;
+                                    out Reply, ErrMsg: string): Boolean;
+var
+  Cfg: TToolLoopConfig;
+  Loop: TToolLoopResult;
+  Msgs: array of TMessage;
+  i: Integer;
+  ModelName: string;
+begin
+  Reply  := '';
+  ErrMsg := '';
+  EnsureConfig;
+  EnsureProvider;
+  if FProvider = nil then
+  begin
+    ErrMsg := 'provider unavailable';
+    Result := False;
+    Exit;
+  end;
+  EnsureRegistry;
+
+  SetLength(Msgs, Length(History));
+  for i := 0 to High(History) do Msgs[i] := History[i];
+
+  if FModel <> '' then ModelName := FModel else ModelName := FConfig.DefaultModel;
+
+  Cfg.Provider      := FProvider;
+  Cfg.Registry      := FRegistry;
+  Cfg.Model         := ModelName;
+  Cfg.MaxIterations := FMaxIterations;
+  Cfg.Options       := DefaultChatOptions;
+  if FSystemPrompt <> '' then Cfg.Options.SystemPrompt := FSystemPrompt;
+  Cfg.OnText        := ForwardText;
+  Cfg.OnToolCall    := ForwardToolCall;
+  Cfg.OnToolResult  := ForwardToolResult;
+
+  try
+    Result := RunToolLoop(Cfg, Msgs, Loop);
+    if Result then
+      Reply := Loop.Content
+    else
+      ErrMsg := 'tool loop failed';
+  except
+    on E: Exception do
+    begin
+      Result := False;
+      ErrMsg := E.ClassName + ': ' + E.Message;
+      RaiseError(ErrMsg);
+    end;
+  end;
+end;
+
+function TPasClawAgent.Execute(const Command: string;
+                                const Args: array of string): Integer;
+begin
+  Result := DispatchCommand(Command, Args);
+end;
+
+{ ============================== TPasClawServer ============================= }
+
+type
+  TServerWorker = class(TThread)
+  private
+    FServer: TGatewayServer;
+    FAddr:   string;
+    FPort:   Integer;
+    FErr:    string;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(AServer: TGatewayServer; const AAddr: string; APort: Integer);
+    property Err: string read FErr;
+  end;
+
+constructor TServerWorker.Create(AServer: TGatewayServer; const AAddr: string; APort: Integer);
+begin
+  inherited Create(True);
+  FreeOnTerminate := False;
+  FServer := AServer;
+  FAddr   := AAddr;
+  FPort   := APort;
+end;
+
+procedure TServerWorker.Execute;
+begin
+  try
+    FServer.Start(FAddr, FPort);
+    FServer.WaitForStop;
+  except
+    on E: Exception do FErr := E.ClassName + ': ' + E.Message;
+  end;
+end;
+
+constructor TPasClawServer.Create(AOwner: TComponent);
+begin
+  if GServerInstance <> nil then
+    raise EPasClawInstance.Create(
+      'Only one TPasClawServer can be live per process — PasClaw.MCP.Bridge ' +
+      'and PasClaw.Skills.Loader hold their state in module-level arrays. ' +
+      'Free the existing instance before creating another.');
+  inherited Create(AOwner);
+  FBindAddr       := '127.0.0.1';
+  FPort           := 8088;
+  FMaxIter        := 25;
+  FEnableTools    := True;
+  FEnableMCP      := True;
+  FEnableHashline := True;
+  GServerInstance := Self;
+end;
+
+destructor TPasClawServer.Destroy;
+begin
+  Stop;
+  if GServerInstance = Self then GServerInstance := nil;
+  inherited Destroy;
+end;
+
+function TPasClawServer.Start: Boolean;
+var
+  Skills: TSkillSpecArray;
+  Err: string;
+begin
+  if IsRunning then Exit(True);
+  { Defensive: if a prior Start failed mid-bind (or the thread exited on
+    its own), Stop joins the dead thread and clears stale state. Cheap
+    no-op when nothing is left over. }
+  if (FThread <> nil) or (FServer <> nil) then Stop;
+
+  FConfig := LoadConfig;
+
+  FProvider := nil;
+  if (FProviderName <> '') or (FConfig.DefaultProvider <> '') then
+  begin
+    if FProviderName <> '' then
+    begin
+      if not NewProviderFromConfig(FConfig, FProviderName, FProvider, Err) then
+        RaiseError('provider unavailable: ' + Err);
+    end
+    else if not NewDefaultProvider(FConfig, FProvider, Err) then
+      RaiseError('provider unavailable: ' + Err);
+  end;
+
+  FRegistry := nil;
+  if FEnableTools then
+  begin
+    FRegistry := TToolRegistry.Create;
+    RegisterFSTools(FRegistry, FEnableHashline);
+    RegisterShellTool(FRegistry);
+    Skills := LoadSkillManifests(GetHome);
+    RegisterSkills(FRegistry, Skills);
+  end;
+
+  SetLength(FMCPClients, 0);
+  if FEnableMCP and (FRegistry <> nil) then
+    FMCPClients := ConnectMCPServers(FConfig, FRegistry);
+
+  FServer := TGatewayServer.Create(FConfig, FProvider, FRegistry);
+  FServer.DebugIO := FDebug;
+  FServer.MaxIter := FMaxIter;
+
+  FThread := TServerWorker.Create(FServer, FBindAddr, FPort);
+  TServerWorker(FThread).Start;
+  Result := True;
+  if Assigned(FOnStarted) then FOnStarted(Self);
+end;
+
+procedure TPasClawServer.Stop;
+begin
+  if FServer <> nil then FServer.Stop;
+  if FThread <> nil then
+  begin
+    FThread.WaitFor;
+    FreeAndNil(FThread);
+  end;
+  FreeAndNil(FServer);
+  FreeMCPClients(FMCPClients);
+  FreeAndNil(FRegistry);
+  FProvider := nil;
+  FreeAndNil(FConfig);
+  if Assigned(FOnStopped) then FOnStopped(Self);
+end;
+
+function TPasClawServer.IsRunning: Boolean;
+begin
+  Result := (FThread <> nil) and (not FThread.Finished);
+end;
+
+procedure TPasClawServer.RaiseError(const Msg: string);
+begin
+  if Assigned(FOnError) then FOnError(Self, Msg);
+end;
+
+{ ============================== Registration ============================== }
+
+procedure Register;
+begin
+  RegisterComponents('PasClaw', [TPasClawAgent, TPasClawServer]);
+end;
+
+end.


### PR DESCRIPTION
## Summary

Lets other Delphi / FPC applications embed PasClaw without shelling out to the CLI. Two `TComponent` descendants in one new unit, plus a tiny extraction from `Cmd.Root` so command dispatch can be called from non-CLI contexts.

### `TPasClawAgent`
- `Chat(Prompt; out Reply, Err): Boolean` — one-shot through the configured provider; `OnText` / `OnToolCall` / `OnToolResult` fire as the tool loop runs.
- `ChatHistory(History; out Reply, Err): Boolean` — multi-turn variant.
- `Execute(Cmd, Args): Integer` — pass-through to every CLI subcommand via the new `DispatchCommand` entry point. Mirrors `pasclaw <cmd> <args...>` byte-for-byte (stdout goes to host process's console).
- Published: `ProviderName`, `Model`, `SystemPrompt`, `MaxIterations`, `UseTools`, `UseMCP`, `UseHashline` + `OnText` / `OnToolCall` / `OnToolResult` / `OnError`.

### `TPasClawServer`
- `Start: Boolean` / `Stop` / `IsRunning`. Start spawns an internal `TThread` that drives `TGatewayServer.Start` + `WaitForStop`; Stop signals shutdown and joins.
- Published: `BindAddr`, `Port`, `MaxIter`, `Debug`, `EnableTools`, `EnableMCP`, `EnableHashline`, `ProviderName`, `Model` + `OnStarted` / `OnStopped` / `OnError`.

### Refactor

`PasClaw.Cmd.Root` now exposes `function DispatchCommand(const Cmd: string; const Argv: array of string): Integer;` which `RunRootCommand` calls after CLI-only setup (argv parsing, `--no-color` stripping, log-level wiring). Same stdout byte-for-byte for the CLI; non-CLI callers (the component, tests) can dispatch any subcommand without re-reading `ParamStr`.

### Single-instance contract

`PasClaw.MCP.Bridge` (`GBindings[32]`) and `PasClaw.Skills.Loader` (`GSpecs[64]`) hold their state in module-level arrays with compile-time fixed handler-slot tables. **Only one live `TPasClawAgent` and one live `TPasClawServer` per process** — each constructor checks a unit-level instance pointer and the second create raises `EPasClawInstance` with a clear message. Lifting that restriction is a larger refactor of those two units' handler tables, deferred.

### Sample

`samples/component-console/SampleConsole.dpr` — ~30-line console program that creates `TPasClawAgent`, calls `Execute('version', [])`, then `Chat('Say hi in three words.')`. Builds under both FPC and Delphi.

## Test plan

- [ ] `make` (FPC) still builds the `pasclaw` binary — new unit included via Makefile UNIT_DIRS
- [ ] Delphi `.dproj` still builds — new unit listed in DCCReference + on the search path
- [ ] CLI unchanged: `pasclaw version`, `pasclaw status`, etc. print identical output as before the `DispatchCommand` extraction
- [ ] Sample console builds and runs: prints the version banner, then prints either a reply or an error string
- [ ] Drop `TPasClawAgent` / `TPasClawServer` on a Delphi form (with the unit installed) — they appear on the `PasClaw` palette tab and the published properties are editable in the Object Inspector
- [ ] Single-instance guard: creating a second `TPasClawAgent` while the first is live raises `EPasClawInstance` with the documented message; freeing the first then creating another succeeds

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_