### PR TITLE
Phase A: provider catalog covering 18 OpenAI-compatible providers + Anthropic

### DIFF
--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -1,8 +1,12 @@
-{
-  Onboard — initialise config and workspace. Mirrors
-  cmd/picoclaw/internal/onboard. Creates ~/.pasclaw, a starter config.json,
-  and prompts for the default provider's API key.
-}
+(*
+  Onboard — initialise config and workspace. Creates ~/.pasclaw, a
+  starter config.json, and walks the user through picking a provider
+  from the catalog (PasClaw.Providers.Catalog). Selection by number
+  populates the saved TProviderConfig with the catalog's default base
+  URL and default model; the user is prompted for the API key only when
+  the provider's auth scheme requires one (skipped for local providers
+  like Ollama and vLLM).
+*)
 unit PasClaw.Cmd.Onboard;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
@@ -18,7 +22,8 @@ uses
   PasClaw.Config,
   PasClaw.Utils,
   PasClaw.CliUI,
-  PasClaw.Logger;
+  PasClaw.Logger,
+  PasClaw.Providers.Catalog;
 
 function ReadLineEcho(const Prompt: string): string;
 begin
@@ -26,13 +31,89 @@ begin
   ReadLn(Result);
 end;
 
+procedure PrintCatalog(const Catalog: TProviderSpecArray);
+var
+  i: Integer;
+begin
+  WriteLn(Ansi.Bold, 'Choose a provider:', Ansi.Reset);
+  for i := 0 to High(Catalog) do
+    WriteLn(Format(' %2d. %-22s %s', [i + 1, Catalog[i].DisplayName, Catalog[i].Notes]));
+end;
+
+function PickFromCatalog(const Catalog: TProviderSpecArray;
+                         const DefaultKind: string;
+                         out Spec: TProviderSpec): Boolean;
+var
+  Input: string;
+  Idx, DefaultIdx, i: Integer;
+begin
+  Result := False;
+  DefaultIdx := -1;
+  for i := 0 to High(Catalog) do
+    if SameText(Catalog[i].Kind, DefaultKind) then
+    begin
+      DefaultIdx := i;
+      Break;
+    end;
+  PrintCatalog(Catalog);
+  if DefaultIdx >= 0 then
+    Input := ReadLineEcho(Format('Pick [1-%d] (default %d=%s): ',
+              [Length(Catalog), DefaultIdx + 1, Catalog[DefaultIdx].DisplayName]))
+  else
+    Input := ReadLineEcho(Format('Pick [1-%d]: ', [Length(Catalog)]));
+  Input := Trim(Input);
+  if (Input = '') and (DefaultIdx >= 0) then
+  begin
+    Spec := Catalog[DefaultIdx];
+    Exit(True);
+  end;
+  if not TryStrToInt(Input, Idx) then Exit;
+  if (Idx < 1) or (Idx > Length(Catalog)) then Exit;
+  Spec := Catalog[Idx - 1];
+  Result := True;
+end;
+
+procedure UpsertProvider(Cfg: TConfig; const Spec: TProviderSpec;
+                         const Model, Key: string);
+var
+  i: Integer;
+  Found: Boolean;
+begin
+  Found := False;
+  for i := 0 to High(Cfg.Providers) do
+    if SameText(Cfg.Providers[i].Name, Spec.Kind) then
+    begin
+      if Key <> '' then Cfg.Providers[i].APIKey := Key;
+      if Model <> '' then Cfg.Providers[i].Model := Model;
+      Cfg.Providers[i].Kind := Spec.Kind;
+      if Cfg.Providers[i].APIBase = '' then
+        Cfg.Providers[i].APIBase := Spec.DefaultBase;
+      Found := True;
+      Break;
+    end;
+  if Found then Exit;
+
+  SetLength(Cfg.Providers, Length(Cfg.Providers) + 1);
+  with Cfg.Providers[High(Cfg.Providers)] do
+  begin
+    Name    := Spec.Kind;
+    Kind    := Spec.Kind;
+    APIBase := Spec.DefaultBase;
+    APIKey  := Key;
+    if Model <> '' then
+      Cfg.Providers[High(Cfg.Providers)].Model := Model
+    else
+      Cfg.Providers[High(Cfg.Providers)].Model := Spec.DefaultModel;
+  end;
+end;
+
 function Cmd_Onboard_Run(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
   Home, CfgPath: string;
-  Key, Prov, Model: string;
-  i: Integer;
-  Found: Boolean;
+  Key, Model: string;
+  Catalog: TProviderSpecArray;
+  Spec: TProviderSpec;
 begin
   Home    := GetHome;
   CfgPath := GetConfigPath;
@@ -61,42 +142,35 @@ begin
     Cfg := TConfig.Create;
 
   try
-    Prov := ReadLineEcho('Default provider [anthropic]: ');
-    if Trim(Prov) = '' then Prov := 'anthropic';
-    Model := ReadLineEcho('Default model [claude-opus-4-7]: ');
-    if Trim(Model) = '' then Model := 'claude-opus-4-7';
-    Key := ReadLineEcho(Prov + ' API key (leave blank to skip): ');
-
-    Cfg.DefaultProvider := Prov;
-    Cfg.DefaultModel    := Model;
-
-    Found := False;
-    for i := 0 to High(Cfg.Providers) do
-      if SameText(Cfg.Providers[i].Name, Prov) then
-      begin
-        if Key <> '' then Cfg.Providers[i].APIKey := Key;
-        Cfg.Providers[i].Model := Model;
-        Found := True;
-        Break;
-      end;
-    if not Found then
+    Catalog := AllProviderSpecs;
+    if not PickFromCatalog(Catalog, 'anthropic', Spec) then
     begin
-      SetLength(Cfg.Providers, Length(Cfg.Providers) + 1);
-      with Cfg.Providers[High(Cfg.Providers)] do
-      begin
-        Name    := Prov;
-        Kind    := Prov;
-        Model   := Model;
-        APIKey  := Key;
-        if      Prov = 'anthropic' then APIBase := 'https://api.anthropic.com'
-        else if Prov = 'openai'    then APIBase := 'https://api.openai.com';
-      end;
+      WriteLn(Ansi.Yellow, 'no valid selection — config not changed', Ansi.Reset);
+      Exit(1);
     end;
+
+    if Spec.DefaultModel <> '' then
+      Model := ReadLineEcho(Format('Default model [%s]: ', [Spec.DefaultModel]))
+    else
+      Model := ReadLineEcho('Default model (provider does not advertise one — required): ');
+    if Trim(Model) = '' then Model := Spec.DefaultModel;
+
+    case Spec.Auth.Kind of
+      asNone:
+        Key := '';
+    else
+      Key := ReadLineEcho(Spec.DisplayName + ' API key (leave blank to skip): ');
+    end;
+
+    Cfg.DefaultProvider := Spec.Kind;
+    if Model <> '' then Cfg.DefaultModel := Model;
+
+    UpsertProvider(Cfg, Spec, Model, Key);
 
     SaveConfig(Cfg);
     WriteLn;
     WriteLn(Ansi.Green, '✓', Ansi.Reset, ' wrote ', CfgPath);
-    WriteLn('Next: ', Ansi.Bold, 'pasclaw agent -m "hello"', Ansi.Reset);
+    WriteLn('Next: ', Ansi.Bold, 'pasclaw agent "hello"', Ansi.Reset);
     Result := 0;
   finally
     Cfg.Free;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -152,6 +152,7 @@
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Types.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Intf.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.HTTP.pas"/>
+        <DCCReference Include="..\pkg\providers\PasClaw.Providers.Catalog.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Anthropic.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.OpenAI.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Factory.pas"/>

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -1,0 +1,259 @@
+(*
+  PasClaw.Providers.Catalog - single source of truth for the list of
+  supported LLM providers and how to wire each one up.
+
+  The CLI's previous if/else over Kind only covered anthropic + a loose
+  openai-compat family. Most of the 23+ providers picoclaw supports are
+  actually OpenAI Chat Completions speakers with just a different base
+  URL (and occasionally a different auth-header convention). One catalog
+  table + a couple of helpers replaces the dispatch and turns "add a new
+  provider" into a one-row change.
+
+  Three protocol families are reserved here:
+
+    pfOpenAI    - POST <base>/v1/chat/completions, JSON shape OpenAI
+                  defined; covers the long tail.
+    pfAnthropic - POST <base>/v1/messages with x-api-key header;
+                  Anthropic only for now.
+    pfGemini    - placeholder for Google's generateContent shape;
+                  no implementation in Phase A — a follow-up PR adds
+                  TGeminiProvider + flips the gemini entry from
+                  pfPlaceholder to pfGemini.
+
+  Three auth schemes:
+
+    asBearer    - Authorization: Bearer <key>
+    asNone      - no auth header (Ollama, vLLM local deployments)
+    asHeader    - send the raw key in a named header. The header name
+                  lives in TAuthScheme.HeaderName. Reserved for Azure's
+                  api-key style; no entry uses it yet in Phase A but the
+                  field exists so adding Azure later does not break the
+                  TProviderSpec layout.
+*)
+unit PasClaw.Providers.Catalog;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+type
+  TProtocolFamily = (
+    pfOpenAI,
+    pfAnthropic,
+    pfPlaceholder  { kind known, no implementation yet — Gemini/Bedrock/etc. }
+  );
+
+  TAuthSchemeKind = (asBearer, asNone, asHeader);
+
+  TAuthScheme = record
+    Kind:       TAuthSchemeKind;
+    HeaderName: string;   { used only when Kind = asHeader; otherwise '' }
+  end;
+
+  TProviderSpec = record
+    Kind:         string;            { canonical id, lowercase, matches TProviderConfig.Kind }
+    DisplayName:  string;            { e.g. 'Anthropic', 'Groq' }
+    Family:       TProtocolFamily;
+    DefaultBase:  string;
+    DefaultModel: string;            { empty when the provider has no obvious default }
+    Auth:         TAuthScheme;
+    Notes:        string;            { one-line description, shown in onboard menus }
+  end;
+
+  TProviderSpecArray = array of TProviderSpec;
+
+{ Returns True and fills Spec when Kind matches a catalog entry
+  (case-insensitive). Returns False otherwise. }
+function LookupProvider(const Kind: string; out Spec: TProviderSpec): Boolean;
+
+{ Returns a copy of every catalog entry, ordered by DisplayName, suitable
+  for menus. The list is small (~19 entries) and rebuilt on each call —
+  callers are not expected to call this in a hot loop. }
+function AllProviderSpecs: TProviderSpecArray;
+
+{ Helper that returns the default base URL for a kind, or '' if no such
+  kind exists. Convenience for callers that don't need the full spec. }
+function DefaultBaseFor(const Kind: string): string;
+
+implementation
+
+uses
+  SysUtils;
+
+function MkAuth(Kind: TAuthSchemeKind; const HeaderName: string = ''): TAuthScheme;
+begin
+  Result.Kind       := Kind;
+  Result.HeaderName := HeaderName;
+end;
+
+function MkSpec(const Kind, DisplayName: string; Family: TProtocolFamily;
+                const DefaultBase, DefaultModel: string;
+                const Auth: TAuthScheme; const Notes: string): TProviderSpec;
+begin
+  Result.Kind         := Kind;
+  Result.DisplayName  := DisplayName;
+  Result.Family       := Family;
+  Result.DefaultBase  := DefaultBase;
+  Result.DefaultModel := DefaultModel;
+  Result.Auth         := Auth;
+  Result.Notes        := Notes;
+end;
+
+{ The catalog. New providers go here — one entry per row, no other code
+  change required for OpenAI-compatible endpoints. }
+function BuildCatalog: TProviderSpecArray;
+begin
+  SetLength(Result, 19);
+  Result[0]  := MkSpec('anthropic',  'Anthropic',
+                       pfAnthropic,  'https://api.anthropic.com',
+                       'claude-opus-4-7',
+                       MkAuth(asHeader, 'x-api-key'),
+                       'Claude Opus / Sonnet / Haiku');
+  Result[1]  := MkSpec('openai',     'OpenAI',
+                       pfOpenAI,     'https://api.openai.com',
+                       'gpt-4o-mini',
+                       MkAuth(asBearer),
+                       'GPT-4o, GPT-5, o3 family');
+  Result[2]  := MkSpec('openrouter', 'OpenRouter',
+                       pfOpenAI,     'https://openrouter.ai/api',
+                       '',
+                       MkAuth(asBearer),
+                       '200+ models, unified API');
+  Result[3]  := MkSpec('zhipu',      'Zhipu (GLM)',
+                       pfOpenAI,     'https://open.bigmodel.cn/api/paas',
+                       'glm-4',
+                       MkAuth(asBearer),
+                       'GLM-4, GLM-5');
+  Result[4]  := MkSpec('deepseek',   'DeepSeek',
+                       pfOpenAI,     'https://api.deepseek.com',
+                       'deepseek-chat',
+                       MkAuth(asBearer),
+                       'DeepSeek-V3, DeepSeek-R1');
+  Result[5]  := MkSpec('volcengine', 'Volcengine (Doubao/Ark)',
+                       pfOpenAI,     'https://ark.cn-beijing.volces.com/api',
+                       '',
+                       MkAuth(asBearer),
+                       'ByteDance Doubao / Ark models');
+  Result[6]  := MkSpec('qwen',       'Qwen (DashScope)',
+                       pfOpenAI,     'https://dashscope.aliyuncs.com/compatible-mode',
+                       'qwen-max',
+                       MkAuth(asBearer),
+                       'Qwen3 / Qwen-Max');
+  Result[7]  := MkSpec('groq',       'Groq',
+                       pfOpenAI,     'https://api.groq.com/openai',
+                       '',
+                       MkAuth(asBearer),
+                       'Fast inference (Llama, Mixtral)');
+  Result[8]  := MkSpec('moonshot',   'Moonshot (Kimi)',
+                       pfOpenAI,     'https://api.moonshot.cn',
+                       'moonshot-v1-32k',
+                       MkAuth(asBearer),
+                       'Kimi models');
+  Result[9]  := MkSpec('minimax',    'MiniMax',
+                       pfOpenAI,     'https://api.minimax.chat',
+                       '',
+                       MkAuth(asBearer),
+                       'MiniMax abab / hailuo');
+  Result[10] := MkSpec('mistral',    'Mistral',
+                       pfOpenAI,     'https://api.mistral.ai',
+                       'mistral-large-latest',
+                       MkAuth(asBearer),
+                       'Mistral Large, Codestral');
+  Result[11] := MkSpec('nvidia',     'NVIDIA NIM',
+                       pfOpenAI,     'https://integrate.api.nvidia.com',
+                       '',
+                       MkAuth(asBearer),
+                       'NVIDIA-hosted models');
+  Result[12] := MkSpec('cerebras',   'Cerebras',
+                       pfOpenAI,     'https://api.cerebras.ai',
+                       '',
+                       MkAuth(asBearer),
+                       'Fast inference');
+  Result[13] := MkSpec('novita',     'Novita AI',
+                       pfOpenAI,     'https://api.novita.ai',
+                       '',
+                       MkAuth(asBearer),
+                       'Various open models');
+  Result[14] := MkSpec('mimo',       'Xiaomi MiMo',
+                       pfOpenAI,     '',
+                       '',
+                       MkAuth(asBearer),
+                       'MiMo (set api_base in config)');
+  Result[15] := MkSpec('ollama',     'Ollama (local)',
+                       pfOpenAI,     'http://localhost:11434',
+                       '',
+                       MkAuth(asNone),
+                       'Local models, self-hosted');
+  Result[16] := MkSpec('vllm',       'vLLM (local)',
+                       pfOpenAI,     'http://localhost:8000',
+                       '',
+                       MkAuth(asNone),
+                       'OpenAI-compatible local deployment');
+  Result[17] := MkSpec('litellm',    'LiteLLM proxy',
+                       pfOpenAI,     '',
+                       '',
+                       MkAuth(asBearer),
+                       'Proxy for 100+ providers (set api_base)');
+  Result[18] := MkSpec('gemini',     'Google Gemini',
+                       pfPlaceholder,'https://generativelanguage.googleapis.com',
+                       'gemini-1.5-flash',
+                       MkAuth(asBearer),
+                       'Gemini (implementation pending — Phase B)');
+end;
+
+function LookupProvider(const Kind: string; out Spec: TProviderSpec): Boolean;
+var
+  Cat: TProviderSpecArray;
+  i: Integer;
+  Lower: string;
+begin
+  Result := False;
+  Lower := LowerCase(Trim(Kind));
+  if Lower = '' then Exit;
+  Cat := BuildCatalog;
+  for i := 0 to High(Cat) do
+    if Cat[i].Kind = Lower then
+    begin
+      Spec := Cat[i];
+      Exit(True);
+    end;
+end;
+
+function CompareSpecs(const A, B: TProviderSpec): Integer;
+begin
+  Result := CompareText(A.DisplayName, B.DisplayName);
+end;
+
+function AllProviderSpecs: TProviderSpecArray;
+var
+  i, j: Integer;
+  Tmp: TProviderSpec;
+begin
+  Result := BuildCatalog;
+  { Simple insertion sort by DisplayName — list is small and we'd rather
+    avoid pulling in System.Generics.Collections just for this. }
+  for i := 1 to High(Result) do
+  begin
+    Tmp := Result[i];
+    j := i;
+    while (j > 0) and (CompareSpecs(Result[j - 1], Tmp) > 0) do
+    begin
+      Result[j] := Result[j - 1];
+      Dec(j);
+    end;
+    Result[j] := Tmp;
+  end;
+end;
+
+function DefaultBaseFor(const Kind: string): string;
+var
+  Spec: TProviderSpec;
+begin
+  if LookupProvider(Kind, Spec) then
+    Result := Spec.DefaultBase
+  else
+    Result := '';
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -23,7 +23,8 @@ implementation
 
 uses
   PasClaw.Providers.Anthropic,
-  PasClaw.Providers.OpenAI;
+  PasClaw.Providers.OpenAI,
+  PasClaw.Providers.Catalog;
 
 function FindProvider(Cfg: TConfig; const Name: string; out Idx: Integer): Boolean;
 var
@@ -39,11 +40,19 @@ begin
   Result := False;
 end;
 
+function FirstNonEmpty(const A, B: string): string; inline;
+begin
+  if A <> '' then Result := A else Result := B;
+end;
+
 function NewProviderFromConfig(Cfg: TConfig; const ProviderName: string;
                                out Provider: ILLMProvider; out ErrMsg: string): Boolean;
 var
   Idx: Integer;
   Kind: string;
+  Spec: TProviderSpec;
+  Base, Model, APIKey: string;
+  RequiresKey: Boolean;
 begin
   Provider := nil;
   ErrMsg := '';
@@ -52,27 +61,43 @@ begin
     ErrMsg := 'no provider entry for "' + ProviderName + '" — run `pasclaw onboard` or `pasclaw auth login ' + ProviderName + '`';
     Exit(False);
   end;
-  if Cfg.Providers[Idx].APIKey = '' then
+  Kind := LowerCase(Cfg.Providers[Idx].Kind);
+  if Kind = '' then Kind := LowerCase(Cfg.Providers[Idx].Name);
+
+  if not LookupProvider(Kind, Spec) then
+  begin
+    ErrMsg := 'unsupported provider kind "' + Cfg.Providers[Idx].Kind +
+              '" — see `pasclaw onboard` or pkg/providers/PasClaw.Providers.Catalog.pas';
+    Exit(False);
+  end;
+
+  APIKey := Cfg.Providers[Idx].APIKey;
+  RequiresKey := Spec.Auth.Kind <> asNone;
+  if RequiresKey and (APIKey = '') then
   begin
     ErrMsg := 'provider "' + ProviderName + '" has no API key — run `pasclaw auth login ' + ProviderName + '`';
     Exit(False);
   end;
-  Kind := LowerCase(Cfg.Providers[Idx].Kind);
-  if Kind = '' then Kind := LowerCase(Cfg.Providers[Idx].Name);
 
-  if Kind = 'anthropic' then
-    Provider := TAnthropicProvider.Create(
-      Cfg.Providers[Idx].APIKey,
-      Cfg.Providers[Idx].APIBase,
-      Cfg.Providers[Idx].Model)
-  else if (Kind = 'openai') or (Kind = 'openai-compat') or (Kind = 'groq') or (Kind = 'together') or (Kind = 'ollama') then
-    Provider := TOpenAIProvider.Create(
-      Cfg.Providers[Idx].APIKey,
-      Cfg.Providers[Idx].APIBase,
-      Cfg.Providers[Idx].Model)
+  { Effective base / model fall back to the catalog's defaults when the
+    config entry left them blank. Lets a freshly-onboarded provider work
+    immediately with no extra fields to fill in. }
+  Base  := FirstNonEmpty(Cfg.Providers[Idx].APIBase, Spec.DefaultBase);
+  Model := FirstNonEmpty(Cfg.Providers[Idx].Model,   Spec.DefaultModel);
+
+  case Spec.Family of
+    pfAnthropic:
+      Provider := TAnthropicProvider.Create(APIKey, Base, Model);
+    pfOpenAI:
+      Provider := TOpenAIProvider.Create(APIKey, Base, Model, Kind, Spec.Auth);
+    pfPlaceholder:
+      begin
+        ErrMsg := 'provider "' + Spec.DisplayName + '" is in the catalog but ' +
+                  'its protocol implementation is not yet bundled in this build';
+        Exit(False);
+      end;
   else
-  begin
-    ErrMsg := 'unsupported provider kind "' + Cfg.Providers[Idx].Kind + '" (supported: anthropic, openai)';
+    ErrMsg := 'provider "' + Spec.DisplayName + '" has no protocol family wired up';
     Exit(False);
   end;
   Result := True;

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -1,9 +1,13 @@
 {
-  PasClaw.Providers.OpenAI - OpenAI Chat Completions client (also handles
-  OpenAI-compatible endpoints: Together, Groq, Ollama, etc.).
+  PasClaw.Providers.OpenAI - OpenAI Chat Completions client and the
+  shared implementation for every OpenAI-compatible provider (Groq,
+  DeepSeek, Together, OpenRouter, Ollama, vLLM, Mistral, etc.). Catalog
+  entries in PasClaw.Providers.Catalog point here with their own base
+  URL + auth scheme; this unit doesn't know which provider it's being
+  used for beyond the display name it was created with.
 
   Endpoint: POST <api_base>/v1/chat/completions
-  Auth:     Authorization: Bearer <key>
+  Auth:     Authorization: Bearer <key>  (default; override via TAuthScheme)
 }
 unit PasClaw.Providers.OpenAI;
 
@@ -15,16 +19,28 @@ interface
 uses
   SysUtils, Classes,
   PasClaw.Providers.Types,
-  PasClaw.Providers.Intf;
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.HTTP,
+  PasClaw.Providers.Catalog;
 
 type
   TOpenAIProvider = class(TInterfacedObject, ILLMProvider)
   private
-    FAPIKey:  string;
-    FAPIBase: string;
+    FAPIKey:       string;
+    FAPIBase:      string;
     FDefaultModel: string;
+    FAuth:         TAuthScheme;
+    FDisplayName:  string;   { surface in GetName / log lines }
+    function BuildAuthHeaders: TArray<THeaderPair>;
   public
-    constructor Create(const APIKey, APIBase, DefaultModel: string);
+    { Backwards-compatible constructor: assumes Bearer auth and the
+      'openai' display name. Existing call sites stay byte-identical. }
+    constructor Create(const APIKey, APIBase, DefaultModel: string); overload;
+    { Catalog-aware constructor used by the factory. DisplayName surfaces
+      in GetName (so 'groq' returns 'groq', not 'openai'); Auth controls
+      how the API key is sent (Bearer / none / custom header). }
+    constructor Create(const APIKey, APIBase, DefaultModel, DisplayName: string;
+                       const Auth: TAuthScheme); overload;
     function Chat(const Messages: array of TMessage;
                   const Tools:    array of TToolDefinition;
                   const Model:    string;
@@ -45,19 +61,59 @@ implementation
 
 uses
   PasClaw.JSON,
-  PasClaw.Providers.HTTP,
   PasClaw.Logger;
 
 constructor TOpenAIProvider.Create(const APIKey, APIBase, DefaultModel: string);
+var
+  Bearer: TAuthScheme;
+begin
+  Bearer.Kind       := asBearer;
+  Bearer.HeaderName := '';
+  Create(APIKey, APIBase, DefaultModel, 'openai', Bearer);
+end;
+
+constructor TOpenAIProvider.Create(const APIKey, APIBase, DefaultModel, DisplayName: string;
+                                    const Auth: TAuthScheme);
 begin
   inherited Create;
   FAPIKey := APIKey;
   if APIBase <> '' then FAPIBase := APIBase else FAPIBase := 'https://api.openai.com';
   if DefaultModel <> '' then FDefaultModel := DefaultModel else FDefaultModel := 'gpt-4o-mini';
+  if DisplayName <> '' then FDisplayName := DisplayName else FDisplayName := 'openai';
+  FAuth := Auth;
+end;
+
+function TOpenAIProvider.BuildAuthHeaders: TArray<THeaderPair>;
+begin
+  case FAuth.Kind of
+    asNone:
+      SetLength(Result, 0);
+    asHeader:
+      begin
+        if (FAuth.HeaderName = '') or (FAPIKey = '') then
+        begin
+          SetLength(Result, 0);
+          Exit;
+        end;
+        SetLength(Result, 1);
+        Result[0] := MakeHeader(FAuth.HeaderName, FAPIKey);
+      end;
+  else
+    { asBearer is the default — and the safety net for any future enum
+      value we forget to handle here. Skip emitting the header when the
+      key is empty (local providers misconfigured as Bearer still work). }
+    if FAPIKey = '' then
+      SetLength(Result, 0)
+    else
+    begin
+      SetLength(Result, 1);
+      Result[0] := MakeHeader('Authorization', 'Bearer ' + FAPIKey);
+    end;
+  end;
 end;
 
 function TOpenAIProvider.GetDefaultModel: string;     begin Result := FDefaultModel; end;
-function TOpenAIProvider.GetName: string;             begin Result := 'openai'; end;
+function TOpenAIProvider.GetName: string;             begin Result := FDisplayName;  end;
 function TOpenAIProvider.SupportsThinking: Boolean;   begin Result := False; end;
 function TOpenAIProvider.SupportsNativeSearch: Boolean; begin Result := False; end;
 function TOpenAIProvider.SupportsStreaming: Boolean;  begin Result := False; end;
@@ -235,16 +291,15 @@ function TOpenAIProvider.Chat(const Messages: array of TMessage;
 var
   Body, URL, UseModel: string;
   Resp: THTTPResult;
-  Headers: array of THeaderPair;
+  Headers: TArray<THeaderPair>;
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1/chat/completions';
   Body := BuildOAIRequest(Messages, Tools, UseModel, Options);
 
-  SetLength(Headers, 1);
-  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FAPIKey);
+  Headers := BuildAuthHeaders;
 
-  LogDebug('openai POST %s (model=%s, body=%d bytes)', [URL, UseModel, Length(Body)]);
+  LogDebug('%s POST %s (model=%s, body=%d bytes)', [FDisplayName, URL, UseModel, Length(Body)]);
   Resp := PostJSON(URL, Body, Headers, 120);
 
   Result.Content := '';
@@ -254,9 +309,9 @@ begin
   else
   begin
     if Resp.Body <> '' then
-      Result.Content := Format('openai error %d: %s', [Resp.StatusCode, Resp.Body])
+      Result.Content := Format('%s error %d: %s', [FDisplayName, Resp.StatusCode, Resp.Body])
     else
-      Result.Content := Format('openai error: status=%d msg=%s', [Resp.StatusCode, Resp.ErrorMsg]);
+      Result.Content := Format('%s error: status=%d msg=%s', [FDisplayName, Resp.StatusCode, Resp.ErrorMsg]);
     Result.FinishReason := 'error';
   end;
 end;


### PR DESCRIPTION
## Summary

Replaces the hardcoded `anthropic` / `openai-compat` if-else in `Factory.NewProviderFromConfig` with a catalog table that lights up 18 OpenAI-compatible providers immediately — most of picoclaw's 23+ supported providers actually speak OpenAI Chat Completions, just at a different base URL.

After this PR, adding another OpenAI-compatible provider is a one-row catalog entry — no new code.

## New unit: `PasClaw.Providers.Catalog`

```pascal
TProtocolFamily = (pfOpenAI, pfAnthropic, pfPlaceholder);
TAuthSchemeKind = (asBearer, asNone, asHeader);
TAuthScheme     = record Kind: TAuthSchemeKind; HeaderName: string; end;
TProviderSpec   = record Kind, DisplayName, DefaultBase, DefaultModel, Notes: string;
                         Family: TProtocolFamily; Auth: TAuthScheme; end;

function LookupProvider(const Kind: string; out Spec: TProviderSpec): Boolean;
function AllProviderSpecs: TProviderSpecArray;   { sorted by display name }
function DefaultBaseFor(const Kind: string): string;
```

19 catalog rows ship in this PR:

| Kind | Family | Default base | Default model | Auth |
|---|---|---|---|---|
| anthropic | pfAnthropic | api.anthropic.com | claude-opus-4-7 | x-api-key |
| openai | pfOpenAI | api.openai.com | gpt-4o-mini | Bearer |
| openrouter | pfOpenAI | openrouter.ai/api | _(user picks)_ | Bearer |
| zhipu | pfOpenAI | open.bigmodel.cn | glm-4 | Bearer |
| deepseek | pfOpenAI | api.deepseek.com | deepseek-chat | Bearer |
| volcengine | pfOpenAI | ark.cn-beijing.volces.com | _(user picks)_ | Bearer |
| qwen | pfOpenAI | dashscope.aliyuncs.com | qwen-max | Bearer |
| groq | pfOpenAI | api.groq.com/openai | _(user picks)_ | Bearer |
| moonshot | pfOpenAI | api.moonshot.cn | moonshot-v1-32k | Bearer |
| minimax | pfOpenAI | api.minimax.chat | _(user picks)_ | Bearer |
| mistral | pfOpenAI | api.mistral.ai | mistral-large-latest | Bearer |
| nvidia | pfOpenAI | integrate.api.nvidia.com | _(user picks)_ | Bearer |
| cerebras | pfOpenAI | api.cerebras.ai | _(user picks)_ | Bearer |
| novita | pfOpenAI | api.novita.ai | _(user picks)_ | Bearer |
| mimo | pfOpenAI | _(user-configured)_ | _(user picks)_ | Bearer |
| ollama | pfOpenAI | localhost:11434 | _(user picks)_ | **none** |
| vllm | pfOpenAI | localhost:8000 | _(user picks)_ | **none** |
| litellm | pfOpenAI | _(user-configured)_ | _(user picks)_ | Bearer |
| gemini | **pfPlaceholder** | generativelanguage.googleapis.com | gemini-1.5-flash | (returns clear error until Phase B lands) |

## Modified

- **`TOpenAIProvider`** — overloaded constructor accepts `TAuthScheme` + a display name. Existing 3-arg constructor forwards with `asBearer` / `'openai'` so every existing call site is byte-identical. `BuildAuthHeaders` centralizes the auth-header construction; logs now show e.g. `groq POST ...` instead of `openai POST ...` for a Groq config.
- **`Factory.NewProviderFromConfig`** — looks up the kind in the catalog, falls back to catalog defaults for empty `APIBase` / `Model`, dispatches on `Family`. `pfPlaceholder` kinds return a clear "implementation not yet bundled" error.
- **`Cmd.Onboard`** — replaces the anthropic/openai prompt with a numbered list from `AllProviderSpecs`. Selection writes a `TProviderConfig` populated from the catalog. The API key prompt is skipped for `asNone` providers (Ollama, vLLM).
- **`PasClaw.dproj`** — new unit added to DCCReference. FPC `Makefile` UNIT_DIRS already covers `src/pkg/providers`, no change needed there.

## Deferred to follow-up PRs

Each follow-up adds one new `TProtocolFamily` enum value + one new `case` branch in `Factory`. Wiring stays the same.

- **Gemini** — `TGeminiProvider` for the `generateContent` REST shape (~300 LOC).
- **AWS Bedrock** — SigV4 signing + per-model schemas; build-tag gated like picoclaw.
- **Azure OpenAI** — `asHeader` is already reserved; needs path quirks (deployment-id, api-version query).
- **GitHub Copilot** — OAuth device flow.
- **Antigravity** — Google Cloud OAuth.

## Test plan

- [ ] FPC build (`make`) and Delphi `.dproj` both build cleanly with the new unit
- [ ] Existing `anthropic` / `openai` configs work unchanged (`pasclaw agent "hi"`) — regression check on the factory refactor
- [ ] Hand-edit `~/.pasclaw/config.json` with `kind: "groq"` + an API key; `pasclaw status` lists it; `pasclaw agent "hi"` round-trips through Groq
- [ ] Same drill with `kind: "deepseek"`, `kind: "openrouter"`
- [ ] `pasclaw onboard` shows the numbered list, accepts a pick, writes the right `APIBase` from the catalog
- [ ] Onboarding `ollama` doesn't prompt for an API key (`asNone`); a chat call to a local Ollama endpoint sends no Authorization header
- [ ] `pasclaw agent "hi"` against a `kind: "gemini"` entry returns the documented "not yet bundled" error rather than crashing

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_