### PR TITLE
Fix openai-compat provider resolution and enforce required model input

### DIFF
--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -152,7 +152,9 @@ begin
     if Spec.DefaultModel <> '' then
       Model := ReadLineEcho(Format('Default model [%s]: ', [Spec.DefaultModel]))
     else
-      Model := ReadLineEcho('Default model (provider does not advertise one — required): ');
+      repeat
+        Model := ReadLineEcho('Default model (provider does not advertise one — required): ');
+      until Trim(Model) <> '';
     if Trim(Model) = '' then Model := Spec.DefaultModel;
 
     case Spec.Auth.Kind of

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -45,6 +45,13 @@ begin
   if A <> '' then Result := A else Result := B;
 end;
 
+function NormalizeProviderKind(const Kind: string): string;
+begin
+  Result := LowerCase(Trim(Kind));
+  if Result = 'openai-compat' then
+    Result := 'openai';
+end;
+
 function NewProviderFromConfig(Cfg: TConfig; const ProviderName: string;
                                out Provider: ILLMProvider; out ErrMsg: string): Boolean;
 var
@@ -61,8 +68,8 @@ begin
     ErrMsg := 'no provider entry for "' + ProviderName + '" — run `pasclaw onboard` or `pasclaw auth login ' + ProviderName + '`';
     Exit(False);
   end;
-  Kind := LowerCase(Cfg.Providers[Idx].Kind);
-  if Kind = '' then Kind := LowerCase(Cfg.Providers[Idx].Name);
+  Kind := NormalizeProviderKind(Cfg.Providers[Idx].Kind);
+  if Kind = '' then Kind := NormalizeProviderKind(Cfg.Providers[Idx].Name);
 
   if not LookupProvider(Kind, Spec) then
   begin


### PR DESCRIPTION
## Summary
- normalize legacy `openai-compat` provider kind to `openai` before catalog lookup in `PasClaw.Providers.Factory`
- preserve existing fallback-from-name behavior while applying the same normalization
- require non-blank model input during onboarding when the selected provider has no catalog default model

## Why
- existing configs using the historical `openai-compat` kind were rejected as unsupported
- onboarding previously allowed blank model for providers without defaults, which could later fall through to OpenAI default model names in downstream provider creation paths

## Files changed
- `src/pkg/providers/PasClaw.Providers.Factory.pas`
- `src/cmd/PasClaw.Cmd.Onboard.pas`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17db695a2c832e87930d4b8e6d7006)