### PR TITLE
Synthesize Gemini tool-call ids so functionResponse name resolves

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -336,9 +336,23 @@ begin
                   FuncCall := Part.ChildObject('functionCall');
                   if FuncCall <> nil then
                   try
-                    TC.Id        := FuncCall.GetStr('id', '');
                     TC.Kind      := 'function';
                     TC.Func.Name := FuncCall.GetStr('name', '');
+                    { Gemini's functionCall has name + args but no
+                      OpenAI-style id. The tool loop later records this
+                      id on the mrTool result, and BuildRequest above
+                      needs a non-empty id to resolve the call->name
+                      map for functionResponse — leaving Id empty
+                      makes the tool result go back with name: "" and
+                      the model can't associate it with the requested
+                      call. Synthesize a deterministic local id from
+                      the function name + the position of this call in
+                      the response. Collisions across turns are fine:
+                      same id always maps to the same name. }
+                    TC.Id        := FuncCall.GetStr('id', '');
+                    if Trim(TC.Id) = '' then
+                      TC.Id := Format('gemini_call_%s_%d',
+                                      [TC.Func.Name, Length(Resp.ToolCalls)]);
                     ArgsObj := FuncCall.ChildObject('args');
                     if ArgsObj <> nil then
                     try


### PR DESCRIPTION
## Summary

The review is correct — this was silently breaking every Gemini multi-turn tool conversation.

## The bug

Gemini's `functionCall` blocks come back with `name` + `args` but **no OpenAI-style `id`**. `TGeminiProvider.ParseResponse` was doing:

```pascal
TC.Id := FuncCall.GetStr('id', '');   // always ''
```

So `TC.Id` ended up empty. The downstream chain:

1. **Tool loop** (`PasClaw.Tools.ToolLoop.pas:278–282`) records the empty id on the `mrTool` result's `ToolCallId`.
2. **Next turn**, `TGeminiProvider.BuildRequest` builds an `id → name` map from the assistant turn's tool calls:
   ```pascal
   if (Messages[i].ToolCalls[j].Id <> '') and ...   // skips empty
   ```
   The guard skips every Gemini call, so the map ends up empty.
3. When the tool result hits the loop, `ToolIds.IndexOf(ToolCallId='')` returns `-1`, name resolves to `''`, and the `functionResponse` goes out with `name: ""`.
4. The model can't associate the result with the call it just made → broken.

## The fix

One spot in `ParseResponse`: when Gemini omits the wire id, synthesize a deterministic local one from the function name plus the position of this call in the current response:

```pascal
TC.Id := FuncCall.GetStr('id', '');
if Trim(TC.Id) = '' then
  TC.Id := Format('gemini_call_%s_%d',
                  [TC.Func.Name, Length(Resp.ToolCalls)]);
```

`Length(Resp.ToolCalls)` at that point is the index of the slot we're about to fill, so two calls to the same function within one response get distinct ids (`gemini_call_fs_read_0`, `gemini_call_fs_read_1`).

## Collision safety

Across turns the same id can repeat (e.g. `gemini_call_fs_read_0` on turn 1 and again on turn 7), but that's fine: the synthesized id **encodes the name**, so any id that does collide still maps to the same name a fresh lookup would produce. The `<> ''` guard in `BuildRequest` is left as defensive cover for any conversation history that was generated pre-fix.

## Test plan

- [ ] `pasclaw agent` with a Gemini config — call a tool, observe the response includes a `functionCall`, confirm the next request's `parts[].functionResponse.name` matches the tool that was called (not `""`)
- [ ] Two tool calls in one Gemini response (e.g. ask it to read two files) — confirm both `functionResponse`s have the correct names and the loop converges
- [ ] Anthropic / OpenAI configs unchanged — no regression (the synthesis only fires when the wire id is empty, which only happens on Gemini)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_