### PR TITLE
PR #66 + #67 review fixes + chat/completions tool labels + FPC brace fix

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1223,6 +1223,18 @@ begin
     [Seq, ResponseJSON]);
 end;
 
+function ResFailedEvt(Seq: Integer; const ResponseJSON: string): string;
+{ Terminal SSE event for the failure path. Streaming clients (the
+  OpenAI Python SDK, Codex CLI) treat response.completed as success
+  even if the response object's status is "failed", so they need a
+  distinct event to surface provider exceptions raised after the
+  headers were already sent. }
+begin
+  Result := Format(
+    '{"type":"response.failed","sequence_number":%d,"response":%s}',
+    [Seq, ResponseJSON]);
+end;
+
 function ResItemAddedEvt(Seq, OutputIdx: Integer;
                          const ItemInProgressJSON: string): string;
 begin
@@ -1608,16 +1620,19 @@ procedure StreamResponsesViaProvider(AContext: TIdContext;
    so its text is only available as a whole at the end, and there
    is no incremental data to forward. *)
 var
-  CreatedObj, CompletedObj, MsgItemObj, PartObj, FinalItemObj: TJsonObject;
+  CreatedObj, CompletedObj, MsgItemObj, PartObj, FinalItemObj,
+  ErrObj: TJsonObject;
   ContentArr: TJsonArray;
   State: TResponsesStreamState;
-  CreatedJSON, CompletedJSON, FinalPartJSON, FinalItemJSON: string;
+  CreatedJSON, CompletedJSON, FinalPartJSON, FinalItemJSON,
+  StreamErr: string;
   EmptyUsage: TUsageInfo;
   NoToolCalls: array of TToolCall;
   Resp: TLLMResponse;
   i: Integer;
   FcItemId, FcCallId, FcArgs, FcEmptyJSON, FcCompletedJSON: string;
   FakeChunk: TStreamChunk;
+  Failed: Boolean;
 begin
   EmptyUsage.InputTokens  := 0;
   EmptyUsage.OutputTokens := 0;
@@ -1685,6 +1700,8 @@ begin
       EmitResponsesEvent(State.Streamer, 'response.in_progress',
         ResInProgressEvt(State.Seq, CreatedJSON)); Inc(State.Seq);
 
+      StreamErr := '';
+      Failed    := False;
       try
         Resp := Provider.ChatStream(Msgs, ToolDefs, Model, Opts, State.OnChunk);
       except
@@ -1696,6 +1713,19 @@ begin
           Resp.FinishReason := 'error';
           Resp.Usage.InputTokens  := 0;
           Resp.Usage.OutputTokens := 0;
+          StreamErr := 'provider ChatStream raised: ' + E.Message;
+          Failed    := True;
+        end;
+      end;
+      if (not Failed) and (Resp.FinishReason = 'error') then
+      begin
+        Failed := True;
+        if StreamErr = '' then
+        begin
+          if Resp.Content <> '' then
+            StreamErr := Resp.Content
+          else
+            StreamErr := 'provider returned finish_reason=error';
         end;
       end;
 
@@ -1704,8 +1734,11 @@ begin
         return the full text via Resp.Content with no OnChunk
         invocations. Feed it through OnChunk so the event sequence
         is the same shape regardless of provider streaming
-        support. }
-      if (not State.TextStarted) and (Resp.Content <> '') then
+        support. Skip on the failure path — Resp.Content carries the
+        provider error string, not a real assistant turn, so it
+        belongs in the response.failed error.message instead of being
+        streamed back as fake text deltas. }
+      if (not Failed) and (not State.TextStarted) and (Resp.Content <> '') then
       begin
         FakeChunk.Kind := 'text';
         FakeChunk.Text := Resp.Content;
@@ -1770,17 +1803,38 @@ begin
         Inc(State.NextOutputIdx);
       end;
 
