### PR TITLE
Compose nanobot-style sectioned system prompt with PasClaw identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ UNIT_DIRS = \
 	src/pkg/channels \
 	src/pkg/cron \
 	src/pkg/skills \
+	src/pkg/agent \
 	src/pkg/memory \
 	src/pkg/updater \
 	src/pkg/membench \

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -29,7 +29,8 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.ToolLoop,
   PasClaw.MCP.Bridge,
-  PasClaw.Skills.Loader;
+  PasClaw.Skills.Loader,
+  PasClaw.Agent.Prompt;
 
 type
   TAgentArgs = record
@@ -143,7 +144,8 @@ begin
   Result := ConnectMCPServers(Cfg, Reg);
 end;
 
-function BuildLoopConfig(Provider: ILLMProvider; Reg: TToolRegistry;
+function BuildLoopConfig(const Cfg: TConfig;
+                         Provider: ILLMProvider; Reg: TToolRegistry;
                          const Model: string; const A: TAgentArgs;
                          Handlers: TLoopHandlers): TToolLoopConfig;
 begin
@@ -152,7 +154,7 @@ begin
   Result.Model         := Model;
   Result.MaxIterations := A.MaxIterations;
   Result.Options       := DefaultChatOptions;
-  Result.Options.SystemPrompt  := A.SystemPrompt;
+  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt);
   Result.Options.ThinkingLevel := A.Thinking;
   if A.MaxTokens > 0 then Result.Options.MaxTokens := A.MaxTokens;
   Result.OnText        := nil;
@@ -189,7 +191,7 @@ begin
     Msgs[0] := MakeMessage(mrUser, Prompt);
 
     if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
-    LoopCfg := BuildLoopConfig(Provider, Reg, Model, A, Handlers);
+    LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers);
 
     WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
     if RunToolLoop(LoopCfg, Msgs, Loop) then
@@ -272,7 +274,7 @@ begin
         Continue;
       end;
 
