### PR TITLE
Skills Phase 3: ClawHub search + slug install

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ pasclaw skills list
 pasclaw skills install owner/repo                         # GitHub: repo root SKILL.md
 pasclaw skills install owner/repo/path/to/skill           # GitHub: subdirectory
 pasclaw skills install owner/repo/path/to/skill@v1.2.3    # GitHub: pinned ref
+pasclaw skills install code-review                        # ClawHub: by slug (latest version)
+pasclaw skills install code-review@1.2.3                  # ClawHub: pinned version
+pasclaw skills search "code review"                       # ClawHub: search the registry
 pasclaw skills install my-skill                           # Legacy: record name in config.json
 pasclaw skills remove my-skill                            # Deletes workspace dir + config entry
 ```
@@ -227,7 +230,13 @@ Skills live under `$PASCLAW_HOME/workspace/skills/`. PasClaw accepts two layouts
 
 `pasclaw skills install owner/repo[/path][@ref]` downloads a zip snapshot from `codeload.github.com`, extracts it via the bundled zip library (`Zipper.TUnZipper` under FPC, `System.Zip.TZipFile` under Delphi — no tar dependency), locates SKILL.md at the requested subpath, validates it through `ParseSkillMD`, and copies the containing directory tree into `$PASCLAW_HOME/workspace/skills/<name>/`. If no `@ref` is given the installer tries `main` then falls back to `master`. The destination directory name defaults to the last segment of the subpath, or the repo name when no subpath was given. Refuses to overwrite an existing skill directory — `pasclaw skills remove <name>` first if you want to reinstall.
 
-Subsequent phases will add a **ClawHub** search/install client (slug-based registry the picoclaw / nanobot ecosystem standardised on), then `scripts/` (callable helpers) + `references/` (lazy-loaded context) runtime support.
+**ClawHub install** (Phase 3, this release):
+
+`pasclaw skills install <slug>[@<version>]` hits ClawHub (`https://clawhub.ai`) — the slug-based registry picoclaw and nanobot standardised on. It optionally fetches metadata first (`/api/v1/skills/<slug>`) to surface the moderation flags and resolve `latestVersion` when no version is pinned, then downloads the zip from `/api/v1/download?slug=<slug>&version=<version>` and runs it through the same `PasClaw.Skills.Zip` + `ParseSkillMD` validation pipeline as the GitHub path. Malware-flagged skills are refused; suspicious skills install with a warning. Slugs are lowercase alphanumerics with `-` / `_`.
+
+`pasclaw skills search <query>` queries `/api/v1/search` and prints slug / version / display-name / summary rows.
+
+Subsequent phases will add `scripts/` (callable helpers) + `references/` (lazy-loaded context) runtime support.
 
 ### Gateway, OpenAI-compatible server, and channels
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ pasclaw skills list
 pasclaw skills install owner/repo                         # GitHub: repo root SKILL.md
 pasclaw skills install owner/repo/path/to/skill           # GitHub: subdirectory
 pasclaw skills install owner/repo/path/to/skill@v1.2.3    # GitHub: pinned ref
-pasclaw skills install code-review                        # ClawHub: by slug (latest version)
-pasclaw skills install code-review@1.2.3                  # ClawHub: pinned version
+pasclaw skills install clawhub:code-review                # ClawHub: by slug (latest version)
+pasclaw skills install clawhub:code-review@1.2.3          # ClawHub: pinned version
 pasclaw skills search "code review"                       # ClawHub: search the registry
 pasclaw skills install my-skill                           # Legacy: record name in config.json
 pasclaw skills remove my-skill                            # Deletes workspace dir + config entry
@@ -232,7 +232,7 @@ Skills live under `$PASCLAW_HOME/workspace/skills/`. PasClaw accepts two layouts
 
 **ClawHub install** (Phase 3, this release):
 
-`pasclaw skills install <slug>[@<version>]` hits ClawHub (`https://clawhub.ai`) — the slug-based registry picoclaw and nanobot standardised on. It optionally fetches metadata first (`/api/v1/skills/<slug>`) to surface the moderation flags and resolve `latestVersion` when no version is pinned, then downloads the zip from `/api/v1/download?slug=<slug>&version=<version>` and runs it through the same `PasClaw.Skills.Zip` + `ParseSkillMD` validation pipeline as the GitHub path. Malware-flagged skills are refused; suspicious skills install with a warning. Slugs are lowercase alphanumerics with `-` / `_`.
+`pasclaw skills install clawhub:<slug>[@<version>]` hits ClawHub (`https://clawhub.ai`) — the slug-based registry picoclaw and nanobot standardised on. It optionally fetches metadata first (`/api/v1/skills/<slug>`) to surface the moderation flags and resolve `latestVersion` when no version is pinned, then downloads the zip from `/api/v1/download?slug=<slug>&version=<version>` and runs it through the same `PasClaw.Skills.Zip` + `ParseSkillMD` validation pipeline as the GitHub path. Malware-flagged skills are refused; suspicious skills install with a warning. Slugs are lowercase alphanumerics with `-` / `_`. The explicit `clawhub:` prefix is required so a bare slug-shaped name like `my-skill` keeps falling through to the legacy `config.json`-only record (preserving backwards compat with pre-Phase-3 scripts) instead of silently swapping places with a same-named registry entry.
 
 `pasclaw skills search <query>` queries `/api/v1/search` and prints slug / version / display-name / summary rows.
 

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -6,21 +6,25 @@
         Fetch a SKILL.md tree from GitHub (zip via codeload, extract
         with PasClaw.Skills.Zip). Default ref tries main then master.
 
