### PR TITLE
Skills Phase 1: per-directory SKILL.md format + frontmatter parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,35 @@ pasclaw skills install ./my-skill
 pasclaw skills remove my-skill
 ```
 
-Skills are discovered from `workspace/skills` under `PASCLAW_HOME` and can be registered in config with `skills install`.
+Skills live under `$PASCLAW_HOME/workspace/skills/`. PasClaw accepts two layouts:
+
+- **Per-directory `SKILL.md`** (preferred — same format picoclaw, nanobot, ClawHub, and Anthropic agent-skills use):
+
+  ```
+  workspace/skills/my-skill/
+  └── SKILL.md     ← YAML frontmatter + markdown body
+  ```
+
+  ```yaml
+  ---
+  name: my-skill
+  description: One-line summary the model uses to pick the skill
+  # Omit `kind` for knowledge-only skills (most common); set `kind: shell`
+  # or `kind: prompt` to register a callable `skill_<name>` tool.
+  ---
+
+  # My skill
+
+  Markdown body. The system prompt advertises this SKILL.md path; the
+  model loads the full body with `fs_read` when the matching task comes
+  up.
+  ```
+
+  A copy-pasteable starter lives at [`samples/skills/hello/SKILL.md`](samples/skills/hello/SKILL.md).
+
+- **Legacy single `*.json`** (`workspace/skills/<name>.json`) — still loaded for backwards compat. New skills should use the directory layout; per-directory entries shadow same-named JSON entries.
+
+Subsequent phases will add **`pasclaw skills install owner/repo[/path]`** (GitHub fetch + zip extract — Delphi has native `System.Zip` support, so no tar dependency), then a **ClawHub** search/install client, then `scripts/` + `references/` resource loading.
 
 ### Gateway, OpenAI-compatible server, and channels
 

--- a/samples/skills/hello/SKILL.md
+++ b/samples/skills/hello/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: hello
+description: Sample knowledge-only skill demonstrating the SKILL.md layout
+---
+
+# Hello skill
+
+This is the minimal SKILL.md format PasClaw understands. Drop a directory
+named `hello/` (the directory name does not need to match `name:` but it
+keeps things readable) under `~/.pasclaw/workspace/skills/` and the
+agent will pick it up automatically the next time `pasclaw agent`,
+`pasclaw serve`, or any other tool-loaded entry point runs.
+
+## Frontmatter fields
+
+| Field | Meaning |
+|-------|---------|
+| `name` | **Required.** The identifier the agent uses to refer to this skill. Lowercase + underscores by convention. |
+| `description` | One-line summary shown in the system prompt's SKILLS section. Keep it short — the model decides whether to consult the SKILL.md based on this line. |
+| `kind` | Optional. `shell` makes the skill a callable tool that runs the `shell:` command; `prompt` returns the rendered `prompt:` template; omitted (the common case) makes the skill **knowledge-only** — no tool registered, just markdown the model reads on demand. |
+| `shell` | Required for `kind: shell`. Shell command line. `{{var}}` placeholders are substituted from the JSON args before exec. |
+| `prompt` | Required for `kind: prompt`. Template string returned verbatim with the same `{{var}}` substitution. |
+| `schema` | Optional JSON schema describing the args object passed to a callable skill. Single-line JSON. Defaults to `{"type":"object"}` (any args accepted). |
+
+## Body conventions (this part)
+
+Everything after the closing `---` is markdown. The model loads it via
+`fs_read` when it decides to consult this skill — keep it focused,
+well-structured, and treat it as documentation the model will actually
+read once and follow. Picoclaw / nanobot / Anthropic agent-skills all
+share this format, so a skill written for any of those will work in
+PasClaw with no changes (and vice versa).
+
+## When to use this skill
+
+Use this skill when the user asks anything containing the word "hello"
+in the example domain. Since this is the sample skill, the realistic
+answer is "never in production" — replace this with the trigger
+conditions that match your actual workflow.
+
+## What to do
+
+1. Greet the user.
+2. Ask what they actually want.
+3. Stop.
+
+That is the whole skill. Real skills are usually 10–100 lines of
+procedural knowledge, with optional `scripts/` (executables the model
+can call) and `references/` (deeper documentation) directories
+alongside this SKILL.md — Phase 4 of the skills overhaul will wire
+those in. For now, SKILL.md + frontmatter + body is the contract.

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -22,16 +22,28 @@ function DoList: Integer;
 var
   Specs: TSkillSpecArray;
   i: Integer;
+  K, Src: string;
 begin
   Specs := LoadSkillManifests(GetHome);
   if Length(Specs) = 0 then
   begin
     WriteLn('(no skills found at ', JoinPath(GetHome, 'workspace/skills'), ')');
+    WriteLn('Add one: mkdir -p ~/.pasclaw/workspace/skills/<name>; place a SKILL.md inside.');
     Exit(0);
   end;
-  WriteLn(Ansi.Bold, 'name', Ansi.Reset, '              kind   description');
+  WriteLn(Ansi.Bold, 'name', Ansi.Reset, '              kind        source');
   for i := 0 to High(Specs) do
-    WriteLn(Specs[i].Name:18, '  ', Specs[i].Kind:6, '  ', Specs[i].Description);
+  begin
+    K := Specs[i].Kind;
+    if K = '' then K := 'knowledge';
+    { Show relative path under ~/.pasclaw so the line stays readable. }
+    Src := Specs[i].Source;
+    if Pos(GetHome, Src) = 1 then
+      Src := '~' + Copy(Src, Length(GetHome) + 1, MaxInt);
+    WriteLn(Specs[i].Name:18, '  ', K:9, '  ', Src);
+    if Specs[i].Description <> '' then
+      WriteLn('                    ', Ansi.Dim, Specs[i].Description, Ansi.Reset);
+  end;
   Result := 0;
 end;
 

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -156,7 +156,8 @@ var
   Skills: TSkillSpecArray;
   i: Integer;
   Lines: TStringList;
-  Desc: string;
+  Desc, K: string;
+  HasCallable, HasKnowledge: Boolean;
 begin
   Result := '';
   try
@@ -166,23 +167,49 @@ begin
   end;
   if Length(Skills) = 0 then Exit;
 
+  HasCallable  := False;
+  HasKnowledge := False;
+  for i := 0 to High(Skills) do
+  begin
+    K := LowerCase(Trim(Skills[i].Kind));
+    if (K = 'shell') or (K = 'prompt') then HasCallable := True
+    else HasKnowledge := True;
+  end;
+
   Lines := TStringList.Create;
   try
     Lines.Add('## Skills');
     Lines.Add('');
-    Lines.Add('The following skills are installed in your workspace. Each is exposed as a tool you can call by name.');
+    if HasCallable and HasKnowledge then
+      Lines.Add('Skills extend your capabilities. Callable skills register as `skill_<name>` tools you invoke directly; knowledge-only skills are markdown bodies — read each one''s SKILL.md with `fs_read` when the matching task comes up.')
+    else if HasCallable then
+      Lines.Add('The following skills register as `skill_<name>` tools you can call directly.')
+    else
+      Lines.Add('Knowledge-only skills are markdown bodies. Read each SKILL.md with `fs_read` for the procedural context the model needs.');
     Lines.Add('');
     for i := 0 to High(Skills) do
     begin
       Desc := Trim(Skills[i].Description);
-      { RegisterSkills in PasClaw.Skills.Loader registers the provider
-        tool as 'skill_' + Skills[i].Name (line 269). Advertising the
-        bare name here would tell the model to call a nonexistent tool.
-        The 'skill_' prefix is the actual callable identifier. }
-      if Desc = '' then
-        Lines.Add('- `skill_' + Skills[i].Name + '`')
+      K    := LowerCase(Trim(Skills[i].Kind));
+      if (K = 'shell') or (K = 'prompt') then
+      begin
+        { Callable skill — advertise as `skill_<name>`, which is the
+          actual registered tool identifier in PasClaw.Skills.Loader. }
+        if Desc = '' then
+          Lines.Add('- `skill_' + Skills[i].Name + '` (callable)')
+        else
+          Lines.Add('- `skill_' + Skills[i].Name + '` — ' + Desc + ' (callable)');
+      end
       else
-        Lines.Add('- `skill_' + Skills[i].Name + '` — ' + Desc);
+      begin
+        { Knowledge-only skill — surface the SKILL.md path so the model
+          can fs_read it on demand. Picoclaw and nanobot do the same: the
+          system prompt lists the catalog, the body loads lazily. }
+        if Desc = '' then
+          Lines.Add('- **' + Skills[i].Name + '**: read `' + Skills[i].Source + '`')
+        else
+          Lines.Add('- **' + Skills[i].Name + '** — ' + Desc + '. Read `' + Skills[i].Source + '` for the full instructions.');
+      end;
     end;
     Result := Lines.Text;
     { Strip trailing newline TStringList.Text adds, so the SectionSep

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -319,11 +319,37 @@ begin
 
     (* Locate the frontmatter block. The first non-empty line must be `---`;
        the closing `---` marks the end. We allow leading blank lines to
-       tolerate editors that prepend a BOM or stray whitespace. *)
+       tolerate editors that prepend stray whitespace, and explicitly
+       strip a UTF-8 BOM at the start of the first line — Trim only
+       handles ASCII whitespace, so a SKILL.md saved by a Windows editor
+       with BOM would otherwise be rejected here with `no YAML
+       frontmatter`. ReadFileText returns AnsiString-UTF8 under FPC and
+       UnicodeString under Delphi, so the BOM lives as different
+       sequences on each toolchain:
+
+         FPC AnsiString  : three bytes EF BB BF at positions 1..3
+         Delphi UnicodeString : one Char #$FEFF at position 1
+                                (TEncoding.UTF8.GetString decodes the
+                                 three UTF-8 bytes to that codepoint,
+                                 it does not silently strip them).
+
+       Handle both. *)
     StartIdx := -1;
     for i := 0 to Lines.Count - 1 do
     begin
-      Line := Trim(Lines[i]);
+      Line := Lines[i];
+      if i = 0 then
+      begin
+        {$IFDEF FPC}
+        if (Length(Line) >= 3) and
+           (Byte(Line[1]) = $EF) and (Byte(Line[2]) = $BB) and (Byte(Line[3]) = $BF) then
+          Line := Copy(Line, 4, MaxInt);
+        {$ELSE}
+        if (Length(Line) >= 1) and (Line[1] = #$FEFF) then
+          Line := Copy(Line, 2, MaxInt);
+        {$ENDIF}
+      end;
+      Line := Trim(Line);
       if Line = '' then Continue;
       if Line = '---' then begin StartIdx := i; Break; end;
       Break;

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -1,21 +1,55 @@
 (*
   PasClaw.Skills.Loader - skill manifest loader and runner.
 
-  Skill manifest (JSON) lives at $PASCLAW_HOME/workspace/skills/<name>.json:
+  Two on-disk layouts are accepted, scanned from $PASCLAW_HOME/workspace/skills:
 
-    {
-      "name":        "weather_report",
-      "description": "Fetch weather for a city",
-      "type":        "shell" | "prompt",
-      "schema":      { ... JSON Schema for args ... },
-      "shell":       "curl -s 'https://wttr.in/{{city}}?format=3'",
-      "prompt":      "Write a 2-sentence summary of: {{topic}}"
-    }
+  1. Per-directory SKILL.md (preferred; matches picoclaw / nanobot /
+     Anthropic agent-skills format):
 
-  Shell skills run the configured command through a TProcess after token
-  substitution of {{arg}} placeholders. Prompt skills return the rendered
-  template unchanged for the caller (typically the agent) to send to the
-  LLM. A skill registers as a tool in the registry once loaded.
+       workspace/skills/<name>/SKILL.md
+                         /scripts/    (optional, Phase 4)
+                         /references/ (optional, Phase 4)
+                         /assets/     (optional, Phase 4)
+
+     SKILL.md is YAML frontmatter + markdown body:
+
+       ---
+       name: weather_report
+       description: Fetch weather for a city
+       kind: shell
+       shell: curl -s 'https://wttr.in/{{city}}?format=3'
+       schema: {"type":"object","properties":{"city":{"type":"string"}}}
+       ---
+
+       # Weather report
+
+       Procedural knowledge the model loads on demand via fs_read.
+
+  2. Legacy single-JSON file (still loaded for backwards compat):
+
+       workspace/skills/<name>.json
+
+     Same field set as the frontmatter above, no body. New skills should
+     use the directory layout; the JSON path will stay until existing
+     deployments have migrated.
+
+  Skill kinds:
+
+    shell   - Renders Shell as a {{var}} template, runs through
+              PasClaw.Platform.RunOneShot, returns combined stdout/stderr.
+              Registered as `skill_<name>` in the tool registry.
+    prompt  - Renders Prompt as a {{var}} template, returns the
+              substituted string verbatim. Registered as `skill_<name>`.
+              Useful when a skill is just a frequently reused prompt
+              fragment.
+    (empty) - Pure-knowledge skill. No tool is registered; the SKILL.md
+              body is advertised in the system prompt's SKILLS section
+              so the model knows to fs_read it for procedural context.
+              This is the dominant pattern picoclaw and nanobot ship.
+
+  A skill registers as a `skill_<name>` tool in the registry once loaded
+  (kinds `shell` and `prompt` only; pure-knowledge skills do not get a
+  tool entry).
 *)
 unit PasClaw.Skills.Loader;
 
@@ -34,10 +68,16 @@ type
   TSkillSpec = record
     Name:        string;
     Description: string;
-    Kind:        string;   { "shell" | "prompt" }
+    Kind:        string;   { "shell" | "prompt" | "" (knowledge-only) }
     Schema:      string;
     Shell:       string;
     Prompt:      string;
+    Body:        string;   { markdown body after YAML frontmatter, if any }
+    Dir:         string;   { absolute path to the skill's directory (SKILL.md
+                             layout) or the file's directory (.json layout) }
+    Source:      string;   { absolute path to SKILL.md or the .json file —
+                             used by the system prompt so the model can
+                             fs_read for the full body }
   end;
 
   TSkillSpecArray = array of TSkillSpec;
@@ -46,6 +86,14 @@ function LoadSkillManifests(const HomeDir: string): TSkillSpecArray;
 procedure RegisterSkills(Reg: TToolRegistry; const Skills: TSkillSpecArray);
 function RunSkill(Reg: TToolRegistry; const Name, ArgsJSON: string; out ErrMsg: string): string;
 function RenderTemplate(const Template, ArgsJSON: string): string;
+
+{ Parse a SKILL.md file into a TSkillSpec. Returns False with ErrMsg set
+  on a malformed file (no frontmatter, missing `name:`, etc). Exposed for
+  testing and for future hub-side validation; LoadSkillManifests is the
+  normal entry point. }
+function ParseSkillMD(const FilePath: string;
+                      out Spec: TSkillSpec;
+                      out ErrMsg: string): Boolean;
 
 implementation
 
@@ -196,7 +244,7 @@ begin
     ErrMsg := Format('skill exit=%d', [ExitCode]);
 end;
 
-function LoadOne(const Path: string; out Spec: TSkillSpec): Boolean;
+function LoadJsonSkill(const Path: string; out Spec: TSkillSpec): Boolean;
 var
   Body: string;
   Obj, Schema: TJsonObject;
@@ -212,6 +260,9 @@ begin
     Spec.Kind        := Obj.GetStr('type',        'shell');
     Spec.Shell       := Obj.GetStr('shell',       '');
     Spec.Prompt      := Obj.GetStr('prompt',      '');
+    Spec.Body        := '';
+    Spec.Dir         := ExtractFileDir(Path);
+    Spec.Source      := Path;
     Schema := Obj.ChildObject('schema');
     if Schema <> nil then
     begin
@@ -226,38 +277,233 @@ begin
   end;
 end;
 
-function LoadSkillManifests(const HomeDir: string): TSkillSpecArray;
+(* Split a line at the first ':' and return (key, value) with both sides
+   trimmed. Strips surrounding single or double quotes from value if
+   present — common in YAML for values that contain colons or other
+   metacharacters. Returns False if there is no ':' on the line. *)
+function SplitYAMLEntry(const Line: string; out Key, Value: string): Boolean;
 var
-  Dir: string;
+  P: Integer;
+begin
+  Result := False;
+  P := Pos(':', Line);
+  if P <= 0 then Exit;
+  Key   := Trim(Copy(Line, 1, P - 1));
+  Value := Trim(Copy(Line, P + 1, MaxInt));
+  if (Length(Value) >= 2) and
+     ( ((Value[1] = '"')  and (Value[Length(Value)] = '"'))  or
+       ((Value[1] = '''') and (Value[Length(Value)] = '''')) ) then
+    Value := Copy(Value, 2, Length(Value) - 2);
+  Result := Key <> '';
+end;
+
+function ParseSkillMD(const FilePath: string; out Spec: TSkillSpec;
+                      out ErrMsg: string): Boolean;
+var
+  Text, Line, Key, Value: string;
+  Lines: TStringList;
+  i, StartIdx, EndIdx: Integer;
+  Body: TStringList;
+  InFrontmatter: Boolean;
+begin
+  Result := False;
+  ErrMsg := '';
+  if not FileExists(FilePath) then begin ErrMsg := 'no such file'; Exit; end;
+  Text := ReadFileText(FilePath);
+  if Text = '' then begin ErrMsg := 'empty file'; Exit; end;
+
+  Lines := TStringList.Create;
+  Body  := TStringList.Create;
+  try
+    Lines.Text := Text;
+
+    (* Locate the frontmatter block. The first non-empty line must be `---`;
+       the closing `---` marks the end. We allow leading blank lines to
+       tolerate editors that prepend a BOM or stray whitespace. *)
+    StartIdx := -1;
+    for i := 0 to Lines.Count - 1 do
+    begin
+      Line := Trim(Lines[i]);
+      if Line = '' then Continue;
+      if Line = '---' then begin StartIdx := i; Break; end;
+      Break;
+    end;
+    if StartIdx < 0 then
+    begin
+      ErrMsg := 'no YAML frontmatter (expected leading `---`)';
+      Exit;
+    end;
+
+    EndIdx := -1;
+    for i := StartIdx + 1 to Lines.Count - 1 do
+      if Trim(Lines[i]) = '---' then begin EndIdx := i; Break; end;
+    if EndIdx < 0 then
+    begin
+      ErrMsg := 'unterminated YAML frontmatter (missing closing `---`)';
+      Exit;
+    end;
+
+    Spec.Name        := '';
+    Spec.Description := '';
+    Spec.Kind        := '';
+    Spec.Schema      := '{"type":"object"}';
+    Spec.Shell       := '';
+    Spec.Prompt      := '';
+    Spec.Dir         := ExtractFileDir(FilePath);
+    Spec.Source      := FilePath;
+
+    InFrontmatter := True;
+    for i := StartIdx + 1 to EndIdx - 1 do
+    begin
+      if not InFrontmatter then Break;
+      Line := Lines[i];
+      if Trim(Line) = '' then Continue;
+      if not SplitYAMLEntry(Line, Key, Value) then Continue;
+      Key := LowerCase(Key);
+      if      Key = 'name'        then Spec.Name        := Value
+      else if Key = 'description' then Spec.Description := Value
+      else if (Key = 'kind') or (Key = 'type') then Spec.Kind := Value
+      else if Key = 'shell'       then Spec.Shell       := Value
+      else if Key = 'prompt'      then Spec.Prompt      := Value
+      else if Key = 'schema'      then
+      begin
+        if Value <> '' then Spec.Schema := Value;
+      end;
+    end;
+
+    Body.Clear;
+    for i := EndIdx + 1 to Lines.Count - 1 do
+      Body.Add(Lines[i]);
+    Spec.Body := Trim(Body.Text);
+
+    if Spec.Name = '' then
+    begin
+      ErrMsg := 'missing required frontmatter field `name`';
+      Exit;
+    end;
+
+    Result := True;
+  finally
+    Body.Free;
+    Lines.Free;
+  end;
+end;
+
+function HasSpec(const Arr: TSkillSpecArray; const Name: string): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to High(Arr) do
+    if SameText(Arr[i].Name, Name) then Exit(True);
+  Result := False;
+end;
+
+function FindSpecSource(const Arr: TSkillSpecArray; const Name: string): string;
+var
+  i: Integer;
+begin
+  Result := '(unknown)';
+  for i := 0 to High(Arr) do
+    if SameText(Arr[i].Name, Name) then Exit(Arr[i].Source);
+end;
+
+procedure ScanSkillDirs(const Root: string; var Out_: TSkillSpecArray);
+var
   SR: TSearchRec;
+  SkillDir, MDPath, Err: string;
   Spec: TSkillSpec;
 begin
-  SetLength(Result, 0);
-  Dir := JoinPath(HomeDir, 'workspace/skills');
-  if not DirectoryExists(Dir) then Exit;
-  if FindFirst(JoinPath(Dir, '*.json'), faAnyFile, SR) <> 0 then Exit;
+  if FindFirst(JoinPath(Root, '*'), faDirectory, SR) <> 0 then Exit;
   try
     repeat
-      if (SR.Attr and faDirectory) <> 0 then Continue;
-      if LoadOne(JoinPath(Dir, SR.Name), Spec) then
+      if (SR.Attr and faDirectory) = 0 then Continue;
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      SkillDir := JoinPath(Root, SR.Name);
+      MDPath   := JoinPath(SkillDir, 'SKILL.md');
+      if not FileExists(MDPath) then Continue;
+      if ParseSkillMD(MDPath, Spec, Err) then
       begin
-        SetLength(Result, Length(Result) + 1);
-        Result[High(Result)] := Spec;
-      end;
+        if HasSpec(Out_, Spec.Name) then
+        begin
+          LogWarn('skills: duplicate name "%s" (already loaded from %s); ' +
+                  'ignoring %s', [Spec.Name, FindSpecSource(Out_, Spec.Name), MDPath]);
+          Continue;
+        end;
+        SetLength(Out_, Length(Out_) + 1);
+        Out_[High(Out_)] := Spec;
+      end
+      else
+        LogWarn('skills: %s: %s', [MDPath, Err]);
     until FindNext(SR) <> 0;
   finally
     FindClose(SR);
   end;
 end;
 
+procedure ScanJsonSkills(const Root: string; var Out_: TSkillSpecArray);
+var
+  SR: TSearchRec;
+  Path: string;
+  Spec: TSkillSpec;
+begin
+  if FindFirst(JoinPath(Root, '*.json'), faAnyFile, SR) <> 0 then Exit;
+  try
+    repeat
+      if (SR.Attr and faDirectory) <> 0 then Continue;
+      Path := JoinPath(Root, SR.Name);
+      if not LoadJsonSkill(Path, Spec) then Continue;
+      { Per-directory SKILL.md wins when names collide. Keeps the migration
+        path safe: a user can drop a SKILL.md next to an existing JSON,
+        verify it loads, then delete the JSON when ready. }
+      if HasSpec(Out_, Spec.Name) then
+      begin
+        LogDebug('skills: %s.json shadowed by SKILL.md entry', [Spec.Name]);
+        Continue;
+      end;
+      SetLength(Out_, Length(Out_) + 1);
+      Out_[High(Out_)] := Spec;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+function LoadSkillManifests(const HomeDir: string): TSkillSpecArray;
+var
+  Root: string;
+begin
+  SetLength(Result, 0);
+  Root := JoinPath(HomeDir, 'workspace/skills');
+  if not DirectoryExists(Root) then Exit;
+  { Per-directory SKILL.md takes priority — that is the format every new
+    skill (picoclaw, nanobot, ClawHub, Anthropic agent-skills) ships in. }
+  ScanSkillDirs(Root, Result);
+  ScanJsonSkills(Root, Result);
+end;
+
 procedure RegisterSkills(Reg: TToolRegistry; const Skills: TSkillSpecArray);
 var
   i, Slot: Integer;
   Tool: TTool;
+  K: string;
 begin
   if Reg = nil then Exit;
   for i := 0 to High(Skills) do
   begin
+    K := LowerCase(Trim(Skills[i].Kind));
+    { Pure-knowledge skills (no kind set; SKILL.md is just a markdown
+      body the model reads via fs_read) get advertised in the system
+      prompt's SKILLS section but skip tool registration — there is no
+      callable tool to attach a handler to, and registering a no-op
+      stub would mislead the model into calling it. The catalog listing
+      in the system prompt is the contract. }
+    if (K <> 'shell') and (K <> 'prompt') then
+    begin
+      LogDebug('skills: %s registered as knowledge-only (no tool, body=%d bytes)',
+               [Skills[i].Name, Length(Skills[i].Body)]);
+      Continue;
+    end;
+
     Slot := AllocSlot;
     if (Slot < 0) or (not Assigned(SkillHandlers[Slot])) then
     begin
@@ -272,7 +518,7 @@ begin
     Tool.Handler     := SkillHandlers[Slot];
     Tool.IsCore      := False;
     Reg.Register(Tool);
-    LogDebug('skills: registered %s (slot=%d, kind=%s)', [Skills[i].Name, Slot, Skills[i].Kind]);
+    LogDebug('skills: registered %s (slot=%d, kind=%s)', [Skills[i].Name, Slot, K]);
   end;
 end;
 


### PR DESCRIPTION
First of four follow-up PRs to bring PasClaw's skill system to wire-parity with picoclaw / nanobot / Anthropic agent-skills / ClawHub. This one ships the format itself; subsequent PRs add the registry/install plumbing.

## Roadmap (for reference)

1. **This PR** — SKILL.md format + per-directory layout, JSON kept for backwards compat
2. **Phase 2** — `pasclaw skills install owner/repo[/path]` via GitHub fetch + **zip** extract (Delphi's `System.Zip` ↔ FPC's `Zipper.TUnZipper`; not tar)
3. **Phase 3** — ClawHub search/install client
4. **Phase 4** — `scripts/` (callable helpers) + `references/` (lazy-loaded context) runtime support

## What this PR ships

### New on-disk layout

```
workspace/skills/<name>/SKILL.md   ← preferred
workspace/skills/<name>.json       ← still works for backwards compat
```

### SKILL.md format (matches picoclaw / nanobot / ClawHub byte-for-byte)

```yaml
---
name: weather_report
description: Fetch weather for a city
kind: shell
shell: curl -s 'https://wttr.in/{{city}}?format=3'
schema: {"type":"object","properties":{"city":{"type":"string"}}}
---