-      CompletedObj := BuildResponsesObject(RespId, Model, 'completed',
-                                            State.TextAccumulated,
-                                            Resp.ToolCalls, ToolsRawJSON,
-                                            Resp.Usage);
-      try
-        CompletedJSON := CompletedObj.ToJSON;
-      finally
-        CompletedObj.Free;
+      if Failed then
+      begin
+        CompletedObj := BuildResponsesObject(RespId, Model, 'failed',
+                                              State.TextAccumulated,
+                                              Resp.ToolCalls, ToolsRawJSON,
+                                              Resp.Usage);
+        try
+          ErrObj := TJsonObject.Create;
+          ErrObj.PutStr('code',    'server_error');
+          ErrObj.PutStr('message', StreamErr);
+          CompletedObj.PutObject('error', ErrObj);
+          CompletedJSON := CompletedObj.ToJSON;
+        finally
+          CompletedObj.Free;
+        end;
+        EmitResponsesEvent(State.Streamer, 'response.failed',
+          ResFailedEvt(State.Seq, CompletedJSON));
+      end
+      else
+      begin
+        CompletedObj := BuildResponsesObject(RespId, Model, 'completed',
+                                              State.TextAccumulated,
+                                              Resp.ToolCalls, ToolsRawJSON,
+                                              Resp.Usage);
+        try
+          CompletedJSON := CompletedObj.ToJSON;
+        finally
+          CompletedObj.Free;
+        end;
+        EmitResponsesEvent(State.Streamer, 'response.completed',
+          ResCompletedEvt(State.Seq, CompletedJSON));
       end;
-      EmitResponsesEvent(State.Streamer, 'response.completed',
-        ResCompletedEvt(State.Seq, CompletedJSON));
       State.Streamer.CloseStream;
     finally
       State.Streamer.Free;
@@ -1837,17 +1891,34 @@ var
     sends previous-turn function_call items as separate input items
     with no parent message. The Chat-Completions-style providers we
     use expect each assistant turn to carry an embedded tool_calls
-    array. Synthesize one assistant message per function_call —
-    Anthropic / OpenAI both tolerate consecutive assistant messages
-    with tool_use blocks, and the per-message grouping doesn't
-    affect tool_result matching since matching is by call_id. }
+    array. When the client emits parallel calls in one turn (multiple
+    consecutive function_call items before any function_call_output),
+    coalesce them into a single assistant message so the request
+    body keeps the original turn boundaries: Anthropic in particular
+    rejects request shapes where a tool_use block appears in a turn
+    whose preceding turn already produced tool_use blocks without
+    intervening tool_result blocks. Matching with the corresponding
+    function_call_output is still by call_id regardless of grouping. }
   var
     Tc: TToolCall;
+    Last: Integer;
   begin
     Tc.Id   := CallId;
     Tc.Kind := 'function';
     Tc.Func.Name      := Name;
     Tc.Func.Arguments := ArgumentsJSON;
+
+    if (MsgCount > 0)
+       and (Msgs[MsgCount - 1].Role = mrAssistant)
+       and (Msgs[MsgCount - 1].Content = '')
+       and (Length(Msgs[MsgCount - 1].ToolCalls) > 0) then
+    begin
+      Last := Length(Msgs[MsgCount - 1].ToolCalls);
+      SetLength(Msgs[MsgCount - 1].ToolCalls, Last + 1);
+      Msgs[MsgCount - 1].ToolCalls[Last] := Tc;
+      Exit;
+    end;
+
     SetLength(Msgs, MsgCount + 1);
     Msgs[MsgCount].Role       := mrAssistant;
     Msgs[MsgCount].Content    := '';

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -198,23 +198,22 @@ begin
       { tool_choice mapping (Anthropic Messages API):
           "auto"     -> {"type":"auto"}     (model decides; Anthropic default)
           "required" -> {"type":"any"}      (must call one of the tools)
-          "none"     -> emit nothing        (Anthropic refuses to call tools
-                                              when the tools array is also
-                                              empty; the cleaner way for the
-                                              caller to express "no tools" is
-                                              to not send any tools at all,
-                                              but if they did and asked for
-                                              "none" we skip the field —
-                                              same as omitting tool_choice
-                                              with no model-side impact).
+          "none"     -> {"type":"none"}     (must not call any tool; needed
+                                              because omitting the field with
+                                              a non-empty tools array still
+                                              lets the model call them)
         Empty string means "don't emit; let provider default apply". }
