### PR TITLE
/v1/responses: emit fields the openai-python SDK marks required

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1028,11 +1028,35 @@ end;
 
 function BuildResponsesObject(const Id, Model, Status, Content: string;
                                Usage: TUsageInfo): TJsonObject;
-{ Minimal OpenAI Responses-compatible non-streaming response. Modern OpenAI
-  clients look for output[].content[].text rather than choices[].message. }
+{ OpenAI Responses-compatible non-streaming response.
+
+  The openai-python SDK's Pydantic `Response` model marks four fields
+  as required (no default) — when any of them is absent from the JSON
+  the SDK raises ValidationError and the client appears to "choke" on
+  what looks like a valid 200 response:
+
+    parallel_tool_calls : bool
+    tool_choice         : ToolChoice (string "auto"/"none" or object)
+    tools               : List[Tool]
+    output              : List[ResponseOutputItem]
+
+  The first three are emitted with safe defaults (`false`, `"auto"`,
+  `[]`) and the fourth carries the assistant message. The remaining
+  optional fields are emitted as explicit `null` rather than absent —
+  Pydantic treats both the same for `Optional[X] = None`, but newer
+  SDK versions have shipped stricter validators in the past, and
+  explicit `null` keeps the response shape stable against future
+  releases.
+
+  `text` is emitted as `{"format": {"type": "text"}}` (the Responses
+  API formatting config). `error` and `incomplete_details` are
+  explicit `null` on the success path so the SDK's branch for those
+  fields takes the success branch deterministically. The non-success
+  path (HandleResponses' RunToolLoop-failed branch) attaches a real
+  `error` object with `code` + `message` per ResponseError schema. }
 var
-  OutputArr, ContentArr, AnnotationsArr: TJsonArray;
-  MsgObj, TextObj, UsageObj: TJsonObject;
+  OutputArr, ContentArr, AnnotationsArr, ToolsArr: TJsonArray;
+  MsgObj, TextObj, UsageObj, TextCfgObj, FormatObj: TJsonObject;
 begin
   Result := TJsonObject.Create;
   Result.PutStr('id',         Id);
@@ -1040,6 +1064,33 @@ begin
   Result.PutInt('created_at', DateTimeToUnix(Now, False));
   Result.PutStr('model',      Model);
   Result.PutStr('status',     Status);
+
+  { Required by openai-python SDK Pydantic validation. }
+  Result.PutBool('parallel_tool_calls', False);
+  Result.PutStr ('tool_choice',         'auto');
+  ToolsArr := TJsonArray.Create;
+  Result.PutArray('tools', ToolsArr);
+
+  { Optional but emitted as explicit null/empty so older or future
+    stricter SDK versions don't trip on absent keys. }
+  Result.PutRaw('error',              'null');
+  Result.PutRaw('incomplete_details', 'null');
+  Result.PutRaw('instructions',       'null');
+  Result.PutRaw('metadata',           'null');
+  Result.PutRaw('temperature',        'null');
+  Result.PutRaw('top_p',              'null');
+  Result.PutRaw('max_output_tokens',  'null');
+  Result.PutRaw('previous_response_id','null');
+  Result.PutRaw('reasoning',          'null');
+  Result.PutRaw('service_tier',       'null');
+  Result.PutRaw('truncation',         'null');
+  Result.PutRaw('user',               'null');
+
+  TextCfgObj := TJsonObject.Create;
+  FormatObj  := TJsonObject.Create;
+  FormatObj.PutStr('type', 'text');
+  TextCfgObj.PutObject('format', FormatObj);
+  Result.PutObject('text', TextCfgObj);
 
   OutputArr := TJsonArray.Create;
   if Content <> '' then
@@ -1284,9 +1335,14 @@ begin
     begin
       ReplyObj := BuildResponsesObject(RespId, ReqModel, 'failed', '', Loop.LastResp.Usage);
       try
+        { ResponseError schema is {code, message}. BuildResponsesObject
+          set error: null on the success path; overwrite with the real
+          shape here. SDK validators expect `code` to match a known
+          enum, with `server_error` covering the "tool loop blew up
+          server-side" case. }
         ErrObj := TJsonObject.Create;
+        ErrObj.PutStr('code',    'server_error');
         ErrObj.PutStr('message', 'tool loop failed');
-        ErrObj.PutStr('type',    'server_error');
         ReplyObj.PutObject('error', ErrObj);
         WriteJSON(AResp, 502, ReplyObj.ToJSON);
       finally


### PR DESCRIPTION
## TL;DR

Your client wasn't choking on a malformed response — it was choking on **missing required fields**. PR #57 shipped a `/v1/responses` handler, but the response object omitted three fields the openai-python SDK's Pydantic `Response` model marks as required (no default). Pydantic raises `ValidationError` → SDK throws → client says it "chokes."

## Verified against the SDK source

[`src/openai/types/responses/response.py`](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response.py) declares these as required (no default value):

```
id, created_at, model, object, output,
parallel_tool_calls : bool          ← missing in PR #57
tool_choice         : ToolChoice    ← missing in PR #57
tools               : List[Tool]    ← missing in PR #57
```

PasClaw was emitting 5 of 8. Pydantic doesn't tolerate missing required fields, period.

## What this PR ships

`BuildResponsesObject` now emits all three with safe defaults:

```json
"parallel_tool_calls": false,
"tool_choice": "auto",
"tools": []
```

That alone unsticks the SDK. To future-proof against the trend toward stricter validators in the openai-python release schedule, the remaining `Optional` fields are also emitted as explicit `null` rather than absent keys (Pydantic treats them the same for `Optional[X] = None` today, but the SDK has shipped stricter checks in the past and explicit null keeps the wire shape stable):

```json
"error": null, "incomplete_details": null, "instructions": null,
"metadata": null, "temperature": null, "top_p": null,
"max_output_tokens": null, "previous_response_id": null,
"reasoning": null, "service_tier": null, "truncation": null, "user": null
```

`text` is emitted as `{"format": {"type": "text"}}` — the Responses-API formatting config. Absence has been observed to fail validation in some SDK builds.

## Secondary fix: `ResponseError` schema inside a Response object

The `RunToolLoop=false` branch was synthesizing an error as `{message, type}` — that's the **HTTP error envelope** shape (which the rest of the gateway uses correctly elsewhere). The `error` field embedded inside a `Response` object is a different schema: `ResponseError` uses `{code, message}`. Fixed; the wrapper envelope on bare HTTP errors stays unchanged.

```diff
- ErrObj.PutStr('message', 'tool loop failed');
- ErrObj.PutStr('type',    'server_error');
+ ErrObj.PutStr('code',    'server_error');
+ ErrObj.PutStr('message', 'tool loop failed');
```

## Test plan

- [ ] `openai-python` ≥ 2.0 with `client.responses.create(model=..., input="hi")` against PasClaw — Pydantic parse succeeds, no `ValidationError`
- [ ] `response.output_text` returns the model's reply text
- [ ] `response.status == "completed"`
- [ ] Streaming request (`stream=True`) still returns the documented `unsupported_streaming` error — no regression
- [ ] Failure path (kill provider mid-request) returns a 502 with the embedded ResponseError now matching `{code, message}` schema

## Other clients

If your client isn't `openai-python`, this PR still fixes the most likely cause. JS / Go / Rust SDKs follow similar deserialization rules — three missing required fields would also have tripped them. If you're still seeing the choke after this lands, paste a sample of the failing request body + the SDK's error and I'll dig further.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_