### PR TITLE
Add Windows build scripts and FPC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,69 +8,32 @@ The main program lives at `src/pasclaw/PasClaw.dpr`. It initializes terminal col
 
 - Free Pascal 3.2+ in Delphi mode, or Delphi/RAD Studio.
 - Indy (`TIdHTTP`, `TIdHTTPServer`) for HTTP clients, the gateway, and channel integrations.
-  - FPC builds vendor Indy with `make get-indy` into `vendor/Indy`.
+  - FPC builds vendor Indy into `vendor/Indy`.
   - Delphi/RAD Studio ships Indy, so no vendored Indy checkout is required.
-- On Debian/Ubuntu FPC systems, install `fp-units-misc` so the `iconvenc` units are available.
 
 ## Build
 
-The repository `Makefile` is the authoritative FPC build entry point.
-
-```sh
-sudo apt install fpc fp-units-misc
-make get-indy
-make
-```
-
-`make` compiles the embedded web UI resource first and then builds `src/pasclaw/PasClaw.dpr` into `build/pasclaw`:
-
-```sh
-make webui-res       # compiles src/pkg/gateway/webui.rc + webui.html to webui.res
-make                 # builds build/pasclaw
-make run             # builds and runs build/pasclaw
-make smoke           # quick top-level command smoke test
-make test-hashline   # hashline patch test binary
-make test            # smoke + test-hashline
-make clean           # removes build/
-make print-version   # prints the version Make will inject
-```
-
-The Makefile injects `PASCLAW_VERSION` from `git describe --tags --always` when building with FPC. You can override key variables when needed:
-
-```sh
-make FPC=/path/to/fpc BUILDDIR=out BIN=out/pasclaw
-make INDY_DIR=/path/to/Indy
-make ICONVENC_DIR=/path/to/fpc/units/iconvenc
-```
-
 ### Delphi / RAD Studio
 
-Open `src/pasclaw/PasClaw.dpr` in RAD Studio and add the source directories from `Makefile`'s `UNIT_DIRS` to the project search path:
+Open `src/pasclaw/PasClaw.dproj` in Delphi/RAD Studio and build the project. The checked-in Delphi project already contains the project search paths.
 
-- `src/pkg/cliui`
-- `src/pkg/utils`
-- `src/pkg/logger`
-- `src/pkg/config`
-- `src/pkg/json`
-- `src/pkg/providers`
-- `src/pkg/tokenizer`
-- `src/pkg/tools`
-- `src/pkg/mcp`
-- `src/pkg/gateway`
-- `src/pkg/channels`
-- `src/pkg/cron`
-- `src/pkg/skills`
-- `src/pkg/agent`
-- `src/pkg/memory`
-- `src/pkg/updater`
-- `src/pkg/membench`
-- `src/pkg/tui`
-- `src/pkg/platform`
-- `src/pkg/hashline`
-- `src/pkg/component`
-- `src/cmd`
+On Windows, you can optionally build from a RAD Studio command prompt with:
 
-For the embedded web UI, compile `src/pkg/gateway/webui.rc` to `src/pkg/gateway/webui.res` with the Delphi resource compiler (`brcc32` or equivalent) before building. The unit `PasClaw.Gateway.WebUI` links `webui.res` with `{$R webui.res}`.
+```bat
+build-delphi.bat
+```
+
+The batch file uses MSBuild with the existing Delphi project when available, and falls back to the installed Delphi command-line compiler.
+
+### Free Pascal
+
+See [`fpc.md`](fpc.md) for detailed FPC prerequisites, Indy vendoring, resource generation, Makefile targets, and variable overrides.
+
+On Windows, you can optionally build with:
+
+```bat
+build-fpc.bat
+```
 
 ## Configuration
 

