### PR TITLE
gateway: surface rich tool activity in streamed chat completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline print-version get-indy webui-res
+.PHONY: all clean run test smoke test-hashline test-toolview print-version get-indy webui-res
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -122,4 +122,11 @@ test-hashline: $(WEBUI_RES) | $(BUILDDIR) $(INDY_DIR)
 	$(FPC) $(FPCFLAGS) src/tests/hashline_patch_tests.pas -o$(BUILDDIR)/hashline_patch_tests
 	@$(BUILDDIR)/hashline_patch_tests
 
-test: smoke test-hashline
+# Pure tool-activity formatter tests. No Indy/webui resource needed — the
+# ToolView unit only depends on PasClaw.JSON and PasClaw.Hashline.
+test-toolview: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/toolview_tests.pas -o$(BUILDDIR)/toolview_tests
+	@$(BUILDDIR)/toolview_tests
+
+test: smoke test-hashline test-toolview

--- a/README.md
+++ b/README.md
@@ -262,6 +262,27 @@ The gateway routes implemented in `src/pkg/gateway/` are:
 | `/v1/responses` | `POST` | OpenAI Responses-compatible endpoint accepting string or message-array `input`; non-streaming only. |
 | `/v1/models` | `GET` | OpenAI-compatible model list containing the configured default model. |
 
