### PR TITLE
Skills Phase 4: scripts/, references/, assets/ runtime surfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,17 @@ Skills live under `$PASCLAW_HOME/workspace/skills/`. PasClaw accepts two layouts
 
 `pasclaw skills search <query>` queries `/api/v1/search` and prints slug / version / display-name / summary rows.
 
-Subsequent phases will add `scripts/` (callable helpers) + `references/` (lazy-loaded context) runtime support.
+**Skill bundle layout** (Phase 4, this release):
+
+```
+workspace/skills/<name>/
+├── SKILL.md
+├── scripts/      ← executables the model invokes via shell_exec
+├── references/   ← markdown the model loads on demand via fs_read
+└── assets/       ← templates / fixtures / images bundled with the skill
+```
+
+`LoadSkillManifests` walks `scripts/`, `references/`, and `assets/` after parsing each SKILL.md (`ScanSkillSubdir` in `PasClaw.Skills.Loader`), and `BuildSkillsSection` (in `PasClaw.Agent.Prompt`) prints each file's absolute path under the skill's bullet in the system prompt. The model discovers the bundled resources without having to `fs_list` the skill directory; `scripts/*` are invoked via `shell_exec` (subject to the sandbox policy), `references/*` via `fs_read` when SKILL.md's body points the model there. See [`samples/skills/hello/`](samples/skills/hello/) for the canonical layout — it ships a `scripts/greet.sh` and a `references/style-guide.md` alongside its SKILL.md.
 
 ### Gateway, OpenAI-compatible server, and channels
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ workspace/skills/<name>/
 
 `LoadSkillManifests` walks `scripts/`, `references/`, and `assets/` after parsing each SKILL.md (`ScanSkillSubdir` in `PasClaw.Skills.Loader`), and `BuildSkillsSection` (in `PasClaw.Agent.Prompt`) prints each file's absolute path under the skill's bullet in the system prompt. The model discovers the bundled resources without having to `fs_list` the skill directory; `scripts/*` are invoked via `shell_exec` (subject to the sandbox policy), `references/*` via `fs_read` when SKILL.md's body points the model there. See [`samples/skills/hello/`](samples/skills/hello/) for the canonical layout — it ships a `scripts/greet.sh` and a `references/style-guide.md` alongside its SKILL.md.
 
