### PR TITLE
Refuse fs_write with missing content so truncated tool calls don't clobber files

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -60,6 +60,33 @@ begin
   end;
 end;
 
+function HasJSONKey(const ArgsJSON, Field: string): Boolean;
+{ Returns True iff the JSON object actually contains the key.
+  Distinct from ParseStringArg, which returns False both when the key
+  is missing AND when its value is the empty string. fs_write needs
+  the distinction: a missing `content` is almost always a truncated
+  tool call (Anthropic hits max_tokens mid-tool_use generation and
+  returns partial JSON) and silently writing 0 bytes would clobber the
+  user's file. A present-but-empty `content` is a legitimate
+  "clear the file" request. }
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      Result := Obj.Has(Field);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
 function ParseBoolArg(const ArgsJSON, Field: string; Default: Boolean): Boolean;
 var
   Obj: TJsonObject;
@@ -120,6 +147,24 @@ begin
   if not ParseStringArg(ArgsJSON, 'path', Path) then
   begin
     ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not HasJSONKey(ArgsJSON, 'content') then
+  begin
+    { A missing `content` key almost always means the model''s response
+      was truncated mid-tool_call (Anthropic / OpenAI hit max_tokens
+      during tool_use generation and returned the partial JSON). The
+      old behavior dutifully treated the missing field as the empty
+      string and overwrote the file with 0 bytes — destroying the
+      user''s content with no error signal to the model, which then
+      retried the same truncated call in a loop. Refuse the call so
+      the model gets feedback and either re-emits with full content or
+      switches to fs_edit_hashline for incremental writes. Pass
+      "content":"" explicitly to legitimately clear a file. }
+    ErrMsg := 'missing required argument: content. ' +
+              'If your previous response was truncated mid-tool_call (model hit max_tokens), ' +
+              're-emit fs_write with the full content as a string, or use fs_edit_hashline ' +
+              'to apply incremental edits. Pass "content":"" explicitly to clear a file.';
     Exit('');
   end;
   ParseStringArg(ArgsJSON, 'content', Content);


### PR DESCRIPTION
## Summary

Fixes the destructive behavior you saw in your debug log:

```
tool_call: name=fs_write args={"path":"...llmchat.Tui.pas"}
tool_result: name=fs_write err= result=wrote 0 bytes to ...llmchat.Tui.pas
(model retries the same truncated call for 6 more iterations,
 wiping the file to 0 bytes each round)
```

### Root cause

The content was large enough that the model hit its per-turn `max_tokens` budget midway through generating the tool_use input JSON. Anthropic returned the partial JSON, our Anthropic parser ended up with just `{"path":"..."}` (no `content` field), and `Tool_FSWrite` happily treated the missing key as the empty string, overwrote the file with 0 bytes, and reported `"wrote 0 bytes"` as a *success message*. The model saw no error, retried, and the same thing happened — file destroyed each round.

### Fix

Introduce `HasJSONKey()` which returns True only when the JSON object actually contains the key — distinct from `ParseStringArg`, which returns False both for missing AND empty-string values.

`Tool_FSWrite` now:

| `content` in args | Behavior |
|---|---|
| missing entirely | **Reject** with `missing required argument: content. If your previous response was truncated mid-tool_call (model hit max_tokens), re-emit fs_write with the full content as a string, or use fs_edit_hashline to apply incremental edits. Pass "content":"" explicitly to clear a file.` |
| present but empty `""` | Allow (legitimate "clear file" request, unchanged) |
| present with value | Existing path, unchanged |

The defensive hashline-prefix stripping is untouched.

### Separate concern (not in this PR)

The default `max_tokens` of 4096 is genuinely too low for code-writing tasks — a typical Pascal unit easily exceeds that in tokens. Worth a follow-up PR that either raises the default for `agent`/`serve` or steers the model toward `fs_edit_hashline` for incremental writes. With this PR the model at least gets a clear error pointing at the escape hatch instead of a silent file wipe.

### About "bytes go up a little each time"

That's the conversation history accumulating each round-trip (assistant turn + tool result get appended). Not a bug.

## Test plan

- [ ] Send a tool_call to fs_write with `{"path":"x.txt"}` (no content) — get the error, file untouched
- [ ] Send `{"path":"x.txt","content":""}` — succeeds, file truncated to 0 bytes (existing semantics)
- [ ] Send `{"path":"x.txt","content":"hello"}` — succeeds as before
- [ ] Long-form regression: the multi-iteration truncation scenario from the original bug report now surfaces the new error to the model after the first truncation, breaking the wipe-and-retry loop

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_