+When `/v1/chat/completions` runs with `stream: true`, the tool loop executes
+server-side and each tool call is surfaced to the client as a visible
+content delta in a Claude-Code-style transcript — the tool name with its key
+argument, followed by a short result summary on the next line:
+
+```
+⏺ fs_read(README.md)
+  ⎿ 312 lines, 12044 bytes — ¶README.md#a1b2
+⏺ shell_exec(ls -la)
+  ⎿ exit=0
+```
+
+Known tools (`fs_read`, `fs_write`, `fs_list`, `fs_grep`,
+`fs_edit_hashline`, `shell_exec`) surface their most meaningful argument;
+MCP and other tools fall back to a compact one-line dump of the raw
+arguments. The full argument and result text also go to the SSE comment
+lines (`: tool_call ...` / `: tool_result ...`) for consumers that log
+structured activity, and to the server debug log when `--debug` is set.
+The formatter lives in `src/pkg/gateway/PasClaw.Gateway.ToolView.pas`
+(unit-tested via `make test-toolview`).
+
 Manual `/v1/responses` verification examples:
 
 ```sh

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -94,6 +94,7 @@ uses
   PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop,
   PasClaw.Agent.Prompt,
+  PasClaw.Gateway.ToolView,
   PasClaw.Gateway.WebUI;
 
 constructor TGatewayServer.Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
@@ -645,16 +646,18 @@ procedure TSSEStreamer.NoteToolCall(const Name, ArgsJSON: string);
 var
   Preview: string;
 begin
-  (* One visible delta with a small bracketed marker so the client
-     actually shows progress, plus a comment with the args for any
-     consumer that wants to log structured tool activity. The visible
-     delta is the bit that turns the long silence into a heartbeat the
-     user can see in their chat UI. *)
+  (* One visible delta carrying a Claude-Code-style summary (tool name +
+     its key argument) so the client renders real progress, not just a
+     bare name. The visible delta is the bit that turns the long silence
+     into a heartbeat the user can see in their chat UI; the full args
+     still go to the debug log and the SSE comment below for any consumer
+     that wants to log structured tool activity. Standard OpenAI clients
+     drop the comment, which is exactly why the summary has to be visible. *)
   Preview := ArgsJSON;
   if Length(Preview) > 200 then Preview := Copy(Preview, 1, 200) + '...';
   if FDebugIO then
     LogDebug('chat/completions tool_call: name=%s args=%s', [Name, ArgsJSON]);
-  WriteChunk(#10'[tool: ' + Name + ']'#10, '');
+  WriteChunk(#10 + FormatToolCallLine(Name, ArgsJSON) + #10, '');
   WriteComment('tool_call name=' + Name + ' args=' + Preview);
 end;
 
@@ -672,6 +675,11 @@ begin
     LogDebug('chat/completions tool_result: name=%s err=%s result=%s',
              [Name, Err, Preview]);
   end;
+  (* Visible delta summarizing the outcome (line/byte counts with a first-line
+     peek, a short echo, or the error) on its own indented line under the call
+     — previously this went only to the dropped SSE comment, so the client saw
+     the call but never its result. *)
+  WriteChunk(FormatToolResultLine(Name, ResultText, Err) + #10, '');
   WriteComment('tool_result name=' + Name + ' ' + Status);
 end;
 

--- a/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
@@ -1,0 +1,214 @@
+(*
+  PasClaw.Gateway.ToolView - human-readable summaries of tool activity for
+  the streaming /v1/chat/completions endpoint.
+
+  Background: when the gateway runs the tool loop for a streamed completion it
+  used to surface each tool to the client as a bare "[tool: <name>]" marker.
+  The interesting detail (which file, which command, how big the result) lived
+  only in the server debug log and in SSE comment lines (`: ...`) that every
+  spec-compliant OpenAI client silently discards. The front end therefore saw
+  "[tool: fs_read]" and nothing else.
+
+  Claude Code's transcript instead shows each call with its name and key
+  argument plus a short result summary. These pure string transforms build the
+  same kind of one-liners so the streamer can emit them as *visible* content
+  deltas. They have no Indy/socket dependency, so they can be unit-tested in
+  isolation (see src/tests/toolview_tests.pas).
+*)
+unit PasClaw.Gateway.ToolView;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+const
+  (* Glyphs mirror the agent CLI handlers (PasClaw.Cmd.Agent) and Claude
+     Code's transcript style: a filled dot marks the call, a corner marks the
+     result line that sits under it. *)
+  TV_CALL_GLYPH   = '⏺';
+  TV_RESULT_GLYPH = '⎿';
+
+{ One visible line describing a tool invocation, e.g.
+    ⏺ fs_read(README.md)
+    ⏺ shell_exec(ls -la)
+    ⏺ fs_grep("TODO" in src)
+  Known tools surface their most meaningful argument; unknown / MCP tools fall
+  back to a compact single-line dump of the raw arguments. The result has no
+  surrounding newlines — the caller frames it for the stream. }
+function FormatToolCallLine(const Name, ArgsJSON: string): string;
+
+{ One visible line summarizing a tool result, indented two spaces to sit under
+  its call line, e.g.
+    ⎿ 312 lines, 12044 bytes — ¶README.md#a1b2
+    ⎿ exit=0
+    ⎿ ✗ file not found
+  No trailing newline. }
+function FormatToolResultLine(const Name, ResultText, Err: string): string;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.JSON,
+  PasClaw.Hashline;
+
+const
+  MaxArgWidth     = 160;  { cap inline arg summaries so a giant command or
+                            patch can't flood the chat transcript }
+  MaxResultWidth  = 200;  { cap single-line result echoes and error text }
+  MaxPreviewWidth = 120;  { cap the first-line preview on multi-line results }
+
+function CollapseWhitespace(const S: string): string;
+{ Fold CR/LF/TAB and runs of spaces into a single space so a multi-line value
+  renders as one tidy inline summary. Implemented with ASCII-only
+  StringReplace, which is byte-safe under FPC's UTF-8 strings: the bytes we
+  match (0x0D / 0x0A / 0x09 / 0x20) never occur inside a multi-byte UTF-8
+  sequence, so a codepoint is never split or corrupted. }
+const
+  ScanCap = 4096;  { bound the squeeze loop on pathological input; the output
+                     is ellipsized far below this anyway }
+var
+  W: string;
+begin
+  if Length(S) > ScanCap then W := Copy(S, 1, ScanCap) else W := S;
+  W := StringReplace(W, #13, ' ', [rfReplaceAll]);
+  W := StringReplace(W, #10, ' ', [rfReplaceAll]);
+  W := StringReplace(W, #9,  ' ', [rfReplaceAll]);
+  { Each pass halves runs of spaces; loop until none remain. }
+  while Pos('  ', W) > 0 do
+    W := StringReplace(W, '  ', ' ', [rfReplaceAll]);
+  Result := Trim(W);
+end;
+
+function Ellipsize(const S: string; MaxLen: Integer): string;
+begin
+  if Length(S) <= MaxLen then Result := S
+  else Result := Copy(S, 1, MaxLen) + '…';
+end;
+
+function FirstLineOf(const S: string): string;
+var
+  NL: Integer;
+begin
+  NL := Pos(#10, S);
+  if NL > 0 then Result := Copy(S, 1, NL - 1)
+  else Result := S;
+end;
+
+function CountLines(const S: string): Integer;
+{ Lines of content, ignoring a single trailing newline so "exit=0"#10 counts
+  as one line, not two. }
+var
+  i: Integer;
+begin
+  if S = '' then Exit(0);
+  Result := 1;
+  for i := 1 to Length(S) do
+    if S[i] = #10 then Inc(Result);
+  if S[Length(S)] = #10 then Dec(Result);
+  if Result < 1 then Result := 1;
+end;
+
+function FirstPatchPath(const Patch: string): string;
+{ Pull the target path out of a hashline patch header (¶path#hash on the
+  first line). Encoding-agnostic: HL_FILE_PREFIX and the patch share the
+  compiler's native string form, so the prefix Copy/compare lines up under
+  both Delphi (WideChar) and FPC (UTF-8 bytes). }
+var
+  Line: string;
+  HashPos: Integer;
+begin
+  Line := Trim(StringReplace(FirstLineOf(Patch), #13, '', [rfReplaceAll]));
+  if Copy(Line, 1, Length(HL_FILE_PREFIX)) = HL_FILE_PREFIX then
+    Line := Copy(Line, Length(HL_FILE_PREFIX) + 1, MaxInt);
+  HashPos := Pos(HL_FILE_HASH_SEP, Line);
+  if HashPos > 0 then Line := Copy(Line, 1, HashPos - 1);
+  Result := Trim(Line);
+end;
+
+function ArgStr(Obj: TJsonObject; const Key: string): string;
+begin
+  if Obj = nil then Result := ''
+  else Result := Obj.GetStr(Key, '');
+end;
+
+function FormatToolCallLine(const Name, ArgsJSON: string): string;
+var
+  Obj: TJsonObject;
+  Summary, Pattern, Path, Inc_: string;
+begin
+  Obj := TJsonObject.Parse(ArgsJSON);
+  try
+    if Name = 'fs_read' then
+    begin
+      Summary := ArgStr(Obj, 'path');
+      if (Obj <> nil) and Obj.GetBool('plain', False) then
+        Summary := Summary + ', plain';
+    end
+    else if (Name = 'fs_write') or (Name = 'fs_list') then
+      Summary := ArgStr(Obj, 'path')
+    else if Name = 'fs_grep' then
+    begin
+      Pattern := ArgStr(Obj, 'pattern');
+      Path    := ArgStr(Obj, 'path');
+      Summary := '"' + Pattern + '"';
+      if Path <> '' then Summary := Summary + ' in ' + Path;
+      Inc_ := ArgStr(Obj, 'include');
+      if Inc_ <> '' then Summary := Summary + ' (' + Inc_ + ')';
+    end
+    else if Name = 'fs_edit_hashline' then
+      Summary := FirstPatchPath(ArgStr(Obj, 'patch'))
+    else if Name = 'shell_exec' then
+      Summary := ArgStr(Obj, 'command')
+    else
+      { Unknown / MCP tool: compact dump of the raw arguments so the client
+        still sees what the model passed. }
+      Summary := ArgsJSON;
+  finally
+    Obj.Free;
+  end;
+
+  Summary := Ellipsize(CollapseWhitespace(Summary), MaxArgWidth);
+  Result := TV_CALL_GLYPH + ' ' + Name + '(' + Summary + ')';
+end;
+
+function FormatToolResultLine(const Name, ResultText, Err: string): string;
+var
+  Body, Preview: string;
+  Lines, Bytes: Integer;
+begin
+  if Err <> '' then
+  begin
+    Result := '  ' + TV_RESULT_GLYPH + ' ✗ ' +
+              Ellipsize(CollapseWhitespace(Err), MaxResultWidth);
+    Exit;
+  end;
+
+  Bytes := Length(ResultText);
+  if Bytes = 0 then
+  begin
+    Result := '  ' + TV_RESULT_GLYPH + ' (no output)';
+    Exit;
+  end;
+
+  Lines := CountLines(ResultText);
+  if Lines <= 1 then
+    { Single-line result: echo it (truncated). Covers fs_write confirmations,
+      short shell output, etc. }
+    Body := Ellipsize(CollapseWhitespace(ResultText), MaxResultWidth)
+  else
+  begin
+    { Multi-line: counts plus a peek at the first line (the hashline header on
+      fs_read/fs_grep, "exit=N" on shell_exec, etc.). }
+    Preview := Ellipsize(CollapseWhitespace(FirstLineOf(ResultText)), MaxPreviewWidth);
+    if Preview <> '' then
+      Body := Format('%d lines, %d bytes — %s', [Lines, Bytes, Preview])
+    else
+      Body := Format('%d lines, %d bytes', [Lines, Bytes]);
+  end;
+
+  Result := '  ' + TV_RESULT_GLYPH + ' ' + Body;
+end;
+
+end.

--- a/src/tests/toolview_tests.pas
+++ b/src/tests/toolview_tests.pas
@@ -1,0 +1,133 @@
+program toolview_tests;
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Gateway.ToolView;
+
+procedure Fail(const Msg: string);
+begin
+  Writeln('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) = 0 then
+    Fail(Msg + ' (expected to find "' + Needle + '" in "' + Haystack + '")');
+end;
+
+procedure AssertEquals(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail(Msg + ' (got "' + Got + '", want "' + Want + '")');
+end;
+
+procedure TestFsReadCall;
+begin
+  AssertEquals(FormatToolCallLine('fs_read', '{"path":"README.md"}'),
+               TV_CALL_GLYPH + ' fs_read(README.md)',
+               'fs_read call summary');
+  AssertContains(FormatToolCallLine('fs_read', '{"path":"a.txt","plain":true}'),
+                 'a.txt, plain', 'fs_read plain flag');
+end;
+
+procedure TestShellCall;
+begin
+  AssertEquals(FormatToolCallLine('shell_exec', '{"command":"ls -la"}'),
+               TV_CALL_GLYPH + ' shell_exec(ls -la)',
+               'shell_exec call summary');
+end;
+
+procedure TestGrepCall;
+begin
+  AssertEquals(FormatToolCallLine('fs_grep', '{"path":"src","pattern":"TODO"}'),
+               TV_CALL_GLYPH + ' fs_grep("TODO" in src)',
+               'fs_grep call summary');
+  AssertContains(FormatToolCallLine('fs_grep',
+                   '{"path":"src","pattern":"TODO","include":"*.pas"}'),
+                 '(*.pas)', 'fs_grep include glob');
+end;
+
+procedure TestEditHashlineCall;
+begin
+  { Path is pulled out of the patch header (¶path#hash on the first line). }
+  AssertEquals(FormatToolCallLine('fs_edit_hashline',
+                 '{"patch":"¶src/foo.pas#abcd\n42:\n|new line"}'),
+               TV_CALL_GLYPH + ' fs_edit_hashline(src/foo.pas)',
+               'fs_edit_hashline path from patch header');
+end;
+
+procedure TestUnknownToolFallback;
+begin
+  { MCP / unknown tools dump the raw args, whitespace collapsed to one line. }
+  AssertContains(FormatToolCallLine('web_search', '{"query":"pascal"}'),
+                 'web_search(', 'unknown tool keeps name');
+  AssertContains(FormatToolCallLine('web_search', '{"query":"pascal"}'),
+                 'query', 'unknown tool dumps raw args');
+end;
+
+procedure TestArgTruncation;
+var
+  Big, Line: string;
+  i: Integer;
+begin
+  Big := '';
+  for i := 1 to 500 do Big := Big + 'x';
+  Line := FormatToolCallLine('shell_exec', '{"command":"' + Big + '"}');
+  AssertContains(Line, '…', 'long argument is ellipsized');
+  if Length(Line) > 220 then
+    Fail('long argument not capped (len=' + IntToStr(Length(Line)) + ')');
+end;
+
+procedure TestResultLineCount;
+begin
+  AssertContains(FormatToolResultLine('fs_read', 'a'#10'b'#10'c', ''),
+                 '3 lines', 'multi-line result counts lines');
+  AssertContains(FormatToolResultLine('fs_read', 'a'#10'b'#10'c', ''),
+                 TV_RESULT_GLYPH, 'result line carries the corner glyph');
+end;
+
+procedure TestResultSingleLineEcho;
+begin
+  { A single short line is echoed verbatim, not reduced to a byte count. }
+  AssertContains(FormatToolResultLine('shell_exec', 'exit=0', ''),
+                 'exit=0', 'short single-line result is echoed');
+end;
+
+procedure TestResultError;
+begin
+  AssertContains(FormatToolResultLine('fs_read', '', 'file not found'),
+                 '✗', 'error result carries the failure glyph');
+  AssertContains(FormatToolResultLine('fs_read', '', 'file not found'),
+                 'file not found', 'error result carries the message');
+end;
+
+procedure TestResultEmpty;
+begin
+  AssertContains(FormatToolResultLine('fs_write', '', ''),
+                 '(no output)', 'empty success result is labelled');
+end;
+
+procedure TestResultTrailingNewline;
+begin
+  { A trailing newline must not inflate the line count. }
+  AssertContains(FormatToolResultLine('shell_exec', 'only line'#10, ''),
+                 'only line', 'trailing newline kept as single line');
+end;
+
+begin
+  TestFsReadCall;
+  TestShellCall;
+  TestGrepCall;
+  TestEditHashlineCall;
+  TestUnknownToolFallback;
+  TestArgTruncation;
+  TestResultLineCount;
+  TestResultSingleLineEcho;
+  TestResultError;
+  TestResultEmpty;
+  TestResultTrailingNewline;
+  Writeln('PASS');
+end.


### PR DESCRIPTION
## Problem

The streaming `/v1/chat/completions` tool loop surfaced each tool to the client as a bare `[tool: <name>]` marker. The useful detail (which file, which command, how big the result) lived only in the server `--debug` log and in SSE comment lines (`: ...`) that **every spec-compliant OpenAI client silently discards**. So a connected front end saw `[tool: fs_read]` and nothing else, even though the server clearly knew much more.

## Change

Add `PasClaw.Gateway.ToolView` — pure string transforms that build Claude-Code-style one-liners — and wire them into `TSSEStreamer` so the rich info goes out as **visible** content deltas instead of the bare marker:

```
⏺ fs_read(README.md)
  ⎿ 312 lines, 12044 bytes — ¶README.md#a1b2
