### PR TITLE
Gemini: switch nested-brace comment to // so dcc64 stops choking

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -151,7 +151,7 @@ begin
 
       if Messages[i].Role = mrTool then
       begin
-        { Tool result → role:user, parts:[{functionResponse}]. }
+        // Tool result -> role:user, parts:[{functionResponse}].
         Content := TJsonObject.Create;
         Content.PutStr('role', 'user');
         Parts := TJsonArray.Create;


### PR DESCRIPTION
## Summary

Fixes the reported Delphi build failure:

```
[dcc64 Error] PasClaw.Providers.Gemini.pas(154): E2029 Statement expected but ']' found
```

## Root cause

Pascal `{ ... }` block comments **do not nest**. Line 154 was:

```pascal
{ Tool result → role:user, parts:[{functionResponse}]. }
```

The inner `}` after `functionResponse` closes the comment, leaving `].` as code — dcc64 errors at the `]`. The FPC build happened to accept it in this codebase but Delphi 64-bit doesn't, and the standard says Delphi is correct on this one.

## Fix

Swap to a `//` line comment so the inner braces are just text:

```pascal
// Tool result -> role:user, parts:[{functionResponse}].
```

Also dropped the `→` Unicode arrow for ASCII `->` — Delphi has historically misread non-BOM UTF-8 source files in some IDE configurations and there's no reason to keep the Unicode glyph when `->` reads the same.

## Audit

Checked the rest of `PasClaw.Providers.Gemini.pas` for the same pattern:

- The header is `(* ... *)`-style — safe, those don't terminate on `}`.
- Other `{ ... }` comments in the file have no inner braces.
- Other provider units (Anthropic, OpenAI) were spot-checked — clean.

## Test plan

- [ ] Open `src/pasclaw/PasClaw.dproj` in Delphi, build 64-bit — compile succeeds, no E2029 at line 154
- [ ] `make` under FPC — still builds (line behaved before, and a `//` comment doesn't regress anything)
- [ ] Gemini provider still works — `pasclaw agent` with a Gemini config round-trips a tool call (the fix is comment-only, no runtime change)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_