### PR TITLE
Raise default max_tokens 4096 -> 8192 to match nanobot / picoclaw

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -76,7 +76,7 @@ begin
   Result.Provider      := '';
   Result.SystemPrompt  := '';
   Result.Thinking      := '';
-  Result.MaxTokens     := 4096;
+  Result.MaxTokens     := 8192;   { see DefaultChatOptions in PasClaw.Providers.Types — same rationale }
   Result.MaxIterations := 8;
   Result.NoTools       := False;
   Result.NoMCP         := False;

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -120,7 +120,16 @@ begin
     "`temperature` is deprecated for this model" 400 on the newer
     Claude models, which reject the field outright. }
   Result.Temperature   := 0;
-  Result.MaxTokens     := 4096;
+  { 8192 matches picoclaw's config.example.json and the recommended
+    setting across nanobot's docs / examples (HKUDS/nanobot and
+    nanobot-ai/nanobot both ship 8192 in their config examples).
+    The previous 4096 was too tight for code-writing tool calls: a
+    typical Pascal/TS unit easily exceeds 4k tokens in a single
+    tool_use input, and Anthropic returns the partial JSON when the
+    budget runs out — see PR #41 for the fs_write fallout that
+    motivated this. Callers can still override per-call via
+    --max-tokens or the gateway's max_tokens request field. }
+  Result.MaxTokens     := 8192;
   Result.Stream        := False;
   Result.SystemPrompt  := '';
   Result.ThinkingLevel := '';


### PR DESCRIPTION
## Summary

Follow-up to #41 — fix the underlying cause instead of just defending against its fallout. The 4096-token default per turn was too tight for code-writing tool calls: a typical Pascal/TS unit's content easily exceeds 4k tokens inside a single `tool_use` input, Anthropic returns the partial JSON when the budget runs out, and that's exactly the truncated-fs_write scenario #41 had to add a guard for.

## What value to use — cross-checked against the closest comparable agents

| Project | Default | Notes |
|---|---|---|
| **picoclaw** (Go project PasClaw ports from) | **8192** | [`config/config.example.json`](https://github.com/FMXExpress/picoclaw) ships `max_tokens: 8192` |
| **HKUDS/nanobot** | method-signature 4096, **example/docs 8192** | Method signature defaults to 4096 but every config example in the docs recommends 8192 for Claude |
| **nanobot-ai/nanobot** | **8192** | Go config examples consistently use `maxTokens: 8192` |

8192 is the consensus.

## Change

Two call sites both bumped to 8192:

- `src/pkg/providers/PasClaw.Providers.Types.pas` — `DefaultChatOptions.MaxTokens`
- `src/cmd/PasClaw.Cmd.Agent.pas` — `DefaultAgentArgs.MaxTokens`

## User overrides still work

Unchanged precedence:

- `pasclaw agent --max-tokens N "..."` — explicit CLI flag
- `POST /v1/chat/completions` with `"max_tokens": N` in the request body — the gateway already does `Req.GetInt('max_tokens', LoopCfg.Options.MaxTokens)` at `PasClaw.Gateway.Server.pas:808`

Both take precedence over this default.

## Test plan

- [ ] `pasclaw agent "write me a small Pascal unit"` — emits `body=...` with `"max_tokens":8192` to Anthropic
- [ ] `pasclaw agent --max-tokens 2048 "..."` — still sends 2048 (override works)
- [ ] `curl /v1/chat/completions` with `"max_tokens": 16384` — still uses 16384 (gateway override works)
- [ ] Long-form regression: the multi-iteration truncated-fs_write scenario from #41's bug report no longer recurs at all for files that fit in 8k tokens (#41's guard remains as the safety net for files that don't)

## Sources

- [picoclaw config example](https://github.com/FMXExpress/picoclaw)
- [HKUDS/nanobot configuration docs](https://github.com/HKUDS/nanobot/blob/main/docs/configuration.md)
- [nanobot-ai/nanobot](https://github.com/nanobot-ai/nanobot)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_