-    pasclaw skills install <slug>[@<version>]
+    pasclaw skills install clawhub:<slug>[@<version>]
         Resolve <slug> on ClawHub (https://clawhub.ai). Picoclaw and
         nanobot's default registry — slug syntax is lowercase
         alphanumerics, '-', and '_'. `@<version>` pins; omitting it
         uses the slug's latestVersion if metadata is available,
-        otherwise 'latest'.
+        otherwise 'latest'. The explicit `clawhub:` prefix is
+        required so a slug-shaped bare name like `my-skill` does
+        not silently swap places with a same-named registry entry
+        — see the docstring on IsClawHubTarget for the backwards
+        compat rationale.
 
     pasclaw skills search <query>
         Hit ClawHub's /api/v1/search and print result rows. No
         install side effects.
 
-  Legacy `pasclaw skills install <name>` (no slash, not a valid
-  slug — e.g. names with capital letters) still records the name in
-  config.json without downloading anything. Kept for backwards
-  compat with older workflows that drove Cfg.Skills directly. }
+  Legacy `pasclaw skills install <name>` (anything not matching the
+  two forms above) still records the name in config.json without
+  downloading anything. Kept for backwards compat with older
+  workflows that drove Cfg.Skills directly. }
 unit PasClaw.Cmd.Skills;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
@@ -43,7 +47,7 @@ begin
   WriteLn;
   WriteLn('  list                                List installed skills.');
   WriteLn('  install owner/repo[/path][@ref]     Install a SKILL.md from GitHub.');
-  WriteLn('  install <slug>[@<version>]          Install from ClawHub (https://clawhub.ai).');
+  WriteLn('  install clawhub:<slug>[@<version>]  Install from ClawHub (https://clawhub.ai).');
   WriteLn('  install <name>                      Legacy: record a name in config.json.');
   WriteLn('  remove <name>                       Remove from config.json + workspace.');
   WriteLn('  search <query>                      Search ClawHub for skills.');
@@ -65,22 +69,35 @@ begin
     if Target[i] = '/' then Exit(True);
 end;
 
-function IsClawHubSlug(const Target: string): Boolean;
-{ ClawHub slugs are lowercase alphanumerics, '-', '_'. Optional
-  `@<version>` suffix permitted but not required. We reject empty
-  and oversize targets here so `pasclaw skills install Foo` (mixed
-  case) falls through to the legacy path with a clear deprecation
-  message rather than 404'ing on ClawHub. }
+const
+  ClawHubPrefix = 'clawhub:';
+
+function IsClawHubTarget(const Target: string; out Slug: string): Boolean;
+{ ClawHub installs require an explicit `clawhub:<slug>[@version]`
+  prefix. Bare slug-shaped names ('my-skill', 'code-review' etc.)
+  stay on the legacy config-only path so pre-existing scripts that
+  used `pasclaw skills install <name>` to record an entry in
+  config.json keep working — they'd otherwise either 404 on
+  ClawHub or, worse, silently install an unrelated registry skill
+  that happened to share the slug.
+
+  Validates the slug after stripping the prefix so e.g.
+  `clawhub:Foo` (mixed case) fails fast here rather than 404'ing
+  on the server. Optional `@<version>` suffix permitted. }
 var
   i, AtPos: Integer;
-  Slug: string;
+  Rest: string;
   C: Char;
 begin
   Result := False;
-  if (Target = '') or (Length(Target) > 128) then Exit;
-  AtPos := Pos('@', Target);
-  if AtPos > 0 then Slug := Copy(Target, 1, AtPos - 1)
-              else Slug := Target;
+  Slug := '';
+  if Length(Target) <= Length(ClawHubPrefix) then Exit;
+  if Copy(Target, 1, Length(ClawHubPrefix)) <> ClawHubPrefix then Exit;
+  Rest := Copy(Target, Length(ClawHubPrefix) + 1, MaxInt);
+  if (Rest = '') or (Length(Rest) > 128) then Exit;
+  AtPos := Pos('@', Rest);
+  if AtPos > 0 then Slug := Copy(Rest, 1, AtPos - 1)
+              else Slug := Rest;
   if Slug = '' then Exit;
   for i := 1 to Length(Slug) do
   begin
@@ -89,6 +106,7 @@ begin
              ((C >= '0') and (C <= '9')) or
              (C = '-') or (C = '_') ) then Exit;
   end;
+  Slug := Rest;   { hand the full "<slug>[@version]" back to caller }
   Result := True;
 end;
 
@@ -203,12 +221,20 @@ begin
 end;
 
 function DoInstall(const Argv: array of string): Integer;
+var
+  ClawHubSlug: string;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
-  if IsGitHubTarget(Argv[1]) then
+  { Check the explicit `clawhub:` prefix before the GitHub
+    owner/repo sniff so a (theoretical) target like
+    `clawhub:owner/repo` routes to the ClawHub validator, which
+    rejects the slash and falls through to legacy. With the old
+    order GitHub's IsGitHubTarget would have eaten the slash and
+    tried to fetch `clawhub:owner/repo`. }
+  if IsClawHubTarget(Argv[1], ClawHubSlug) then
+    Result := DoInstallClawHub(ClawHubSlug)
+  else if IsGitHubTarget(Argv[1]) then
     Result := DoInstallGitHub(Argv[1])