--- a/build-delphi.bat
+++ b/build-delphi.bat
@@ -22,7 +22,7 @@ call :compile_resource || exit /b 1
 
 where msbuild.exe >nul 2>nul
 if not errorlevel 1 (
-  echo Building %DPROJ% with MSBuild (%CONFIG%|%PLATFORM%)...
+  echo Building %DPROJ% with MSBuild ^(%CONFIG%^|%PLATFORM%^)...
   msbuild.exe "%DPROJ%" /t:Build /p:Config=%CONFIG% /p:Platform=%PLATFORM%
   if errorlevel 1 (
     echo ERROR: Delphi MSBuild build failed.

--- a/build-delphi.bat
+++ b/build-delphi.bat
@@ -1,0 +1,88 @@
+@echo off
+setlocal EnableExtensions
+
+rem PasClaw Delphi/RAD Studio build helper for Windows.
+rem Prefer MSBuild and the checked-in .dproj so source paths stay centralized.
+rem Override CONFIG and PLATFORM in the environment if needed.
+
+set "ROOT=%~dp0"
+cd /d "%ROOT%" || exit /b 1
+
+if "%CONFIG%"=="" set "CONFIG=Release"
+if "%PLATFORM%"=="" set "PLATFORM=Win64"
+set "DPROJ=src\pasclaw\PasClaw.dproj"
+set "DPR=src\pasclaw\PasClaw.dpr"
+
+if not exist "%DPROJ%" (
+  echo ERROR: Expected Delphi project "%DPROJ%" was not found.
+  exit /b 1
+)
+
+call :compile_resource || exit /b 1
+
+where msbuild.exe >nul 2>nul
+if not errorlevel 1 (
+  echo Building %DPROJ% with MSBuild (%CONFIG%|%PLATFORM%)...
+  msbuild.exe "%DPROJ%" /t:Build /p:Config=%CONFIG% /p:Platform=%PLATFORM%
+  if errorlevel 1 (
+    echo ERROR: Delphi MSBuild build failed.
+    exit /b 1
+  )
+  echo Build complete.
+  exit /b 0
+)
+
+where dcc64.exe >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: Neither msbuild.exe nor dcc64.exe was found on PATH.
+  echo Open a RAD Studio command prompt, or run rsvars.bat before this script.
+  exit /b 1
+)
+
+if not exist "build\delphi\%PLATFORM%\%CONFIG%" mkdir "build\delphi\%PLATFORM%\%CONFIG%" || exit /b 1
+if not exist "build\delphi\%PLATFORM%\%CONFIG%\dcu" mkdir "build\delphi\%PLATFORM%\%CONFIG%\dcu" || exit /b 1
+
+set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\cron;src\pkg\skills;src\pkg\agent;src\pkg\memory;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\vendor\dmvcframework"
+
+echo Building %DPR% with dcc64.exe...
+dcc64.exe -B -CC -E"build\delphi\%PLATFORM%\%CONFIG%" -N0"build\delphi\%PLATFORM%\%CONFIG%\dcu" -U"%UNIT_PATH%" -NSSystem;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi "%DPR%"
+if errorlevel 1 (
+  echo ERROR: Delphi dcc64 build failed.
+  exit /b 1
+)
+
+echo Build complete.
+exit /b 0
+
+:compile_resource
+where brcc32.exe >nul 2>nul
+if not errorlevel 1 (
+  echo Compiling embedded web UI resource with brcc32...
+  pushd src\pkg\gateway || exit /b 1
+  brcc32.exe webui.rc
+  if errorlevel 1 (
+    popd
+    echo ERROR: Failed to compile src\pkg\gateway\webui.rc with brcc32.exe.
+    exit /b 1
+  )
+  popd
+  exit /b 0
+)
+
+where rc.exe >nul 2>nul
+if not errorlevel 1 (
+  echo Compiling embedded web UI resource with rc...
+  pushd src\pkg\gateway || exit /b 1
+  rc.exe /fo webui.res webui.rc
+  if errorlevel 1 (
+    popd
+    echo ERROR: Failed to compile src\pkg\gateway\webui.rc with rc.exe.
+    exit /b 1
+  )
+  popd
+  exit /b 0
+)
+
+echo ERROR: Neither brcc32.exe nor rc.exe was found on PATH.
+echo Open a RAD Studio command prompt, or run rsvars.bat before this script.
+exit /b 1

--- a/build-fpc.bat
+++ b/build-fpc.bat
@@ -1,0 +1,67 @@
+@echo off
+setlocal EnableExtensions
+
+rem PasClaw FPC build helper for Windows.
+rem Mirrors the repository Makefile defaults. Override FPC, BUILDDIR,
+rem INDY_DIR, ICONVENC_DIR, or BIN in the environment if needed.
+
+set "ROOT=%~dp0"
+cd /d "%ROOT%" || exit /b 1
+
+if "%FPC%"=="" set "FPC=fpc.exe"
+if "%BUILDDIR%"=="" set "BUILDDIR=build"
+if "%BIN%"=="" set "BIN=%BUILDDIR%\pasclaw.exe"
+if "%INDY_DIR%"=="" set "INDY_DIR=vendor\Indy"
+if "%ICONVENC_DIR%"=="" set "ICONVENC_DIR="
+
+if exist "%FPC%" (
+  rem FPC points directly at an executable path.
+) else (
+  where "%FPC%" >nul 2>nul
+  if errorlevel 1 (
+    echo ERROR: %FPC% was not found on PATH.
+    echo Install Free Pascal 3.2 or newer, or set FPC=C:\path\to\fpc.exe.
+    exit /b 1
+  )
+)
+
+where fpcres.exe >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: fpcres.exe was not found on PATH.
+  echo Ensure the Free Pascal bin directory is on PATH before building.
+  exit /b 1
+)
+
+if not exist "%INDY_DIR%\Lib\Core" (
+  echo ERROR: Indy was not found at "%INDY_DIR%".
+  echo Run "make get-indy" where make is available, or clone IndySockets/Indy to "%INDY_DIR%".
+  exit /b 1
+)
+
+if not exist "%BUILDDIR%" mkdir "%BUILDDIR%" || exit /b 1
+if not exist "%BUILDDIR%\lib" mkdir "%BUILDDIR%\lib" || exit /b 1
+
+echo Compiling embedded web UI resource...
+pushd src\pkg\gateway || exit /b 1
+fpcres.exe -of res -o webui.res webui.rc
+if errorlevel 1 (
+  popd
+  echo ERROR: Failed to compile src\pkg\gateway\webui.rc to src\pkg\gateway\webui.res.
+  exit /b 1
+)
+popd
+
+set "FPCFLAGS=-MDelphi -Sh -O2 -Xs -XX"
+set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\cmd"
+set "FPCFLAGS=%FPCFLAGS% -Fu%INDY_DIR%\Lib\Core -Fu%INDY_DIR%\Lib\Protocols -Fu%INDY_DIR%\Lib\System -Fi%INDY_DIR%\Lib\Core -Fi%INDY_DIR%\Lib\Protocols -Fi%INDY_DIR%\Lib\System"
+if not "%ICONVENC_DIR%"=="" set "FPCFLAGS=%FPCFLAGS% -Fu%ICONVENC_DIR%"
+set "FPCFLAGS=%FPCFLAGS% -FE%BUILDDIR% -FU%BUILDDIR%\lib"
+
+echo Building src\pasclaw\PasClaw.dpr with %FPC%...
+"%FPC%" %FPCFLAGS% src\pasclaw\PasClaw.dpr -o"%BIN%"
+if errorlevel 1 (
+  echo ERROR: FPC build failed.
+  exit /b 1
+)
+
+echo Build complete: %BIN%

