### PR TITLE
Skill tool names + tools-disabled mode in BuildSystemPrompt

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -154,7 +154,7 @@ begin
   Result.Model         := Model;
   Result.MaxIterations := A.MaxIterations;
   Result.Options       := DefaultChatOptions;
-  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt);
+  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt, not A.NoTools);
   Result.Options.ThinkingLevel := A.Thinking;
   if A.MaxTokens > 0 then Result.Options.MaxTokens := A.MaxTokens;
   Result.OnText        := nil;

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -56,8 +56,19 @@ uses
   PasClaw.Providers.Types;
 
 { Returns the fully-composed system prompt. UserSys is appended verbatim
-  as the final section if non-empty. Pass '' if there's nothing extra. }
-function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
+  as the final section if non-empty. Pass '' if there's nothing extra.
+
+  ToolsEnabled controls whether tool-dependent sections (the skill
+  catalog, the "ALWAYS use tools" rule, the truncated-fs_write rule,
+  the verify-by-running-checks rule, the update-MEMORY.md rule) are
+  emitted. Callers running `--no-tools` (or constructing the component
+  with UseTools=False) MUST pass False here — otherwise the prompt
+  tells the model to call tools that the tool loop will refuse to
+  pass through, producing a confused conversation. Identity, workspace
+  paths, and memory contents stay in either mode since they are useful
+  as context even without tools available. }
+function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
+                           ToolsEnabled: Boolean = True): string;
 
 { True iff at least one message in the array is mrSystem. The gateway's
   /v1/chat/completions handler uses this to decide whether to inject the
@@ -164,10 +175,14 @@ begin
     for i := 0 to High(Skills) do
     begin
       Desc := Trim(Skills[i].Description);
+      { RegisterSkills in PasClaw.Skills.Loader registers the provider
+        tool as 'skill_' + Skills[i].Name (line 269). Advertising the
+        bare name here would tell the model to call a nonexistent tool.
+        The 'skill_' prefix is the actual callable identifier. }
       if Desc = '' then
-        Lines.Add('- `' + Skills[i].Name + '`')
+        Lines.Add('- `skill_' + Skills[i].Name + '`')
       else
-        Lines.Add('- `' + Skills[i].Name + '` — ' + Desc);
+        Lines.Add('- `skill_' + Skills[i].Name + '` — ' + Desc);
     end;
     Result := Lines.Text;
     { Strip trailing newline TStringList.Text adds, so the SectionSep
@@ -179,10 +194,30 @@ begin
   end;
 end;
 
-function BuildRulesSection: string;
+function BuildRulesSection(ToolsEnabled: Boolean): string;
 var
   MemPath: string;
 begin
+  if not ToolsEnabled then
+  begin
+    { No-tools mode: the model cannot call fs_write, fs_edit_hashline,
+      skills, or anything else. Rules 1, 3, 4, and 5 all assume tool
+      access — emitting them would tell the model to do things the
+      tool loop is configured to refuse. Keep the precision rule
+      because it is purely advisory and language-agnostic. }
+    Result :=
+      '## Rules' + sLineBreak +
+      sLineBreak +
+      '1. **Be precise** — match the language''s native idioms, name things ' +
+      'clearly, do not introduce abstractions the task does not actually need. ' +
+      'Three similar lines is fine; a premature framework is not.' + sLineBreak +
+      sLineBreak +
+      '2. **No tools in this session** — the user invoked you in text-only ' +
+      'mode. Do not claim to read files, run commands, or modify state. ' +
+      'Answer from what is in this conversation.';
+    Exit;
+  end;
+
   MemPath := JoinPath(GetHome, 'workspace/memory/MEMORY.md');
   Result :=
     '## Rules' + sLineBreak +
@@ -217,14 +252,19 @@ begin
   Result := Acc + SectionSep + Section;
 end;
 
-function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
+function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
+                           ToolsEnabled: Boolean): string;
 begin
   Result := '';
   Result := AppendSection(Result, BuildIdentitySection);
   Result := AppendSection(Result, BuildWorkspaceSection);
   Result := AppendSection(Result, BuildMemorySection);
-  Result := AppendSection(Result, BuildSkillsSection);
-  Result := AppendSection(Result, BuildRulesSection);
+  { Skills are only callable when the tool registry was actually built.
+    --no-tools (and component UseTools=False) bypass RegisterSkills, so
+    advertising the catalog would be a lie. }
+  if ToolsEnabled then
+    Result := AppendSection(Result, BuildSkillsSection);
+  Result := AppendSection(Result, BuildRulesSection(ToolsEnabled));
   if Trim(UserSys) <> '' then
     Result := AppendSection(Result, Trim(UserSys));
 end;

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -292,7 +292,7 @@ begin
   Cfg.Model         := ModelName;
   Cfg.MaxIterations := FMaxIterations;
   Cfg.Options       := DefaultChatOptions;
-  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt);
+  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt, FUseTools);
   Cfg.OnText        := ForwardText;
   Cfg.OnToolCall    := ForwardToolCall;
   Cfg.OnToolResult  := ForwardToolResult;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -359,7 +359,7 @@ begin
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 8;
   LoopCfg.Options       := DefaultChatOptions;