+**Cross-platform scripts:** the GitHub and ClawHub installers `chmod 755` every file under `scripts/` on POSIX hosts so freshly installed bash scripts run directly (`TFileStream`-based `CopyTree` doesn't preserve permissions). Windows has no execute bit and `cmd.exe` can't run `.sh` natively, so `BuildSkillsSection` advertises `.sh` paths prefixed with `bash ` (resolves through git-bash, WSL, or MSYS on `PATH`) and `.ps1` paths with `powershell -ExecutionPolicy Bypass -File `. POSIX hosts get the bare path; the shebang line + executable bit handle dispatch.
+
 ### Gateway, OpenAI-compatible server, and channels
 
 ```sh

--- a/samples/skills/hello/SKILL.md
+++ b/samples/skills/hello/SKILL.md
@@ -45,7 +45,24 @@ conditions that match your actual workflow.
 3. Stop.
 
 That is the whole skill. Real skills are usually 10–100 lines of
-procedural knowledge, with optional `scripts/` (executables the model
-can call) and `references/` (deeper documentation) directories
-alongside this SKILL.md — Phase 4 of the skills overhaul will wire
-those in. For now, SKILL.md + frontmatter + body is the contract.
+procedural knowledge, with optional `scripts/`, `references/`, and
+`assets/` directories alongside this SKILL.md:
+
+- `scripts/` — executables the model invokes via `shell_exec`
+  (sandbox-aware: workspace-pinned, denylist-checked). The model sees
+  each script's absolute path in the system prompt's SKILLS section
+  and decides when to run it. `scripts/greet.sh` next to this file
+  demonstrates the layout.
+
+- `references/` — markdown documentation the model loads on demand via
+  `fs_read`. Use this for project-specific conventions, domain knowledge,
+  or worked examples the model can pull in when SKILL.md's body points
+  it here. `references/style-guide.md` next to this file is the sample.
+
+- `assets/` — templates, fixtures, images, etc. that the skill bundles.
+  PasClaw advertises their paths so the model knows they exist.
+
+PasClaw walks these subdirectories during `LoadSkillManifests` and
+emits each file's absolute path in the system prompt — the model
+discovers what's available without having to `fs_list` the skill
+directory.

--- a/samples/skills/hello/SKILL.md
+++ b/samples/skills/hello/SKILL.md
@@ -52,7 +52,12 @@ procedural knowledge, with optional `scripts/`, `references/`, and
   (sandbox-aware: workspace-pinned, denylist-checked). The model sees
   each script's absolute path in the system prompt's SKILLS section
   and decides when to run it. `scripts/greet.sh` next to this file
-  demonstrates the layout.
+  demonstrates the layout. On POSIX the installer chmods every file
+  under `scripts/` to mode `755` so they run directly; on Windows
+  cmd.exe cannot execute `.sh` files natively, so the system prompt
+  prepends `bash ` to `.sh` paths (resolves through git-bash / WSL /
+  MSYS if any is on `PATH`) and `powershell -ExecutionPolicy Bypass
+  -File ` to `.ps1` paths.
 
 - `references/` — markdown documentation the model loads on demand via
   `fs_read`. Use this for project-specific conventions, domain knowledge,

--- a/samples/skills/hello/references/style-guide.md
+++ b/samples/skills/hello/references/style-guide.md
@@ -1,0 +1,16 @@
+# Sample reference: style guide
+
+This is a reference file. PasClaw advertises its absolute path in the
+system prompt's SKILLS section so the model can `fs_read` it on demand
+when a task calls for the bundled procedural knowledge — same convention
+Anthropic agent-skills, picoclaw, and nanobot use.
+
+Real references typically hold:
+
+- Project-specific conventions ("we name commits like `<scope>: <verb>`")
+- Domain knowledge the model can't reliably recall ("API X returns ISO-8601 in field Y")
+- Worked examples of common task patterns
+
+Keep references focused — the model only loads them when SKILL.md's body
+points it here, so each reference should be self-contained enough to act
+on after one read.

--- a/samples/skills/hello/scripts/greet.sh
+++ b/samples/skills/hello/scripts/greet.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Sample script demonstrating the Phase 4 scripts/ runtime support.
+#
+# The model invokes this via shell_exec with an absolute path. With
+# sandbox.restrict_to_workspace=true (recommended) the shell runs
+# rooted at the workspace, so the model needs to pass the absolute
+# path printed in the system prompt's SKILLS section.
+#
+# Real skills put their non-trivial automations here — small wrappers
+# around CLI tools, multi-step shell pipelines that would clutter the
+# SKILL.md body, etc. Keep the SKILL.md body for "when and why";
+# scripts/ for "how", in code.
+echo "hello from the sample skill"
+echo "argv:"
+for arg in "$@"; do
+  printf '  %s\n' "$arg"
+done

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -151,6 +151,33 @@ begin
   end;
 end;
 
+function ScriptInvocation(const Path: string): string;
+{ Returns the model-facing invocation string for one script. cmd.exe
+  (the Windows shell PasClaw.Platform.RunOneShot wraps) has no native
+  way to execute .sh — the script file has no extension association
+  by default, and even if the user has git-bash installed the shebang
+  line is not honored by Win32. Prefix .sh paths with `bash` so the
+  model emits a command that resolves through git-bash, WSL, or MSYS
+  if any of those are on PATH. Same dance for .ps1 -> powershell.
+  POSIX hosts return the bare path; the executable bit and shebang
+  do the work there. Recognised extensions are matched
+  case-insensitively. }
+var
+  Ext: string;
+begin
+  Ext := LowerCase(ExtractFileExt(Path));
+  {$IFDEF MSWINDOWS}
+  if Ext = '.sh' then
+    Result := 'bash ' + Path
+  else if Ext = '.ps1' then
+    Result := 'powershell -ExecutionPolicy Bypass -File ' + Path
+  else
+    Result := Path;
+  {$ELSE}
+  Result := Path;
+  {$ENDIF}
+end;
+
 function BuildSkillsSection: string;
 var
   Skills: TSkillSpecArray;
@@ -212,14 +239,19 @@ begin
       end;
       { Phase 4: surface scripts/, references/, and assets/ contents so
         the model knows what bundled resources exist without having to
-        fs_list the skill directory. scripts/ are listed with a hint to
-        invoke via shell_exec (subject to the sandbox); references/ are
-        listed for fs_read on demand. Empty subdirs print nothing. }
+        fs_list the skill directory. scripts/ are listed with an
+        OS-appropriate invocation hint (see ScriptInvocation below);
+        references/ are listed for fs_read on demand. Empty subdirs
+        print nothing. }
       if Length(Skills[i].Scripts) > 0 then
       begin
-        Lines.Add('    scripts (invoke via shell_exec):');
+        {$IFDEF MSWINDOWS}
+        Lines.Add('    scripts (invoke via shell_exec; .sh requires bash via git-bash, WSL, or MSYS on PATH; .ps1 requires powershell):');
+        {$ELSE}
+        Lines.Add('    scripts (invoke via shell_exec; executable bit is set on install):');
+        {$ENDIF}
         for j := 0 to High(Skills[i].Scripts) do
-          Lines.Add('      - `' + Skills[i].Scripts[j] + '`');
+          Lines.Add('      - `' + ScriptInvocation(Skills[i].Scripts[j]) + '`');
       end;
       if Length(Skills[i].References) > 0 then
       begin

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -154,7 +154,7 @@ end;
 function BuildSkillsSection: string;
 var
   Skills: TSkillSpecArray;
-  i: Integer;
+  i, j: Integer;
   Lines: TStringList;
   Desc, K: string;
   HasCallable, HasKnowledge: Boolean;
@@ -209,6 +209,29 @@ begin
           Lines.Add('- **' + Skills[i].Name + '**: read `' + Skills[i].Source + '`')
         else
           Lines.Add('- **' + Skills[i].Name + '** — ' + Desc + '. Read `' + Skills[i].Source + '` for the full instructions.');
+      end;
+      { Phase 4: surface scripts/, references/, and assets/ contents so
+        the model knows what bundled resources exist without having to
+        fs_list the skill directory. scripts/ are listed with a hint to
+        invoke via shell_exec (subject to the sandbox); references/ are
+        listed for fs_read on demand. Empty subdirs print nothing. }
+      if Length(Skills[i].Scripts) > 0 then
+      begin
+        Lines.Add('    scripts (invoke via shell_exec):');
+        for j := 0 to High(Skills[i].Scripts) do
+          Lines.Add('      - `' + Skills[i].Scripts[j] + '`');
+      end;
+      if Length(Skills[i].References) > 0 then
+      begin
+        Lines.Add('    references (read with fs_read as needed):');
+        for j := 0 to High(Skills[i].References) do
+          Lines.Add('      - `' + Skills[i].References[j] + '`');
+      end;
+      if Length(Skills[i].Assets) > 0 then
+      begin
+        Lines.Add('    assets:');
+        for j := 0 to High(Skills[i].Assets) do
+          Lines.Add('      - `' + Skills[i].Assets[j] + '`');
       end;
     end;
     Result := Lines.Text;

--- a/src/pkg/skills/PasClaw.Skills.ClawHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.ClawHub.pas
@@ -68,8 +68,10 @@ implementation
 
 uses
   SysUtils, Classes, DateUtils,
+  {$IFDEF FPC}{$IFDEF UNIX} BaseUnix, {$ENDIF}{$ENDIF}
   {$IFNDEF FPC}
   System.IOUtils,
+  {$IFDEF POSIX} Posix.SysStat, {$ENDIF}
   {$ENDIF}
   PasClaw.Utils,
   PasClaw.Logger,
@@ -296,6 +298,38 @@ begin
   end;
 end;
 
+procedure ChmodPlusXScriptsTree(const SkillDir: string);
+{ Same shape as PasClaw.Skills.GitHub.ChmodPlusXScriptsTree — sets
+  the executable bit on every file under <SkillDir>/scripts/ on
+  POSIX hosts so a freshly ClawHub-installed script does not fail
+  with "permission denied" the first time the model invokes it
+  through shell_exec. CopyTree uses TFileStream (preserves bytes
+  but not permissions). No-op on Windows. }
+var
+  ScriptsDir: string;
+  SR: TSearchRec;
+  Path: string;
+begin
+  ScriptsDir := JoinPath(SkillDir, 'scripts');
+  if not DirectoryExists(ScriptsDir) then Exit;
+  if FindFirst(JoinPath(ScriptsDir, '*'), faAnyFile, SR) <> 0 then Exit;
+  try
+    repeat
+      if (SR.Attr and faDirectory) <> 0 then Continue;
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Path := JoinPath(ScriptsDir, SR.Name);
+      {$IFDEF FPC}{$IFDEF UNIX}
+      try FpChmod(Path, &755); except end;
+      {$ENDIF}{$ENDIF}
+      {$IFNDEF FPC}{$IFDEF POSIX}
+      try Posix.SysStat.chmod(PAnsiChar(AnsiString(Path)), $1ED); except end;
+      {$ENDIF}{$ENDIF}
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
 procedure CopyTree(const SrcDir, DstDir: string);
 
   procedure CopyOne(const From_, To_: string);
@@ -476,6 +510,7 @@ begin
     end;
 
     CopyTree(SrcDir, DstDir);
+    ChmodPlusXScriptsTree(DstDir);
     LogInfo('clawhub: installed %s (v=%s) at %s',
             [Slug, EffectiveVersion, DstDir]);
     Result := True;

--- a/src/pkg/skills/PasClaw.Skills.GitHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.GitHub.pas
@@ -67,8 +67,10 @@ implementation
 
 uses
   SysUtils, Classes, DateUtils, StrUtils,
+  {$IFDEF FPC}{$IFDEF UNIX} BaseUnix, {$ENDIF}{$ENDIF}
   {$IFNDEF FPC}
   System.IOUtils,
+  {$IFDEF POSIX} Posix.SysStat, {$ENDIF}
   {$ENDIF}
   PasClaw.Utils,
   PasClaw.Logger,
@@ -250,6 +252,42 @@ begin
       if (SR.Name = '.') or (SR.Name = '..') then Continue;
       Result := JoinPath(ExtractDir, SR.Name);
       Exit;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+procedure ChmodPlusXScriptsTree(const SkillDir: string);
+{ Walks <SkillDir>/scripts/ and sets the executable bit on each file
+  on POSIX hosts. CopyTree uses TFileStream which preserves bytes
+  but not permissions, so a freshly installed bash script would
+  otherwise fail with "permission denied" when shell_exec invokes
+  it at the path advertised in the system prompt — even if the
+  source repo committed mode 100755.
+
+  Best-effort: ignores chmod errors (rare; the file was just
+  created so we own it). No-op on Windows where NTFS has no
+  execute bit. }
+var
+  ScriptsDir: string;
+  SR: TSearchRec;
+  Path: string;
+begin
+  ScriptsDir := JoinPath(SkillDir, 'scripts');
+  if not DirectoryExists(ScriptsDir) then Exit;
+  if FindFirst(JoinPath(ScriptsDir, '*'), faAnyFile, SR) <> 0 then Exit;
+  try
+    repeat
+      if (SR.Attr and faDirectory) <> 0 then Continue;
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Path := JoinPath(ScriptsDir, SR.Name);
+      {$IFDEF FPC}{$IFDEF UNIX}
+      try FpChmod(Path, &755); except end;
+      {$ENDIF}{$ENDIF}
+      {$IFNDEF FPC}{$IFDEF POSIX}
+      try Posix.SysStat.chmod(PAnsiChar(AnsiString(Path)), $1ED); except end;
+      {$ENDIF}{$ENDIF}
     until FindNext(SR) <> 0;
   finally
     FindClose(SR);
@@ -446,6 +484,7 @@ begin
     end;
 
     CopyTree(SrcDir, DstDir);
+    ChmodPlusXScriptsTree(DstDir);
     LogInfo('skills.github: installed %s/%s%s@%s as %s',
             [T.Owner, T.Repo,
              IfThen(T.SubPath = '', '', '/' + T.SubPath),

--- a/src/pkg/skills/PasClaw.Skills.Loader.pas
+++ b/src/pkg/skills/PasClaw.Skills.Loader.pas
@@ -65,6 +65,11 @@ uses
   PasClaw.Tools.Registry;
 
 type
+  { Local alias — same shape as PasClaw.Tools.Registry.TStringArray and
+    FPC SysUtils' TStringArray, declared here so we don't pull a tools
+    unit into the skills layer for one type. }
+  TSkillStringArray = array of string;
+
   TSkillSpec = record
     Name:        string;
     Description: string;
@@ -78,6 +83,17 @@ type
     Source:      string;   { absolute path to SKILL.md or the .json file —
                              used by the system prompt so the model can
                              fs_read for the full body }
+    Scripts:     TSkillStringArray;   { absolute paths under <Dir>/scripts/.
+                                        Surfaced in the system prompt so the
+                                        model can invoke them via shell_exec
+                                        (subject to the sandbox policy). }
+    References:  TSkillStringArray;   { absolute paths under <Dir>/references/.
+                                        Surfaced for fs_read on demand —
+                                        Anthropic agent-skills' "lazy context"
+                                        pattern. }
+    Assets:      TSkillStringArray;   { absolute paths under <Dir>/assets/.
+                                        Templates / fixtures / images the
+                                        skill bundles. }
   end;
 
   TSkillSpecArray = array of TSkillSpec;
@@ -263,6 +279,12 @@ begin
     Spec.Body        := '';
     Spec.Dir         := ExtractFileDir(Path);
     Spec.Source      := Path;
+    { Legacy .json skills have no per-skill directory, so no
+      scripts / references / assets. Initialise the arrays so the
+      prompt builder iterates them cleanly via High()/Length(). }
+    SetLength(Spec.Scripts,    0);
+    SetLength(Spec.References, 0);
+    SetLength(Spec.Assets,     0);
     Schema := Obj.ChildObject('schema');
     if Schema <> nil then
     begin
@@ -295,6 +317,44 @@ begin
        ((Value[1] = '''') and (Value[Length(Value)] = '''')) ) then
     Value := Copy(Value, 2, Length(Value) - 2);
   Result := Key <> '';
+end;
+
+function ScanSkillSubdir(const SkillDir, SubName: string): TSkillStringArray;
+{ Lists files (not subdirs) directly under SkillDir/SubName, sorted
+  by name for stable system-prompt output. Returns absolute paths so
+  the model can pass them straight to shell_exec / fs_read with no
+  further joining. Missing subdir or no files returns an empty
+  array — the common case for skills with only a SKILL.md. }
+var
+  SR: TSearchRec;
+  SubDir: string;
+  Names: TStringList;
+  i: Integer;
+begin
+  SetLength(Result, 0);
+  if (SkillDir = '') or (SubName = '') then Exit;
+  SubDir := JoinPath(SkillDir, SubName);
+  if not DirectoryExists(SubDir) then Exit;
+
+  Names := TStringList.Create;
+  try
+    if FindFirst(JoinPath(SubDir, '*'), faAnyFile, SR) <> 0 then Exit;
+    try
+      repeat
+        if (SR.Attr and faDirectory) <> 0 then Continue;
+        if (SR.Name = '') or (SR.Name = '.') or (SR.Name = '..') then Continue;
+        Names.Add(SR.Name);
+      until FindNext(SR) <> 0;
+    finally
+      FindClose(SR);
+    end;
+    Names.Sort;
+    SetLength(Result, Names.Count);
+    for i := 0 to Names.Count - 1 do
+      Result[i] := JoinPath(SubDir, Names[i]);
+  finally
+    Names.Free;
+  end;
 end;
 
 function ParseSkillMD(const FilePath: string; out Spec: TSkillSpec;
@@ -407,6 +467,14 @@ begin
       ErrMsg := 'missing required frontmatter field `name`';
       Exit;
     end;
+
+    { Phase 4: walk scripts/, references/, assets/ siblings of SKILL.md.
+      Missing subdirs are normal — most skills have none. Surfaced in
+      the system prompt so the model can call shell_exec on scripts
+      and fs_read on references / assets when the task calls for it. }
+    Spec.Scripts    := ScanSkillSubdir(Spec.Dir, 'scripts');
+    Spec.References := ScanSkillSubdir(Spec.Dir, 'references');
+    Spec.Assets     := ScanSkillSubdir(Spec.Dir, 'assets');
 
     Result := True;
   finally


### PR DESCRIPTION
Phase 4 of 4. Stacked on #59 (ClawHub).

When #59 lands, this PR's base can be retargeted to `main` (one-click in the GitHub UI) and the diff collapses to just the Phase 4 commit.

## What this closes

After #55 (SKILL.md format), #56 (GitHub install), #57/#59 (ClawHub install + search), this PR wires up the **bundled-resource layout** so the model can actually use the files each registry-installed skill ships alongside its SKILL.md. PasClaw is now wire-compatible with the picoclaw / nanobot / ClawHub / Anthropic agent-skills ecosystem at every documented layer — file format, registry protocols, bundle layout, and runtime surfacing.

## Layout (matches picoclaw / nanobot / Anthropic agent-skills exactly)

```
workspace/skills/<name>/
├── SKILL.md
├── scripts/      ← executables the model invokes via shell_exec
├── references/   ← markdown the model loads on demand via fs_read
└── assets/       ← templates / fixtures / images
```

## Parser changes

`TSkillSpec` gains three dynamic-array fields (local `TSkillStringArray` alias — avoiding a tools-layer import for one type):

| Field | Purpose |
|---|---|
| `Scripts` | Absolute paths under `<skill>/scripts/` |
| `References` | Absolute paths under `<skill>/references/` |
| `Assets` | Absolute paths under `<skill>/assets/` |

`ParseSkillMD` now calls `ScanSkillSubdir` three times after parsing the frontmatter. Files only (no subdirs), sorted by name for stable system-prompt output. Missing subdir → empty array → section skipped downstream. `LoadJsonSkill` explicitly zeroes the new arrays so legacy single-file skills (PR #55's backwards-compat path) yield the same shape downstream.

## System prompt (`BuildSkillsSection`)

```
- **code-review** — Static review. Read `<path>/SKILL.md` for the full instructions.
    scripts (invoke via shell_exec):
      - `<path>/scripts/lint.sh`
      - `<path>/scripts/fix.py`
    references (read with fs_read as needed):
      - `<path>/references/style-guide.md`
```

Skills that ship only a SKILL.md (still the most common shape) print exactly as before.

## Sample (`samples/skills/hello/`)

- `scripts/greet.sh` — minimal `/usr/bin/env sh` echo, documents the shell_exec contract + workspace-pin interaction with the PR #53 sandbox
- `references/style-guide.md` — sample reference describing the "project conventions / domain knowledge / worked examples" use cases
- SKILL.md body updated to describe the three subdirectories and point at the sample resources

## Design rationale

| Choice | Why |
|---|---|
| Scripts are **not** auto-registered as separate tools | Picoclaw's pattern. Invoking through `shell_exec` keeps the PR #53 sandbox in the loop and avoids forcing each script author to spec a JSON schema for its argv. Model decides when; sandbox decides whether. |
| References / assets are **not** auto-loaded into context | Anthropic agent-skills' "lazy context" pattern. The system prompt advertises the paths; the model uses `fs_read` only when SKILL.md's body says to. Eager loading explodes prompt size for skills the model never reaches for. |
| `ScanSkillSubdir` returns rather than mutates an open-array param | Open arrays disallow `SetLength` inside the procedure under both FPC and Delphi. Returning matches the Pascal idiom for dynamic-array producers and is cleaner. |

## Test plan

- [ ] FPC build (`make`) + Delphi `.dproj` build cleanly
- [ ] `cp -r samples/skills/hello ~/.pasclaw/workspace/skills/` then `pasclaw skills list` — entry still shows; `pasclaw agent "what's in the hello skill?"` — system prompt now advertises `greet.sh` + `style-guide.md` with absolute paths
- [ ] Install a skill from ClawHub (PR #59 path) that ships `scripts/` and `references/` — files copy through the install pipeline intact; system prompt picks them up
- [ ] Install a SKILL.md-only skill (no subdirs) — system prompt for that skill doesn't print any "scripts:" / "references:" / "assets:" subsection (empty arrays skipped)
- [ ] Add a non-file entry under `scripts/` (e.g. `scripts/lib/` subdir) — `ScanSkillSubdir` skips it (files-only)
- [ ] Legacy `<name>.json` skill — system prompt shape unchanged (PR #55 path, no resource arrays populated)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_