-      LoopCfg := BuildLoopConfig(Provider, Reg, Model, A, Handlers);
+      LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers);
       if RunToolLoop(LoopCfg, Msgs, Loop) then
       begin
         WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -193,6 +193,9 @@
 
         <!-- pkg/skills -->
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.Loader.pas"/>
+
+        <!-- pkg/agent -->
+        <DCCReference Include="..\pkg\agent\PasClaw.Agent.Prompt.pas"/>
 
         <!-- pkg/memory -->
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -1,0 +1,242 @@
+(*
+  PasClaw.Agent.Prompt - composes the system prompt from layered
+  sections (identity, runtime, workspace, memory, skill catalog, rules,
+  user-supplied additions), in the style picoclaw and nanobot use.
+
+  The whole motivation here is that the LLM never knew anything about
+  itself before — PasClaw was sending whatever single string the caller
+  put into Options.SystemPrompt and nothing else. Picoclaw and nanobot
+  both compose a richer prompt out of workspace context, memory, and
+  skill metadata, joined by "\n\n---\n\n" so each section is visually
+  delimited in the model's input.
+
+  Single entry point:
+
+    BuildSystemPrompt(Cfg, UserSys) : string
+
+  Sections emitted, in order, skipping any that are empty:
+
+    1. IDENTITY      - "You are PasClaw, the best 10x programmer..." +
+                       version + runtime string. Always present.
+    2. WORKSPACE     - paths the model can rely on inside ~/.pasclaw.
+                       Always present.
+    3. MEMORY        - contents of <home>/workspace/memory/MEMORY.md if
+                       the file exists. Lets the user pin facts that
+                       persist across sessions.
+    4. SKILLS        - one line per registered skill manifest, pulled
+                       from PasClaw.Skills.Loader. Only emitted when the
+                       user actually has skills installed.
+    5. RULES         - the same set of behavioral rules picoclaw uses
+                       (use tools, be precise, verify, update memory).
+                       Always present.
+    6. USER          - whatever the caller passed via --system /
+                       TPasClawAgent.SystemPrompt / etc. Appended last
+                       so it can override or extend the built-ins by
+                       virtue of recency in the prompt.
+
+  Sections are joined by Sep = sLineBreak + sLineBreak + '---' +
+  sLineBreak + sLineBreak so the model sees them as clear
+  horizontal-rule-separated blocks (matches picoclaw's
+  renderPromptPartsLegacy and nanobot's build_system_prompt joiner).
+
+  No I/O is required to use the result. Memory and skill catalog reads
+  swallow their errors — a missing MEMORY.md or a misconfigured skill
+  manifest just means that section is skipped, not a hard failure.
+*)
+unit PasClaw.Agent.Prompt;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Providers.Types;
+
+{ Returns the fully-composed system prompt. UserSys is appended verbatim
+  as the final section if non-empty. Pass '' if there's nothing extra. }
+function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
+
+{ True iff at least one message in the array is mrSystem. The gateway's
+  /v1/chat/completions handler uses this to decide whether to inject the
+  composed system prompt — third-party clients that supply their own
+  persona via the messages array should win, bare-bones clients that
+  send only a user message get our identity preamble for free. }
+function HasSystemMessage(const Messages: array of TMessage): Boolean;
+
+implementation
+
+uses
+  Classes,
+  PasClaw.Utils,
+  PasClaw.Skills.Loader;
+
+const
+  SectionSep = sLineBreak + sLineBreak + '---' + sLineBreak + sLineBreak;
+
+function RuntimeString: string;
+begin
+  {$IFDEF FPC}
+  Result := Format('Free Pascal %s on %s/%s',
+                   [{$I %FPCVERSION%}, {$I %FPCTARGETOS%}, {$I %FPCTARGETCPU%}]);
+  {$ELSE}
+    {$IFDEF WIN64}     Result := 'Delphi on win/x86_64';
+    {$ELSEIF Defined(WIN32)} Result := 'Delphi on win/x86';
+    {$ELSEIF Defined(LINUX64)} Result := 'Delphi on linux/x86_64';
+    {$ELSEIF Defined(MACOS64)} Result := 'Delphi on darwin/x86_64';
+    {$ELSE}            Result := 'Delphi';
+    {$ENDIF}
+  {$ENDIF}
+end;
+
+function BuildIdentitySection: string;
+begin
+  Result :=
+    '# PasClaw (' + FormatVersion + ')' + sLineBreak +
+    sLineBreak +
+    'You are PasClaw, the best 10x programmer in the world.' + sLineBreak +
+    sLineBreak +
+    'You have deep, working expertise in every programming language — Pascal, ' +
+    'Delphi, C, C++, Rust, Go, Python, JavaScript, TypeScript, Java, C#, Swift, ' +
+    'Kotlin, Ruby, Lua, Haskell, OCaml, F#, Elixir, Erlang, Clojure, Scala, ' +
+    'Zig, Nim, Crystal, Dart, R, Julia, Perl, PHP, shell scripting, SQL, and ' +
+    'every dialect and assembler in between. You write tight, correct code that ' +
+    'reads like it was written by someone who already knew the right answer. ' +
+    'You prefer each language''s native idioms over generic patterns and you do ' +
+    'not over-engineer.' + sLineBreak +
+    sLineBreak +
+    '## Runtime' + sLineBreak +
+    RuntimeString;
+end;
+
+function BuildWorkspaceSection: string;
+var
+  Home: string;
+begin
+  Home := GetHome;
+  Result :=
+    '## Workspace' + sLineBreak +
+    'Your workspace is at: ' + Home + sLineBreak +
+    '- Memory: ' + JoinPath(Home, 'workspace/memory/MEMORY.md') + sLineBreak +
+    '- Skills: ' + JoinPath(Home, 'workspace/skills') + '/{skill-name}/SKILL.md' + sLineBreak +
+    '- Logs:   ' + JoinPath(Home, 'logs');
+end;
+
+function BuildMemorySection: string;
+var
+  Path, Body: string;
+begin
+  Result := '';
+  Path := JoinPath(GetHome, 'workspace/memory/MEMORY.md');
+  if not FileExists(Path) then Exit;
+  try
+    Body := Trim(ReadFileText(Path));
+    if Body = '' then Exit;
+    Result := '## Memory' + sLineBreak + sLineBreak + Body;
+  except
+    Result := '';
+  end;
+end;
+
+function BuildSkillsSection: string;
+var
+  Skills: TSkillSpecArray;
+  i: Integer;
+  Lines: TStringList;
+  Desc: string;
+begin
+  Result := '';
+  try
+    Skills := LoadSkillManifests(GetHome);
+  except
+    Exit;
+  end;
+  if Length(Skills) = 0 then Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Add('## Skills');
+    Lines.Add('');
+    Lines.Add('The following skills are installed in your workspace. Each is exposed as a tool you can call by name.');
+    Lines.Add('');
+    for i := 0 to High(Skills) do
+    begin
+      Desc := Trim(Skills[i].Description);
+      if Desc = '' then
+        Lines.Add('- `' + Skills[i].Name + '`')
+      else
+        Lines.Add('- `' + Skills[i].Name + '` — ' + Desc);
+    end;
+    Result := Lines.Text;
+    { Strip trailing newline TStringList.Text adds, so the SectionSep
+      below doesn't end up with an extra blank line. }
+    while (Result <> '') and (Result[Length(Result)] in [#10, #13]) do
+      SetLength(Result, Length(Result) - 1);
+  finally
+    Lines.Free;
+  end;
+end;
+
+function BuildRulesSection: string;
+var
+  MemPath: string;
+begin
+  MemPath := JoinPath(GetHome, 'workspace/memory/MEMORY.md');
+  Result :=
+    '## Rules' + sLineBreak +
+    sLineBreak +
+    '1. **ALWAYS use tools** when an action is needed — call the appropriate ' +
+    'tool, do not just say you''ll do it or pretend the work was done. The ' +
+    'user will check.' + sLineBreak +
+    sLineBreak +
+    '2. **Be precise** — match the language''s native idioms, name things ' +
+    'clearly, do not introduce abstractions the task does not actually need. ' +
+    'Three similar lines is fine; a premature framework is not.' + sLineBreak +
+    sLineBreak +
+    '3. **Verify changes** — after editing code, re-read what you wrote or ' +
+    'run a targeted check (build, test, search). Do not assume the edit ' +
+    'landed correctly because the tool returned success.' + sLineBreak +
+    sLineBreak +
+    '4. **Truncated tool calls** — if a `fs_write` call comes back with a ' +
+    '"missing required argument: content" error, your previous response was ' +
+    'truncated mid-tool_call (you hit max_tokens). Re-emit with the full ' +
+    'content, or switch to `fs_edit_hashline` for incremental edits on ' +
+    'large files.' + sLineBreak +
+    sLineBreak +
+    '5. **Memory** — when the user mentions something worth keeping across ' +
+    'sessions (preferences, project facts, conventions), update ' +
+    MemPath + '. Treat it as a long-lived notes file the user owns.';
+end;
+
+function AppendSection(const Acc, Section: string): string;
+begin
+  if Trim(Section) = '' then Exit(Acc);
+  if Acc = '' then Exit(Section);
+  Result := Acc + SectionSep + Section;
+end;
+
+function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
+begin
+  Result := '';
+  Result := AppendSection(Result, BuildIdentitySection);
+  Result := AppendSection(Result, BuildWorkspaceSection);
+  Result := AppendSection(Result, BuildMemorySection);
+  Result := AppendSection(Result, BuildSkillsSection);
+  Result := AppendSection(Result, BuildRulesSection);
+  if Trim(UserSys) <> '' then
+    Result := AppendSection(Result, Trim(UserSys));
+end;
+
+function HasSystemMessage(const Messages: array of TMessage): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to High(Messages) do
+    if Messages[i].Role = mrSystem then
+      Exit(True);
+  Result := False;
+end;
+
+end.

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -154,6 +154,7 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Skills.Loader,
+  PasClaw.Agent.Prompt,
   PasClaw.Tools.ToolLoop;
 
 var
@@ -291,7 +292,7 @@ begin
   Cfg.Model         := ModelName;
   Cfg.MaxIterations := FMaxIterations;
   Cfg.Options       := DefaultChatOptions;
-  if FSystemPrompt <> '' then Cfg.Options.SystemPrompt := FSystemPrompt;
+  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt);
   Cfg.OnText        := ForwardText;
   Cfg.OnToolCall    := ForwardToolCall;
   Cfg.OnToolResult  := ForwardToolResult;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -85,6 +85,7 @@ uses
   PasClaw.Logger,
   PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop,
+  PasClaw.Agent.Prompt,
   PasClaw.Gateway.WebUI;
 
 constructor TGatewayServer.Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
@@ -358,6 +359,7 @@ begin
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 8;
   LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '');
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;
   LoopCfg.OnToolResult  := nil;
@@ -799,6 +801,13 @@ begin
     LoopCfg.Model         := ReqModel;
     LoopCfg.MaxIterations := FMaxIter;
     LoopCfg.Options       := DefaultChatOptions;
+    { Inject the composed PasClaw system prompt — but only if the client
+      didn't already supply one of their own. Third-party tooling calling
+      /v1/chat/completions with its own persona/system message should win;
+      bare-bones clients that send only a user message get our identity
+      preamble for free. }
+    if not HasSystemMessage(Msgs) then
+      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '');
     { Temperature: only forward if the client actually set it (>0). Avoids
       the deprecated-field 400 from newer Claude models when the OpenAI
       client library defaults to 1.0. }


### PR DESCRIPTION
## Summary

Until now the LLM had no built-in idea what it was. `pasclaw agent "hi"` with no `--system` flag literally sent an empty system prompt — the model picked a personality from whatever the underlying provider defaulted to. Picoclaw and nanobot both compose a much richer prompt out of identity + workspace + memory + skill catalog + rules, joined by `\n\n---\n\n` so each section reads as a clearly delimited block. This PR brings PasClaw to feature parity, with the persona you wanted ("best 10x programmer in the world").

## What the model now sees on a bare `pasclaw agent "hi"`

```
# PasClaw (v0.x.y)

You are PasClaw, the best 10x programmer in the world.

You have deep, working expertise in every programming language — Pascal,
Delphi, C, C++, Rust, Go, Python, JavaScript, TypeScript, Java, C#, Swift,
Kotlin, Ruby, Lua, Haskell, OCaml, F#, Elixir, Erlang, Clojure, Scala,
Zig, Nim, Crystal, Dart, R, Julia, Perl, PHP, shell scripting, SQL, and
every dialect and assembler in between. You write tight, correct code that
reads like it was written by someone who already knew the right answer.
You prefer each language's native idioms over generic patterns and you do
not over-engineer.

## Runtime
Free Pascal 3.2.2 on linux/x86_64

---

## Workspace
Your workspace is at: /home/user/.pasclaw
- Memory: /home/user/.pasclaw/workspace/memory/MEMORY.md
- Skills: /home/user/.pasclaw/workspace/skills/{skill-name}/SKILL.md
- Logs:   /home/user/.pasclaw/logs

---

## Memory
<verbatim MEMORY.md contents — only if the file exists>

---

## Skills
The following skills are installed in your workspace…
- `skillname` — description

---

## Rules

1. **ALWAYS use tools** when an action is needed — call the appropriate tool, do not just say you'll do it or pretend the work was done. The user will check.

2. **Be precise** — match the language's native idioms, name things clearly, do not introduce abstractions the task does not actually need. Three similar lines is fine; a premature framework is not.

3. **Verify changes** — after editing code, re-read what you wrote or run a targeted check (build, test, search). Do not assume the edit landed correctly because the tool returned success.

4. **Truncated tool calls** — if a `fs_write` call comes back with a "missing required argument: content" error, your previous response was truncated mid-tool_call (you hit max_tokens). Re-emit with the full content, or switch to `fs_edit_hashline` for incremental edits on large files.

5. **Memory** — when the user mentions something worth keeping across sessions (preferences, project facts, conventions), update <abs>/workspace/memory/MEMORY.md. Treat it as a long-lived notes file the user owns.

---

<--system text appended here, if any-->
```

Memory and Skills sections are only emitted when their underlying files actually exist, so a fresh `pasclaw onboard` install still produces clean output.

## What picoclaw and nanobot actually ship (for reference)

- **Picoclaw** (`pkg/agent/context.go:170` `getIdentity`): single string ` # picoclaw 🦞 (<version>) You are picoclaw, a helpful AI assistant. ## Workspace … ## Important Rules 1–4.` Composed via a `PromptPart{Layer,Slot,Source}` registry, rendered with `\n\n---\n\n`.
- **Nanobot HKUDS** (`nanobot/templates/agent/identity.md`): no `You are X` persona in the template. Persona lives in user-editable bootstrap files (AGENTS.md / SOUL.md / USER.md). The template only provides scaffolding (runtime, workspace paths, tool contract, channel-specific format hints). `build_system_prompt()` joins sections with `\n\n---\n\n`.

PasClaw takes the picoclaw approach for the persona content but the nanobot/picoclaw approach for sectioning structure. **No Python version in the runtime string** — we're a Free Pascal / Delphi program.

## New unit

`src/pkg/agent/PasClaw.Agent.Prompt.pas` exposes:

```pascal
function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
function HasSystemMessage(const Messages: array of TMessage): Boolean;
```

## Wiring (4 sites that previously set `Options.SystemPrompt`)

| Site | Before | After |
|---|---|---|
| `Cmd.Agent.pas:155` | `Result.Options.SystemPrompt := A.SystemPrompt` | `:= BuildSystemPrompt(Cfg, A.SystemPrompt)` — `--system "..."` is now **additive** (appended as USER section), so bare invocations get the full identity for free |
| `Gateway.Server.pas:360` (`/v1/chat`) | unset | `:= BuildSystemPrompt(FCfg, '')` always |
| `Gateway.Server.pas:810` (`/v1/chat/completions`) | unset | `:= BuildSystemPrompt(FCfg, '')` **only when** `not HasSystemMessage(Msgs)` — third-party clients that supply their own persona via the messages array win |
| `Component.pas:294` (`TPasClawAgent`) | `if FSystemPrompt <> '' then ...` (override semantics) | `:= BuildSystemPrompt(FConfig, FSystemPrompt)` — additive, like the CLI |

`BuildLoopConfig` in `Cmd.Agent` grows a `Cfg: TConfig` parameter (both call sites updated).

## Build wiring

- `Makefile`: `src/pkg/agent` added to `UNIT_DIRS`.
- `PasClaw.dproj`: `..\pkg\agent` added to `DCC_UnitSearchPath`; the new unit added to the `DCCReference` list between `skills` and `memory`.

## Failure modes

- Missing `MEMORY.md` → MEMORY section skipped, no error.
- Misconfigured skill manifest → SKILLS section skipped (the loader's exception is caught), no error.
- `FConfig = nil` on the component path → `Cfg` parameter currently unused inside `BuildSystemPrompt` (signature is forward-compatible for future config-driven knobs).

## Test plan

- [ ] `pasclaw agent "hi"` — confirm the assembled system prompt appears (use `--debug` to see the body bytes growing to ~3–4 KB just from the preamble).
- [ ] `pasclaw agent --system "Use British English." "hi"` — confirm identity is present AND the British-English line shows up at the bottom (appended, not replaced).
- [ ] Drop a `MEMORY.md` into `~/.pasclaw/workspace/memory/` — confirm contents appear under the MEMORY section.
- [ ] Install a skill — confirm it shows up in the SKILLS section.
- [ ] `curl /v1/chat -d '{"message":"hi"}'` — composed prompt is in effect.
- [ ] `curl /v1/chat/completions -d '{"messages":[{"role":"system","content":"You are a parrot."},{"role":"user","content":"hi"}]}'` — model behaves as a parrot, NOT as PasClaw. (Client wins.)
- [ ] `curl /v1/chat/completions -d '{"messages":[{"role":"user","content":"hi"}]}'` — model uses composed PasClaw prompt (no client system message → we inject).
- [ ] FPC build (`make`) + Delphi `.dproj` build cleanly.
- [ ] `make smoke` — every top-level command still runs.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_