-  else if IsClawHubSlug(Argv[1]) then
-    Result := DoInstallClawHub(Argv[1])
   else
     Result := DoInstallLegacy(Argv);
 end;

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -1,22 +1,26 @@
-{ Skills — list / install / remove skill extensions.
+{ Skills — list / install / remove / search skill extensions.
 
-  install accepts three target shapes:
+  install accepts three target shapes (in this dispatch order):
 
     pasclaw skills install owner/repo[/sub/path][@ref]
         Fetch a SKILL.md tree from GitHub (zip via codeload, extract
         with PasClaw.Skills.Zip). Default ref tries main then master.
 
-    pasclaw skills install ./local/path
-        Copy a local directory (containing SKILL.md at the root) into
-        the workspace. Phase 2 target — defers to a follow-up. Right
-        now the install command refuses local paths with a clear
-        error message; "drop the directory under workspace/skills/
-        yourself" is the manual fallback.
+    pasclaw skills install <slug>[@<version>]
+        Resolve <slug> on ClawHub (https://clawhub.ai). Picoclaw and
+        nanobot's default registry — slug syntax is lowercase
+        alphanumerics, '-', and '_'. `@<version>` pins; omitting it
+        uses the slug's latestVersion if metadata is available,
+        otherwise 'latest'.
 
-    pasclaw skills install <name>
-        Legacy form. Records the name in config.json without
-        downloading anything. Kept for backwards compat with the
-        existing Cfg.Skills array used by older workflows. }
+    pasclaw skills search <query>
+        Hit ClawHub's /api/v1/search and print result rows. No
+        install side effects.
+
+  Legacy `pasclaw skills install <name>` (no slash, not a valid
+  slug — e.g. names with capital letters) still records the name in
+  config.json without downloading anything. Kept for backwards
+  compat with older workflows that drove Cfg.Skills directly. }
 unit PasClaw.Cmd.Skills;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
@@ -30,23 +34,26 @@ implementation
 uses
   SysUtils, PasClaw.Config, PasClaw.CliUI, PasClaw.Utils, PasClaw.Logger,
   PasClaw.Skills.Loader,
-  PasClaw.Skills.GitHub;
+  PasClaw.Skills.GitHub,
+  PasClaw.Skills.ClawHub;
 
 procedure Help;
 begin
-  WriteLn('Usage: pasclaw skills <list|install|remove> [target]');
+  WriteLn('Usage: pasclaw skills <list|install|remove|search> [args]');
   WriteLn;
   WriteLn('  list                                List installed skills.');
   WriteLn('  install owner/repo[/path][@ref]     Install a SKILL.md from GitHub.');
-  WriteLn('  install <name>                      Record a name in config.json.');
+  WriteLn('  install <slug>[@<version>]          Install from ClawHub (https://clawhub.ai).');
+  WriteLn('  install <name>                      Legacy: record a name in config.json.');
   WriteLn('  remove <name>                       Remove from config.json + workspace.');
+  WriteLn('  search <query>                      Search ClawHub for skills.');
 end;
 
 function IsGitHubTarget(const Target: string): Boolean;
 { Cheapest sniff: a slash that is not at position 1 (so not a local
   absolute path starting with /), no leading dot (so not ./relative
   or ../relative), and not starting with a Windows drive letter.
-  Anything else falls through to the legacy config-only install. }
+  Anything else falls through to the ClawHub / legacy paths. }
 var
   i: Integer;
 begin
@@ -56,6 +63,50 @@ begin
   if (Length(Target) >= 2) and (Target[2] = ':') then Exit; { drive letter }
   for i := 1 to Length(Target) do
     if Target[i] = '/' then Exit(True);
