### PR TITLE
Skills Phase 2: install from GitHub via codeload zip + native zip extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,11 @@ pasclaw cron enable daily-summary
 pasclaw cron remove daily-summary
 
 pasclaw skills list
-pasclaw skills install ./my-skill
-pasclaw skills remove my-skill
+pasclaw skills install owner/repo                         # GitHub: repo root SKILL.md
+pasclaw skills install owner/repo/path/to/skill           # GitHub: subdirectory
+pasclaw skills install owner/repo/path/to/skill@v1.2.3    # GitHub: pinned ref
+pasclaw skills install my-skill                           # Legacy: record name in config.json
+pasclaw skills remove my-skill                            # Deletes workspace dir + config entry
 ```
 
 Skills live under `$PASCLAW_HOME/workspace/skills/`. PasClaw accepts two layouts:
@@ -220,7 +223,11 @@ Skills live under `$PASCLAW_HOME/workspace/skills/`. PasClaw accepts two layouts
 
 - **Legacy single `*.json`** (`workspace/skills/<name>.json`) — still loaded for backwards compat. New skills should use the directory layout; per-directory entries shadow same-named JSON entries.
 
-Subsequent phases will add **`pasclaw skills install owner/repo[/path]`** (GitHub fetch + zip extract — Delphi has native `System.Zip` support, so no tar dependency), then a **ClawHub** search/install client, then `scripts/` + `references/` resource loading.
+**GitHub install** (Phase 2, this release):
+
+`pasclaw skills install owner/repo[/path][@ref]` downloads a zip snapshot from `codeload.github.com`, extracts it via the bundled zip library (`Zipper.TUnZipper` under FPC, `System.Zip.TZipFile` under Delphi — no tar dependency), locates SKILL.md at the requested subpath, validates it through `ParseSkillMD`, and copies the containing directory tree into `$PASCLAW_HOME/workspace/skills/<name>/`. If no `@ref` is given the installer tries `main` then falls back to `master`. The destination directory name defaults to the last segment of the subpath, or the repo name when no subpath was given. Refuses to overwrite an existing skill directory — `pasclaw skills remove <name>` first if you want to reinstall.
+
+Subsequent phases will add a **ClawHub** search/install client (slug-based registry the picoclaw / nanobot ecosystem standardised on), then `scripts/` (callable helpers) + `references/` (lazy-loaded context) runtime support.
 
 ### Gateway, OpenAI-compatible server, and channels
 

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -1,4 +1,22 @@
-{ Skills — list/install skill extensions (manifest-only for Phase 1). }
+{ Skills — list / install / remove skill extensions.
+
+  install accepts three target shapes:
+
+    pasclaw skills install owner/repo[/sub/path][@ref]
+        Fetch a SKILL.md tree from GitHub (zip via codeload, extract
+        with PasClaw.Skills.Zip). Default ref tries main then master.
+
+    pasclaw skills install ./local/path
+        Copy a local directory (containing SKILL.md at the root) into
+        the workspace. Phase 2 target — defers to a follow-up. Right
+        now the install command refuses local paths with a clear
+        error message; "drop the directory under workspace/skills/
+        yourself" is the manual fallback.
+
+    pasclaw skills install <name>
+        Legacy form. Records the name in config.json without
+        downloading anything. Kept for backwards compat with the
+        existing Cfg.Skills array used by older workflows. }
 unit PasClaw.Cmd.Skills;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
@@ -10,12 +28,34 @@ function Cmd_Skills_Run(const Argv: array of string): Integer;
 implementation
 
 uses
-  SysUtils, PasClaw.Config, PasClaw.CliUI, PasClaw.Utils,
-  PasClaw.Skills.Loader;
+  SysUtils, PasClaw.Config, PasClaw.CliUI, PasClaw.Utils, PasClaw.Logger,
+  PasClaw.Skills.Loader,
+  PasClaw.Skills.GitHub;
 
 procedure Help;
 begin
-  WriteLn('Usage: pasclaw skills <list|install|remove> [name|path]');
+  WriteLn('Usage: pasclaw skills <list|install|remove> [target]');
+  WriteLn;
+  WriteLn('  list                                List installed skills.');
+  WriteLn('  install owner/repo[/path][@ref]     Install a SKILL.md from GitHub.');
+  WriteLn('  install <name>                      Record a name in config.json.');
+  WriteLn('  remove <name>                       Remove from config.json + workspace.');
+end;
+
+function IsGitHubTarget(const Target: string): Boolean;
+{ Cheapest sniff: a slash that is not at position 1 (so not a local
+  absolute path starting with /), no leading dot (so not ./relative
+  or ../relative), and not starting with a Windows drive letter.
+  Anything else falls through to the legacy config-only install. }
+var
+  i: Integer;
+begin
+  Result := False;
+  if Target = '' then Exit;
+  if (Target[1] = '/') or (Target[1] = '\') or (Target[1] = '.') then Exit;
+  if (Length(Target) >= 2) and (Target[2] = ':') then Exit; { drive letter }
+  for i := 1 to Length(Target) do
+    if Target[i] = '/' then Exit(True);
 end;
 
 function DoList: Integer;
@@ -47,12 +87,30 @@ begin
   Result := 0;
 end;
 
-function DoInstall(const Argv: array of string): Integer;
+function DoInstallGitHub(const Target: string): Integer;
+var
+  DestRoot, Installed, ErrMsg: string;
+begin
+  DestRoot := JoinPath(GetHome, 'workspace/skills');
+  WriteLn('Fetching ', Target, ' …');
+  if not InstallFromGitHub(Target, DestRoot, Installed, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'install failed: ', ErrMsg);
+    Exit(1);
+  end;
+  WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'installed as ',
+          JoinPath(DestRoot, Installed));
+  WriteLn('  Run ', Ansi.Bold, 'pasclaw skills list', Ansi.Reset,
+          ' to confirm; next ', Ansi.Bold, 'pasclaw agent', Ansi.Reset,
+          ' invocation will pick it up.');
+  Result := 0;
+end;
+
+function DoInstallLegacy(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
   n: Integer;
 begin
-  if Length(Argv) < 2 then begin Help; Exit(1); end;
   Cfg := LoadConfig;
   try
     n := Length(Cfg.Skills);
@@ -61,19 +119,74 @@ begin
     Cfg.Skills[n].Source  := Argv[1];
     Cfg.Skills[n].Enabled := True;
     SaveConfig(Cfg);
-    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'installed ', Argv[1]);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'recorded ', Argv[1], ' in config.json');
+    WriteLn(Ansi.Dim, '  (no files downloaded — for a GitHub install use ',
+            'owner/repo syntax)', Ansi.Reset);
     Result := 0;
   finally
     Cfg.Free;
   end;
 end;
 
+function DoInstall(const Argv: array of string): Integer;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  if IsGitHubTarget(Argv[1]) then
+    Result := DoInstallGitHub(Argv[1])
+  else
+    Result := DoInstallLegacy(Argv);
+end;
+
+procedure RemoveSkillDir(const Dir: string);
+{ Recursive delete used by `skills remove`. Best-effort: failures get
+  logged but do not block the config-side removal. }
+
+  procedure Walk(const D: string);
+  var
+    SR: TSearchRec;
+    Path: string;
+  begin
+    if FindFirst(JoinPath(D, '*'), faAnyFile, SR) <> 0 then Exit;
+    try
+      repeat
+        if (SR.Name = '.') or (SR.Name = '..') then Continue;
+        Path := JoinPath(D, SR.Name);
+        if (SR.Attr and faDirectory) <> 0 then Walk(Path)
+        else try DeleteFile(Path); except end;
+      until FindNext(SR) <> 0;
+    finally
+      FindClose(SR);
+    end;
+    try RemoveDir(D); except end;
+  end;
+
+begin
+  if DirectoryExists(Dir) then Walk(Dir);
+end;
+
 function DoRemove(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
   i, dst: Integer;
+  WorkspaceDir, LegacyJSON: string;
+  RemovedFiles: Boolean;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
+  RemovedFiles := False;
+
+  WorkspaceDir := JoinPath(GetHome, 'workspace/skills');
+  LegacyJSON   := JoinPath(WorkspaceDir, Argv[1] + '.json');
+  if FileExists(LegacyJSON) then
+  begin
+    if DeleteFile(LegacyJSON) then RemovedFiles := True
+    else LogWarn('skills: could not delete %s', [LegacyJSON]);
+  end;
+  if DirectoryExists(JoinPath(WorkspaceDir, Argv[1])) then
+  begin
+    RemoveSkillDir(JoinPath(WorkspaceDir, Argv[1]));
+    RemovedFiles := True;
+  end;
+
   Cfg := LoadConfig;
   try
     dst := 0;
@@ -85,10 +198,16 @@ begin
       end;
     SetLength(Cfg.Skills, dst);
     SaveConfig(Cfg);
-    Result := 0;
   finally
     Cfg.Free;
   end;
+  if RemovedFiles then
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'removed ', Argv[1])
+  else
+    WriteLn(Ansi.Yellow, '(', Argv[1],
+            ' was not found on disk; config entry cleared if present)',
+            Ansi.Reset);
+  Result := 0;
 end;
 
 function Cmd_Skills_Run(const Argv: array of string): Integer;

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -164,6 +164,28 @@ begin
   if DirectoryExists(Dir) then Walk(Dir);
 end;
 
+function IsSafeSkillName(const Name: string): Boolean;
+{ Skill names go into JoinPath without canonicalisation, so a path
+  with separators or '..' would escape workspace/skills/ and let
+  `pasclaw skills remove ../memory` recursively delete an unrelated
+  workspace subtree. Only single-segment ASCII-ish names are
+  accepted on the remove path. Names that came from
+  InstallFromGitHub are derived from URL path segments — none of
+  the rejected characters can appear there — so legitimate
+  installs always pass. }
+var
+  i: Integer;
+begin
+  Result := False;
+  if (Name = '') or (Name = '.') or (Name = '..') then Exit;
+  for i := 1 to Length(Name) do
+    case Name[i] of
+      '/', '\', ':', #0..#31: Exit;
+    end;
+  if Pos('..', Name) > 0 then Exit;
+  Result := True;
+end;
+
 function DoRemove(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
@@ -172,6 +194,13 @@ var
   RemovedFiles: Boolean;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
+  if not IsSafeSkillName(Argv[1]) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset,
+            'unsafe skill name "', Argv[1], '" — skill names must be a single ',
+            'path segment with no /, \, :, or ".." sequence');
+    Exit(1);
+  end;
   RemovedFiles := False;
 
   WorkspaceDir := JoinPath(GetHome, 'workspace/skills');

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -195,6 +195,8 @@
 
         <!-- pkg/skills -->
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.Loader.pas"/>
+        <DCCReference Include="..\pkg\skills\PasClaw.Skills.Zip.pas"/>
+        <DCCReference Include="..\pkg\skills\PasClaw.Skills.GitHub.pas"/>
 
         <!-- pkg/agent -->
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Prompt.pas"/>

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -40,6 +40,19 @@ function PostJSON(const URL, JSON: string;
 function GetJSONURL(const URL: string;
                     const Headers: array of THeaderPair;
                     TimeoutSeconds: Integer): THTTPResult;
+
+{ Binary HTTP GET into a caller-owned stream. Use this for zip
+  downloads, embedding fetches, etc. — anything where TStringStream's
+  UTF-8 decoding would corrupt the payload. Caller positions and
+  sizes Stream however they need afterward.
+
+  Returns a THTTPResult with StatusCode and ErrorMsg set; Body stays
+  empty (the bytes went into Stream). HandleRedirects is on so a
+  GitHub codeload 302 -> Amazon S3 URL works transparently. }
+function GetURLToStream(const URL: string; Stream: TStream;
+                        const Headers: array of THeaderPair;
+                        TimeoutSeconds: Integer): THTTPResult;
+
 function MakeHeader(const Name, Value: string): THeaderPair;
 
 { Returns True if Indy can load OpenSSL; otherwise False and ErrMsg
@@ -226,6 +239,47 @@ begin
     Http.Request.Accept := 'application/json';
     ApplyHeaders(Http, Headers);
     Result := DoRequest(Http, URL, nil, False);
+  finally
+    Http.Free;
+  end;
+end;
+
+function GetURLToStream(const URL: string; Stream: TStream;
+                        const Headers: array of THeaderPair;
+                        TimeoutSeconds: Integer): THTTPResult;
+var
+  Http: TIdHTTP;
+  SSLErr: string;
+begin
+  Result.StatusCode := 0;
+  Result.Body       := '';
+  Result.ErrorMsg   := '';
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  if SSLErr <> '' then
+  begin
+    Result.StatusCode := -1;
+    Result.ErrorMsg   := SSLErr;
+    Http.Free;
+    Exit;
+  end;
+  try
+    Http.Request.Accept := '*/*';
+    ApplyHeaders(Http, Headers);
+    try
+      Http.Get(URL, Stream);
+      Result.StatusCode := Http.ResponseCode;
+    except
+      on E: EIdHTTPProtocolException do
+      begin
+        Result.StatusCode := E.ErrorCode;
+        Result.ErrorMsg   := E.Message;
+      end;
+      on E: Exception do
+      begin
+        Result.StatusCode := Http.ResponseCode;
+        Result.ErrorMsg   := E.Message;
+      end;
+    end;
   finally
     Http.Free;
   end;

--- a/src/pkg/skills/PasClaw.Skills.GitHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.GitHub.pas
@@ -176,9 +176,24 @@ begin
     end;
 end;
 
-function CodeloadURL(const Owner, Repo, Ref: string): string;
+function CodeloadBranchURL(const Owner, Repo, Branch: string): string;
+{ Specific to branches. Used for the implicit `main` then `master`
+  fallback when the user did not pin a ref — `refs/heads/<branch>`
+  forces a branch lookup so a tag or PR-branch with the same name
+  as a default branch never wins by accident. }
 begin
   Result := Format('https://codeload.github.com/%s/%s/zip/refs/heads/%s',
+                   [Owner, Repo, Branch]);
+end;
+
+function CodeloadAnyRefURL(const Owner, Repo, Ref: string): string;
+{ Short codeload form. Accepts branches, tags, and commit SHAs
+  uniformly — used when the user pinned an explicit ref via the
+  `@v1.2.3` / `@sha` syntax. The previous hardcoded
+  `refs/heads/<ref>` only worked for branches and 404'd on tags
+  and SHAs even though the archives existed. }
+begin
+  Result := Format('https://codeload.github.com/%s/%s/zip/%s',
                    [Owner, Repo, Ref]);
 end;
 
@@ -359,32 +374,42 @@ begin
   try
     if T.Ref <> '' then
     begin
-      SetLength(Refs, 1);
-      Refs[0] := T.Ref;
+      { Explicit ref — use the short codeload form that accepts
+        branches, tags, and commit SHAs alike. One attempt only;
+        a 404 here means the ref does not exist, not that we should
+        try a default branch. }
+      LogDebug('skills.github: trying %s/%s @ %s', [T.Owner, T.Repo, T.Ref]);
+      if not DownloadZip(CodeloadAnyRefURL(T.Owner, T.Repo, T.Ref), ZipPath, ErrMsg) then
+      begin
+        ErrMsg := Format('download failed for %s/%s@%s: %s',
+                         [T.Owner, T.Repo, T.Ref, ErrMsg]);
+        Exit;
+      end;
     end
     else
     begin
+      { Implicit ref — try main then master. Use refs/heads/<branch>
+        explicitly so a tag or unrelated ref with the same name does
+        not slip in via the short form. }
       SetLength(Refs, 2);
       Refs[0] := 'main';
       Refs[1] := 'master';
-    end;
-
-    T.Ref := '';
-    for i := 0 to High(Refs) do
-    begin
-      LogDebug('skills.github: trying %s/%s @ %s', [T.Owner, T.Repo, Refs[i]]);
-      if DownloadZip(CodeloadURL(T.Owner, T.Repo, Refs[i]), ZipPath, ErrMsg) then
+      for i := 0 to High(Refs) do
       begin
-        ErrMsg := '';
-        T.Ref  := Refs[i];
-        Break;
+        LogDebug('skills.github: trying %s/%s @ %s', [T.Owner, T.Repo, Refs[i]]);
+        if DownloadZip(CodeloadBranchURL(T.Owner, T.Repo, Refs[i]), ZipPath, ErrMsg) then
+        begin
+          ErrMsg := '';
+          T.Ref  := Refs[i];
+          Break;
+        end;
       end;
-    end;
-    if T.Ref = '' then
-    begin
-      if ErrMsg = '' then ErrMsg := 'all refs failed' else
-        ErrMsg := 'download failed: ' + ErrMsg;
-      Exit;
+      if T.Ref = '' then
+      begin
+        if ErrMsg = '' then ErrMsg := 'main and master both unreachable' else
+          ErrMsg := 'download failed: ' + ErrMsg;
+        Exit;
+      end;
     end;
 
     if not ExtractZipToDir(ZipPath, ExtractDir, ErrMsg) then Exit;

--- a/src/pkg/skills/PasClaw.Skills.GitHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.GitHub.pas
@@ -1,0 +1,435 @@
+(*
+  PasClaw.Skills.GitHub - install a skill from a GitHub repository.
+
+  Surface:
+
+    InstallFromGitHub(Target, DestRoot, out InstalledName, out ErrMsg)
+
+  Target shapes accepted:
+
+    owner/repo                  Install the repo's root SKILL.md.
+    owner/repo/sub/path         Install the SKILL.md at sub/path/.
+    owner/repo@branch           Pin to a branch / tag / commit instead
+    owner/repo/sub/path@ref     of trying main then master.
+
+  How it works (no clone / no git binary required — PasClaw stays an
+  Indy-only HTTP client):
+
+    1. Parse Target into (Owner, Repo, SubPath, Ref).
+    2. Download a zip snapshot of the repo from codeload.github.com.
+       If Ref is empty, try `main` first and fall back to `master` on
+       404. codeload returns a 302 to S3 and the zip itself; Indy
+       follows redirects so this is one Get call.
+    3. Save the zip to a temp file (memory-streaming the extract path
+       would also work but the disk path is simpler and the zips are
+       small enough that the I/O is invisible).
+    4. Extract through PasClaw.Skills.Zip (FPC: Zipper, Delphi:
+       System.Zip — both natively ship a zip implementation; no tar
+       dependency).
+    5. GitHub's zip wraps everything in a `<repo>-<ref>/` directory.
+       Strip that prefix; locate the SKILL.md at the requested
+       SubPath; copy the containing directory tree into
+       `<DestRoot>/<InstalledName>/`.
+    6. Validate: the installed directory must contain SKILL.md, and
+       ParseSkillMD must accept it. Otherwise remove the partial
+       install and return an error.
+
+  Naming: InstalledName defaults to the last segment of SubPath, or
+  the repo name when SubPath is empty. The skill's own `name:`
+  frontmatter is not used for the directory — directory name is what
+  the model sees in the system prompt's SKILLS section path, and
+  matching the GitHub layout makes it easier for users to find the
+  source.
+
+  Overwrite policy: if the destination directory already exists we
+  refuse and return an error. The caller (Cmd.Skills) surfaces a
+  hint about re-running with a different name or removing the
+  existing entry first. No `--force` yet; can add when there is real
+  demand.
+
+  Not in scope here (Phase 3+):
+    - ClawHub registry — separate HTTP API + slug resolution
+    - Multiple registries in one install command
+    - Lockfile / version pinning per skill
+    - Signed downloads
+*)
+unit PasClaw.Skills.GitHub;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function InstallFromGitHub(const Target, DestRoot: string;
+                           out InstalledName, ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  SysUtils, Classes, DateUtils, StrUtils,
+  {$IFNDEF FPC}
+  System.IOUtils,
+  {$ENDIF}
+  PasClaw.Utils,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP,
+  PasClaw.Skills.Zip,
+  PasClaw.Skills.Loader;
+
+function PlatformTempDir: string;
+begin
+  {$IFDEF FPC}
+  Result := GetTempDir;
+  {$ELSE}
+  Result := TPath.GetTempPath;
+  {$ENDIF}
+end;
+
+function UniqueSuffix: string;
+{ A 16-digit-ish unique suffix using milliseconds since epoch + a
+  random tail. Avoids GetTickCount (Windows-only) and the FPC/Delphi
+  differences in epoch helpers. Collision probability across two
+  installs in the same millisecond is vanishingly small for an
+  interactive CLI; the random tail covers the rest. }
+begin
+  Result := Format('%d-%d',
+                   [MilliSecondsBetween(Now, EncodeDate(1970, 1, 1)),
+                    Random(1 shl 30)]);
+end;
+
+const
+  MaxZipBytes = 64 * 1024 * 1024;  { GitHub repo snapshot cap }
+
+type
+  TTarget = record
+    Owner:   string;
+    Repo:    string;
+    SubPath: string;   { '' for repo root, or 'sub/path' (no leading/trailing slash) }
+    Ref:     string;   { '' means: try main then master; else use as-is }
+  end;
+
+function ParseTarget(const Target: string; out T: TTarget; out ErrMsg: string): Boolean;
+var
+  S, Spec, Rest: string;
+  AtPos, Slash1, Slash2: Integer;
+begin
+  Result := False;
+  ErrMsg := '';
+  T.Owner   := '';
+  T.Repo    := '';
+  T.SubPath := '';
+  T.Ref     := '';
+
+  S := Trim(Target);
+  if S = '' then begin ErrMsg := 'empty target'; Exit; end;
+
+  { Split on '@' for the ref. The first '@' separates spec from ref;
+    GitHub repo names cannot contain '@' so this is unambiguous. }
+  AtPos := Pos('@', S);
+  if AtPos > 0 then
+  begin
+    Spec  := Copy(S, 1, AtPos - 1);
+    T.Ref := Trim(Copy(S, AtPos + 1, MaxInt));
+  end
+  else
+    Spec := S;
+
+  Slash1 := Pos('/', Spec);
+  if Slash1 <= 0 then
+  begin
+    ErrMsg := 'target must look like "owner/repo[/sub/path][@ref]"';
+    Exit;
+  end;
+  T.Owner := Copy(Spec, 1, Slash1 - 1);
+  Rest    := Copy(Spec, Slash1 + 1, MaxInt);
+
+  Slash2 := Pos('/', Rest);
+  if Slash2 <= 0 then
+  begin
+    T.Repo    := Rest;
+    T.SubPath := '';
+  end
+  else
+  begin
+    T.Repo    := Copy(Rest, 1, Slash2 - 1);
+    T.SubPath := Copy(Rest, Slash2 + 1, MaxInt);
+  end;
+
+  if (T.Owner = '') or (T.Repo = '') then
+  begin
+    ErrMsg := 'malformed target — both owner and repo are required';
+    Exit;
+  end;
+  Result := True;
+end;
+
+function LastPathSegment(const P: string): string;
+var
+  i: Integer;
+begin
+  Result := P;
+  for i := Length(P) downto 1 do
+    if (P[i] = '/') or (P[i] = '\') then
+    begin
+      Result := Copy(P, i + 1, MaxInt);
+      Exit;
+    end;
+end;
+
+function CodeloadURL(const Owner, Repo, Ref: string): string;
+begin
+  Result := Format('https://codeload.github.com/%s/%s/zip/refs/heads/%s',
+                   [Owner, Repo, Ref]);
+end;
+
+function DownloadZip(const URL, DestPath: string; out ErrMsg: string): Boolean;
+var
+  Strm: TFileStream;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Headers, 0);
+  Strm := TFileStream.Create(DestPath, fmCreate);
+  try
+    Resp := GetURLToStream(URL, Strm, Headers, 60);
+    if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+    begin
+      if Resp.StatusCode = 404 then
+        ErrMsg := 'not found'
+      else if Resp.ErrorMsg <> '' then
+        ErrMsg := Format('http %d: %s', [Resp.StatusCode, Resp.ErrorMsg])
+      else
+        ErrMsg := Format('http %d', [Resp.StatusCode]);
+      Exit;
+    end;
+    if Strm.Size > MaxZipBytes then
+    begin
+      ErrMsg := Format('archive too large (%d bytes; cap %d)',
+                       [Strm.Size, MaxZipBytes]);
+      Exit;
+    end;
+    if Strm.Size = 0 then
+    begin
+      ErrMsg := 'empty archive';
+      Exit;
+    end;
+    Result := True;
+  finally
+    Strm.Free;
+  end;
+end;
+
+(* GitHub zips wrap every entry in `<repo>-<ref>/`. Returns the absolute
+   path to that wrapper after extraction, or '' if it can't be found. *)
+function FindExtractedRoot(const ExtractDir: string): string;
+var
+  SR: TSearchRec;
+begin
+  Result := '';
+  if FindFirst(JoinPath(ExtractDir, '*'), faDirectory, SR) <> 0 then Exit;
+  try
+    repeat
+      if (SR.Attr and faDirectory) = 0 then Continue;
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Result := JoinPath(ExtractDir, SR.Name);
+      Exit;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+procedure CopyTree(const SrcDir, DstDir: string);
+{ Recursive copy. ForceDirectories DstDir, then iterate SrcDir
+  copying files and recursing into subdirs. Uses TFileStream to
+  preserve bytes verbatim (no UTF-8 decoding the way ReadFileText
+  would). }
+
+  procedure CopyOne(const From_, To_: string);
+  var
+    A, B: TFileStream;
+  begin
+    A := TFileStream.Create(From_, fmOpenRead or fmShareDenyWrite);
+    try
+      B := TFileStream.Create(To_, fmCreate);
+      try
+        if A.Size > 0 then B.CopyFrom(A, A.Size);
+      finally
+        B.Free;
+      end;
+    finally
+      A.Free;
+    end;
+  end;
+
+  procedure Walk(const FromDir, ToDir: string);
+  var
+    SR: TSearchRec;
+    Src, Dst: string;
+  begin
+    ForceDirectories(ToDir);
+    if FindFirst(JoinPath(FromDir, '*'), faAnyFile, SR) <> 0 then Exit;
+    try
+      repeat
+        if (SR.Name = '.') or (SR.Name = '..') then Continue;
+        Src := JoinPath(FromDir, SR.Name);
+        Dst := JoinPath(ToDir,   SR.Name);
+        if (SR.Attr and faDirectory) <> 0 then Walk(Src, Dst)
+        else CopyOne(Src, Dst);
+      until FindNext(SR) <> 0;
+    finally
+      FindClose(SR);
+    end;
+  end;
+
+begin
+  Walk(SrcDir, DstDir);
+end;
+
+procedure RemoveTree(const Dir: string);
+{ Recursive delete. Failures swallowed — used in the cleanup path
+  where partial state is better than a stuck install. }
+var
+  SR: TSearchRec;
+  Path: string;
+begin
+  if not DirectoryExists(Dir) then Exit;
+  if FindFirst(JoinPath(Dir, '*'), faAnyFile, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Path := JoinPath(Dir, SR.Name);
+      if (SR.Attr and faDirectory) <> 0 then RemoveTree(Path)
+      else try DeleteFile(Path); except end;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  try RemoveDir(Dir); except end;
+end;
+
+function InstallFromGitHub(const Target, DestRoot: string;
+                           out InstalledName, ErrMsg: string): Boolean;
+var
+  T: TTarget;
+  TempBase, ZipPath, ExtractDir, RepoRoot, SrcDir, DstDir: string;
+  Refs: array of string;
+  i: Integer;
+  TempName: string;
+  Spec: TSkillSpec;
+  ParseErr: string;
+begin
+  Result := False;
+  InstalledName := '';
+  ErrMsg := '';
+
+  if not ParseTarget(Target, T, ErrMsg) then Exit;
+
+  if T.SubPath <> '' then
+    InstalledName := LastPathSegment(T.SubPath)
+  else
+    InstalledName := T.Repo;
+
+  DstDir := JoinPath(DestRoot, InstalledName);
+  if DirectoryExists(DstDir) then
+  begin
+    ErrMsg := Format('skill "%s" already exists at %s — remove it or pick a different target',
+                     [InstalledName, DstDir]);
+    Exit;
+  end;
+  if not ForceDirectories(DestRoot) then
+  begin
+    ErrMsg := 'cannot create skills root: ' + DestRoot;
+    Exit;
+  end;
+
+  { Stage everything under a unique temp dir so a failed install
+    never leaves half-written files in DstDir. }
+  TempName := 'pasclaw-skill-' + UniqueSuffix;
+  TempBase := JoinPath(PlatformTempDir, TempName);
+  if not ForceDirectories(TempBase) then
+  begin
+    ErrMsg := 'cannot create temp dir: ' + TempBase;
+    Exit;
+  end;
+  ZipPath    := JoinPath(TempBase, 'archive.zip');
+  ExtractDir := JoinPath(TempBase, 'extracted');
+  try
+    if T.Ref <> '' then
+    begin
+      SetLength(Refs, 1);
+      Refs[0] := T.Ref;
+    end
+    else
+    begin
+      SetLength(Refs, 2);
+      Refs[0] := 'main';
+      Refs[1] := 'master';
+    end;
+
+    T.Ref := '';
+    for i := 0 to High(Refs) do
+    begin
+      LogDebug('skills.github: trying %s/%s @ %s', [T.Owner, T.Repo, Refs[i]]);
+      if DownloadZip(CodeloadURL(T.Owner, T.Repo, Refs[i]), ZipPath, ErrMsg) then
+      begin
+        ErrMsg := '';
+        T.Ref  := Refs[i];
+        Break;
+      end;
+    end;
+    if T.Ref = '' then
+    begin
+      if ErrMsg = '' then ErrMsg := 'all refs failed' else
+        ErrMsg := 'download failed: ' + ErrMsg;
+      Exit;
+    end;
+
+    if not ExtractZipToDir(ZipPath, ExtractDir, ErrMsg) then Exit;
+
+    RepoRoot := FindExtractedRoot(ExtractDir);
+    if RepoRoot = '' then
+    begin
+      ErrMsg := 'extracted archive has no top-level directory';
+      Exit;
+    end;
+
+    if T.SubPath = '' then SrcDir := RepoRoot
+    else                   SrcDir := JoinPath(RepoRoot, T.SubPath);
+
+    if not FileExists(JoinPath(SrcDir, 'SKILL.md')) then
+    begin
+      if T.SubPath = '' then
+        ErrMsg := Format('repo %s/%s @ %s has no SKILL.md at the root — ' +
+                         'specify a subpath, e.g. owner/repo/path-to-skill',
+                         [T.Owner, T.Repo, T.Ref])
+      else
+        ErrMsg := Format('%s/SKILL.md not found in %s/%s @ %s',
+                         [T.SubPath, T.Owner, T.Repo, T.Ref]);
+      Exit;
+    end;
+
+    { Validate by parsing — refusing here is friendlier than letting a
+      malformed skill land on disk and show up in `pasclaw skills list`
+      with a warn-but-keep behaviour. }
+    if not ParseSkillMD(JoinPath(SrcDir, 'SKILL.md'), Spec, ParseErr) then
+    begin
+      ErrMsg := 'SKILL.md is invalid: ' + ParseErr;
+      Exit;
+    end;
+
+    CopyTree(SrcDir, DstDir);
+    LogInfo('skills.github: installed %s/%s%s@%s as %s',
+            [T.Owner, T.Repo,
+             IfThen(T.SubPath = '', '', '/' + T.SubPath),
+             T.Ref, DstDir]);
+    Result := True;
+  finally
+    RemoveTree(TempBase);
+    if (not Result) and DirectoryExists(DstDir) then RemoveTree(DstDir);
+  end;
+end;
+
+end.

--- a/src/pkg/skills/PasClaw.Skills.Zip.pas
+++ b/src/pkg/skills/PasClaw.Skills.Zip.pas
@@ -1,0 +1,91 @@
+(*
+  PasClaw.Skills.Zip - thin cross-toolchain wrapper around the two
+  bundled zip libraries:
+
+    FPC    : Zipper.TUnZipper (fcl-base, ships in every FPC install)
+    Delphi : System.Zip.TZipFile (RTL since Delphi XE2)
+
+  Single function exposed:
+
+    ExtractZipToDir(const ZipPath, DestDir: string; out ErrMsg)
+
+  Caller is responsible for creating DestDir if needed. ErrMsg is
+  set on failure; the function returns False without raising so the
+  skills-install path can format a user-friendly message instead of
+  surfacing the raw Indy / TZipFile exception text.
+
+  We deliberately do not pre-validate the archive (size limit, file
+  count, etc.) — the install layer in PasClaw.Skills.GitHub already
+  bounds the download to a sensible cap and validates the final tree
+  by looking for SKILL.md. Anything weirder (zip-slip, encrypted
+  archives, etc.) should be checked there, not here.
+*)
+unit PasClaw.Skills.Zip;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function ExtractZipToDir(const ZipPath, DestDir: string;
+                         out ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  SysUtils,
+  {$IFDEF FPC}
+    Zipper
+  {$ELSE}
+    System.Zip
+  {$ENDIF};
+
+function ExtractZipToDir(const ZipPath, DestDir: string;
+                         out ErrMsg: string): Boolean;
+{$IFDEF FPC}
+var
+  UZ: TUnZipper;
+begin
+  Result := False;
+  ErrMsg := '';
+  if not FileExists(ZipPath) then begin ErrMsg := 'archive not found'; Exit; end;
+  if not ForceDirectories(DestDir) then
+  begin
+    ErrMsg := 'cannot create destination directory: ' + DestDir;
+    Exit;
+  end;
+  UZ := TUnZipper.Create;
+  try
+    try
+      UZ.FileName   := ZipPath;
+      UZ.OutputPath := DestDir;
+      UZ.Examine;
+      UZ.UnZipAllFiles;
+      Result := True;
+    except
+      on E: Exception do ErrMsg := 'unzip failed: ' + E.Message;
+    end;
+  finally
+    UZ.Free;
+  end;
+end;
+{$ELSE}
+begin
+  Result := False;
+  ErrMsg := '';
+  if not FileExists(ZipPath) then begin ErrMsg := 'archive not found'; Exit; end;
+  if not ForceDirectories(DestDir) then
+  begin
+    ErrMsg := 'cannot create destination directory: ' + DestDir;
+    Exit;
+  end;
+  try
+    TZipFile.ExtractZipFile(ZipPath, DestDir);
+    Result := True;
+  except
+    on E: Exception do ErrMsg := 'unzip failed: ' + E.Message;
+  end;
+end;
+{$ENDIF}
+
+end.


### PR DESCRIPTION
Phase 2 of the 4-PR skills roadmap. After #55 landed the SKILL.md format, this PR makes it usable end-to-end — `pasclaw skills install owner/repo[/path][@ref]` downloads a zip, extracts it natively, validates the SKILL.md, and drops the result under `workspace/skills/`. Same UX picoclaw and nanobot ship for the GitHub registry.

## New surface

```sh
pasclaw skills install owner/repo                       # root SKILL.md
pasclaw skills install owner/repo/path/to/skill         # subdirectory
pasclaw skills install owner/repo/path/to/skill@v1.2.3  # pinned ref
```

## Pipeline (`PasClaw.Skills.GitHub`)

1. **Parse** the target into `(Owner, Repo, SubPath, Ref)`. `@` cannot appear in GitHub repo names → unambiguous split.
2. **Refuse if destination exists** — no `--force` yet; `pasclaw skills remove <name>` first if you need to reinstall.
3. **Download** `codeload.github.com/<owner>/<repo>/zip/refs/heads/<ref>` (it 302s to S3, Indy follows redirects). No `@ref` → try `main` then fall back to `master`. 64 MiB cap.
4. **Extract** through `PasClaw.Skills.Zip`:
   - `{$IFDEF FPC}` → `Zipper.TUnZipper` (fcl-base, bundled with FPC)
   - `{$ELSE}` → `System.Zip.TZipFile` (RTL since Delphi XE2)
   - **No tar.** Both toolchains ship zip natively.
5. **Strip** the GitHub-wrapper directory (`<repo>-<ref>/`), descend into the requested SubPath.
6. **Validate** by re-parsing the SKILL.md through `ParseSkillMD` — refuses malformed skills here instead of letting them surface as warnings in `pasclaw skills list`.
7. **Copy** the tree into `workspace/skills/<InstalledName>/`. Cleans up the temp directory always; removes the partial destination on any failure.

## New helper

`PasClaw.Providers.HTTP.GetURLToStream(URL, Stream, Headers, Timeout)` — natural binary counterpart to `PostJSON`. Reuses `NewClient` + the existing OpenSSL probe so it picks up Indy's TLS config without duplication.

## CLI changes (`Cmd.Skills`)

- `install` now dispatches on target shape via `IsGitHubTarget` (string contains `/`, doesn't start with `.`/`/`/`\`/`X:`). Anything else falls through to the legacy "record name in config.json" path so existing workflows don't regress.
- `remove` now deletes the workspace directory **and** legacy `<name>.json` alongside clearing the config entry.
- Help text updated.

## Cross-toolchain details

- `PlatformTempDir` — `GetTempDir` (FPC) vs `TPath.GetTempPath` (Delphi)
- `UniqueSuffix` — `MilliSecondsBetween(Now, EncodeDate(1970,1,1)) + Random(1 shl 30)` to avoid the Windows-only `GetTickCount`. Collisions vanishingly unlikely for interactive CLI use; the random tail covers concurrent installs in the same millisecond.

## Not in this PR (sequenced next)

- **Phase 3 — ClawHub** (slug-based registry: `pasclaw skills install code-review` → resolve via clawhub.ai → install via #56's pipeline).
- **Phase 4 — `scripts/` + `references/` runtime support** (callable helpers; lazy-loaded context).
- `--force` overwrite.
- Real local-path install (`./path` currently falls through to the legacy config-only flow).
- Multi-skill installs (`owner/repo` repos that ship N skills in subdirectories).

## Test plan

- [ ] FPC build (`make`) + Delphi `.dproj` build cleanly
- [ ] `pasclaw skills install anthropics/anthropic-quickstarts/agents/skills/file_io` (or any public skill repo that ships SKILL.md at a subpath) — succeeds; `pasclaw skills list` shows the new entry with path
- [ ] `pasclaw skills install does-not-exist/nope` — fails with `download failed: not found`, no temp files left over (`ls /tmp/pasclaw-skill-*` after)
- [ ] `pasclaw skills install someone/repo-with-no-skill` — fails with the "no SKILL.md at the root" hint pointing at subpath syntax
- [ ] `pasclaw skills install owner/repo` then `pasclaw skills install owner/repo` again — second call refuses with "already exists" and a hint to `skills remove` first
- [ ] `pasclaw skills remove <name>` — deletes the workspace directory AND clears the config entry (green ✓); for a name that doesn't exist anywhere, yellow notice
- [ ] `pasclaw agent` after install — the new skill appears in the system prompt's SKILLS section with the full SKILL.md path; model can `fs_read` it
- [ ] Ref pinning: `pasclaw skills install owner/repo@v1.0.0` works against a real tag, `@nonexistent-ref` fails cleanly
- [ ] Legacy `pasclaw skills install my-skill` (no slash) still records in config.json as before — no regression

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_