-  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '');
+  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', FRegistry <> nil);
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;
   LoopCfg.OnToolResult  := nil;
@@ -807,7 +807,7 @@ begin
       bare-bones clients that send only a user message get our identity
       preamble for free. }
     if not HasSystemMessage(Msgs) then
-      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '');
+      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', FRegistry <> nil);
     { Temperature: only forward if the client actually set it (>0). Avoids
       the deprecated-field 400 from newer Claude models when the OpenAI
       client library defaults to 1.0. }


### PR DESCRIPTION
Stacked on top of #50. Two real bugs in the prompt builder from #50, both caught in review.

When #50 lands, this PR's base can be retargeted to `main` (one-click in the GitHub UI) and the diff will collapse to just the one fix commit.

## Bug 1 — Skill catalog advertised the wrong tool names

`RegisterSkills` in `PasClaw.Skills.Loader.pas:269` registers each manifest as `'skill_' + Skills[i].Name`, so the actual callable identifier is `skill_weather`, not `weather`. PR #50's `BuildSkillsSection` was advertising the bare name — every skill invocation would have hit "tool not found" and the model would either retry in a loop or avoid the skill entirely.

**Fix:** prefix `skill_` in `BuildSkillsSection` so the bullet matches what the registry exposes.

## Bug 2 — Prompt told the model to use tools when tools were disabled

`pasclaw agent --no-tools` (Cmd.Agent line 185), `TPasClawAgent` with `UseTools=False` (Component line 224), and `pasclaw serve --no-tools` (Cmd.Serve line 111) all leave the tool registry `nil`, so `RunToolLoop` sends an empty tool list. But PR #50's system prompt still emitted the SKILLS catalog and a RULES block whose top rule was "ALWAYS use tools." The model would then either invent tool calls the loop refused to pass through, or oscillate between the no-tools reality and the system prompt's tool-use directive — producing confused or unusable responses.

**Fix:** new `ToolsEnabled` parameter on `BuildSystemPrompt` (default `True` so existing callers stay byte-identical), gates tool-dependent content:

| Mode | Sections emitted |
|---|---|
| `ToolsEnabled = True` (default) | Identity + Workspace + Memory + **Skills** + 5-rule block (use tools / be precise / verify / truncated tool calls / memory) + user-supplied `--system` text |
| `ToolsEnabled = False` | Identity + Workspace + Memory + 2-rule block (**be precise** + new **"No tools in this session — do not claim to read files, run commands, or modify state. Answer from what is in this conversation."**) + user-supplied text |

Identity, workspace paths, and memory contents stay in either mode — they're useful as plain context regardless of whether tools are wired up.

## Wiring at every call site

- `Cmd.Agent.pas` passes `not A.NoTools`
- `Component.pas` passes `FUseTools`
- `Gateway.Server.pas` passes `FRegistry <> nil` (covers both `/v1/chat` and `/v1/chat/completions`; the latter still gated on `HasSystemMessage(Msgs)` for client-supplied personas)

## Test plan

- [ ] `pasclaw agent --no-tools "hi"` — system prompt has no SKILLS section, no "ALWAYS use tools" rule, contains the new "No tools in this session" rule
- [ ] `pasclaw agent "hi"` (with tools) — system prompt advertises any installed skills as `skill_<name>`, not `<name>`
- [ ] Install a skill named `weather`, then `pasclaw agent "what's my weather skill called?"` — model answers `skill_weather` and can actually call it
- [ ] `pasclaw serve --no-tools` + curl a chat completion — composed prompt is in no-tools mode
- [ ] Component constructed with `UseTools := False` — same effect

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_