### PR TITLE
Fix Delphi build error in ToolLoop JSON retry path

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -248,8 +248,8 @@ begin
         begin
           ArgsObj := TJsonObject.Create;
           try
-            ArgsObj.Put('patch', CanonicalPatch);
-            RetryArgs := ArgsObj.Stringify;
+            ArgsObj.PutStr('patch', CanonicalPatch);
+            RetryArgs := ArgsObj.ToJSON;
           finally
             ArgsObj.Free;
           end;


### PR DESCRIPTION
## Summary
- replace invalid `TJsonObject` calls in `PasClaw.Tools.ToolLoop.pas`
- use `PutStr` instead of `Put`
- use `ToJSON` instead of `Stringify`

## Why
Delphi reported undeclared identifiers for `Put` and `Stringify` because `TJsonObject` in `PasClaw.JSON` exposes `PutStr` and `ToJSON`.

## Files changed
- `src/pkg/tools/PasClaw.Tools.ToolLoop.pas`

## Validation
- static inspection only (no test execution requested)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e1f5ae1c832e88b9c6938fda2ca8)