--- a/fpc.md
+++ b/fpc.md
@@ -1,0 +1,77 @@
+# Building PasClaw with Free Pascal
+
+PasClaw builds with Free Pascal (FPC) 3.2 or newer in Delphi mode. The repository `Makefile` is the source of truth for FPC flags, source paths, resource generation, and output locations.
+
+## Requirements
+
+- Free Pascal 3.2+.
+- Indy for HTTP client/server units (`TIdHTTP`, `TIdHTTPServer`). FPC builds vendor Indy into `vendor/Indy`.
+- On Debian/Ubuntu FPC systems, install `fp-units-misc` so the `iconvenc` units are available. FPC's default configuration finds `iconvenc` on most distributions, but the Makefile also exposes `ICONVENC_DIR` for systems that need an explicit path.
+
+```sh
+sudo apt install fpc fp-units-misc
+```
+
+## Vendoring Indy
+
+Fetch Indy before the first FPC build:
+
+```sh
+make get-indy
+```
+
+This clones `IndySockets/Indy` into `vendor/Indy` unless that directory already exists. Override the location with `INDY_DIR=/path/to/Indy` when needed.
+
+## Embedded web UI resource
+
+The gateway embeds `src/pkg/gateway/webui.html` through `src/pkg/gateway/webui.rc`. Compile the resource with:
+
+```sh
+make webui-res
+```
+
+This produces `src/pkg/gateway/webui.res`, which is linked by `PasClaw.Gateway.WebUI` using `{$R webui.res}`. The default `make` target runs this step before compiling `src/pasclaw/PasClaw.dpr`.
+
+## Build commands
+
+```sh
+make                 # compiles webui.res and builds build/pasclaw
+make run             # builds and runs build/pasclaw
+make smoke           # quick top-level command smoke test
+make test-hashline   # hashline patch test binary
+make test            # smoke + test-hashline
+make clean           # removes build/
+make print-version   # prints the version Make will inject
+```
+
+The Makefile injects `PASCLAW_VERSION` from `git describe --tags --always` during FPC builds.
+
+## Variable overrides
+
+Override Makefile variables on the command line when needed:
+
+```sh
+make FPC=/path/to/fpc BUILDDIR=out BIN=out/pasclaw
+make INDY_DIR=/path/to/Indy
+make ICONVENC_DIR=/path/to/fpc/units/iconvenc
+```
+
+Common variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FPC` | `fpc` | Free Pascal compiler executable. |
+| `BUILDDIR` | `build` | Directory for build outputs and compiled units. |
+| `BIN` | `$(BUILDDIR)/pasclaw` | Final executable path. |
+| `INDY_DIR` | `vendor/Indy` | Vendored Indy checkout used for FPC builds. |
+| `ICONVENC_DIR` | `/usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/iconvenc` | Optional explicit `iconvenc` unit path. |
+
+## Windows
+
+On Windows, use `build-fpc.bat` from the repository root after installing FPC 3.2+ and ensuring `fpc.exe` and `fpcres.exe` are on `PATH`:
+
+```bat
+build-fpc.bat
+```
+
+The batch file compiles `src\pkg\gateway\webui.rc` to `src\pkg\gateway\webui.res` before building `src\pasclaw\PasClaw.dpr`. It mirrors the Makefile's FPC flags and source paths, and supports environment overrides for `FPC`, `BUILDDIR`, `BIN`, `INDY_DIR`, and `ICONVENC_DIR`.


### PR DESCRIPTION
### Motivation

- Provide simple, supported Windows build entrypoints for both FPC and Delphi that mirror the Makefile behavior and avoid asking users to manually copy Makefile UNIT_DIRS into IDE search paths. 
- Ensure the embedded web UI resource is always compiled before building the Delphi/FPC DPR so builds succeed on Windows as they do with `make` on Unix. 
- Move detailed FPC-specific guidance out of the top-level README into a focused `fpc.md` to keep the README high-level and platform-agnostic. 

### Description

- Add `build-fpc.bat` at the repository root that validates `fpc.exe` and `fpcres.exe` availability (or accepts an explicit `FPC=` path), checks for a vendored Indy checkout, compiles `src/pkg/gateway/webui.rc` to `webui.res`, composes Makefile-equivalent `-Fu`/`-Fi`/`-FE` flags, and invokes `fpc` to build `src/pasclaw/PasClaw.dpr`. 
- Add `build-delphi.bat` at the repository root that compiles the embedded web UI resource (using `brcc32.exe` or `rc.exe`), prefers building the checked-in `src/pasclaw/PasClaw.dproj` via `msbuild.exe`, and falls back to `dcc64.exe` with a prepared unit search path if MSBuild is not available, emitting clear error messages when RAD Studio tools are missing. 
- Add `fpc.md` containing the full FPC-focused README material (FPC 3.2+ requirement, `fp-units-misc` / `iconvenc` note, Indy vendoring and `make get-indy`, `make webui-res`, `make` targets, and the Makefile variable overrides such as `FPC=`, `BUILDDIR=`, `INDY_DIR=`, `ICONVENC_DIR=`), plus a short Windows section pointing at `build-fpc.bat`. 
- Update `README.md` to remove the long FPC build section and the instruction telling Delphi users to manually add all `UNIT_DIRS` to the project search path, replacing it with a short Build section that links to `fpc.md` and mentions the optional `build-fpc.bat`/`build-delphi.bat` scripts. 

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff issues, and it returned no problems. 
- Verified both batch files exist with `test -f build-fpc.bat && test -f build-delphi.bat`, which succeeded. 
- Confirmed `README.md` links to `fpc.md` by checking for the literal link ``[`fpc.md`](fpc.md)`` which was found. 
- Confirmed removal of stale manual-Delphi-search-path guidance by asserting the README does not match patterns like `add .*source directories|Makefile.*UNIT_DIRS|UNIT_DIRS.*search path|manually add|add all.*source`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a64515f8832e912f2b5ff21a2454)