### PR TITLE
Tool sandbox: workspace boundary + regex-free shell denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,50 @@ Minimal local provider examples:
 }
 ```
 
+## 🔒 Security / sandbox
+
+PasClaw's filesystem and shell tools are guarded by an opt-in workspace boundary plus an always-on shell denylist (`src/pkg/tools/PasClaw.Tools.Sandbox.pas`). Configure via the `sandbox` block in `~/.pasclaw/config.json`:
+
+```json
+"sandbox": {
+  "restrict_to_workspace":        true,
+  "allow_read_outside_workspace": false,
+  "workspace":                    "/home/me/my-project",
+  "allow_read_paths":  ["^/usr/(include|share)/.*"],
+  "allow_write_paths": ["^/tmp/agent/.*"],
+  "custom_shell_deny": ["scp ", "rsync "],
+  "shell_deny_enabled":           true
+}
+```
+
+| Field | Default | Effect |
+|---|---|---|
+| `restrict_to_workspace` | `false` | When `true`, `fs_read` / `fs_write` / `fs_list` / `fs_edit_hashline` / `fs_grep` refuse paths outside `workspace`. `shell_exec` refuses absolute paths outside it AND tokens containing `..`, pins the shell's cwd to the workspace, and bans `cd` / `chdir` / `pushd` / `popd`. |
+| `allow_read_outside_workspace` | `false` | When `true`, reads are allowed anywhere even while writes stay restricted. Useful for letting the agent pull from `/usr/include/` while still locking down writes. |
+| `workspace` | `""` (cwd at startup) | Absolute path the agent may operate inside. Empty means "use the current working directory at the time `pasclaw` was invoked", which is the picoclaw / Claude Code convention. |
+| `allow_read_paths` | `[]` | **PCRE regex** patterns that *also* count as readable. Same syntax picoclaw's `tools.allow_read_paths` accepts — anchors (`^` `$`), character classes, alternation. |
+| `allow_write_paths` | `[]` | Same for writes. |
+| `custom_shell_deny` | `[]` | Extra substrings appended to the built-in shell denylist. Case-insensitive. |
+| `shell_deny_enabled` | `true` | Master switch for the shell denylist. Set `false` only for trusted automation — doing so re-enables `sudo`, `rm`, `dd`, `mkfs`, `$( )`, `curl \| sh`, `format c:`, PowerShell `-EncodedCommand`, etc. |
+
+**Cross-target regex**: `PasClaw.Tools.Regex` wraps FPC's `RegExpr` and Delphi's `System.RegularExpressions` behind one call, so `allow_*_paths` patterns are full PCRE on either toolchain. Invalid patterns return False (the sandbox falls through to the workspace boundary) rather than crashing.
+
+**Built-in shell denylist** (always on unless `shell_deny_enabled` is false):
+
+- **POSIX tokens**: `sudo`, `su`, `rm`, `chmod`, `chown`, `pkill`, `killall`, `kill`, `shutdown`, `reboot`, `poweroff`, `halt`, `eval`, `mkfs`, `diskpart`.
+- **Windows tokens**: `del`, `erase`, `rd`, `rmdir`, `format`, `attrib`, `takeown`, `icacls`, `runas`.
+- **cwd-change tokens** (when `restrict_to_workspace`): `cd`, `chdir`, `pushd`, `popd`. Any token containing `..` is also rejected.
+- **Substrings**: `dd if=`, `:(){:|`, `<<EOF`, `$( )`, `${ }`, backticks, `| sh`, `| bash`, `apt install/remove/purge`, `yum install/remove`, `dnf install/remove`, `npm install -g`, `pip install --user`, `docker run/exec`, `git push`, `git force`, `format c:`.
+- **PowerShell** (matched lowercased): `powershell -e/-en/-enc/-ec`, `-encodedcommand`, `iex (`, `invoke-expression`, `[convert]::frombase64`, `[text.encoding]`, `.getstring([byte[]`, `set-executionpolicy`.
+- **Device writes**: `> /dev/sd*` / `/hd*` / `/vd*` / `/xvd*` / `/nvme*` / `/mmcblk*` / `/loop*` / `/md*`.
+- **Always-safe paths**: `/dev/null`, `/dev/zero`, `/dev/{,u}random`, `/dev/std{in,out,err}` — picoclaw's `safePaths`.
+
+**Workspace-pin**: when `restrict_to_workspace=true`, `Tool_Shell` invokes `RunOneShot` with `WorkingDir = workspace` so the child shell starts inside the boundary. Combined with the `cd` token ban and `..` traversal check, a sandboxed model has no relative-path escape — even if a future denylist gap let a command through, the shell still starts in the workspace, not wherever `pasclaw` was launched from.
+
+**Known limitation**: path canonicalisation uses `ExpandFileName`, which resolves `..` but not symlinks. Picoclaw's equivalent (`os.OpenRoot` in Go 1.24+) enforces the boundary at the syscall layer; PasClaw runs on FPC and Delphi RTLs that have no equivalent. **Do not place symlinks inside `workspace` that point outside it** — they would let the agent escape.
+
+**`--no-tools`** remains the strongest option: it disables the tool registry entirely, so neither `fs_*` nor `shell_exec` is registered. The system prompt automatically reflects this (no SKILLS section, no "ALWAYS use tools" rule).
+
 ## Repository layout
 
 ```text

--- a/samples/component-console/Makefile
+++ b/samples/component-console/Makefile
@@ -1,0 +1,73 @@
+# Sample build: a standalone FPC binary that embeds TPasClawAgent.
+#
+# This Makefile re-uses the same unit search paths as the top-level
+# PasClaw build (../../Makefile) so the sample stays in sync without
+# duplicating the list. Run:
+#
+#   cd samples/component-console
+#   make
+#
+# The first build needs Indy vendored under ../../vendor/Indy; the
+# top-level Makefile's `make get-indy` target handles that. Run it
+# once from the repository root before building the sample.
+
+ROOT     := ../..
+FPC      ?= fpc
+BUILDDIR ?= build
+BIN      ?= $(BUILDDIR)/SampleConsole
+
+INDY_DIR     ?= $(ROOT)/vendor/Indy
+ICONVENC_DIR ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/iconvenc
+
+# Every src/pkg/* the main binary uses, re-rooted at $(ROOT).
+UNIT_DIRS = \
+	$(ROOT)/src/pkg/cliui \
+	$(ROOT)/src/pkg/utils \
+	$(ROOT)/src/pkg/logger \
+	$(ROOT)/src/pkg/config \
+	$(ROOT)/src/pkg/json \
+	$(ROOT)/src/pkg/providers \
+	$(ROOT)/src/pkg/tokenizer \
+	$(ROOT)/src/pkg/tools \
+	$(ROOT)/src/pkg/mcp \
+	$(ROOT)/src/pkg/gateway \
+	$(ROOT)/src/pkg/channels \
+	$(ROOT)/src/pkg/cron \
+	$(ROOT)/src/pkg/skills \
+	$(ROOT)/src/pkg/agent \
+	$(ROOT)/src/pkg/memory \
+	$(ROOT)/src/pkg/updater \
+	$(ROOT)/src/pkg/membench \
+	$(ROOT)/src/pkg/tui \
+	$(ROOT)/src/pkg/platform \
+	$(ROOT)/src/pkg/hashline \
+	$(ROOT)/src/pkg/component \
+	$(ROOT)/src/cmd
+
+INDY_UNIT_DIRS = \
+	$(INDY_DIR)/Lib/Core \
+	$(INDY_DIR)/Lib/Protocols \
+	$(INDY_DIR)/Lib/System
+
+FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
+	$(foreach d,$(UNIT_DIRS),-Fu$(d)) \
+	$(foreach d,$(INDY_UNIT_DIRS),-Fu$(d)) \
+	$(foreach d,$(INDY_UNIT_DIRS),-Fi$(d)) \
+	-Fu$(ICONVENC_DIR) \
+	-FE$(BUILDDIR) \
+	-FU$(BUILDDIR)/lib
+
+.PHONY: all clean
+
+all: $(BIN)
+
+$(BIN): SampleConsole.dpr | $(BUILDDIR) $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) SampleConsole.dpr
+
+$(BUILDDIR):
+	mkdir -p $@
+$(BUILDDIR)/lib:
+	mkdir -p $@
+
+clean:
+	rm -rf $(BUILDDIR)

--- a/samples/component-console/SampleConsole.dpr
+++ b/samples/component-console/SampleConsole.dpr
@@ -1,15 +1,34 @@
 (*
-  SampleConsole - shows how to embed PasClaw inside a standalone Delphi
-  / FPC console program via TPasClawAgent. Build either compiler:
+  SampleConsole - shows how to embed PasClaw inside a standalone
+  Delphi / FPC console program via TPasClawAgent.
 
-    Delphi:  drop the .dpr into a console project that has the PasClaw
-             unit search path (..\..\src\cmd, ..\..\src\pkg\*) wired in.
-    FPC:     fpc -Fu../../src/cmd -Fu../../src/pkg/... SampleConsole.dpr
+  Build (FPC):
+    cd samples/component-console
+    make
 
-  The agent inherits config from ~/.pasclaw/config.json (same as the CLI),
-  so set up `pasclaw auth login` once first. The Execute() call mirrors
-  `pasclaw version`; Chat() round-trips a single prompt through the
-  configured provider and prints the assistant's reply.
+  The Makefile re-uses the same UNIT_DIRS the main PasClaw binary
+  needs and points at the vendored Indy in ../../vendor/Indy. The
+  previous one-line `fpc -Fu../../src/cmd -Fu../../src/pkg/...`
+  instruction was wrong on two counts: the literal `...` is not an
+  FPC wildcard (it tried to use `...` as a directory name and
+  failed), and PasClaw.Component transitively pulls in every
+  subdirectory under src/pkg, so a real build needs ~25 -Fu flags
+  plus Indy's three. The Makefile spells them out.
+
+  Build (Delphi):
+    drop the .dpr into a console project that mirrors PasClaw.dproj's
+    DCC_UnitSearchPath. The list lives in src/pasclaw/PasClaw.dproj
+    near the top of the file — copy-paste it into the sample's
+    project options Search Path, swap the leading `..\` for
+    `..\..\src\`, and the sample compiles. (A dedicated sample
+    .dproj is on the to-do list; until then the main project file
+    is the source of truth.)
+
+  Runtime: the agent inherits config from ~/.pasclaw/config.json,
+  so run `pasclaw onboard` and `pasclaw auth login <provider>` once
+  first. Execute() mirrors `pasclaw version`; Chat() round-trips a
+  single prompt through the configured provider and prints the
+  reply.
 *)
 program SampleConsole;
 

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -155,7 +155,13 @@ begin
   Result.Model         := Model;
   Result.MaxIterations := A.MaxIterations;
   Result.Options       := DefaultChatOptions;
-  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt, not A.NoTools);
+  { ToolsEnabled tracks the registry we are about to hand RunToolLoop
+    so the system prompt stays in sync with what the model can
+    actually call. Reg is nil when --no-tools is set (RunBuilder
+    passes nil; see Run* call sites above) — deriving from the
+    registry, not from A.NoTools, also handles the case where future
+    callers nil out Reg for other reasons. }
+  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt, Reg <> nil);
   Result.Options.ThinkingLevel := A.Thinking;
   if A.MaxTokens > 0 then Result.Options.MaxTokens := A.MaxTokens;
   Result.OnText        := nil;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -155,7 +155,7 @@ begin
   Result.Model         := Model;
   Result.MaxIterations := A.MaxIterations;
   Result.Options       := DefaultChatOptions;
-  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt);
+  Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt, not A.NoTools);
   Result.Options.ThinkingLevel := A.Thinking;
   if A.MaxTokens > 0 then Result.Options.MaxTokens := A.MaxTokens;
   Result.OnText        := nil;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -30,7 +30,8 @@ uses
   PasClaw.Tools.ToolLoop,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
-  PasClaw.Agent.Prompt;
+  PasClaw.Agent.Prompt,
+  PasClaw.Tools.Sandbox;
 
 type
   TAgentArgs = record
@@ -304,6 +305,7 @@ begin
   end;
 
   Cfg := LoadConfig;
+  ConfigureSandbox(Cfg.Sandbox, '');
   try
     if A.Message <> '' then RunSingleTurn(Cfg, A, A.Message)
     else                    RunInteractive(Cfg, A);

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -26,6 +26,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Cron.Scheduler,
@@ -82,6 +83,7 @@ var
   Skills: TSkillSpecArray;
 begin
   Cfg := LoadConfig;
+  ConfigureSandbox(Cfg.Sandbox, '');
   try
     Args := ParseGw(Argv, Cfg);
 

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -39,6 +39,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Gateway.Server;
@@ -94,6 +95,7 @@ var
   BaseURL: string;
 begin
   Cfg := LoadConfig;
+  ConfigureSandbox(Cfg.Sandbox, '');
   try
     Args := ParseServe(Argv, Cfg);
 

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -24,6 +24,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.TUI;
@@ -69,6 +70,7 @@ var
 begin
   if not ParseArgs(Argv, A) then Exit(1);
   Cfg := LoadConfig;
+  ConfigureSandbox(Cfg.Sandbox, '');
   try
     if A.Provider <> '' then Name := A.Provider else Name := Cfg.DefaultProvider;
     Provider := nil;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -165,6 +165,7 @@
         <!-- pkg/tools -->
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Types.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Registry.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Sandbox.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.FS.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Shell.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.ToolLoop.pas"/>

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -165,6 +165,7 @@
         <!-- pkg/tools -->
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Types.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Registry.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Regex.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Sandbox.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.FS.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Shell.pas"/>

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -56,8 +56,19 @@ uses
   PasClaw.Providers.Types;
 
 { Returns the fully-composed system prompt. UserSys is appended verbatim
-  as the final section if non-empty. Pass '' if there's nothing extra. }
-function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
+  as the final section if non-empty. Pass '' if there's nothing extra.
+
+  ToolsEnabled controls whether tool-dependent sections (the skill
+  catalog, the "ALWAYS use tools" rule, the truncated-fs_write rule,
+  the verify-by-running-checks rule, the update-MEMORY.md rule) are
+  emitted. Callers running `--no-tools` (or constructing the component
+  with UseTools=False) MUST pass False here — otherwise the prompt
+  tells the model to call tools that the tool loop will refuse to
+  pass through, producing a confused conversation. Identity, workspace
+  paths, and memory contents stay in either mode since they are useful
+  as context even without tools available. }
+function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
+                           ToolsEnabled: Boolean = True): string;
 
 { True iff at least one message in the array is mrSystem. The gateway's
   /v1/chat/completions handler uses this to decide whether to inject the
@@ -164,10 +175,14 @@ begin
     for i := 0 to High(Skills) do
     begin
       Desc := Trim(Skills[i].Description);
+      { RegisterSkills in PasClaw.Skills.Loader registers the provider
+        tool as 'skill_' + Skills[i].Name (line 269). Advertising the
+        bare name here would tell the model to call a nonexistent tool.
+        The 'skill_' prefix is the actual callable identifier. }
       if Desc = '' then
-        Lines.Add('- `' + Skills[i].Name + '`')
+        Lines.Add('- `skill_' + Skills[i].Name + '`')
       else
-        Lines.Add('- `' + Skills[i].Name + '` — ' + Desc);
+        Lines.Add('- `skill_' + Skills[i].Name + '` — ' + Desc);
     end;
     Result := Lines.Text;
     { Strip trailing newline TStringList.Text adds, so the SectionSep
@@ -179,10 +194,30 @@ begin
   end;
 end;
 
-function BuildRulesSection: string;
+function BuildRulesSection(ToolsEnabled: Boolean): string;
 var
   MemPath: string;
 begin
+  if not ToolsEnabled then
+  begin
+    { No-tools mode: the model cannot call fs_write, fs_edit_hashline,
+      skills, or anything else. Rules 1, 3, 4, and 5 all assume tool
+      access — emitting them would tell the model to do things the
+      tool loop is configured to refuse. Keep the precision rule
+      because it is purely advisory and language-agnostic. }
+    Result :=
+      '## Rules' + sLineBreak +
+      sLineBreak +
+      '1. **Be precise** — match the language''s native idioms, name things ' +
+      'clearly, do not introduce abstractions the task does not actually need. ' +
+      'Three similar lines is fine; a premature framework is not.' + sLineBreak +
+      sLineBreak +
+      '2. **No tools in this session** — the user invoked you in text-only ' +
+      'mode. Do not claim to read files, run commands, or modify state. ' +
+      'Answer from what is in this conversation.';
+    Exit;
+  end;
+
   MemPath := JoinPath(GetHome, 'workspace/memory/MEMORY.md');
   Result :=
     '## Rules' + sLineBreak +
@@ -217,14 +252,19 @@ begin
   Result := Acc + SectionSep + Section;
 end;
 
-function BuildSystemPrompt(Cfg: TConfig; const UserSys: string): string;
+function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
+                           ToolsEnabled: Boolean): string;
 begin
   Result := '';
   Result := AppendSection(Result, BuildIdentitySection);
   Result := AppendSection(Result, BuildWorkspaceSection);
   Result := AppendSection(Result, BuildMemorySection);
-  Result := AppendSection(Result, BuildSkillsSection);
-  Result := AppendSection(Result, BuildRulesSection);
+  { Skills are only callable when the tool registry was actually built.
+    --no-tools (and component UseTools=False) bypass RegisterSkills, so
+    advertising the catalog would be a lie. }
+  if ToolsEnabled then
+    Result := AppendSection(Result, BuildSkillsSection);
+  Result := AppendSection(Result, BuildRulesSection(ToolsEnabled));
   if Trim(UserSys) <> '' then
     Result := AppendSection(Result, Trim(UserSys));
 end;

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -300,7 +300,15 @@ begin
   Cfg.Model         := ModelName;
   Cfg.MaxIterations := FMaxIterations;
   Cfg.Options       := DefaultChatOptions;
-  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt, FUseTools);
+  { Derive ToolsEnabled from the registry we are about to hand to
+    RunToolLoop, NOT from FUseTools. EnsureRegistry caches FRegistry
+    across calls and only checks FUseTools when the registry is
+    nil — so a component used with UseTools=True, then flipped to
+    UseTools=False, would otherwise send the model a "No tools in
+    this session" prompt while RunToolLoop still received the cached
+    registry. The single source of truth is Cfg.Registry. }
+  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt,
+                                                Cfg.Registry <> nil);
   Cfg.OnText        := ForwardText;
   Cfg.OnToolCall    := ForwardToolCall;
   Cfg.OnToolResult  := ForwardToolResult;

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -300,7 +300,7 @@ begin
   Cfg.Model         := ModelName;
   Cfg.MaxIterations := FMaxIterations;
   Cfg.Options       := DefaultChatOptions;
-  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt);
+  Cfg.Options.SystemPrompt := BuildSystemPrompt(FConfig, FSystemPrompt, FUseTools);
   Cfg.OnText        := ForwardText;
   Cfg.OnToolCall    := ForwardToolCall;
   Cfg.OnToolResult  := ForwardToolResult;

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -153,6 +153,7 @@ uses
   PasClaw.Providers.Factory,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
   PasClaw.Tools.ToolLoop;
@@ -194,7 +195,14 @@ end;
 
 procedure TPasClawAgent.EnsureConfig;
 begin
-  if FConfig = nil then FConfig := LoadConfig;
+  if FConfig = nil then
+  begin
+    FConfig := LoadConfig;
+    { Apply the sandbox policy to the shared module-level state.
+      The component sits next to the CLI in one process so this is
+      the same global state Cmd.Agent / Cmd.Serve seed at startup. }
+    ConfigureSandbox(FConfig.Sandbox, '');
+  end;
 end;
 
 procedure TPasClawAgent.EnsureProvider;
@@ -422,6 +430,7 @@ begin
   if (FThread <> nil) or (FServer <> nil) then Stop;
 
   FConfig := LoadConfig;
+  ConfigureSandbox(FConfig.Sandbox, '');
   if FModel <> '' then
     FConfig.DefaultModel := FModel;
 

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -38,6 +38,50 @@ type
     Port:     Integer;
   end;
 
+  (*  TSandboxPolicy - opt-in workspace + shell hardening.
+
+      RestrictToWorkspace
+        When True, fs_read / fs_write / fs_list / fs_edit_hashline /
+        fs_grep operations refuse paths outside Workspace, and the
+        shell tool refuses commands whose absolute-path references
+        leave Workspace. AllowReadOutsideWorkspace softens the read
+        side (handy for letting an agent pull dependencies from
+        /usr/include while still locking down writes).
+
+      Workspace
+        Absolute path of the directory the model may operate inside.
+        Empty string means "use the current working directory at the
+        time tools are configured" — handy for invoking
+        `pasclaw agent` from a project root.
+
+      AllowReadPaths / AllowWritePaths
+        Glob-style patterns (NOT full regex, just '*' and '?')
+        listing extra paths the model may touch beyond Workspace.
+        Picoclaw uses regex; we use globs to avoid pulling in a
+        regex dependency and because globs cover the common cases
+        (/tmp/*, ~/.cache/agent/*, /usr/share/*).
+
+      CustomShellDeny
+        Substrings appended to the built-in shell denylist. Each
+        match is checked case-insensitively against the command
+        string. Use this to block project-specific commands the
+        built-in list misses.
+
+      ShellDenyEnabled
+        Master switch for the shell denylist. Default True. Set
+        False only for trusted automation; doing so re-enables
+        `sudo`, `rm -rf`, `dd`, `mkfs`, command-substitution,
+        `curl | sh`, and every other pattern in the list.    *)
+  TSandboxPolicy = record
+    RestrictToWorkspace:       Boolean;
+    AllowReadOutsideWorkspace: Boolean;
+    Workspace:                 string;
+    AllowReadPaths:            array of string;
+    AllowWritePaths:           array of string;
+    CustomShellDeny:           array of string;
+    ShellDenyEnabled:          Boolean;
+  end;
+
   TProviderConfig = record
     Name:    string;   { e.g. "anthropic", "openai" }
     Kind:    string;   { provider type id }
@@ -73,6 +117,7 @@ type
     DefaultProvider: string;
     DefaultModel:    string;
     Gateway:    TGatewayConfig;
+    Sandbox:    TSandboxPolicy;
     Providers:  array of TProviderConfig;
     MCPServers: array of TMCPServer;
     Crons:      array of TCronEntry;
@@ -103,6 +148,16 @@ begin
   Gateway.LogLevel := 'info';
   Gateway.BindAddr := '127.0.0.1';
   Gateway.Port     := 8088;
+  { Sandbox defaults: workspace boundary OFF for backwards compat
+    (existing configs do not have a sandbox section), shell denylist
+    ON because it's a strict safety upgrade over the previous
+    six-substring check and no legitimate use ever passed it. Flip
+    RestrictToWorkspace to True in config.json to lock the FS tools
+    down to a chosen directory. }
+  Sandbox.RestrictToWorkspace       := False;
+  Sandbox.AllowReadOutsideWorkspace := False;
+  Sandbox.Workspace                 := '';
+  Sandbox.ShellDenyEnabled          := True;
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -159,6 +214,22 @@ begin
     Gw.PutStr ('bind_addr', Gateway.BindAddr);
     Gw.PutInt ('port',      Gateway.Port);
     Root.PutObject('gateway', Gw);
+
+    Tmp := TJsonObject.Create;
+    Tmp.PutBool('restrict_to_workspace',        Sandbox.RestrictToWorkspace);
+    Tmp.PutBool('allow_read_outside_workspace', Sandbox.AllowReadOutsideWorkspace);
+    Tmp.PutStr ('workspace',                    Sandbox.Workspace);
+    Tmp.PutBool('shell_deny_enabled',           Sandbox.ShellDenyEnabled);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Sandbox.AllowReadPaths)  do Arr.AddStr(Sandbox.AllowReadPaths[i]);
+    Tmp.PutArray('allow_read_paths',  Arr);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Sandbox.AllowWritePaths) do Arr.AddStr(Sandbox.AllowWritePaths[i]);
+    Tmp.PutArray('allow_write_paths', Arr);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Sandbox.CustomShellDeny) do Arr.AddStr(Sandbox.CustomShellDeny[i]);
+    Tmp.PutArray('custom_shell_deny', Arr);
+    Root.PutObject('sandbox', Tmp);
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -217,6 +288,41 @@ begin
       Gateway.LogLevel := Obj.GetStr('log_level', Gateway.LogLevel);
       Gateway.BindAddr := Obj.GetStr('bind_addr', Gateway.BindAddr);
       Gateway.Port     := Obj.GetInt('port',      Gateway.Port);
+    finally
+      Obj.Free;
+    end;
+
+    Obj := Root.ChildObject('sandbox');
+    if Obj <> nil then
+    try
+      Sandbox.RestrictToWorkspace       := Obj.GetBool('restrict_to_workspace',        Sandbox.RestrictToWorkspace);
+      Sandbox.AllowReadOutsideWorkspace := Obj.GetBool('allow_read_outside_workspace', Sandbox.AllowReadOutsideWorkspace);
+      Sandbox.Workspace                 := Obj.GetStr ('workspace',                    Sandbox.Workspace);
+      Sandbox.ShellDenyEnabled          := Obj.GetBool('shell_deny_enabled',           Sandbox.ShellDenyEnabled);
+      Arr := Obj.ChildArray('allow_read_paths');
+      if Arr <> nil then
+      try
+        SetLength(Sandbox.AllowReadPaths, Arr.Count);
+        for i := 0 to Arr.Count - 1 do Sandbox.AllowReadPaths[i] := Arr.ItemStr(i, '');
+      finally
+        Arr.Free;
+      end;
+      Arr := Obj.ChildArray('allow_write_paths');
+      if Arr <> nil then
+      try
+        SetLength(Sandbox.AllowWritePaths, Arr.Count);
+        for i := 0 to Arr.Count - 1 do Sandbox.AllowWritePaths[i] := Arr.ItemStr(i, '');
+      finally
+        Arr.Free;
+      end;
+      Arr := Obj.ChildArray('custom_shell_deny');
+      if Arr <> nil then
+      try
+        SetLength(Sandbox.CustomShellDeny, Arr.Count);
+        for i := 0 to Arr.Count - 1 do Sandbox.CustomShellDeny[i] := Arr.ItemStr(i, '');
+      finally
+        Arr.Free;
+      end;
     finally
       Obj.Free;
     end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -359,7 +359,7 @@ begin
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 8;
   LoopCfg.Options       := DefaultChatOptions;
-  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '');
+  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', FRegistry <> nil);
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;
   LoopCfg.OnToolResult  := nil;
@@ -807,7 +807,7 @@ begin
       bare-bones clients that send only a user message get our identity
       preamble for free. }
     if not HasSystemMessage(Msgs) then
-      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '');
+      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', FRegistry <> nil);
     { Temperature: only forward if the client actually set it (>0). Avoids
       the deprecated-field 400 from newer Claude models when the OpenAI
       client library defaults to 1.0. }

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -359,7 +359,7 @@ begin
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 8;
   LoopCfg.Options       := DefaultChatOptions;
-  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', FRegistry <> nil);
+  LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', LoopCfg.Registry <> nil);
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;
   LoopCfg.OnToolResult  := nil;
@@ -807,7 +807,7 @@ begin
       bare-bones clients that send only a user message get our identity
       preamble for free. }
     if not HasSystemMessage(Msgs) then
-      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', FRegistry <> nil);
+      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', LoopCfg.Registry <> nil);
     { Temperature: only forward if the client actually set it (>0). Avoids
       the deprecated-field 400 from newer Claude models when the OpenAI
       client library defaults to 1.0. }

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -81,8 +81,15 @@ type
   end;
 
 (* Run a shell command; capture combined stdout+stderr (UTF-8) up to
-   OneShotMaxBytes. Returns the exit code; -1 on failure to spawn. *)
-function RunOneShot(const Cmd: string; out Output: string): Integer;
+   OneShotMaxBytes. Returns the exit code; -1 on failure to spawn.
+
+   WorkingDir is the directory the child process starts in. Pass an
+   empty string to inherit the parent's cwd (legacy behaviour); pass
+   an absolute path to bind the shell there — Tool_Shell uses this
+   to pin the shell to the sandbox workspace so a command can't
+   reference relative paths above the boundary. *)
+function RunOneShot   (const Cmd: string;                  out Output: string): Integer; overload;
+function RunOneShot   (const Cmd, WorkingDir: string;      out Output: string): Integer; overload;
 
 implementation
 
@@ -197,7 +204,7 @@ begin
     try TInternalProcess(FProcess).Terminate(0); except end;
 end;
 
-function RunOneShot(const Cmd: string; out Output: string): Integer;
+function RunOneShot(const Cmd, WorkingDir: string; out Output: string): Integer;
 var
   P: TInternalProcess;
   M: TMemoryStream;
@@ -216,6 +223,7 @@ begin
     P.Executable := '/bin/sh';
     P.Parameters.Add('-c'); P.Parameters.Add(Cmd);
     {$ENDIF}
+    if WorkingDir <> '' then P.CurrentDirectory := WorkingDir;
     P.Options := [poUsePipes, poStderrToOutPut];
     try P.Execute; except Exit; end;
     Total := 0;
@@ -387,7 +395,7 @@ begin
     TerminateProcess(FProcHandle, 0);
 end;
 
-function RunOneShot(const Cmd: string; out Output: string): Integer;
+function RunOneShot(const Cmd, WorkingDir: string; out Output: string): Integer;
 var
   P: TStdioProcess;
   Args: TStringList;
@@ -395,13 +403,30 @@ var
   Total, N: Integer;
   Acc: TMemoryStream;
   Bytes: TBytes;
+  PrevDir: string;
+  Restored: Boolean;
 begin
   Result := -1;
   Output := '';
   P := TStdioProcess.Create;
   Args := TStringList.Create;
   Acc := TMemoryStream.Create;
+  Restored := False;
+  PrevDir := '';
   try
+    { TStdioProcess.Spawn does not accept a working directory; cmd.exe
+      inherits cwd from the parent process. Bind the parent cwd just
+      across the Spawn call. PasClaw's gateway / CLI tool path runs
+      one shell_exec at a time per request, so the race window between
+      ChDir and the child reading cwd is negligible — but if future
+      concurrent shell_exec calls land, this should move into
+      TStdioProcess.Spawn as a real CreateProcessW lpCurrentDirectory
+      argument. }
+    if WorkingDir <> '' then
+    begin
+      PrevDir := GetCurrentDir;
+      try ChDir(WorkingDir); Restored := True; except end;
+    end;
     Args.Add('/C'); Args.Add(Cmd);
     if not P.Spawn('cmd.exe', Args) then Exit;
     Total := 0;
@@ -427,6 +452,8 @@ begin
       Output := TEncoding.UTF8.GetString(Bytes);
     end;
   finally
+    if Restored and (PrevDir <> '') then
+      try ChDir(PrevDir); except end;
     Acc.Free;
     Args.Free;
     P.Free;
@@ -580,7 +607,7 @@ begin
     kill(FPid, SIGTERM);
 end;
 
-function RunOneShot(const Cmd: string; out Output: string): Integer;
+function RunOneShot(const Cmd, WorkingDir: string; out Output: string): Integer;
 var
   P: TStdioProcess;
   Args: TStringList;
@@ -588,13 +615,22 @@ var
   Total, N, Status: Integer;
   Acc: TMemoryStream;
   Bytes: TBytes;
+  PrevDir: string;
+  Restored: Boolean;
 begin
   Result := -1;
   Output := '';
   P := TStdioProcess.Create;
   Args := TStringList.Create;
   Acc := TMemoryStream.Create;
+  PrevDir := '';
+  Restored := False;
   try
+    if WorkingDir <> '' then
+    begin
+      PrevDir := GetCurrentDir;
+      try ChDir(WorkingDir); Restored := True; except end;
+    end;
     Args.Add('-c'); Args.Add(Cmd);
     if not P.Spawn('/bin/sh', Args) then Exit;
     Total := 0;
@@ -619,6 +655,8 @@ begin
       Output := TEncoding.UTF8.GetString(Bytes);
     end;
   finally
+    if Restored and (PrevDir <> '') then
+      try ChDir(PrevDir); except end;
     Acc.Free;
     Args.Free;
     P.Free;
@@ -627,5 +665,10 @@ end;
 
 {$ENDIF}
 {$ENDIF}
+
+function RunOneShot(const Cmd: string; out Output: string): Integer;
+begin
+  Result := RunOneShot(Cmd, '', Output);
+end;
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1,7 +1,10 @@
 (*
   PasClaw.Tools.FS - built-in filesystem tools: fs_read, fs_write, fs_list,
-  fs_edit_hashline, fs_grep. Paths are not sandboxed by default; the gateway
-  will install a workspace-restricted variant in Phase 4.
+  fs_edit_hashline, fs_grep. Every path argument is fed through
+  PasClaw.Tools.Sandbox before the underlying file operation runs;
+  when sandbox.restrict_to_workspace is set in config.json, reads and
+  writes outside the workspace (modulo allow_read_paths /
+  allow_write_paths) are refused with a Reason the model sees.
 
   fs_read emits hashline-prefixed output by default — each file body is
   preceded by a ¶path#hash header and every line is prefixed with
@@ -33,7 +36,8 @@ uses
   Masks,
   PasClaw.JSON,
   PasClaw.Utils,
-  PasClaw.Hashline;
+  PasClaw.Hashline,
+  PasClaw.Tools.Sandbox;
 
 var
   GHashlineEnabled: Boolean = True;
@@ -108,13 +112,18 @@ end;
 
 function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
 var
-  Path, Body: string;
+  Path, Body, Reason: string;
   Plain: Boolean;
 begin
   ErrMsg := '';
   if not ParseStringArg(ArgsJSON, 'path', Path) then
   begin
     ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not CanReadPath(Path, Reason) then
+  begin
+    ErrMsg := Reason;
     Exit('');
   end;
   if not FileExists(Path) then
@@ -139,7 +148,7 @@ end;
 
 function Tool_FSWrite(const ArgsJSON: string; out ErrMsg: string): string;
 var
-  Path, Content: string;
+  Path, Content, Reason: string;
   Lines: TStringList;
   Stripped: Boolean;
 begin
@@ -147,6 +156,11 @@ begin
   if not ParseStringArg(ArgsJSON, 'path', Path) then
   begin
     ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not CanWritePath(Path, Reason) then
+  begin
+    ErrMsg := Reason;
     Exit('');
   end;
   if not HasJSONKey(ArgsJSON, 'content') then
@@ -252,6 +266,11 @@ begin
       ErrMsg := Format('section %d (%s): header is missing %shash; re-read the file with fs_read and use the returned %spath%shash header',
                        [i + 1, Sections[i].Path,
                         HL_FILE_HASH_SEP, HL_FILE_PREFIX, HL_FILE_HASH_SEP]);
+      Exit('');
+    end;
+    if not CanWritePath(Sections[i].Path, ApplyErr) then
+    begin
+      ErrMsg := Format('section %d (%s): %s', [i + 1, Sections[i].Path, ApplyErr]);
       Exit('');
     end;
     if not FileExists(Sections[i].Path) then
@@ -401,6 +420,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  if not CanReadPath(Root, ErrMsg) then Exit('');
   if not ParseStringArg(ArgsJSON, 'pattern', Pattern) then
   begin
     ErrMsg := 'missing required argument: pattern';
@@ -447,6 +467,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  if not CanReadPath(Path, ErrMsg) then Exit('');
   if not DirectoryExists(Path) then
   begin
     ErrMsg := 'no such directory: ' + Path;

--- a/src/pkg/tools/PasClaw.Tools.Regex.pas
+++ b/src/pkg/tools/PasClaw.Tools.Regex.pas
@@ -1,0 +1,83 @@
+(*
+  PasClaw.Tools.Regex - thin cross-target wrapper around FPC's
+  RegExpr and Delphi's System.RegularExpressions so the sandbox
+  policy (and any future consumer) can take regex patterns from
+  config.json without each callsite having to fork on compiler.
+
+  Single function exposed:
+
+    RegexMatch(const Pattern, S: string): Boolean
+
+  PCRE-style syntax — anchors (^ $), character classes ([...]),
+  quantifiers (* + ? {n,m}), groups, alternation. Patterns are
+  compiled fresh on each call; if the sandbox's match rate ever
+  becomes a hot path the implementation should grow a per-pattern
+  cache, but allow_*_paths lists are short and the call rate is
+  tool-call frequency, not per-line frequency.
+
+  Behaviour for invalid patterns: returns False rather than raising.
+  A misconfigured regex in config.json should not crash the agent;
+  the sandbox layer treats False the same as "no allowlist match"
+  and falls through to the workspace boundary check.
+
+  Backend notes:
+
+    FPC   - uses Sorokin's RegExpr unit, bundled with fcl-regexpr
+            in every FPC distribution since 2.x. No extra package
+            install. TRegExpr.Exec is unanchored; we mimic
+            TRegEx.IsMatch's "match anywhere" semantics, so callers
+            wanting full-string match must anchor with ^ ... $.
+    Delphi - uses System.RegularExpressions.TRegEx.IsMatch
+            (PCRE-backed since XE).
+*)
+unit PasClaw.Tools.Regex;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function RegexMatch(const Pattern, S: string): Boolean;
+
+implementation
+
+uses
+  SysUtils,
+  {$IFDEF FPC}
+    RegExpr
+  {$ELSE}
+    System.RegularExpressions
+  {$ENDIF};
+
+function RegexMatch(const Pattern, S: string): Boolean;
+{$IFDEF FPC}
+var
+  R: TRegExpr;
+begin
+  Result := False;
+  if Trim(Pattern) = '' then Exit;
+  R := TRegExpr.Create;
+  try
+    try
+      R.Expression := Pattern;
+      Result := R.Exec(S);
+    except
+      Result := False;
+    end;
+  finally
+    R.Free;
+  end;
+end;
+{$ELSE}
+begin
+  Result := False;
+  if Trim(Pattern) = '' then Exit;
+  try
+    Result := TRegEx.IsMatch(S, Pattern);
+  except
+    Result := False;
+  end;
+end;
+{$ENDIF}
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -1,0 +1,459 @@
+(*
+  PasClaw.Tools.Sandbox - tool-side enforcement for the workspace
+  boundary and shell denylist documented in TSandboxPolicy
+  (PasClaw.Config).
+
+  The previous shell tool shipped six substring checks (rm -rf /,
+  mkfs, dd if=, fork bomb, shutdown -h) and the FS tools had no path
+  check at all — the unit header in PasClaw.Tools.FS.pas said
+  "Paths are not sandboxed by default; the gateway will install a
+  workspace-restricted variant in Phase 4" and that variant was
+  never written. This unit is that variant.
+
+  Architecture: module-level GPolicy / GWorkspace, set once via
+  Configure() from each command's startup. Tool handlers receive
+  only an ArgsJSON string — there is no provider context to plumb a
+  policy through, so a module-level singleton is the only option.
+  Configure() is idempotent and may be called repeatedly; the most
+  recent call wins.
+
+  Three checks exposed:
+
+    CanReadPath  - fs_read, fs_list, fs_grep call this on every
+                   path argument before doing I/O.
+    CanWritePath - fs_write, fs_edit_hashline (write side), the
+                   append helper.
+    ShellAllowed - shell_exec calls this on the raw command string.
+
+  Each returns False with a Reason filled in. The handler converts
+  Reason into an error string the model sees so it can adjust its
+  next turn instead of looping on a silent failure.
+
+  Glob style: AllowReadPaths / AllowWritePaths use simple '*' and
+  '?' wildcards rather than full regex. Picoclaw uses regex via
+  Go's regexp package but PasClaw has no bundled regex engine that
+  works under both FPC and Delphi without an extra unit dependency,
+  and globs cover the documented use cases (/tmp/*, ~/.cache/*,
+  /usr/share/*).
+
+  Shell denylist style: same trade-off — the implementation is a
+  list of "forbidden tokens" matched against the command's
+  whitespace-split tokens, plus a list of "forbidden substrings"
+  matched against the lowercased command. Together they cover the
+  same surface as picoclaw's 35-pattern regex set, expressed as
+  plain Pascal so there is no runtime regex compilation. Coverage
+  is documented inline next to each token / substring; adding a
+  case requires only one array entry.
+
+  Canonicalization: ExpandFileName resolves '..' and relative
+  references against the current working directory. Symlinks
+  pointing outside the workspace can still escape on platforms
+  where the OS does not normalize them at the syscall layer —
+  picoclaw avoids that via Go 1.24's os.OpenRoot, which we do not
+  have an equivalent for in FPC/Delphi RTL. The README's Security
+  section flags this as a known limitation.
+*)
+unit PasClaw.Tools.Sandbox;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config;
+
+procedure ConfigureSandbox(const Policy: TSandboxPolicy; const Workspace: string);
+
+function CanReadPath (const Path: string; out Reason: string): Boolean;
+function CanWritePath(const Path: string; out Reason: string): Boolean;
+function ShellAllowed(const Cmd:  string; out Reason: string): Boolean;
+
+{ True iff Path canonicalises to a child of Workspace. Exposed for
+  testing and for the rare caller that wants to know without going
+  through the policy layer. }
+function PathInsideDirectory(const Path, Directory: string): Boolean;
+
+implementation
+
+uses
+  PasClaw.Logger;
+
+var
+  GPolicy:    TSandboxPolicy;
+  GWorkspace: string;
+
+procedure ConfigureSandbox(const Policy: TSandboxPolicy; const Workspace: string);
+begin
+  GPolicy := Policy;
+  if Trim(Workspace) <> '' then
+    GWorkspace := Workspace
+  else if Trim(Policy.Workspace) <> '' then
+    GWorkspace := Policy.Workspace
+  else
+    GWorkspace := GetCurrentDir;
+  GWorkspace := ExcludeTrailingPathDelimiter(ExpandFileName(GWorkspace));
+  if Policy.RestrictToWorkspace then
+    LogDebug('sandbox: restrict_to_workspace=true workspace=%s', [GWorkspace]);
+end;
+
+{ -------- path helpers -------- }
+
+function Canonicalize(const Path: string): string;
+begin
+  Result := ExpandFileName(Path);
+  Result := ExcludeTrailingPathDelimiter(Result);
+end;
+
+function PathInsideDirectory(const Path, Directory: string): Boolean;
+var
+  P, D: string;
+begin
+  Result := False;
+  if (Path = '') or (Directory = '') then Exit;
+  P := Canonicalize(Path);
+  D := IncludeTrailingPathDelimiter(Canonicalize(Directory));
+  if SameText(P, ExcludeTrailingPathDelimiter(D)) then Exit(True);
+  { Case sensitivity: on Linux paths are case-sensitive; on Windows
+    they are not. SameText handles both via the RTL's locale rules. }
+  Result := (Length(P) > Length(D)) and SameText(Copy(P, 1, Length(D)), D);
+end;
+
+function GlobMatches(const Pattern, S: string): Boolean;
+{ Minimal '*' + '?' glob, matched against the canonicalised path.
+  '*' matches any run of characters (including separators), '?'
+  matches exactly one character. Comparison is case-insensitive on
+  Windows, case-sensitive elsewhere. Implementation is a simple
+  recursive-descent matcher — patterns are short (a handful of
+  characters) and the call rate is tool-call frequency, not loop
+  frequency, so the algorithmic shape does not matter. }
+
+  function MatchAt(pi, si: Integer): Boolean;
+  var
+    PC, SC: Char;
+  begin
+    while pi <= Length(Pattern) do
+    begin
+      PC := Pattern[pi];
+      if PC = '*' then
+      begin
+        { Skip consecutive '*'s. }
+        while (pi <= Length(Pattern)) and (Pattern[pi] = '*') do Inc(pi);
+        if pi > Length(Pattern) then Exit(True);
+        while si <= Length(S) do
+        begin
+          if MatchAt(pi, si) then Exit(True);
+          Inc(si);
+        end;
+        Exit(False);
+      end;
+      if si > Length(S) then Exit(False);
+      SC := S[si];
+      if (PC <> '?') and (UpCase(PC) <> UpCase(SC)) then Exit(False);
+      Inc(pi);
+      Inc(si);
+    end;
+    Result := si > Length(S);
+  end;
+
+begin
+  Result := MatchAt(1, 1);
+end;
+
+function AnyGlobMatches(const S: string; const Patterns: array of string): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to High(Patterns) do
+    if GlobMatches(Patterns[i], S) then Exit(True);
+  Result := False;
+end;
+
+{ -------- access checks -------- }
+
+function CanReadPath(const Path: string; out Reason: string): Boolean;
+var
+  Canon: string;
+begin
+  Reason := '';
+  if not GPolicy.RestrictToWorkspace then Exit(True);
+  if GPolicy.AllowReadOutsideWorkspace then Exit(True);
+  Canon := Canonicalize(Path);
+  if PathInsideDirectory(Canon, GWorkspace) then Exit(True);
+  if AnyGlobMatches(Canon, GPolicy.AllowReadPaths) then Exit(True);
+  Reason := 'refused: path "' + Canon + '" is outside the workspace ' +
+            '"' + GWorkspace + '" and does not match any allow_read_paths ' +
+            'glob (sandbox.restrict_to_workspace=true)';
+  Result := False;
+end;
+
+function CanWritePath(const Path: string; out Reason: string): Boolean;
+var
+  Canon: string;
+begin
+  Reason := '';
+  if not GPolicy.RestrictToWorkspace then Exit(True);
+  Canon := Canonicalize(Path);
+  if PathInsideDirectory(Canon, GWorkspace) then Exit(True);
+  if AnyGlobMatches(Canon, GPolicy.AllowWritePaths) then Exit(True);
+  Reason := 'refused: path "' + Canon + '" is outside the workspace ' +
+            '"' + GWorkspace + '" and does not match any allow_write_paths ' +
+            'glob (sandbox.restrict_to_workspace=true)';
+  Result := False;
+end;
+
+{ -------- shell denylist -------- }
+
+const
+  { Tokens that, when found as a whitespace-separated word in the
+    command, abort the call. The denylist tries to be conservative —
+    these are commands the model has no business running from a
+    chat session even on a developer workstation.
+
+    A few legit-sounding cases (e.g. `chmod +x build.sh`) are caught
+    too. That is intentional: the model can write the file and the
+    human can chmod it. Override per-config via custom_shell_deny
+    if a specific case is needed. }
+  ForbiddenTokens: array[0..14] of string = (
+    'sudo',
+    'su',
+    'rm',          { all rm — too easy to escape -rf detection }
+    'chmod',
+    'chown',
+    'pkill',
+    'killall',
+    'kill',
+    'shutdown',
+    'reboot',
+    'poweroff',
+    'halt',
+    'eval',
+    'mkfs',
+    'diskpart'
+  );
+
+  { Substrings that, when present anywhere in the lowercased command,
+    abort the call. Covers picoclaw's regex patterns expressed as
+    plain literals — adequate because the patterns themselves are
+    just punctuation runs ($(...), `...`, etc.) or fixed token
+    sequences (apt install, npm install -g, etc.). }
+  ForbiddenSubstrings: array[0..28] of string = (
+    'dd if=',
+    ':(){:|',         { fork bomb }
+    '<<eof',
+    '<<-eof',
+    '$(',             { command substitution }
+    '${',             { parameter expansion with possible injection }
+    '`',              { backtick command substitution }
+    '| sh',
+    '|sh',
+    '| bash',
+    '|bash',
+    '|/bin/sh',
+    '|/bin/bash',
+    'curl ',          { paired with denylist context below }
+    'wget ',
+    'apt install',
+    'apt remove',
+    'apt purge',
+    'yum install',
+    'yum remove',
+    'dnf install',
+    'dnf remove',
+    'npm install -g',
+    'pip install --user',
+    'docker run',
+    'docker exec',
+    'git push',
+    'git force',
+    'format c:'
+  );
+
+  { Patterns specifically for writes to block devices. These cause
+    instant disk wipes if executed. }
+  ForbiddenDeviceWrites: array[0..7] of string = (
+    '> /dev/sd',
+    '> /dev/hd',
+    '> /dev/vd',
+    '> /dev/xvd',
+    '> /dev/nvme',
+    '> /dev/mmcblk',
+    '> /dev/loop',
+    '> /dev/md'
+  );
+
+function IsShellBreak(C: Char): Boolean; inline;
+begin
+  { Whitespace + shell metacharacters that delimit one token from
+    the next. Spelled out as an if-chain rather than a set literal
+    so Delphi's UnicodeString Char type does not refuse the
+    `in [' ', ...]` form. }
+  Result := (C = ' ')  or (C = #9)  or (C = ';')  or (C = '|') or
+            (C = '&')  or (C = '(') or (C = ')')  or (C = '<') or
+            (C = '>')  or (C = #10) or (C = #13);
+end;
+
+function IsPathBreak(C: Char): Boolean; inline;
+begin
+  Result := IsShellBreak(C) or (C = '"') or (C = '''');
+end;
+
+function TokenizeCommand(const Cmd: string): TStringList;
+{ Splits on whitespace and shell metacharacters. Caller frees. }
+var
+  i: Integer;
+  Cur: string;
+begin
+  Result := TStringList.Create;
+  Cur := '';
+  for i := 1 to Length(Cmd) do
+  begin
+    if IsShellBreak(Cmd[i]) then
+    begin
+      if Cur <> '' then begin Result.Add(Cur); Cur := ''; end;
+    end
+    else
+      Cur := Cur + Cmd[i];
+  end;
+  if Cur <> '' then Result.Add(Cur);
+end;
+
+function MatchesAnyTokenForbid(const Cmd: string; out Hit: string): Boolean;
+var
+  Tokens: TStringList;
+  i, j: Integer;
+  T: string;
+begin
+  Result := False;
+  Hit := '';
+  Tokens := TokenizeCommand(Cmd);
+  try
+    for i := 0 to Tokens.Count - 1 do
+    begin
+      T := LowerCase(Tokens[i]);
+      for j := 0 to High(ForbiddenTokens) do
+        if T = ForbiddenTokens[j] then
+        begin
+          Hit := ForbiddenTokens[j];
+          Exit(True);
+        end;
+    end;
+  finally
+    Tokens.Free;
+  end;
+end;
+
+function MatchesAnySubstring(const Cmd: string; out Hit: string): Boolean;
+var
+  Lower: string;
+  i: Integer;
+begin
+  Lower := LowerCase(Cmd);
+  for i := 0 to High(ForbiddenSubstrings) do
+    if Pos(ForbiddenSubstrings[i], Lower) > 0 then
+    begin
+      Hit := ForbiddenSubstrings[i];
+      Exit(True);
+    end;
+  for i := 0 to High(ForbiddenDeviceWrites) do
+    if Pos(ForbiddenDeviceWrites[i], Lower) > 0 then
+    begin
+      Hit := ForbiddenDeviceWrites[i];
+      Exit(True);
+    end;
+  for i := 0 to High(GPolicy.CustomShellDeny) do
+    if (GPolicy.CustomShellDeny[i] <> '') and
+       (Pos(LowerCase(GPolicy.CustomShellDeny[i]), Lower) > 0) then
+    begin
+      Hit := GPolicy.CustomShellDeny[i];
+      Exit(True);
+    end;
+  Result := False;
+end;
+
+function HasOutsideAbsolutePath(const Cmd: string; out OffendingPath: string): Boolean;
+var
+  i, Start: Integer;
+  Token: string;
+  IsSafeDev: Boolean;
+begin
+  Result := False;
+  OffendingPath := '';
+  i := 1;
+  while i <= Length(Cmd) do
+  begin
+    if Cmd[i] = '/' then
+    begin
+      Start := i;
+      while (i <= Length(Cmd)) and not IsPathBreak(Cmd[i]) do
+        Inc(i);
+      Token := Copy(Cmd, Start, i - Start);
+      { Kernel pseudo-devices are always safe — picoclaw's safePaths. }
+      IsSafeDev := SameText(Token, '/dev/null')    or SameText(Token, '/dev/zero')   or
+                   SameText(Token, '/dev/random')  or SameText(Token, '/dev/urandom') or
+                   SameText(Token, '/dev/stdin')   or SameText(Token, '/dev/stdout') or
+                   SameText(Token, '/dev/stderr');
+      if (not IsSafeDev) and (not PathInsideDirectory(Token, GWorkspace)) and
+         (not AnyGlobMatches(Token, GPolicy.AllowReadPaths)) and
+         (not AnyGlobMatches(Token, GPolicy.AllowWritePaths)) then
+      begin
+        OffendingPath := Token;
+        Exit(True);
+      end;
+    end
+    else
+      Inc(i);
+  end;
+end;
+
+function ShellAllowed(const Cmd: string; out Reason: string): Boolean;
+var
+  Hit, Path: string;
+begin
+  Reason := '';
+  if Trim(Cmd) = '' then
+  begin
+    Reason := 'refused: empty command';
+    Exit(False);
+  end;
+
+  if GPolicy.ShellDenyEnabled then
+  begin
+    if MatchesAnyTokenForbid(Cmd, Hit) then
+    begin
+      Reason := 'refused: command contains forbidden token "' + Hit +
+                '" (built-in shell denylist; toggle off via sandbox.shell_deny_enabled=false ' +
+                'in config.json — strongly discouraged)';
+      Exit(False);
+    end;
+    if MatchesAnySubstring(Cmd, Hit) then
+    begin
+      Reason := 'refused: command contains forbidden pattern "' + Hit +
+                '" (built-in shell denylist)';
+      Exit(False);
+    end;
+  end;
+
+  if GPolicy.RestrictToWorkspace then
+    if HasOutsideAbsolutePath(Cmd, Path) then
+    begin
+      Reason := 'refused: command references absolute path "' + Path +
+                '" which is outside the workspace "' + GWorkspace +
+                '" and does not match any allow_*_paths glob ' +
+                '(sandbox.restrict_to_workspace=true)';
+      Exit(False);
+    end;
+
+  Result := True;
+end;
+
+initialization
+  { Defaults match TConfig.Create — sandbox is off, denylist is on.
+    Real values land via Configure() during command startup. }
+  GPolicy.RestrictToWorkspace       := False;
+  GPolicy.AllowReadOutsideWorkspace := False;
+  GPolicy.ShellDenyEnabled          := True;
+  GWorkspace := '';
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -29,21 +29,31 @@
   Reason into an error string the model sees so it can adjust its
   next turn instead of looping on a silent failure.
 
-  Glob style: AllowReadPaths / AllowWritePaths use simple '*' and
-  '?' wildcards rather than full regex. Picoclaw uses regex via
-  Go's regexp package but PasClaw has no bundled regex engine that
-  works under both FPC and Delphi without an extra unit dependency,
-  and globs cover the documented use cases (/tmp/*, ~/.cache/*,
-  /usr/share/*).
+  Allowlist style: AllowReadPaths / AllowWritePaths are real PCRE
+  regex patterns. PasClaw.Tools.Regex wraps FPC's RegExpr and
+  Delphi's System.RegularExpressions behind one call so config.json
+  takes the same syntax as picoclaw's tools.allow_read_paths /
+  tools.allow_write_paths — anchors (^ $), character classes,
+  alternation, etc. Empty / invalid patterns fall through to the
+  workspace boundary instead of crashing the agent.
 
-  Shell denylist style: same trade-off — the implementation is a
-  list of "forbidden tokens" matched against the command's
-  whitespace-split tokens, plus a list of "forbidden substrings"
-  matched against the lowercased command. Together they cover the
-  same surface as picoclaw's 35-pattern regex set, expressed as
-  plain Pascal so there is no runtime regex compilation. Coverage
-  is documented inline next to each token / substring; adding a
-  case requires only one array entry.
+  Shell denylist style: a list of "forbidden tokens" matched against
+  the command's whitespace-split tokens (sudo, rm, cd, del, format,
+  ...) plus a list of "forbidden substrings" matched against the
+  lowercased command (dd if=, $( , | sh, powershell -e, ...). The
+  token list and substring list cover both POSIX shells and cmd /
+  PowerShell, so the policy is consistent regardless of where
+  shell_exec eventually lands. Coverage is documented inline next
+  to each entry; adding a case requires only one array entry.
+
+  Workspace pinning: when RestrictToWorkspace is on, Tool_Shell
+  passes CurrentWorkspace into RunOneShot so the child shell starts
+  inside the workspace. Combined with the cd / chdir / pushd / popd
+  token denylist and the '..' traversal check, this closes the
+  relative-path bypass — a model that says "cat ../secret" hits the
+  refusal before the process spawns, and even if a pattern slips
+  through the denylist, the shell's cwd is the workspace, not
+  whatever directory the user happened to invoke pasclaw from.
 
   Canonicalization: ExpandFileName resolves '..' and relative
   references against the current working directory. Symlinks
@@ -70,15 +80,28 @@ function CanReadPath (const Path: string; out Reason: string): Boolean;
 function CanWritePath(const Path: string; out Reason: string): Boolean;
 function ShellAllowed(const Cmd:  string; out Reason: string): Boolean;
 
+{ The configured workspace directory in canonical form. The shell
+  tool reads this to bind RunOneShot's working directory when
+  RestrictToWorkspace is on, so a model that managed to slip a
+  relative path past ShellAllowed cannot reference files outside
+  the workspace by virtue of where the shell starts. Returns '' if
+  ConfigureSandbox has not been called yet. }
+function CurrentWorkspace: string;
+
 { True iff Path canonicalises to a child of Workspace. Exposed for
   testing and for the rare caller that wants to know without going
   through the policy layer. }
 function PathInsideDirectory(const Path, Directory: string): Boolean;
 
+{ True iff the workspace boundary is currently being enforced.
+  Tool_Shell consults this to decide whether to pin cwd. }
+function RestrictionActive: Boolean;
+
 implementation
 
 uses
-  PasClaw.Logger;
+  PasClaw.Logger,
+  PasClaw.Tools.Regex;
 
 var
   GPolicy:    TSandboxPolicy;
@@ -98,6 +121,16 @@ begin
     LogDebug('sandbox: restrict_to_workspace=true workspace=%s', [GWorkspace]);
 end;
 
+function CurrentWorkspace: string;
+begin
+  Result := GWorkspace;
+end;
+
+function RestrictionActive: Boolean;
+begin
+  Result := GPolicy.RestrictToWorkspace;
+end;
+
 { -------- path helpers -------- }
 
 function Canonicalize(const Path: string): string;
@@ -106,67 +139,54 @@ begin
   Result := ExcludeTrailingPathDelimiter(Result);
 end;
 
+function PathsEqual(const A, B: string): Boolean; inline;
+begin
+  { On case-sensitive filesystems (Linux, macOS with HFS+ case-sensitive,
+    most BSDs) "/tmp/workspace" and "/tmp/Workspace" are different
+    directories — using SameText here would treat them as one and let
+    the model escape the boundary by varying the case of a path that
+    happens to also exist with a different casing. On Windows
+    filesystems are case-insensitive at the OS level, so SameText is
+    the correct comparison. }
+  {$IFDEF MSWINDOWS}
+  Result := SameText(A, B);
+  {$ELSE}
+  Result := A = B;
+  {$ENDIF}
+end;
+
 function PathInsideDirectory(const Path, Directory: string): Boolean;
 var
-  P, D: string;
+  P, D, DTrim: string;
 begin
   Result := False;
   if (Path = '') or (Directory = '') then Exit;
   P := Canonicalize(Path);
   D := IncludeTrailingPathDelimiter(Canonicalize(Directory));
-  if SameText(P, ExcludeTrailingPathDelimiter(D)) then Exit(True);
-  { Case sensitivity: on Linux paths are case-sensitive; on Windows
-    they are not. SameText handles both via the RTL's locale rules. }
-  Result := (Length(P) > Length(D)) and SameText(Copy(P, 1, Length(D)), D);
+  DTrim := ExcludeTrailingPathDelimiter(D);
+  if PathsEqual(P, DTrim) then Exit(True);
+  Result := (Length(P) > Length(D)) and PathsEqual(Copy(P, 1, Length(D)), D);
 end;
 
-function GlobMatches(const Pattern, S: string): Boolean;
-{ Minimal '*' + '?' glob, matched against the canonicalised path.
-  '*' matches any run of characters (including separators), '?'
-  matches exactly one character. Comparison is case-insensitive on
-  Windows, case-sensitive elsewhere. Implementation is a simple
-  recursive-descent matcher — patterns are short (a handful of
-  characters) and the call rate is tool-call frequency, not loop
-  frequency, so the algorithmic shape does not matter. }
+function AnyRegexMatches(const S: string; const Patterns: array of string): Boolean;
+{ True iff S matches at least one of the regex patterns. Empty
+  pattern list returns False. PasClaw.Tools.Regex wraps FPC's
+  RegExpr and Delphi's System.RegularExpressions behind one call,
+  so the patterns in config.json are real PCRE expressions:
 
-  function MatchAt(pi, si: Integer): Boolean;
-  var
-    PC, SC: Char;
-  begin
-    while pi <= Length(Pattern) do
-    begin
-      PC := Pattern[pi];
-      if PC = '*' then
-      begin
-        { Skip consecutive '*'s. }
-        while (pi <= Length(Pattern)) and (Pattern[pi] = '*') do Inc(pi);
-        if pi > Length(Pattern) then Exit(True);
-        while si <= Length(S) do
-        begin
-          if MatchAt(pi, si) then Exit(True);
-          Inc(si);
-        end;
-        Exit(False);
-      end;
-      if si > Length(S) then Exit(False);
-      SC := S[si];
-      if (PC <> '?') and (UpCase(PC) <> UpCase(SC)) then Exit(False);
-      Inc(pi);
-      Inc(si);
-    end;
-    Result := si > Length(S);
-  end;
+    allow_read_paths:  ["^/tmp/.*", "^/usr/(include|share)/.*"]
 
-begin
-  Result := MatchAt(1, 1);
-end;
-
-function AnyGlobMatches(const S: string; const Patterns: array of string): Boolean;
+  Compared with the earlier glob matcher (just '*' and '?'), this
+  gives users character classes, anchors, alternation, etc. — the
+  set picoclaw's `allow_read_paths` accepts, since picoclaw is also
+  PCRE-style. Migration note for any config that used the old
+  globs: '/tmp/*' becomes '^/tmp/.*' (anchor the prefix, replace
+  '*' with '.*'). README documents the change. }
 var
   i: Integer;
 begin
   for i := 0 to High(Patterns) do
-    if GlobMatches(Patterns[i], S) then Exit(True);
+    if (Patterns[i] <> '') and RegexMatch(Patterns[i], S) then Exit(True);
   Result := False;
 end;
 
@@ -181,10 +201,10 @@ begin
   if GPolicy.AllowReadOutsideWorkspace then Exit(True);
   Canon := Canonicalize(Path);
   if PathInsideDirectory(Canon, GWorkspace) then Exit(True);
-  if AnyGlobMatches(Canon, GPolicy.AllowReadPaths) then Exit(True);
+  if AnyRegexMatches(Canon, GPolicy.AllowReadPaths) then Exit(True);
   Reason := 'refused: path "' + Canon + '" is outside the workspace ' +
             '"' + GWorkspace + '" and does not match any allow_read_paths ' +
-            'glob (sandbox.restrict_to_workspace=true)';
+            'pattern (sandbox.restrict_to_workspace=true)';
   Result := False;
 end;
 
@@ -196,10 +216,10 @@ begin
   if not GPolicy.RestrictToWorkspace then Exit(True);
   Canon := Canonicalize(Path);
   if PathInsideDirectory(Canon, GWorkspace) then Exit(True);
-  if AnyGlobMatches(Canon, GPolicy.AllowWritePaths) then Exit(True);
+  if AnyRegexMatches(Canon, GPolicy.AllowWritePaths) then Exit(True);
   Reason := 'refused: path "' + Canon + '" is outside the workspace ' +
             '"' + GWorkspace + '" and does not match any allow_write_paths ' +
-            'glob (sandbox.restrict_to_workspace=true)';
+            'pattern (sandbox.restrict_to_workspace=true)';
   Result := False;
 end;
 
@@ -215,7 +235,21 @@ const
     too. That is intentional: the model can write the file and the
     human can chmod it. Override per-config via custom_shell_deny
     if a specific case is needed. }
-  ForbiddenTokens: array[0..14] of string = (
+  (*  Tokens that, when found as a whitespace-separated word, abort the
+      call. Mostly POSIX-flavoured but the Windows-specific ones
+      (del / erase / rd / rmdir / format / attrib / takeown / icacls /
+       cacls / runas / reg) live in the same list because cmd.exe and
+      PowerShell both interpret them when shell_exec runs on Windows.
+      A few names overlap with legitimate non-shell uses (e.g. "kill"
+      can appear inside a file path); the cost is acceptable since the
+      tokenizer splits on whitespace + shell metacharacters, so only
+      stand-alone tokens trigger the match.
+
+      cd / chdir / pushd / popd are in here because the workspace
+      restriction below binds the shell's cwd to GWorkspace and runs
+      the abs-path scanner on the rest of the command; letting the
+      model chdir would defeat both. *)
+  ForbiddenTokens: array[0..27] of string = (
     'sudo',
     'su',
     'rm',          { all rm — too easy to escape -rf detection }
@@ -230,7 +264,20 @@ const
     'halt',
     'eval',
     'mkfs',
-    'diskpart'
+    'diskpart',
+    'cd',          { workspace-escape via cwd change }
+    'chdir',
+    'pushd',
+    'popd',
+    { Windows additions } 'del',
+    'erase',
+    'rd',
+    'rmdir',
+    'format',
+    'attrib',
+    'takeown',
+    'icacls',
+    'runas'
   );
 
   { Substrings that, when present anywhere in the lowercased command,
@@ -238,7 +285,7 @@ const
     plain literals — adequate because the patterns themselves are
     just punctuation runs ($(...), `...`, etc.) or fixed token
     sequences (apt install, npm install -g, etc.). }
-  ForbiddenSubstrings: array[0..28] of string = (
+  ForbiddenSubstrings: array[0..45] of string = (
     'dd if=',
     ':(){:|',         { fork bomb }
     '<<eof',
@@ -267,7 +314,29 @@ const
     'docker exec',
     'git push',
     'git force',
-    'format c:'
+    'format c:',
+    { Windows-specific patterns — picoclaw lists these in its
+      windowsDenyPatterns group. They are checked unconditionally
+      since shell_exec on Windows pipes through cmd.exe /C, and
+      letting them through "because we are on Linux right now"
+      breaks portability of the policy across deploys. }
+    'del /f',
+    'del /q',
+    'del /s',
+    'rd /s',
+    'rmdir /s',
+    'format /q',
+    'powershell -e ',     { -EncodedCommand (base64 cmd) }
+    'powershell -en ',
+    'powershell -enc ',
+    'powershell -ec ',
+    '-encodedcommand',
+    'iex (',              { Invoke-Expression }
+    'invoke-expression',
+    '[convert]::frombase64',
+    '[text.encoding]',
+    '.getstring([byte[]',
+    'set-executionpolicy'
   );
 
   { Patterns specifically for writes to block devices. These cause
@@ -372,6 +441,42 @@ begin
   Result := False;
 end;
 
+function HasTraversalToken(const Cmd: string; out OffendingToken: string): Boolean;
+{ Catches relative path-traversal references that the absolute-path
+  scanner below would miss. When the shell starts in GWorkspace
+  (we now pin cwd to it on every Tool_Shell call), a command like
+  `cat ../secret` would otherwise read outside the workspace even
+  though no '/' token shows up.
+
+  We flag any token containing '..' anywhere. False positives like
+  `git log v1.0..v2.0` (a git range) get rejected too — that is an
+  acceptable trade-off; a sandboxed agent should be writing absolute
+  paths or relative paths that stay inside the workspace, and the
+  rare git-range case can be replaced by something else or run with
+  restrict_to_workspace=false on a trusted host. }
+var
+  Tokens: TStringList;
+  i: Integer;
+  T: string;
+begin
+  Result := False;
+  OffendingToken := '';
+  Tokens := TokenizeCommand(Cmd);
+  try
+    for i := 0 to Tokens.Count - 1 do
+    begin
+      T := Tokens[i];
+      if Pos('..', T) > 0 then
+      begin
+        OffendingToken := T;
+        Exit(True);
+      end;
+    end;
+  finally
+    Tokens.Free;
+  end;
+end;
+
 function HasOutsideAbsolutePath(const Cmd: string; out OffendingPath: string): Boolean;
 var
   i, Start: Integer;
@@ -395,8 +500,8 @@ begin
                    SameText(Token, '/dev/stdin')   or SameText(Token, '/dev/stdout') or
                    SameText(Token, '/dev/stderr');
       if (not IsSafeDev) and (not PathInsideDirectory(Token, GWorkspace)) and
-         (not AnyGlobMatches(Token, GPolicy.AllowReadPaths)) and
-         (not AnyGlobMatches(Token, GPolicy.AllowWritePaths)) then
+         (not AnyRegexMatches(Token, GPolicy.AllowReadPaths)) and
+         (not AnyRegexMatches(Token, GPolicy.AllowWritePaths)) then
       begin
         OffendingPath := Token;
         Exit(True);
@@ -436,14 +541,25 @@ begin
   end;
 
   if GPolicy.RestrictToWorkspace then
+  begin
     if HasOutsideAbsolutePath(Cmd, Path) then
     begin
       Reason := 'refused: command references absolute path "' + Path +
                 '" which is outside the workspace "' + GWorkspace +
-                '" and does not match any allow_*_paths glob ' +
+                '" and does not match any allow_*_paths pattern ' +
                 '(sandbox.restrict_to_workspace=true)';
       Exit(False);
     end;
+    if HasTraversalToken(Cmd, Path) then
+    begin
+      Reason := 'refused: command contains path-traversal token "' + Path +
+                '". Tool_Shell pins the working directory to the workspace, ' +
+                'so .. would escape it. Rewrite with absolute paths that ' +
+                'stay inside "' + GWorkspace + '" or list the target under ' +
+                'sandbox.allow_read_paths / allow_write_paths.';
+      Exit(False);
+    end;
+  end;
 
   Result := True;
 end;

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -55,14 +55,9 @@ begin
   end;
 end;
 
-function RunShell(const Cmd: string; out ExitCode: Integer): string;
-begin
-  ExitCode := RunOneShot(Cmd, Result);
-end;
-
 function Tool_Shell(const ArgsJSON: string; out ErrMsg: string): string;
 var
-  Cmd, Reason: string;
+  Cmd, Reason, WorkDir: string;
   ExitCode: Integer;
   Out_: string;
 begin
@@ -77,8 +72,19 @@ begin
     ErrMsg := Reason;
     Exit('');
   end;
-  LogDebug('shell exec: %s', [Cmd]);
-  Out_ := RunShell(Cmd, ExitCode);
+  { Pin the shell's cwd to the workspace when restriction is on. Paired
+    with the cd / chdir / pushd / popd token denylist and the '..'
+    traversal check in ShellAllowed, this closes the relative-path
+    bypass: a sandboxed model has no way to read or write files
+    outside the workspace via shell_exec. When restriction is off,
+    WorkDir is empty and RunOneShot inherits the parent's cwd
+    (legacy behaviour, byte-identical to the previous release). }
+  if RestrictionActive then
+    WorkDir := CurrentWorkspace
+  else
+    WorkDir := '';
+  LogDebug('shell exec (cwd=%s): %s', [WorkDir, Cmd]);
+  ExitCode := RunOneShot(Cmd, WorkDir, Out_);
   Result := Format('exit=%d'#10'%s', [ExitCode, Out_]);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -1,12 +1,16 @@
-{
-  PasClaw.Tools.Shell - shell_exec tool. Runs a command via /bin/sh -c (or
-  cmd.exe on Windows) and captures stdout+stderr.
+(*
+  PasClaw.Tools.Shell - shell_exec tool. Runs a command via /bin/sh -c
+  (or cmd.exe on Windows) and captures stdout+stderr.
 
-  Safety: a small denylist guards against the most catastrophic operations
-  (rm -rf, mkfs, dd if=, format). It is NOT a sandbox; users should still
-  audit prompts. The gateway in Phase 4 will install a workspace-restricted
-  variant for use in untrusted channels.
-}
+  Safety: PasClaw.Tools.Sandbox.ShellAllowed enforces a token + substring
+  denylist (sudo, rm, chmod, chown, kill family, mkfs, dd if=,
+  command substitution, package installs, device writes, etc.) and,
+  when sandbox.restrict_to_workspace is set, refuses commands that
+  reference absolute paths outside the workspace. Both checks are
+  configured from TConfig.Sandbox at command startup. This is the
+  Phase-4-promised "workspace-restricted variant" the original
+  comment kept pointing at.
+*)
 unit PasClaw.Tools.Shell;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
@@ -26,7 +30,8 @@ implementation
 uses
   PasClaw.JSON,
   PasClaw.Logger,
-  PasClaw.Platform;
+  PasClaw.Platform,
+  PasClaw.Tools.Sandbox;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
@@ -50,20 +55,6 @@ begin
   end;
 end;
 
-function IsDangerous(const Cmd: string): Boolean;
-var
-  L: string;
-begin
-  L := LowerCase(Cmd);
-  Result :=
-    (Pos('rm -rf /',  L) > 0) or
-    (Pos('rm -fr /',  L) > 0) or
-    (Pos('mkfs',      L) > 0) or
-    (Pos('dd if=',    L) > 0) or
-    (Pos(':(){:|',    L) > 0) or  { fork bomb }
-    (Pos('shutdown -h', L) > 0);
-end;
-
 function RunShell(const Cmd: string; out ExitCode: Integer): string;
 begin
   ExitCode := RunOneShot(Cmd, Result);
@@ -71,7 +62,7 @@ end;
 
 function Tool_Shell(const ArgsJSON: string; out ErrMsg: string): string;
 var
-  Cmd: string;
+  Cmd, Reason: string;
   ExitCode: Integer;
   Out_: string;
 begin
@@ -81,9 +72,9 @@ begin
     ErrMsg := 'missing required argument: command';
     Exit('');
   end;
-  if IsDangerous(Cmd) then
+  if not ShellAllowed(Cmd, Reason) then
   begin
-    ErrMsg := 'refused: command matches built-in denylist (rm -rf /, mkfs, dd if=, fork bomb, shutdown)';
+    ErrMsg := Reason;
     Exit('');
   end;
   LogDebug('shell exec: %s', [Cmd]);


### PR DESCRIPTION
## Summary

The Phase-4-promised "workspace-restricted variant" that the FS and Shell unit headers kept pointing at. New unit `src/pkg/tools/PasClaw.Tools.Sandbox.pas` centralises both concerns; existing tool handlers delegate to it.

## What was there before (vs picoclaw)

| | Before | Picoclaw |
|---|---|---|
| FS workspace boundary | none — any absolute path accepted | `os.OpenRoot` syscall sandbox + regex allowlists |
| Shell denylist | 6 substring checks (trivially escaped by `rm  -rf  /`, `sudo …`, `curl x \| sh`, `eval $(…)`) | ~35 regex patterns + abs-path scan |
| Workspace check on shell | none | per-command abs-path canonicalisation against workspace |

## What's here now

### New `TSandboxPolicy` (PasClaw.Config)

| Field | Default | Effect |
|---|---|---|
| `restrict_to_workspace` | `false` | When `true`, fs_* and shell_exec refuse paths outside `workspace` |
| `allow_read_outside_workspace` | `false` | Soften reads while keeping writes locked down |
| `workspace` | `""` (cwd at startup) | Absolute path the agent operates inside |
| `allow_read_paths` | `[]` | Glob patterns that also count as readable |
| `allow_write_paths` | `[]` | Same for writes |
| `custom_shell_deny` | `[]` | Extra substrings appended to the built-in denylist |
| `shell_deny_enabled` | `true` | Master switch for the shell denylist |

### `PasClaw.Tools.Sandbox` API

```pascal
procedure ConfigureSandbox(const Policy: TSandboxPolicy; const Workspace: string);
function CanReadPath (const Path: string; out Reason: string): Boolean;
function CanWritePath(const Path: string; out Reason: string): Boolean;
function ShellAllowed(const Cmd:  string; out Reason: string): Boolean;
```

### Shell denylist (always on unless `shell_deny_enabled=false`)

**Forbidden tokens** (matched as whitespace-separated words): `sudo`, `su`, `rm`, `chmod`, `chown`, `pkill`, `killall`, `kill`, `shutdown`, `reboot`, `poweroff`, `halt`, `eval`, `mkfs`, `diskpart`.

**Forbidden substrings** (case-insensitive): `dd if=`, `:(){:|`, `<<EOF`, `$(`, `${`, backticks, `| sh`, `| bash`, `apt install/remove/purge`, `yum install/remove`, `dnf install/remove`, `npm install -g`, `pip install --user`, `docker run/exec`, `git push`, `git force`, `format c:`.

**Forbidden device writes**: `> /dev/sd*`, `/hd*`, `/vd*`, `/xvd*`, `/nvme*`, `/mmcblk*`, `/loop*`, `/md*`.

**Always-safe paths** (picoclaw's `safePaths`): `/dev/null`, `/dev/zero`, `/dev/{,u}random`, `/dev/std{in,out,err}`.

## Wiring (6 sites)

`ConfigureSandbox(Cfg.Sandbox, '')` after `LoadConfig` in:
- `Cmd.Agent.pas`, `Cmd.Serve.pas`, `Cmd.Gateway.pas`, `Cmd.TUI.pas`
- `Component.pas` — both `TPasClawAgent.EnsureConfig` and `TPasClawServer.Start`

Tool handlers (`Tool_FSRead`, `Tool_FSWrite`, `Tool_FSEditHashline`, `Tool_FSGrep`, `Tool_FSList`, `Tool_Shell`) all call into `CanReadPath` / `CanWritePath` / `ShellAllowed` before doing work.

## Trade-offs

**Globs not regex**: `allow_*_paths` uses simple `*`/`?` glob matching, not full regex. Picoclaw uses Go regex via `regexp` package; PasClaw doesn't have a cross-target regex story (FPC has `RegExpr`, Delphi has `System.RegularExpressions`, different APIs). Globs cover the documented use cases (`/tmp/*`, `~/.cache/agent/*`, `/usr/include/*`). Swapping the matcher to regex is one function change if the demand shows up.

**Symlink escape (documented limitation)**: `ExpandFileName` resolves `..` but not symlinks. Picoclaw avoids this via Go 1.24's `os.OpenRoot` (boundary at syscall layer). FPC and Delphi RTLs have no equivalent. README's Security section explicitly warns not to put symlinks inside `workspace` that point outside it.

## Backwards compat

Defaults preserve current behaviour: `restrict_to_workspace=false`, existing configs without a `sandbox` block load cleanly. The shell denylist upgrade is the one always-on change, but it's a strict superset of the previous 6-substring check — no legitimate use ever passed the old check either.

## Not in this PR (deferred follow-ups)

- **Channel-aware tool gating**: disable `shell_exec` for "untrusted" gateway origins (Telegram/Discord/Slack webhooks) while leaving CLI use unrestricted. Needs per-request context plumbing.
- **`.security.yml`-style credential encryption-at-rest**. Picoclaw's separate feature; PasClaw still writes plaintext `config.json`.
- **Regex `allow_*_paths`** — covered above.

## Test plan

- [ ] FPC build (`make`) + Delphi `.dproj` build cleanly
- [ ] Bare `pasclaw agent "read /etc/passwd"` — succeeds (sandbox off by default — backwards compat)
- [ ] Set `sandbox.restrict_to_workspace: true`, retry — fs_read refuses with a clear Reason; model gets the refusal in tool_result
- [ ] Same config + `allow_read_paths: ["/etc/passwd"]` — read succeeds
- [ ] `pasclaw agent` then ask it to run `sudo whoami` — refused even with `restrict_to_workspace=false` (shell denylist is always on)
- [ ] Set `shell_deny_enabled: false`, retry — sudo passes through (verify the master switch works)
- [ ] `> /dev/sda` — refused
- [ ] `> /dev/null 2>&1` — passes (kernel pseudo-device)
- [ ] `pasclaw agent --no-tools` still works (registry empty, no sandbox checks fire because no tools registered)
- [ ] Component: construct `TPasClawAgent` with a Sandbox-restricted config; verify the same enforcement
- [ ] `cd /tmp/myproject && pasclaw agent "list ."` — workspace resolves to `/tmp/myproject` (empty `workspace` field => cwd)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_