-      if (Options.ToolChoice = 'auto') or (Options.ToolChoice = 'required') then
+      if (Options.ToolChoice = 'auto')
+         or (Options.ToolChoice = 'required')
+         or (Options.ToolChoice = 'none') then
       begin
         ToolObj := TJsonObject.Create;
         if Options.ToolChoice = 'auto' then
           ToolObj.PutStr('type', 'auto')
+        else if Options.ToolChoice = 'required' then
+          ToolObj.PutStr('type', 'any')
         else
-          ToolObj.PutStr('type', 'any');
+          ToolObj.PutStr('type', 'none');
         Root.PutObject('tool_choice', ToolObj);
       end;
     end;
@@ -349,12 +348,24 @@ var
   GStreamCB:   TStreamCallback;
   GStreamAcc:  string;
   GStreamLast: TLLMResponse;
+  { Tool-use accumulation across content_block_start / _delta / _stop.
+    Anthropic streams tool_use blocks as: start carries id+name+(empty)
+    input, delta carries partial_json fragments, stop signals end. We
+    buffer the JSON and flush into GStreamLast.ToolCalls on stop so
+    the streaming path matches Chat()'s non-streaming behavior — without
+    this, tool-call-only assistant turns reached the gateway with no
+    ToolCalls and Codex never saw its function_call output items. }
+  GToolBlockActive: Boolean;
+  GToolBlockId:     string;
+  GToolBlockName:   string;
+  GToolBlockArgs:   string;
 
 procedure HandleAnthropicSSE(const Event, Data: string);
 var
-  Root, Delta, Usage, MsgObj: TJsonObject;
-  Kind, Text: string;
+  Root, Delta, Usage, MsgObj, CB: TJsonObject;
+  Kind, Text, BlockKind, PartialJson: string;
   Chunk: TStreamChunk;
+  Tc: TToolCall;
 begin
   if Data = '' then Exit;
   Root := TJsonObject.Parse(Data);
@@ -362,7 +373,24 @@ begin
   try
     Kind := Root.GetStr('type', Event);
 
-    if Kind = 'content_block_delta' then
+    if Kind = 'content_block_start' then
+    begin
+      CB := Root.ChildObject('content_block');
+      if CB <> nil then
+      try
+        BlockKind := CB.GetStr('type', '');
+        if BlockKind = 'tool_use' then
+        begin
+          GToolBlockActive := True;
+          GToolBlockId     := CB.GetStr('id',   '');
+          GToolBlockName   := CB.GetStr('name', '');
+          GToolBlockArgs   := '';
+        end;
+      finally
+        CB.Free;
+      end;
+    end
+    else if Kind = 'content_block_delta' then
     begin
       Delta := Root.ChildObject('delta');
       if Delta = nil then Exit;
@@ -377,9 +405,34 @@ begin
             Chunk.Text := Text;
             if Assigned(GStreamCB) then GStreamCB(Chunk);
           end;
+        end
+        else if (Delta.GetStr('type', '') = 'input_json_delta') and GToolBlockActive then
+        begin
+          PartialJson := Delta.GetStr('partial_json', '');
+          if PartialJson <> '' then
+            GToolBlockArgs := GToolBlockArgs + PartialJson;
         end;
       finally
         Delta.Free;
+      end;
+    end
+    else if Kind = 'content_block_stop' then
+    begin
+      if GToolBlockActive then
+      begin
+        Tc.Id   := GToolBlockId;
+        Tc.Kind := 'function';
+        Tc.Func.Name := GToolBlockName;
+        if Trim(GToolBlockArgs) <> '' then
+          Tc.Func.Arguments := GToolBlockArgs
+        else
+          Tc.Func.Arguments := '{}';
+        SetLength(GStreamLast.ToolCalls, Length(GStreamLast.ToolCalls) + 1);
+        GStreamLast.ToolCalls[High(GStreamLast.ToolCalls)] := Tc;
+        GToolBlockActive := False;
+        GToolBlockId     := '';
+        GToolBlockName   := '';
+        GToolBlockArgs   := '';
       end;
     end
     else if Kind = 'message_delta' then
@@ -468,8 +521,13 @@ begin
 
   GStreamCB  := OnChunk;
   GStreamAcc := '';
+  Finalize(GStreamLast);
   FillChar(GStreamLast, SizeOf(GStreamLast), 0);
   GStreamLast.Model := UseModel;