⏺ shell_exec(ls -la)
  ⎿ exit=0
⏺ fs_grep("TODO" in src)
  ⎿ 7 lines, 240 bytes — ¶src/foo.pas#abcd
```

- Known tools (`fs_read`, `fs_write`, `fs_list`, `fs_grep`, `fs_edit_hashline`, `shell_exec`) surface their most meaningful argument; MCP/other tools fall back to a compact one-line dump of the raw arguments.
- Results get a summary line: line/byte counts with a first-line peek, a short echo for single-line output, or `✗ <error>` on failure.
- Summaries are length-bounded (160/200/120 chars) so a giant patch or file dump can't flood the transcript.
- The full args/result still go to the debug log and the SSE comment lines for structured consumers — nothing is removed, the detail is just promoted into a channel clients actually render.

## Scope

Only the **streaming** `/v1/chat/completions` path changes — that's the one that emitted the `[tool:]` marker. The non-streaming JSON path is unchanged (it never emitted tool markers), and the bundled web UI uses the non-streaming `/v1/chat`, so it's unaffected.

## Tests

The formatter is Indy-free, so it is unit-tested in isolation: `src/tests/toolview_tests.pas` (11 assertions), wired into `make test` via a new `test-toolview` target. README documents the streamed transcript format.

> Note: FPC was not available in the authoring environment, so the Pascal was verified by reading and by matching patterns already proven in the codebase (UTF-8-safe hashline prefix comparison, `Exit(value)`, `TJsonObject` usage). Please run `make test` in CI / locally to confirm the build.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_