+end;
+
+function IsClawHubSlug(const Target: string): Boolean;
+{ ClawHub slugs are lowercase alphanumerics, '-', '_'. Optional
+  `@<version>` suffix permitted but not required. We reject empty
+  and oversize targets here so `pasclaw skills install Foo` (mixed
+  case) falls through to the legacy path with a clear deprecation
+  message rather than 404'ing on ClawHub. }
+var
+  i, AtPos: Integer;
+  Slug: string;
+  C: Char;
+begin
+  Result := False;
+  if (Target = '') or (Length(Target) > 128) then Exit;
+  AtPos := Pos('@', Target);
+  if AtPos > 0 then Slug := Copy(Target, 1, AtPos - 1)
+              else Slug := Target;
+  if Slug = '' then Exit;
+  for i := 1 to Length(Slug) do
+  begin
+    C := Slug[i];
+    if not ( ((C >= 'a') and (C <= 'z')) or
+             ((C >= '0') and (C <= '9')) or
+             (C = '-') or (C = '_') ) then Exit;
+  end;
+  Result := True;
+end;
+
+procedure SplitSlugAtVersion(const Target: string; out Slug, Version: string);
+var
+  AtPos: Integer;
+begin
+  AtPos := Pos('@', Target);
+  if AtPos > 0 then
+  begin
+    Slug    := Copy(Target, 1, AtPos - 1);
+    Version := Copy(Target, AtPos + 1, MaxInt);
+  end
+  else
+  begin
+    Slug    := Target;
+    Version := '';
+  end;
 end;
 
 function DoList: Integer;
@@ -128,13 +179,76 @@ begin
   end;
 end;
 
+function DoInstallClawHub(const Target: string): Integer;
+var
+  Slug, Version, DestRoot, Installed, ErrMsg: string;
+begin
+  SplitSlugAtVersion(Target, Slug, Version);
+  DestRoot := JoinPath(GetHome, 'workspace/skills');
+  if Version <> '' then
+    WriteLn('Fetching clawhub:', Slug, ' @', Version, ' …')
+  else
+    WriteLn('Fetching clawhub:', Slug, ' …');
+  if not InstallFromClawHub(Slug, Version, DestRoot, Installed, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'install failed: ', ErrMsg);
+    Exit(1);
+  end;
+  WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'installed as ',
+          JoinPath(DestRoot, Installed));
+  WriteLn('  Run ', Ansi.Bold, 'pasclaw skills list', Ansi.Reset,
+          ' to confirm; next ', Ansi.Bold, 'pasclaw agent', Ansi.Reset,
+          ' invocation will pick it up.');
+  Result := 0;
+end;
+
 function DoInstall(const Argv: array of string): Integer;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
   if IsGitHubTarget(Argv[1]) then
     Result := DoInstallGitHub(Argv[1])
+  else if IsClawHubSlug(Argv[1]) then
+    Result := DoInstallClawHub(Argv[1])
   else
     Result := DoInstallLegacy(Argv);
+end;
+
+function DoSearch(const Argv: array of string): Integer;
+var
+  Query, ErrMsg: string;
+  Results: TClawHubResultArray;
+  i: Integer;
+  Summary: string;
+begin
+  if Length(Argv) < 2 then
+  begin
+    WriteLn('Usage: pasclaw skills search <query>');
+    Exit(1);
+  end;
+  Query := Argv[1];
+  WriteLn('Searching clawhub: ', Query, ' …');
+  if not SearchClawHub(Query, 20, Results, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'search failed: ', ErrMsg);
+    Exit(1);
+  end;
+  if Length(Results) = 0 then
+  begin
+    WriteLn('(no matches)');
+    Exit(0);
+  end;
+  WriteLn(Ansi.Bold, 'slug', Ansi.Reset, '                       version    name');
+  for i := 0 to High(Results) do
+  begin
+    WriteLn(Results[i].Slug:26, '  ', Results[i].Version:9, '  ', Results[i].DisplayName);
+    Summary := Trim(Results[i].Summary);
+    if Summary <> '' then
+      WriteLn('                            ', Ansi.Dim, Summary, Ansi.Reset);
+  end;
+  WriteLn;
+  WriteLn(Ansi.Dim, 'Install with: ', Ansi.Reset,
+          Ansi.Bold, 'pasclaw skills install <slug>', Ansi.Reset);
+  Result := 0;
 end;
 
 procedure RemoveSkillDir(const Dir: string);
@@ -248,6 +362,7 @@ begin
   if      Sub = 'list'    then Result := DoList
   else if Sub = 'install' then Result := DoInstall(Argv)
   else if Sub = 'remove'  then Result := DoRemove(Argv)
+  else if Sub = 'search'  then Result := DoSearch(Argv)
   else begin Help; Result := 1; end;
 end;
 

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -197,6 +197,7 @@
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.Loader.pas"/>
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.Zip.pas"/>
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.GitHub.pas"/>
+        <DCCReference Include="..\pkg\skills\PasClaw.Skills.ClawHub.pas"/>
 
         <!-- pkg/agent -->
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Prompt.pas"/>

--- a/src/pkg/skills/PasClaw.Skills.ClawHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.ClawHub.pas
@@ -186,13 +186,28 @@ begin
   LogDebug('clawhub: GET %s', [URL]);
   if not DoGetJSON(URL, Body, ErrMsg) then Exit;
 
-  Root := TJsonObject.Parse(Body);
-  if Root = nil then
-  begin
-    ErrMsg := 'malformed JSON response';
-    Exit;
-  end;
+  { Same EPasClawJSON guard as FetchMetadata: TJsonObject.Parse
+    raises rather than returning nil, so a bad-bytes-from-server
+    case would otherwise propagate up to Cmd.Skills as an
+    unhandled exception. Here a parse failure IS a search error
+    (unlike the metadata path, which is best-effort), so surface
+    it through ErrMsg. }
+  Root := nil;
   try
+    try
+      Root := TJsonObject.Parse(Body);
+    except
+      on E: Exception do
+      begin
+        ErrMsg := 'malformed JSON response: ' + E.Message;
+        Exit;
+      end;
+    end;
+    if Root = nil then
+    begin
+      ErrMsg := 'malformed JSON response';
+      Exit;
+    end;
     Arr := Root.ChildArray('results');
     if Arr = nil then Exit(True);   { empty result set, not an error }
     try
@@ -241,9 +256,23 @@ begin
     LogDebug('clawhub: metadata fetch failed (%s) — proceeding without it', [Err]);
     Exit;
   end;
-  Root := TJsonObject.Parse(Body);
-  if Root = nil then Exit;
+  { TJsonObject.Parse raises EPasClawJSON on malformed JSON rather
+    than returning nil. The metadata fetch is best-effort — a
+    parsing failure should leave LatestVersion / Blocked /
+    Suspicious at their defaults and let the install continue. }
+  Root := nil;
   try
+    try
+      Root := TJsonObject.Parse(Body);
+    except
+      on E: Exception do
+      begin
+        LogDebug('clawhub: metadata JSON parse failed (%s) — proceeding without it',
+                 [E.Message]);
+        Exit;
+      end;
+    end;
+    if Root = nil then Exit;
     LV := Root.ChildObject('latestVersion');
     if LV <> nil then
     try

--- a/src/pkg/skills/PasClaw.Skills.ClawHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.ClawHub.pas
@@ -1,0 +1,488 @@
+(*
+  PasClaw.Skills.ClawHub - install / search skills from the public
+  ClawHub registry (https://clawhub.ai), the slug-based hub that
+  picoclaw and nanobot standardised on.
+
+  Endpoints (the same paths picoclaw's clawhub_registry.go targets):
+
+    GET /api/v1/search?q=<query>&limit=<n>
+       {"results":[{"score":0.91, "slug":"code-review",
+                    "displayName":"Code review",
+                    "summary":"Static review …",
+                    "version":"1.2.3"}, …]}
+
+    GET /api/v1/skills/<slug>
+       {"slug":"code-review",
+        "displayName":"Code review",
+        "summary":"…",
+        "latestVersion":{"version":"1.2.3"},
+        "moderation":{"isMalwareBlocked":false,"isSuspicious":false}}
+
+    GET /api/v1/download?slug=<slug>&version=<version>
+       application/zip
+
+  No authentication is required for the public skill catalogue;
+  ClawHubConfig.AuthToken (picoclaw's term) is reserved for private
+  skill packs and not exposed here.
+
+  Install pipeline:
+    1. Parse slug + optional @version.
+    2. (Optional) fetch metadata so we can warn about
+       moderation flags. Failure to fetch metadata does not block
+       the install — picoclaw treats the metadata fetch as advisory.
+    3. Refuse if the destination directory already exists.
+    4. GET the zip into a temp file (`download` endpoint).
+    5. Extract through PasClaw.Skills.Zip.
+    6. Validate by re-parsing the installed SKILL.md.
+    7. Copy the extracted tree into workspace/skills/<slug>/.
+
+  Output sharing the PasClaw.Skills.GitHub shape lets Cmd.Skills
+  dispatch on the target form (slug vs owner/repo vs local) and
+  delegate without each path knowing the other exists.
+*)
+unit PasClaw.Skills.ClawHub;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+type
+  TClawHubResult = record
+    Slug:        string;
+    DisplayName: string;
+    Summary:     string;
+    Version:     string;
+    Score:       Double;
+  end;
+  TClawHubResultArray = array of TClawHubResult;
+
+function SearchClawHub(const Query: string; Limit: Integer;
+                       out Results: TClawHubResultArray;
+                       out ErrMsg: string): Boolean;
+
+function InstallFromClawHub(const Slug, Version, DestRoot: string;
+                            out InstalledName, ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  SysUtils, Classes, DateUtils,
+  {$IFNDEF FPC}
+  System.IOUtils,
+  {$ENDIF}
+  PasClaw.Utils,
+  PasClaw.Logger,
+  PasClaw.JSON,
+  PasClaw.Providers.HTTP,
+  PasClaw.Skills.Zip,
+  PasClaw.Skills.Loader;
+
+const
+  ClawHubBaseURL  = 'https://clawhub.ai';
+  SearchEndpoint  = '/api/v1/search';
+  SkillsEndpoint  = '/api/v1/skills';
+  DownloadEndpoint = '/api/v1/download';
+  MaxZipBytes     = 64 * 1024 * 1024;
+
+function PlatformTempDir: string;
+begin
+  {$IFDEF FPC}
+  Result := GetTempDir;
+  {$ELSE}
+  Result := TPath.GetTempPath;
+  {$ENDIF}
+end;
+
+function UniqueSuffix: string;
+begin
+  Result := Format('%d-%d',
+                   [MilliSecondsBetween(Now, EncodeDate(1970, 1, 1)),
+                    Random(1 shl 30)]);
+end;
+
+function UrlEncode(const S: string): string;
+{ Minimal percent-encoder for query-string values. Encodes everything
+  outside the URL-safe set per RFC 3986; conservative is fine here. }
+var
+  i: Integer;
+  C: Char;
+begin
+  Result := '';
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if ((C >= 'A') and (C <= 'Z')) or
+       ((C >= 'a') and (C <= 'z')) or
+       ((C >= '0') and (C <= '9')) or
+       (C = '-') or (C = '_') or (C = '.') or (C = '~') then
+      Result := Result + C
+    else
+      Result := Result + Format('%%%2.2X', [Ord(C)]);
+  end;
+end;
+
+function IsValidSlug(const S: string): Boolean;
+{ ClawHub slugs are lowercase-alphanumeric with optional hyphens or
+  underscores. Reject anything else early so we do not turn a typo
+  into a 404 round-trip. Matches picoclaw's ValidateSkillIdentifier
+  in spirit. }
+var
+  i: Integer;
+  C: Char;
+begin
+  Result := False;
+  if (S = '') or (Length(S) > 128) then Exit;
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if not ( ((C >= 'a') and (C <= 'z')) or
+             ((C >= '0') and (C <= '9')) or
+             (C = '-') or (C = '_') ) then Exit;
+  end;
+  Result := True;
+end;
+
+function DoGetJSON(const URL: string; out Body, ErrMsg: string): Boolean;
+var
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Headers, 0);
+  Resp := GetJSONURL(URL, Headers, 30);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    if Resp.StatusCode = 404 then ErrMsg := 'not found'
+    else if Resp.ErrorMsg <> '' then ErrMsg := Format('http %d: %s', [Resp.StatusCode, Resp.ErrorMsg])
+    else ErrMsg := Format('http %d', [Resp.StatusCode]);
+    Exit;
+  end;
+  Body := Resp.Body;
+  Result := True;
+end;
+
+function SearchClawHub(const Query: string; Limit: Integer;
+                       out Results: TClawHubResultArray;
+                       out ErrMsg: string): Boolean;
+var
+  URL, Body, S: string;
+  Root: TJsonObject;
+  Arr: TJsonArray;
+  Item: TJsonObject;
+  i: Integer;
+  Res: TClawHubResult;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Results, 0);
+  if Trim(Query) = '' then begin ErrMsg := 'empty query'; Exit; end;
+  if Limit <= 0 then Limit := 10;
+
+  URL := ClawHubBaseURL + SearchEndpoint +
+         '?q=' + UrlEncode(Query) +
+         '&limit=' + IntToStr(Limit);
+  LogDebug('clawhub: GET %s', [URL]);
+  if not DoGetJSON(URL, Body, ErrMsg) then Exit;
+
+  Root := TJsonObject.Parse(Body);
+  if Root = nil then
+  begin
+    ErrMsg := 'malformed JSON response';
+    Exit;
+  end;
+  try
+    Arr := Root.ChildArray('results');
+    if Arr = nil then Exit(True);   { empty result set, not an error }
+    try
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          S := Item.GetStr('slug', '');
+          if S = '' then Continue;
+          Res.Slug        := S;
+          Res.DisplayName := Item.GetStr('displayName', S);
+          Res.Summary     := Item.GetStr('summary',     '');
+          Res.Version     := Item.GetStr('version',     '');
+          Res.Score       := Item.GetFloat('score',     0);
+          SetLength(Results, Length(Results) + 1);
+          Results[High(Results)] := Res;
+        finally
+          Item.Free;
+        end;
+      end;
+    finally
+      Arr.Free;
+    end;
+    Result := True;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure FetchMetadata(const Slug: string; out LatestVersion: string;
+                       out Blocked, Suspicious: Boolean);
+{ Best-effort. Failure to fetch (network, 404, malformed JSON) leaves
+  the out values at defaults: LatestVersion = '', Blocked = False,
+  Suspicious = False. The caller treats the metadata as advisory. }
+var
+  URL, Body, Err: string;
+  Root, LV, Mod_: TJsonObject;
+begin
+  LatestVersion := '';
+  Blocked       := False;
+  Suspicious    := False;
+  URL := ClawHubBaseURL + SkillsEndpoint + '/' + UrlEncode(Slug);
+  if not DoGetJSON(URL, Body, Err) then
+  begin
+    LogDebug('clawhub: metadata fetch failed (%s) — proceeding without it', [Err]);
+    Exit;
+  end;
+  Root := TJsonObject.Parse(Body);
+  if Root = nil then Exit;
+  try
+    LV := Root.ChildObject('latestVersion');
+    if LV <> nil then
+    try
+      LatestVersion := LV.GetStr('version', '');
+    finally
+      LV.Free;
+    end;
+    Mod_ := Root.ChildObject('moderation');
+    if Mod_ <> nil then
+    try
+      Blocked    := Mod_.GetBool('isMalwareBlocked', False);
+      Suspicious := Mod_.GetBool('isSuspicious',     False);
+    finally
+      Mod_.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+function DownloadZip(const URL, DestPath: string; out ErrMsg: string): Boolean;
+var
+  Strm: TFileStream;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Headers, 0);
+  Strm := TFileStream.Create(DestPath, fmCreate);
+  try
+    Resp := GetURLToStream(URL, Strm, Headers, 60);
+    if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+    begin
+      if Resp.StatusCode = 404 then ErrMsg := 'not found'
+      else if Resp.ErrorMsg <> '' then ErrMsg := Format('http %d: %s', [Resp.StatusCode, Resp.ErrorMsg])
+      else ErrMsg := Format('http %d', [Resp.StatusCode]);
+      Exit;
+    end;
+    if Strm.Size > MaxZipBytes then
+    begin
+      ErrMsg := Format('archive too large (%d bytes; cap %d)',
+                       [Strm.Size, MaxZipBytes]);
+      Exit;
+    end;
+    if Strm.Size = 0 then begin ErrMsg := 'empty archive'; Exit; end;
+    Result := True;
+  finally
+    Strm.Free;
+  end;
+end;
+
+procedure CopyTree(const SrcDir, DstDir: string);
+
+  procedure CopyOne(const From_, To_: string);
+  var
+    A, B: TFileStream;
+  begin
+    A := TFileStream.Create(From_, fmOpenRead or fmShareDenyWrite);
+    try
+      B := TFileStream.Create(To_, fmCreate);
+      try
+        if A.Size > 0 then B.CopyFrom(A, A.Size);
+      finally
+        B.Free;
+      end;
+    finally
+      A.Free;
+    end;
+  end;
+
+  procedure Walk(const FromDir, ToDir: string);
+  var
+    SR: TSearchRec;
+    Src, Dst: string;
+  begin
+    ForceDirectories(ToDir);
+    if FindFirst(JoinPath(FromDir, '*'), faAnyFile, SR) <> 0 then Exit;
+    try
+      repeat
+        if (SR.Name = '.') or (SR.Name = '..') then Continue;
+        Src := JoinPath(FromDir, SR.Name);
+        Dst := JoinPath(ToDir,   SR.Name);
+        if (SR.Attr and faDirectory) <> 0 then Walk(Src, Dst)
+        else CopyOne(Src, Dst);
+      until FindNext(SR) <> 0;
+    finally
+      FindClose(SR);
+    end;
+  end;
+
+begin
+  Walk(SrcDir, DstDir);
+end;
+
+procedure RemoveTree(const Dir: string);
+var
+  SR: TSearchRec;
+  Path: string;
+begin
+  if not DirectoryExists(Dir) then Exit;
+  if FindFirst(JoinPath(Dir, '*'), faAnyFile, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Path := JoinPath(Dir, SR.Name);
+      if (SR.Attr and faDirectory) <> 0 then RemoveTree(Path)
+      else try DeleteFile(Path); except end;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  try RemoveDir(Dir); except end;
+end;
+
+function FindSkillRoot(const ExtractDir: string): string;
+{ ClawHub archives, like GitHub's codeload, wrap entries in a single
+  top-level directory. Return its path. If there is no wrapper (the
+  zip has SKILL.md at its root) return ExtractDir verbatim. }
+var
+  SR: TSearchRec;
+  Found, SkillMdAtRoot: Boolean;
+  Candidate: string;
+begin
+  Result := ExtractDir;
+  SkillMdAtRoot := FileExists(JoinPath(ExtractDir, 'SKILL.md'));
+  if SkillMdAtRoot then Exit;
+  Found := False;
+  if FindFirst(JoinPath(ExtractDir, '*'), faDirectory, SR) <> 0 then Exit;
+  try
+    repeat
+      if (SR.Attr and faDirectory) = 0 then Continue;
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Candidate := JoinPath(ExtractDir, SR.Name);
+      if FileExists(JoinPath(Candidate, 'SKILL.md')) then
+      begin
+        Result := Candidate;
+        Found := True;
+        Break;
+      end;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  if not Found then Result := '';
+end;
+
+function InstallFromClawHub(const Slug, Version, DestRoot: string;
+                            out InstalledName, ErrMsg: string): Boolean;
+var
+  URL, TempBase, ZipPath, ExtractDir, SrcDir, DstDir: string;
+  EffectiveVersion, LatestVersion: string;
+  Blocked, Suspicious: Boolean;
+  Spec: TSkillSpec;
+  ParseErr: string;
+begin
+  Result := False;
+  InstalledName := '';
+  ErrMsg := '';
+
+  if not IsValidSlug(Slug) then
+  begin
+    ErrMsg := Format('invalid clawhub slug "%s" — expected lowercase ' +
+                     'letters, digits, "-", and "_" only', [Slug]);
+    Exit;
+  end;
+
+  InstalledName := Slug;
+  DstDir := JoinPath(DestRoot, InstalledName);
+  if DirectoryExists(DstDir) then
+  begin
+    ErrMsg := Format('skill "%s" already exists at %s — remove it first',
+                     [InstalledName, DstDir]);
+    Exit;
+  end;
+  if not ForceDirectories(DestRoot) then
+  begin
+    ErrMsg := 'cannot create skills root: ' + DestRoot;
+    Exit;
+  end;
+
+  { Metadata fetch is advisory — failure does not block the install,
+    but a successful fetch lets us reject malware-flagged skills and
+    surface the latest version when the caller did not pin one. }
+  FetchMetadata(Slug, LatestVersion, Blocked, Suspicious);
+  if Blocked then
+  begin
+    ErrMsg := Format('clawhub flagged "%s" as malware — refusing install', [Slug]);
+    Exit;
+  end;
+  if Suspicious then
+    LogWarn('clawhub: "%s" is flagged as suspicious — proceeding anyway', [Slug]);
+
+  EffectiveVersion := Version;
+  if (EffectiveVersion = '') and (LatestVersion <> '') then
+    EffectiveVersion := LatestVersion;
+
+  URL := ClawHubBaseURL + DownloadEndpoint + '?slug=' + UrlEncode(Slug);
+  if (EffectiveVersion <> '') and not SameText(EffectiveVersion, 'latest') then
+    URL := URL + '&version=' + UrlEncode(EffectiveVersion);
+
+  TempBase := JoinPath(PlatformTempDir, 'pasclaw-clawhub-' + UniqueSuffix);
+  if not ForceDirectories(TempBase) then
+  begin
+    ErrMsg := 'cannot create temp dir: ' + TempBase;
+    Exit;
+  end;
+  ZipPath    := JoinPath(TempBase, 'archive.zip');
+  ExtractDir := JoinPath(TempBase, 'extracted');
+  try
+    LogDebug('clawhub: GET %s', [URL]);
+    if not DownloadZip(URL, ZipPath, ErrMsg) then
+    begin
+      ErrMsg := 'download failed: ' + ErrMsg;
+      Exit;
+    end;
+    if not ExtractZipToDir(ZipPath, ExtractDir, ErrMsg) then Exit;
+
+    SrcDir := FindSkillRoot(ExtractDir);
+    if SrcDir = '' then
+    begin
+      ErrMsg := 'archive has no SKILL.md (neither at root nor in a single top-level directory)';
+      Exit;
+    end;
+
+    if not ParseSkillMD(JoinPath(SrcDir, 'SKILL.md'), Spec, ParseErr) then
+    begin
+      ErrMsg := 'SKILL.md is invalid: ' + ParseErr;
+      Exit;
+    end;
+
+    CopyTree(SrcDir, DstDir);
+    LogInfo('clawhub: installed %s (v=%s) at %s',
+            [Slug, EffectiveVersion, DstDir]);
+    Result := True;
+  finally
+    RemoveTree(TempBase);
+    if (not Result) and DirectoryExists(DstDir) then RemoveTree(DstDir);
+  end;
+end;
+
+end.


### PR DESCRIPTION
Phase 3 of the 4-PR skills roadmap. After #55 (SKILL.md format) and #56 (GitHub install), this PR ships the **ClawHub** slug-based registry — same one picoclaw and nanobot use. Phase 4 (`scripts/` + `references/` runtime) stacks next.

## New surface

```sh
pasclaw skills install code-review            # ClawHub: latest version
pasclaw skills install code-review@1.2.3      # ClawHub: pinned version
pasclaw skills search "code review"           # ClawHub: search
```

## Pipeline (`PasClaw.Skills.ClawHub`)

1. **Validate slug** (lowercase alphanumerics + `-`/`_`) before any network round-trip
2. **Refuse if destination exists** — `pasclaw skills remove <slug>` first
3. **Best-effort metadata fetch** (`GET /api/v1/skills/<slug>`) for moderation flags + `latestVersion`:
   - `isMalwareBlocked: true` → refuse install
   - `isSuspicious: true` → warn and proceed
   - Metadata fetch failure → advisory, proceed without it (picoclaw does the same)
4. **Resolve version**: caller's pin → metadata's `latestVersion` → `latest`
5. **Download** `GET /api/v1/download?slug=<slug>&version=<version>` to a temp zip. 64 MiB cap.
6. **Extract** via `PasClaw.Skills.Zip` (`Zipper.TUnZipper` ↔ `System.Zip.TZipFile`)
7. **Find SKILL.md**: at extraction root, or descend into a single top-level wrapper directory (ClawHub archives are inconsistent here; picoclaw's extractor tolerates both)
8. **Validate** by re-parsing the SKILL.md through `ParseSkillMD`
9. **Copy** the tree into `workspace/skills/<slug>/`. Cleans up temp dir always; removes partial destination on failure

## Search (`SearchClawHub`)

Decodes the `{results:[{slug,displayName,summary,version,score}]}` envelope into a `TClawHubResultArray`. Missing fields fall back gracefully. Empty response and an empty result array are distinct from an HTTP error.

## CLI dispatch order (`Cmd.Skills`)

```
IsGitHubTarget(target)  → InstallFromGitHub    (owner/repo[/path][@ref])
IsClawHubSlug(target)   → InstallFromClawHub   (lowercase slug[@version])
otherwise               → legacy config-only flow
```

`IsClawHubSlug` enforces the same character set ClawHub validates server-side so `pasclaw skills install Foo` (mixed case) falls through to the legacy path with a clear deprecation message rather than 404'ing on ClawHub.

New `pasclaw skills search <query>` subcommand prints slug / version / displayName / summary in a tabular layout with a pointer at `pasclaw skills install <slug>` for installation.

## Trade-offs

The `CopyTree` / `RemoveTree` / `DownloadZip` helpers are intentionally local to this unit rather than extracted into a `Skills.Shared` — keeping each registry independent reads better and the duplication is ~80 LOC across two units. If a fourth registry shows up that would tip the balance toward a shared helper.

## Not in this PR (Phase 4)

`scripts/` (auto-callable helpers; agent invokes via `shell_exec` in the sandbox) + `references/` (path-only in system prompt; loaded into context on demand via `fs_read`) runtime support. Stacked as the next PR — needs the SKILL.md parser to walk the per-skill directory rather than just parse the file.

## Test plan

- [ ] FPC build (`make`) + Delphi `.dproj` build cleanly
- [ ] `pasclaw skills search code` — prints any matching results from the live ClawHub
- [ ] `pasclaw skills search asdfasdfnomatch12345` — prints `(no matches)`
- [ ] `pasclaw skills install <real-slug-from-search>` — succeeds; `pasclaw skills list` shows the new entry
- [ ] `pasclaw skills install nonexistent-slug` — fails with `download failed: not found`, no temp files left over
- [ ] `pasclaw skills install Foo` (mixed case) — falls through to the legacy config-only path with the existing deprecation hint
- [ ] `pasclaw skills install owner/repo` — still routes to the GitHub installer (PR #56 path unchanged)
- [ ] `pasclaw skills install code-review@<real-version>` — pins version; `latest` resolution unaffected
- [ ] Existing `skills list` / `skills remove` paths unchanged

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_