### PR TITLE
docs: refresh PasClaw README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,168 +1,388 @@
 # PasClaw
 
-PasClaw is a Delphi Object Pascal port of PicoClaw —
-Sipeed's ultra-lightweight personal AI agent. It targets Free Pascal 3.2+ in
-`{$MODE DELPHI}` so the same sources build with both FPC and Delphi RAD Studio.
+PasClaw is an ultra-lightweight personal AI agent written in Delphi Object Pascal. It is a Delphi/FPC port inspired by [picoclaw](https://github.com/sipeed/picoclaw), with a command-line assistant, tool calling, MCP integration, an HTTP gateway, an OpenAI-compatible API surface, a small embedded web UI, scheduled tasks, skills, and channel integrations.
 
-The port is being done in phases. Phase 1 (this commit) ships the full
-command-tree skeleton; subsequent phases fill in real provider, MCP, gateway,
-cron, skills, and channel implementations.
+The main program lives at `src/pasclaw/PasClaw.dpr`. It initializes terminal color handling, prints the banner, applies timezone configuration, and dispatches into the command tree implemented under `src/cmd/`.
+
+## Requirements
+
+- Free Pascal 3.2+ in Delphi mode, or Delphi/RAD Studio.
+- Indy (`TIdHTTP`, `TIdHTTPServer`) for HTTP clients, the gateway, and channel integrations.
+  - FPC builds vendor Indy with `make get-indy` into `vendor/Indy`.
+  - Delphi/RAD Studio ships Indy, so no vendored Indy checkout is required.
+- On Debian/Ubuntu FPC systems, install `fp-units-misc` so the `iconvenc` units are available.
 
 ## Build
 
-### With Free Pascal (Linux / Windows)
+The repository `Makefile` is the authoritative FPC build entry point.
 
+```sh
+sudo apt install fpc fp-units-misc
+make get-indy
+make
 ```
-sudo apt install fpc fp-units-misc       # Free Pascal 3.2+, includes iconvenc
-make get-indy                            # clones IndySockets/Indy → vendor/Indy
-make                                     # produces build/pasclaw
-make smoke                               # runs every top-level command
+
+`make` compiles the embedded web UI resource first and then builds `src/pasclaw/PasClaw.dpr` into `build/pasclaw`:
+
+```sh
+make webui-res       # compiles src/pkg/gateway/webui.rc + webui.html to webui.res
+make                 # builds build/pasclaw
+make run             # builds and runs build/pasclaw
+make smoke           # quick top-level command smoke test
+make test-hashline   # hashline patch test binary
+make test            # smoke + test-hashline
+make clean           # removes build/
+make print-version   # prints the version Make will inject
 ```
 
-The HTTP client/server, Telegram channel, and any forthcoming socket-based
-adapter all go through Indy — the same units build under Delphi without
-any source changes.
+The Makefile injects `PASCLAW_VERSION` from `git describe --tags --always` when building with FPC. You can override key variables when needed:
 
-### With Delphi / RAD Studio
-
-Open `src/pasclaw/PasClaw.dpr`. Add the following to the project search path:
-`src/cmd`, `src/pkg/cliui`, `src/pkg/utils`, `src/pkg/logger`,
-`src/pkg/config`, `src/pkg/providers`, `src/pkg/tokenizer`, `src/pkg/tools`,
-`src/pkg/mcp`, `src/pkg/gateway`, `src/pkg/channels`. Indy ships with RAD
-Studio so no vendoring is needed.
-
-> **JSON note:** Phase 1-5 use FPC's `fpjson`. The Delphi port will swap that
-> for `System.JSON` (Delphi 10.4+) or `JsonDataObjects` via a thin abstraction
-> unit — flagged for the next phase.
-
-## Usage
-
+```sh
+make FPC=/path/to/fpc BUILDDIR=out BIN=out/pasclaw
+make INDY_DIR=/path/to/Indy
+make ICONVENC_DIR=/path/to/fpc/units/iconvenc
 ```
-pasclaw onboard                            # initialise ~/.pasclaw + config.json
-pasclaw agent -m "hello"                   # one-shot chat (real LLM)
-pasclaw agent                              # interactive chat with tools + MCP
-pasclaw tui                                # full-screen TUI chat
-pasclaw gateway                            # HTTP API + web UI on 127.0.0.1:8088
-pasclaw gateway --telegram --token <TOK>   # API + Telegram bot
+
+### Delphi / RAD Studio
+
+Open `src/pasclaw/PasClaw.dpr` in RAD Studio and add the source directories from `Makefile`'s `UNIT_DIRS` to the project search path:
+
+- `src/pkg/cliui`
+- `src/pkg/utils`
+- `src/pkg/logger`
+- `src/pkg/config`
+- `src/pkg/json`
+- `src/pkg/providers`
+- `src/pkg/tokenizer`
+- `src/pkg/tools`
+- `src/pkg/mcp`
+- `src/pkg/gateway`
+- `src/pkg/channels`
+- `src/pkg/cron`
+- `src/pkg/skills`
+- `src/pkg/agent`
+- `src/pkg/memory`
+- `src/pkg/updater`
+- `src/pkg/membench`
+- `src/pkg/tui`
+- `src/pkg/platform`
+- `src/pkg/hashline`
+- `src/pkg/component`
+- `src/cmd`
+
+For the embedded web UI, compile `src/pkg/gateway/webui.rc` to `src/pkg/gateway/webui.res` with the Delphi resource compiler (`brcc32` or equivalent) before building. The unit `PasClaw.Gateway.WebUI` links `webui.res` with `{$R webui.res}`.
+
+## Configuration
+
+PasClaw stores configuration as JSON. By default:
+
+- Home directory: `~/.pasclaw`
+- Config file: `~/.pasclaw/config.json`
+- Default provider: `anthropic`
+- Default model: `claude-opus-4-7`
+- Gateway bind address: `127.0.0.1`
+- Gateway port: `8088`
+- Gateway log level: `info`
+
+Environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `PASCLAW_HOME` | Overrides the PasClaw home directory. |
+| `PASCLAW_CONFIG` | Overrides the config file path. |
+| `PASCLAW_VERSION` | Compile-time FPC version override used by the Makefile. |
+| `PASCLAW_TELEGRAM_TOKEN` | Default Telegram bot token for `pasclaw gateway --telegram`. |
+| `NO_COLOR` | Disables ANSI color output. |
+
+Useful config commands:
+
+```sh
+pasclaw onboard       # create/update home, workspace directories, and provider config
+pasclaw config        # print current JSON config
+pasclaw config path   # print resolved config path
+pasclaw config reset  # write a default config
+```
+
+## Command surface
+
+Global flags:
+
+```sh
+pasclaw --help
+pasclaw --no-color status
+NO_COLOR=1 pasclaw status
+```
+
+Top-level commands are dispatched by `src/cmd/PasClaw.Cmd.Root.pas`:
+
+| Command | Purpose |
+|---------|---------|
+| `config` | View or reset the JSON configuration. |
+| `onboard` | Initialize `PASCLAW_HOME`, workspace folders, and provider settings. |
+| `agent` | Chat with the assistant from the terminal. |
+| `tui` | Chat in the full-screen TUI. |
+| `auth` | Store, clear, or inspect provider API keys. |
+| `gateway` | Start the full HTTP gateway, embedded web UI, cron scheduler, tools, MCP, and optional Telegram channel. |
+| `serve` | Start the OpenAI-compatible API server surface. |
+| `status` | Show provider, model, gateway, MCP, cron, and skill status. |
+| `cron` | Manage scheduled tasks. |
+| `mcp` | Manage MCP server entries. |
+| `migrate` | Run data migrations for older versions. |
+| `skills` | List, install, or remove skill extensions. |
+| `model` | Show or change the default model. |
+| `post` | Send a one-shot message to Discord or Slack webhooks. |
+| `membench` | Benchmark the memory log subsystem. |
+| `update` | Check GitHub releases or self-update. |
+| `version` | Print version/build information. |
+
+### Chat and UI
+
+```sh
+pasclaw agent
+pasclaw agent -m "hello"
+pasclaw agent --model claude-opus-4-7 --provider anthropic -m "summarize this repo"
+pasclaw agent --system "Be concise" --thinking medium --max-tokens 2048 --max-iterations 25
+pasclaw agent --no-tools --no-mcp --no-hashline
+
+pasclaw tui
+pasclaw tui --provider openai --model gpt-4o-mini
+pasclaw tui --no-tools --no-mcp --no-hashline
+```
+
+### Provider authentication and model selection
+
+```sh
+pasclaw auth status
+pasclaw auth login anthropic
+pasclaw auth logout anthropic
+pasclaw auth weixin
+
+pasclaw model show
+pasclaw model set claude-opus-4-7
+pasclaw model add openai gpt-4o-mini
+```
+
+`auth login` prompts for an API key and stores it in the matching provider entry. `model set` changes `default_model`; `model add` upserts a provider entry and records a model for that provider.
+
+### MCP servers
+
+```sh
+pasclaw mcp list
+pasclaw mcp add filesystem npx -y @modelcontextprotocol/server-filesystem /tmp
+pasclaw mcp add remote https://example.com/mcp
+pasclaw mcp show filesystem
+pasclaw mcp test filesystem
+pasclaw mcp remove filesystem
+pasclaw mcp edit
+```
+
+MCP entries are stored in the config as `mcp_servers`. A command starting with `http://` or `https://` is tested with the HTTP MCP client; other commands are spawned with the stdio MCP client.
+
+### Cron and skills
+
+```sh
+pasclaw cron list
+pasclaw cron add daily-summary "0 9 * * *" summarize "workspace/memory"
+pasclaw cron disable daily-summary
+pasclaw cron enable daily-summary
+pasclaw cron remove daily-summary
+
+pasclaw skills list
+pasclaw skills install ./my-skill
+pasclaw skills remove my-skill
+```
+
+Skills are discovered from `workspace/skills` under `PASCLAW_HOME` and can be registered in config with `skills install`.
+
+### Gateway, OpenAI-compatible server, and channels
+
+```sh
+pasclaw gateway
 pasclaw gateway --addr 0.0.0.0 --port 8088
-pasclaw status
-pasclaw mcp list | mcp add <name> <cmd> [args] | mcp test <name>
-pasclaw cron list|add|disable|enable|remove
-pasclaw skills list|install|remove
-pasclaw model show|set <name>
-pasclaw post discord|slack <webhook-url> "<content>"
-pasclaw membench [--records N] [--content N]
-pasclaw update [--check] [--repo owner/name]
-pasclaw auth login|logout|status <provider>
-pasclaw version
+pasclaw gateway --telegram --token <BOT_TOKEN>
+pasclaw gateway --no-tools --no-mcp --no-hashline
+
+pasclaw serve
+pasclaw serve --addr 0.0.0.0 --port 8088
+pasclaw serve --debug
+pasclaw serve --max-iter 40
+pasclaw serve --no-tools --no-mcp --no-hashline
 ```
 
-The gateway exposes:
+Both commands use the same `TGatewayServer` implementation. `gateway` starts the full surface and can also run the Telegram long-poll channel. `serve` is a focused wrapper for OpenAI-compatible clients and prints copy-pasteable client configuration.
 
-| Route          | Method | Body / Returns                              |
-|----------------|--------|---------------------------------------------|
-| `/v1/health`   | GET    | `{status, version}`                         |
-| `/v1/version`  | GET    | `{version, build}`                          |
-| `/v1/status`   | GET    | counts of providers, tools, MCP servers     |
-| `/v1/tools`    | GET    | registered tool descriptors                 |
-| `/v1/chat`     | POST   | `{message}` ⇒ `{content, iterations, …}`    |
+OpenAI-compatible client example:
 
-Globals: `--no-color` (or `NO_COLOR=1`) disables ANSI styling.
-`PASCLAW_HOME` overrides the home directory (default `~/.pasclaw`).
-`PASCLAW_CONFIG` overrides the config path.
+```python
+from openai import OpenAI
 
-## 🔌 Providers (LLM)
+client = OpenAI(base_url="http://127.0.0.1:8088/v1", api_key="sk-pasclaw")
+response = client.chat.completions.create(
+    model="claude-opus-4-7",
+    messages=[{"role": "user", "content": "hello"}],
+)
+print(response.choices[0].message.content)
+```
 
-PasClaw ships a single provider catalog (`src/pkg/providers/PasClaw.Providers.Catalog.pas`) that's surfaced through `pasclaw onboard`. Picking a provider populates the right default base URL, default model, and auth scheme so you only need to paste in an API key. Most entries below are OpenAI Chat Completions compatible and share one underlying provider implementation — adding another OpenAI-shaped provider is a one-row catalog change.
+Curl examples:
 
-| Provider | `kind` | API Key | Notes |
-|----------|--------|---------|-------|
-| [Anthropic](https://console.anthropic.com/settings/keys) | `anthropic` | Required | Claude Opus / Sonnet / Haiku |
-| [OpenAI](https://platform.openai.com/api-keys) | `openai` | Required | GPT-4o, GPT-5, o3 family |
-| [OpenRouter](https://openrouter.ai/keys) | `openrouter` | Required | 200+ models, unified API |
-| [Zhipu (GLM)](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) | `zhipu` | Required | GLM-4, GLM-5 |
-| [DeepSeek](https://platform.deepseek.com/api_keys) | `deepseek` | Required | DeepSeek-V3, DeepSeek-R1 |
-| [Volcengine](https://console.volcengine.com) | `volcengine` | Required | ByteDance Doubao / Ark |
-| [Qwen](https://dashscope.console.aliyun.com/apiKey) | `qwen` | Required | Qwen3 / Qwen-Max |
-| [Groq](https://console.groq.com/keys) | `groq` | Required | Fast inference (Llama, Mixtral) |
-| [Moonshot (Kimi)](https://platform.moonshot.cn/console/api-keys) | `moonshot` | Required | Kimi models |
-| [MiniMax](https://platform.minimaxi.com/user-center/basic-information/interface-key) | `minimax` | Required | MiniMax abab / hailuo |
-| [Mistral](https://console.mistral.ai/api-keys) | `mistral` | Required | Mistral Large, Codestral |
-| [NVIDIA NIM](https://build.nvidia.com/) | `nvidia` | Required | NVIDIA-hosted models |
-| [Cerebras](https://cloud.cerebras.ai/) | `cerebras` | Required | Fast inference |
-| [Novita AI](https://novita.ai/) | `novita` | Required | Various open models |
-| [Xiaomi MiMo](https://platform.xiaomimimo.com/) | `mimo` | Required | Set `api_base` per deployment |
-| [Ollama](https://ollama.com/) | `ollama` | Not needed | Local, self-hosted |
-| [vLLM](https://docs.vllm.ai/) | `vllm` | Not needed | Local, OpenAI-compatible |
-| [LiteLLM](https://docs.litellm.ai/) | `litellm` | Varies | Proxy for 100+ providers (set `api_base`) |
-| [Google Gemini](https://aistudio.google.com/apikey) | `gemini` | Required | Gemini 1.5 / 2.0 (`generateContent` REST, `x-goog-api-key` auth) |
+```sh
+curl http://127.0.0.1:8088/v1/health
+curl http://127.0.0.1:8088/v1/tools
+curl http://127.0.0.1:8088/v1/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"hello"}'
+curl http://127.0.0.1:8088/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}'
+```
 
-Deferred to follow-up PRs (each adds one new `TProtocolFamily` enum value and one new branch in `Factory`): **Azure OpenAI** (`asHeader` auth slot already reserved), **AWS Bedrock** (needs SigV4 signing, build-tag gated like picoclaw), **GitHub Copilot** (OAuth device flow), **Antigravity** (Google Cloud OAuth).
+The gateway routes implemented in `src/pkg/gateway/` are:
 
-<details>
-<summary><b>Local deployment (Ollama, vLLM)</b></summary>
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/` | `GET` | Embedded single-page web UI from `src/pkg/gateway/webui.html`. |
+| `/v1` | `GET` | JSON index listing gateway routes. |
+| `/v1/health` | `GET` | Health check with PasClaw version. |
+| `/v1/version` | `GET` | Version and build metadata. |
+| `/v1/status` | `GET` | Default provider/model plus provider, MCP, cron, skill, and tool counts. |
+| `/v1/tools` | `GET` | Registered tool descriptors. |
+| `/v1/chat` | `POST` | PasClaw JSON chat endpoint accepting `{"message":"..."}`. |
+| `/v1/chat/completions` | `POST` | OpenAI Chat Completions-compatible endpoint; supports streaming with `stream: true`. |
+| `/v1/models` | `GET` | OpenAI-compatible model list containing the configured default model. |
 
-`pasclaw onboard` will skip the API-key prompt for `ollama` and `vllm` (the catalog marks them `asNone`). The resulting `~/.pasclaw/config.json` entry looks like:
+Channel posting commands:
 
-**Ollama:**
+```sh
+pasclaw post discord <webhook-url> "hello"
+pasclaw post slack <webhook-url> "hello"
+```
+
+### Maintenance and diagnostics
+
+```sh
+pasclaw status
+pasclaw version
+pasclaw migrate
+pasclaw update --check
+pasclaw update --repo owner/name
+pasclaw membench --records 1000 --content 128
+pasclaw membench --records 1000 --content 128 --keep --out /tmp
+```
+
+## Providers
+
+Provider definitions live in `src/pkg/providers/PasClaw.Providers.Catalog.pas`. `pasclaw onboard` uses the catalog to populate provider `kind`, default API base URL, default model, and auth scheme.
+
+Implemented protocol families:
+
+- `pfAnthropic`: Anthropic Messages API using `x-api-key`.
+- `pfOpenAI`: OpenAI Chat Completions-compatible HTTP API. This powers OpenAI and most compatible hosted/local providers.
+- `pfGemini`: Google Gemini `generateContent` REST API using `x-goog-api-key`.
+- `pfPlaceholder`: catalog placeholder for known future provider families that are not wired into this build.
+
+Auth schemes:
+
+- `asBearer`: `Authorization: Bearer <key>`.
+- `asNone`: no auth header, used for local Ollama/vLLM deployments.
+- `asHeader`: raw key in the catalog-specified header name.
+
+Current catalog entries:
+
+| Provider | `kind` | Family | Default base | Default model | Auth |
+|----------|--------|--------|--------------|---------------|------|
+| Anthropic | `anthropic` | Anthropic | `https://api.anthropic.com` | `claude-opus-4-7` | `x-api-key` header |
+| OpenAI | `openai` | OpenAI-compatible | `https://api.openai.com` | `gpt-4o-mini` | Bearer |
+| OpenRouter | `openrouter` | OpenAI-compatible | `https://openrouter.ai/api` | provider-selected | Bearer |
+| Zhipu (GLM) | `zhipu` | OpenAI-compatible | `https://open.bigmodel.cn/api/paas` | `glm-4` | Bearer |
+| DeepSeek | `deepseek` | OpenAI-compatible | `https://api.deepseek.com` | `deepseek-chat` | Bearer |
+| Volcengine (Doubao/Ark) | `volcengine` | OpenAI-compatible | `https://ark.cn-beijing.volces.com/api` | provider-selected | Bearer |
+| Qwen (DashScope) | `qwen` | OpenAI-compatible | `https://dashscope.aliyuncs.com/compatible-mode` | `qwen-max` | Bearer |
+| Groq | `groq` | OpenAI-compatible | `https://api.groq.com/openai` | provider-selected | Bearer |
+| Moonshot (Kimi) | `moonshot` | OpenAI-compatible | `https://api.moonshot.cn` | `moonshot-v1-32k` | Bearer |
+| MiniMax | `minimax` | OpenAI-compatible | `https://api.minimax.chat` | provider-selected | Bearer |
+| Mistral | `mistral` | OpenAI-compatible | `https://api.mistral.ai` | `mistral-large-latest` | Bearer |
+| NVIDIA NIM | `nvidia` | OpenAI-compatible | `https://integrate.api.nvidia.com` | provider-selected | Bearer |
+| Cerebras | `cerebras` | OpenAI-compatible | `https://api.cerebras.ai` | provider-selected | Bearer |
+| Novita AI | `novita` | OpenAI-compatible | `https://api.novita.ai` | provider-selected | Bearer |
+| Xiaomi MiMo | `mimo` | OpenAI-compatible | set `api_base` in config | provider-selected | Bearer |
+| Ollama (local) | `ollama` | OpenAI-compatible | `http://localhost:11434` | required during onboarding | none |
+| vLLM (local) | `vllm` | OpenAI-compatible | `http://localhost:8000` | required during onboarding | none |
+| LiteLLM proxy | `litellm` | OpenAI-compatible | set `api_base` in config | provider-selected | Bearer |
+| Google Gemini | `gemini` | Gemini | `https://generativelanguage.googleapis.com` | `gemini-1.5-flash` | `x-goog-api-key` header |
+
+Minimal local provider examples:
+
 ```json
 {
+  "default_provider": "ollama",
+  "default_model": "llama3.1:8b",
+  "gateway": { "log_level": "info", "bind_addr": "127.0.0.1", "port": 8088 },
   "providers": [
     {
       "name": "ollama",
       "kind": "ollama",
       "api_base": "http://localhost:11434",
+      "api_key": "",
       "model": "llama3.1:8b"
     }
   ],
-  "default_provider": "ollama",
-  "default_model": "llama3.1:8b"
+  "mcp_servers": [],
+  "crons": [],
+  "skills": []
 }
 ```
 
-**vLLM:**
 ```json
 {
+  "default_provider": "vllm",
+  "default_model": "your-model",
+  "gateway": { "log_level": "info", "bind_addr": "127.0.0.1", "port": 8088 },
   "providers": [
     {
       "name": "vllm",
       "kind": "vllm",
       "api_base": "http://localhost:8000",
+      "api_key": "",
       "model": "your-model"
     }
   ],
-  "default_provider": "vllm",
-  "default_model": "your-model"
+  "mcp_servers": [],
+  "crons": [],
+  "skills": []
 }
 ```
 
-</details>
+## Repository layout
 
-## Layout
-
-```
+```text
 src/
-  pasclaw/          program entry (PasClaw.dpr)
-  cmd/              one unit per CLI subcommand
+  pasclaw/          Program entry point (`PasClaw.dpr`)
+  cmd/              CLI command units and root dispatcher
   pkg/
-    cliui/          colour, banner, panel rendering
-    config/         on-disk JSON config + version constants
-    logger/         levelled logging
-    utils/          path / string / file helpers
+    agent/          Agent execution and prompts
+    channels/       Telegram, Discord, Slack integrations
+    cliui/          ANSI styling, banner, command help rendering
+    component/      Shared components
+    config/         Version constants and on-disk config model
+    cron/           Cron scheduler
+    gateway/        Indy HTTP server, OpenAI-compatible API, embedded web UI
+    hashline/       Hashline patch/edit support
+    json/           Project JSON abstraction
+    logger/         Levelled logging
+    mcp/            MCP stdio/HTTP clients and tool bridge
+    membench/       Memory benchmark helpers
+    memory/         Memory log storage
+    platform/       Platform helpers
+    providers/      Provider catalog and LLM HTTP clients
+    skills/         Skill manifest loading and tool registration
+    tokenizer/      Token counting helpers
+    tools/          Built-in tool registry, filesystem, shell, and tool loop
+    tui/            Full-screen terminal UI
+    updater/        GitHub release update support
+    utils/          Path, file, and string helpers
 ```
 
-## Roadmap
+## License
 
-| Phase | Scope | Status |
-|-------|-------|--------|
-| 1 | CLI skeleton, banner, config, command dispatch         | ✅ done |
-| 2 | Anthropic + OpenAI HTTP clients (Indy), tokenizer      | ✅ done |
-| 3 | Tool registry + built-in tools (fs/shell) + tool loop  | ✅ done |
-| 4 | MCP stdio client + bridge into tools registry          | ✅ done |
-| 5 | Indy gateway (TIdHTTPServer) + Telegram long-poll bot  | ✅ done |
-| 6 | JSON abstraction, additional channels (Discord/Slack)  | ✅ done |
-| 7 | Cron scheduler, skills loader, memory store            | ✅ done |
-| 8 | MCP over HTTP/SSE, SSE-streaming helper, web UI        | ✅ done |
-| 9 | Self-update (GitHub releases), membench, TUI front-end | ✅ done |
-
-License: MIT (see LICENSE).
+MIT. See `LICENSE`.


### PR DESCRIPTION
### Motivation

- Bring the repository README into alignment with the current source tree and Makefile so documentation reflects the actual build and runtime behavior.
- Provide accurate, copy-pasteable build instructions for both FPC and Delphi/RAD Studio including the Indy vendoring and embedded web UI resource steps.
- Surface the CLI command surface and examples from `src/cmd/PasClaw.Cmd.Root.pas` so users can discover and run top-level commands easily.
- Document gateway/API/provider details to match the implemented `TGatewayServer` and provider catalog so onboarding and integration are clear.

### Description

- Replaced the root `README.md` with an updated overview that keeps the project name `PasClaw` and points to the program entry at `src/pasclaw/PasClaw.dpr`.
- Updated FPC build instructions to match the `Makefile`, documented `make webui-res`, `make`, `make run`, `make smoke`, `make test-hashline`, `make test`, `make clean`, and how `PASCLAW_VERSION` is injected at build time.
- Added Delphi/RAD Studio guidance including the source directories from `Makefile`'s `UNIT_DIRS` and resource compilation notes for `src/pkg/gateway/webui.rc` -> `webui.res` used by `PasClaw.Gateway.WebUI`.
- Documented configuration defaults and environment variables from `src/pkg/config/PasClaw.Config.pas`, and the top-level CLI surface and flags from `src/cmd/PasClaw.Cmd.Root.pas` with representative examples for `agent`, `tui`, `gateway`, and `serve`.
- Described the HTTP gateway routes and OpenAI-compatible `/v1/chat/completions` behavior implemented in `src/pkg/gateway/PasClaw.Gateway.Server.pas`, and listed provider catalog entries and auth/protocol families from `src/pkg/providers/PasClaw.Providers.Catalog.pas`.
- Included usage examples for OpenAI-client and `curl`, MCP/cron/skills commands, provider onboarding snippets, and repository layout updated to match `src/` structure.

### Testing

- Ran `git diff --check` to validate whitespace and patch hygiene and it returned no problems.
- Ran `make print-version` and `make -n` to inspect build invocation and flags and they completed successfully, showing the `fpcres` and `fpc` invocations used by the `Makefile`.
- Attempted `make get-indy` to vendor Indy but the network clone failed due to an external proxy/GitHub access error (`CONNECT tunnel failed, response 403`), which is an environmental/network issue rather than a code problem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1874041034832e93c83a9990a49b75)