### PR TITLE
Add OpenAI Responses API route (/v1/responses) to gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ curl http://127.0.0.1:8088/v1/chat \
 curl http://127.0.0.1:8088/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}'
+curl http://127.0.0.1:8088/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","input":"hello"}'
 ```
 
 The gateway routes implemented in `src/pkg/gateway/` are:
@@ -284,7 +287,32 @@ The gateway routes implemented in `src/pkg/gateway/` are:
 | `/v1/tools` | `GET` | Registered tool descriptors. |
 | `/v1/chat` | `POST` | PasClaw JSON chat endpoint accepting `{"message":"..."}`. |
 | `/v1/chat/completions` | `POST` | OpenAI Chat Completions-compatible endpoint; supports streaming with `stream: true`. |
+| `/v1/responses` | `POST` | OpenAI Responses-compatible endpoint accepting string or message-array `input`; non-streaming only. |
 | `/v1/models` | `GET` | OpenAI-compatible model list containing the configured default model. |
+
+Manual `/v1/responses` verification examples:
+
+```sh
+# string input
+curl http://127.0.0.1:8088/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","input":"hello"}'
+
+# message-array input
+curl http://127.0.0.1:8088/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}]}'
+
+# missing or empty input should return invalid_request_error
+curl http://127.0.0.1:8088/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","input":""}'
+
+# streaming is intentionally unsupported on this route
+curl http://127.0.0.1:8088/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","input":"hello","stream":true}'
+```
 
 Channel posting commands:
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -10,6 +10,9 @@
                                       (request: {model, messages, ...},
                                        response: {id, choices[{message}], usage}
                                        — SSE if stream:true is set)
+    POST /v1/responses             -> OpenAI Responses-compatible
+                                      (request: {model, input, ...},
+                                       response: {id, output[{content}], usage})
     GET  /v1/models                -> OpenAI-compatible model list
     GET  /v1/version               -> build version
 
@@ -58,6 +61,11 @@ type
                                     AResp: TIdHTTPResponseInfo;
                                     out AWasStreamingRequest: Boolean;
                                     out AResponseStarted: Boolean);
+    procedure HandleResponses(AContext: TIdContext;
+                              ARequest: TIdHTTPRequestInfo;
+                              AResp: TIdHTTPResponseInfo;
+                              out AWasStreamingRequest: Boolean;
+                              out AResponseStarted: Boolean);
     procedure HandleModels(AResp: TIdHTTPResponseInfo);
     procedure WriteJSON(AResp: TIdHTTPResponseInfo; Code: Integer; const Body: string);
     procedure WriteSSE(AResp: TIdHTTPResponseInfo; const Body: string);
@@ -199,6 +207,8 @@ begin
     else if (ARequest.Command = 'POST') and (Doc = '/v1/chat')    then HandleChat(ARequest, AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/chat/completions') then
       HandleChatCompletions(AContext, ARequest, AResponse, IsChatCompletionsStream, ResponseStarted)
+    else if (ARequest.Command = 'POST') and (Doc = '/v1/responses') then
+      HandleResponses(AContext, ARequest, AResponse, IsChatCompletionsStream, ResponseStarted)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/models')  then HandleModels(AResponse)
     else if Doc = '/' then
     begin
@@ -213,7 +223,7 @@ begin
     end
     else if Doc = '/v1' then
       WriteJSON(AResponse, 200,
-        '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat","/v1/chat/completions","/v1/models"]}')
+        '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat","/v1/chat/completions","/v1/responses","/v1/models"]}')
     else
       WriteJSON(AResponse, 404, '{"error":"not found","path":"' + Doc + '"}');
   except
@@ -999,6 +1009,328 @@ begin
   finally
     Req.Free;
     if Streamer <> nil then Streamer.Free;
+  end;
+end;
+
+
+function GenResponseId: string;
+{ Opaque Responses API id. Keep it distinct from chatcmpl-* so logs can
+  distinguish which OpenAI-compatible surface handled the request. }
+const
+  Alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+var
+  i: Integer;
+begin
+  Result := 'resp_';
+  for i := 1 to 24 do
+    Result := Result + Alphabet[1 + Random(Length(Alphabet))];
+end;
+
+function BuildResponsesObject(const Id, Model, Status, Content: string;
+                               Usage: TUsageInfo): TJsonObject;
+{ Minimal OpenAI Responses-compatible non-streaming response. Modern OpenAI
+  clients look for output[].content[].text rather than choices[].message. }
+var
+  OutputArr, ContentArr, AnnotationsArr: TJsonArray;
+  MsgObj, TextObj, UsageObj: TJsonObject;
+begin
+  Result := TJsonObject.Create;
+  Result.PutStr('id',         Id);
+  Result.PutStr('object',     'response');
+  Result.PutInt('created_at', DateTimeToUnix(Now, False));
+  Result.PutStr('model',      Model);
+  Result.PutStr('status',     Status);
+
+  OutputArr := TJsonArray.Create;
+  if Content <> '' then
+  begin
+    MsgObj := TJsonObject.Create;
+    MsgObj.PutStr('id',     'msg_' + Copy(Id, 6, MaxInt));
+    MsgObj.PutStr('type',   'message');
+    MsgObj.PutStr('status', Status);
+    MsgObj.PutStr('role',   'assistant');
+
+    TextObj := TJsonObject.Create;
+    TextObj.PutStr('type', 'output_text');
+    TextObj.PutStr('text', Content);
+    AnnotationsArr := TJsonArray.Create;
+    TextObj.PutArray('annotations', AnnotationsArr);
+
+    ContentArr := TJsonArray.Create;
+    ContentArr.AddObject(TextObj);
+    MsgObj.PutArray('content', ContentArr);
+    OutputArr.AddObject(MsgObj);
+  end;
+  Result.PutArray('output', OutputArr);
+
+  UsageObj := TJsonObject.Create;
+  UsageObj.PutInt('input_tokens',  Usage.InputTokens);
+  UsageObj.PutInt('output_tokens', Usage.OutputTokens);
+  UsageObj.PutInt('total_tokens',  Usage.InputTokens + Usage.OutputTokens);
+  Result.PutObject('usage', UsageObj);
+end;
+
+procedure TGatewayServer.HandleResponses(AContext: TIdContext;
+                                          ARequest: TIdHTTPRequestInfo;
+                                          AResp: TIdHTTPResponseInfo;
+                                          out AWasStreamingRequest: Boolean;
+                                          out AResponseStarted: Boolean);
+(* OpenAI Responses API compatibility. Accepts the request shape used by
+   modern OpenAI clients and KAI: model, input (string or array of
+   role/content messages), stream, temperature, and max_output_tokens. The
+   request is translated into the same TMessageArray/TToolLoopConfig path as
+   /v1/chat/completions. Responses streaming has a different event protocol,
+   so this endpoint deliberately returns an OpenAI-shaped unsupported-streaming
+   error instead of pretending chat-completion chunks are Responses events. *)
+var
+  Body, ReqModel, InputText, FinishReason, RespId: string;
+  Bytes: TBytes;
+  Req, InputObj, ReplyObj, ErrObj: TJsonObject;
+  InputArr: TJsonArray;
+  Msgs: array of TMessage;
+  i, MsgCount: Integer;
+  WantsStream: Boolean;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+  RawTemp: Double;
+
+  procedure AppendMessage(Role: TMsgRole; const Content: string);
+  begin
+    if Trim(Content) = '' then Exit;
+    SetLength(Msgs, MsgCount + 1);
+    Msgs[MsgCount] := MakeMessage(Role, Content);
+    Inc(MsgCount);
+  end;
+
+  function FlattenTextArray(Arr: TJsonArray): string;
+  var
+    PartObj: TJsonObject;
+    NestedArr: TJsonArray;
+    PartText, NestedText: string;
+    j: Integer;
+  begin
+    Result := '';
+    if Arr = nil then Exit;
+    for j := 0 to Arr.Count - 1 do
+    begin
+      PartText := Arr.ItemStr(j, '');
+      if PartText = '' then
+      begin
+        PartObj := Arr.ItemObject(j);
+        if PartObj <> nil then
+        try
+          PartText := PartObj.GetStr('text', '');
+          if PartText = '' then PartText := PartObj.GetStr('input_text', '');
+          if PartText = '' then PartText := PartObj.GetStr('output_text', '');
+          if PartText = '' then
+          begin
+            NestedArr := PartObj.ChildArray('content');
+            if NestedArr <> nil then
+            try
+              NestedText := FlattenTextArray(NestedArr);
+              PartText := NestedText;
+            finally
+              NestedArr.Free;
+            end;
+          end;
+        finally
+          PartObj.Free;
+        end;
+      end;
+      if Trim(PartText) <> '' then
+      begin
+        if Result <> '' then Result := Result + sLineBreak;
+        Result := Result + PartText;
+      end;
+    end;
+  end;
+
+  function ExtractMessageContent(Obj: TJsonObject): string;
+  var
+    ContentArr: TJsonArray;
+  begin
+    Result := '';
+    if Obj = nil then Exit;
+    ContentArr := Obj.ChildArray('content');
+    if ContentArr <> nil then
+    try
+      Result := FlattenTextArray(ContentArr);
+    finally
+      ContentArr.Free;
+    end
+    else
+    begin
+      Result := Obj.GetStr('content', '');
+      if Result = '' then Result := Obj.GetStr('text', '');
+      if Result = '' then Result := Obj.GetStr('input_text', '');
+    end;
+  end;
+
+begin
+  AWasStreamingRequest := False;
+  AResponseStarted := False;
+  Body := '';
+  SetLength(Msgs, 0);
+  MsgCount := 0;
+
+  if ARequest.PostStream <> nil then
+  begin
+    ARequest.PostStream.Position := 0;
+    SetLength(Bytes, ARequest.PostStream.Size);
+    if ARequest.PostStream.Size > 0 then
+    begin
+      ARequest.PostStream.ReadBuffer(Bytes[0], ARequest.PostStream.Size);
+      Body := TEncoding.UTF8.GetString(Bytes);
+    end;
+  end;
+
+  if FDebugIO then
+    LogDebug('responses <- %d bytes from %s: %s',
+             [Length(Bytes), ARequest.RemoteIP, Body]);
+
+  if Trim(Body) = '' then
+  begin
+    WriteJSON(AResp, 400,
+      '{"error":{"message":"empty request body","type":"invalid_request_error"}}');
+    Exit;
+  end;
+
+  try
+    Req := TJsonObject.Parse(Body);
+  except
+    on E: Exception do
+    begin
+      WriteJSON(AResp, 400,
+        '{"error":{"message":"invalid JSON","type":"invalid_request_error"}}');
+      Exit;
+    end;
+  end;
+
+  if Req = nil then
+  begin
+    WriteJSON(AResp, 400,
+      '{"error":{"message":"invalid JSON object","type":"invalid_request_error"}}');
+    Exit;
+  end;
+
+  try
+    ReqModel    := Req.GetStr('model', FCfg.DefaultModel);
+    WantsStream := Req.GetBool('stream', False);
+    AWasStreamingRequest := WantsStream;
+
+    if WantsStream then
+    begin
+      WriteJSON(AResp, 400,
+        '{"error":{"message":"Responses streaming is not yet supported; use stream:false or /v1/chat/completions for SSE.","type":"invalid_request_error","param":"stream","code":"unsupported_streaming"}}');
+      Exit;
+    end;
+
+    InputArr := Req.ChildArray('input');
+    if InputArr <> nil then
+    try
+      for i := 0 to InputArr.Count - 1 do
+      begin
+        InputObj := InputArr.ItemObject(i);
+        if InputObj <> nil then
+        try
+          InputText := ExtractMessageContent(InputObj);
+          AppendMessage(MsgRoleFromString(InputObj.GetStr('role', 'user')), InputText);
+        finally
+          InputObj.Free;
+        end
+        else
+          AppendMessage(mrUser, InputArr.ItemStr(i, ''));
+      end;
+    finally
+      InputArr.Free;
+    end
+    else
+      AppendMessage(mrUser, Req.GetStr('input', ''));
+
+    if MsgCount = 0 then
+    begin
+      WriteJSON(AResp, 400,
+        '{"error":{"message":"missing or empty input","type":"invalid_request_error","param":"input"}}');
+      Exit;
+    end;
+
+    if FProvider = nil then
+    begin
+      WriteJSON(AResp, 503,
+        '{"error":{"message":"no provider configured","type":"server_error"}}');
+      Exit;
+    end;
+
+    LoopCfg.Provider      := FProvider;
+    LoopCfg.Registry      := FRegistry;
+    LoopCfg.Model         := ReqModel;
+    LoopCfg.MaxIterations := FMaxIter;
+    LoopCfg.Options       := DefaultChatOptions;
+    if not HasSystemMessage(Msgs) then
+      LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', LoopCfg.Registry <> nil);
+    RawTemp := Req.GetFloat('temperature', 0);
+    if RawTemp > 0 then LoopCfg.Options.Temperature := RawTemp;
+    if Req.Has('max_output_tokens') then
+      LoopCfg.Options.MaxTokens := Req.GetInt('max_output_tokens', LoopCfg.Options.MaxTokens)
+    else if Req.Has('max_tokens') then
+      LoopCfg.Options.MaxTokens := Req.GetInt('max_tokens', LoopCfg.Options.MaxTokens);
+    LoopCfg.OnText        := nil;
+    LoopCfg.OnToolCall    := nil;
+    LoopCfg.OnToolResult  := nil;
+
+    RespId := GenResponseId;
+
+    if not RunToolLoop(LoopCfg, Msgs, Loop) then
+    begin
+      ReplyObj := BuildResponsesObject(RespId, ReqModel, 'failed', '', Loop.LastResp.Usage);
+      try
+        ErrObj := TJsonObject.Create;
+        ErrObj.PutStr('message', 'tool loop failed');
+        ErrObj.PutStr('type',    'server_error');
+        ReplyObj.PutObject('error', ErrObj);
+        WriteJSON(AResp, 502, ReplyObj.ToJSON);
+      finally
+        ReplyObj.Free;
+      end;
+      Exit;
+    end;
+
+    if Loop.LastResp.FinishReason <> '' then
+      FinishReason := Loop.LastResp.FinishReason
+    else
+      FinishReason := 'stop';
+
+    if Length(Loop.LastResp.ToolCalls) > 0 then
+    begin
+      Loop.Content := Trim(Loop.Content);
+      if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
+      Loop.Content := Loop.Content + Format(
+        '(reached MaxIterations=%d while the model was still calling tools; '+
+        'last finish_reason=%s, %d pending tool call(s) — raise the --max-iter '+
+        'cap on `pasclaw serve` or reduce the task scope.)',
+        [FMaxIter, FinishReason, Length(Loop.LastResp.ToolCalls)]);
+      FinishReason := 'length';
+      LogWarn('responses: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
+              [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
+    end
+    else if Loop.Content = '' then
+    begin
+      Loop.Content := Format('(no content returned by the model; finish_reason=%s)',
+                              [FinishReason]);
+      LogWarn('responses: empty content with finish=%s iterations=%d',
+              [FinishReason, Loop.Iterations]);
+    end;
+
+    ReplyObj := BuildResponsesObject(RespId, ReqModel, 'completed', Loop.Content,
+                                      Loop.LastResp.Usage);
+    try
+      if FDebugIO then LogDebug('responses -> 200 JSON: %s', [ReplyObj.ToJSON]);
+      WriteJSON(AResp, 200, ReplyObj.ToJSON);
+    finally
+      ReplyObj.Free;
+    end;
+  finally
+    Req.Free;
   end;
 end;
 


### PR DESCRIPTION
### Motivation

- Expose a Responses-compatible endpoint that modern OpenAI clients and KAI expect (`/v1/responses`) so callers can send `model` + `input` (string or message-array) and receive Responses-shaped output.
- Reuse the existing tool-loop flow (`TToolLoopConfig` / `RunToolLoop`) so Responses requests get the same provider/tool execution semantics as `/v1/chat/completions`.

### Description

- Added routing and handler declaration for `POST /v1/responses` and included the route in the `/v1` index and README examples (files touched: `src/pkg/gateway/PasClaw.Gateway.Server.pas`, `README.md`).
- Implemented `TGatewayServer.HandleResponses` to parse `model`, `input` (accepting either a string or an array of message/content items), `stream`, `temperature`, and `max_output_tokens`/`max_tokens`, convert to `TMessage` array, and run the existing tool-loop.
- Added `GenResponseId` and `BuildResponsesObject` helpers to emit a minimal Responses-compatible non-streaming JSON object with `id`, `object: "response"`, `created_at`, `model`, `status`, `output` (assistant message content) and `usage` fields.
- Streaming behavior for Responses is intentionally not implemented and yields a clear OpenAI-shaped invalid-request error when `stream:true` is requested.

### Testing

- Ran `git diff --check` and repository grep checks for the new route and handler (`rg -n "POST /v1/responses|HandleResponses|unsupported_streaming|/v1/responses"`) which reported the expected symbols in `src/pkg/gateway/PasClaw.Gateway.Server.pas` and `README.md`.
- Performed smoke/manual verification edits to `README.md` showing curl examples for string `input`, message-array `input`, missing/empty input, and unsupported streaming behavior (examples added to README).
- Attempted `make test-hashline` but the build step is blocked in this environment because `fpcres` is not available, so FPC-focused tests could not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a1ce7248832e9834ae7080314d95)