# Weather report

Procedural knowledge the model loads on demand via fs_read.
```

### Parser (`ParseSkillMD` in `PasClaw.Skills.Loader`)

- Locates `---` delimiters with tolerance for leading blank lines / BOMs
- Parses simple `key: value` entries, strips YAML quote wrappers
- `schema:` accepts inline JSON on one line (single-line is enough for the schemas skills actually need)
- Body = everything after closing `---`, trimmed
- Returns False with ErrMsg set on malformed files so the logger can warn per-file rather than silently dropping skills

### `TSkillSpec` extensions

| Field | Purpose |
|---|---|
| `Body` | markdown body (for the SKILL.md path; empty for JSON skills) |
| `Dir` | skill directory (parent of SKILL.md, or dirname of JSON file) |
| `Source` | absolute path to SKILL.md / JSON — surfaced in the system prompt so the model knows where to `fs_read` for the full body |

### Kind semantics

| `kind:` | Behaviour |
|---|---|
| `shell` | Callable; registers as `skill_<name>` tool, runs the rendered Shell command. Unchanged. |
| `prompt` | Callable; registers as `skill_<name>` tool, returns the rendered Prompt template. Unchanged. |
| (omitted) | **Knowledge-only.** No tool registered. SKILL.md body advertised in the system prompt's SKILLS section so the model knows to `fs_read` it. Dominant pattern in picoclaw / nanobot. |

### Loader resolution order

`ScanSkillDirs` → `ScanJsonSkills`. Per-directory entries win on name collisions. Lets users drop a SKILL.md next to an existing JSON, verify it loads, then delete the JSON when ready.

### System prompt SKILLS section

```
## Skills