+  GToolBlockActive := False;
+  GToolBlockId     := '';
+  GToolBlockName   := '';
+  GToolBlockArgs   := '';
   try
     LogDebug('anthropic SSE POST %s (model=%s)', [URL, UseModel]);
     PostStreaming(URL, Body, Headers, 120, @HandleAnthropicSSE, Status, Err);
@@ -477,6 +535,7 @@ begin
     Result.FinishReason := GStreamLast.FinishReason;
     Result.Usage        := GStreamLast.Usage;
     Result.Model        := GStreamLast.Model;
+    Result.ToolCalls    := Copy(GStreamLast.ToolCalls, 0, Length(GStreamLast.ToolCalls));
     if (Status < 200) or (Status >= 300) then
     begin
       if Result.Content = '' then


### PR DESCRIPTION
Three layered changes on the open PR:

## 1. Review fixes from PRs #66 + #67 (commit `539fb31`)

- **Group parallel `function_call` inputs into one assistant turn (PR #66).** Anthropic rejects request shapes where parallel tool_use blocks are spread across consecutive assistant messages. `AppendAssistantToolCall` now appends to the previous message when it is an empty-content assistant with `ToolCalls`.
- **Anthropic SSE: accumulate `tool_use` blocks (PR #67, P1).** `HandleAnthropicSSE` now handles `content_block_start` (type `tool_use`), `content_block_delta` (type `input_json_delta`), and `content_block_stop`; flushed `TToolCall`s reach `Result.ToolCalls` so streaming-mode tool-call-only turns no longer drop the function_call output items.
- **Anthropic: emit `tool_choice: {type:"none"}` explicitly (PR #67, P2).**
- **Streaming failures emit `response.failed` (PR #67, P2).** New `ResFailedEvt` helper + `Failed` flag in `StreamResponsesViaProvider`. Swaps `response.completed` for `response.failed` with `{code:"server_error", message:<err>}`.

## 2. Friendly tool-activity labels on `/v1/chat/completions` (commit `9e46fe8`)

Clients used to see `[tool: fs_read]` as the heartbeat — almost no signal. Args (which the server logs fully under `--debug`) never reached the frontend at all. Closes that gap on **both** delivery modes with a per-tool label, args+results still gated server-side.

New `PasClaw.Tools.Labels.LabelToolCall(Name, ArgsJSON)`:

| Tool | Label |
|---|---|
| `fs_read` `{"path":"foo.pas"}` | `Reading foo.pas` |
| `fs_write` `{"path":"bar.pas",...}` | `Writing bar.pas` |
| `fs_list` `{"path":"src/"}` | `Listing src/` |
| `fs_grep` `{"pattern":"X","path":"src","include":"*.pas"}` | `Searching for "X" in src (*.pas)` |
| `fs_edit_hashline` `{"patch":"¶foo#..."}` | `Editing foo` |
| `shell_exec` `{"command":"go test ./..."}` | `Running: go test ./...` |
| `skill_<name>` | `Running skill <name>` |
| (other) | `Calling <name>` |

| Delivery | Surface |
|---|---|
| Streaming | `TSSEStreamer.NoteToolCall` wraps the label in brackets → visible delta `[Reading foo.pas]` instead of `[tool: fs_read]`. Raw args still go to the structured SSE comment + debug log. |
| Non-streaming | New `TToolLabelCollector` hooked onto `LoopCfg.OnToolCall`. `PrependToolTranscript` sticks one `[Label]` line per call above the model's content with a blank-line separator. |

Only the label crosses to the client. Args and results stay in the `--debug` server log.

## 3. FPC brace-comment build fix (commit `9e46fe8`)

The first two commits' own comments embedded literal `{"type":"..."}` fragments inside `{ ... }` Pascal block comments. FPC closes the comment on the first unbalanced `}`, leaving the JSON as live code:

```
PasClaw.Providers.Anthropic.pas(199,52) Fatal: Syntax error, ")" expected but "identifier DECIDES" found
PasClaw.Gateway.Server.pas(2287,53) Fatal: illegal character "'}'" ($7D)
```

Switched both to `(* ... *)` and dropped the literal braces from the prose. Behaviour and field-emission logic unchanged.

## Verification

`make` builds clean against FPC 3.2.2 after this PR.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon