### PR TITLE
Wire TPasClawServer.Model into startup config default model

### DIFF
--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -421,6 +421,8 @@ begin
   if (FThread <> nil) or (FServer <> nil) then Stop;
 
   FConfig := LoadConfig;
+  if FModel <> '' then
+    FConfig.DefaultModel := FModel;
 
   FProvider := nil;
   if (FProviderName <> '') or (FConfig.DefaultProvider <> '') then


### PR DESCRIPTION
### Motivation
- Ensure the component-level `Model` property becomes the server-wide default/fallback model so endpoints that report or use the default (for example `/v1/models`, `/v1/chat`, and omitted `model` in `/v1/chat/completions`) reflect the component override.

### Description
- In `TPasClawServer.Start` immediately after `FConfig := LoadConfig;` add `if FModel <> '' then FConfig.DefaultModel := FModel;` so the `TGatewayServer` receives the overridden default model while preserving per-request `model` semantics.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d415f114832eb6ec81fe5ed93e94)