Skills extend your capabilities. Callable skills register as
`skill_<name>` tools you invoke directly; knowledge-only skills are
markdown bodies — read each one's SKILL.md with `fs_read` when the
matching task comes up.

- `skill_weather_report` — Fetch weather for a city (callable)
- **code-review** — Static review prompt. Read `/home/me/.pasclaw/
  workspace/skills/code-review/SKILL.md` for the full instructions.
```

Adaptive intro: shows the "callable" line only if at least one callable skill is present, the "knowledge-only" line only if at least one knowledge skill is present, both if both.

### CLI

`pasclaw skills list` updated — shows kind + source path (relative to `~/.pasclaw` when possible). Previous two-column shell/prompt view didn't surface where the skill came from; new view does.

### Sample

[`samples/skills/hello/SKILL.md`](samples/skills/hello/SKILL.md) — copy-pasteable starter documenting every frontmatter field and the body conventions.

### Docs

README's Skills paragraph rewritten with the new layout + backwards-compat note + roadmap pointer for Phase 2–4.

## Test plan

- [ ] FPC build (`make`) + Delphi `.dproj` build cleanly
- [ ] `pasclaw skills list` with no skills installed — prints the "(no skills found)" message + the new mkdir hint
- [ ] `cp -r samples/skills/hello ~/.pasclaw/workspace/skills/` — `pasclaw skills list` shows it as knowledge-only with `~/workspace/skills/hello/SKILL.md` as source
- [ ] `pasclaw agent "what does the hello skill do?"` — model finds the SKILL.md entry in the system prompt, calls `fs_read` on the path, summarizes from the body
- [ ] Convert the sample to `kind: shell` with a one-liner — `pasclaw skills list` shows it as `shell`, `pasclaw agent "run hello"` invokes the registered `skill_hello` tool
- [ ] Drop an existing `workspace/skills/legacy.json` (old format) — still loads, listed alongside the new dir entries
- [ ] Put a SKILL.md with `name: legacy` next to `legacy.json` — JSON gets shadowed (debug log warns); only the SKILL.md entry shows in `skills list`
- [ ] Malformed SKILL.md (no frontmatter, unterminated frontmatter, missing `name:`) — logged at WARN, skipped, other skills still load

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_