### PR TITLE
gateway: surface tool activity on non-streaming /v1/chat/completions too

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -691,6 +691,80 @@ begin
   CloseStream;
 end;
 
+type
+  { Per-request collector that hooks LoopCfg.OnToolCall/OnToolResult on the
+    non-streaming chat-completions path. RunToolLoop runs tools server-side
+    and the buffered Chat Completions response shape has no standard slot
+    for "tools that already ran" — so we collect ToolView's friendly per-
+    tool lines here (the same ones the streaming path emits as visible
+    deltas via TSSEStreamer.NoteToolCall/NoteToolResult) and the handler
+    prepends them above the model's content. Both delivery modes now show
+    the same activity transcript. }
+  TToolActivityCollector = class
+  public
+    Lines: TStringList;
+    constructor Create;
+    destructor Destroy; override;
+    procedure OnToolCall(const Name, ArgsJSON: string);
+    procedure OnToolResult(const Name, ResultText, Err: string);
+    function Transcript: string;
+  end;
+
+constructor TToolActivityCollector.Create;
+begin
+  inherited Create;
+  Lines := TStringList.Create;
+end;
+
+destructor TToolActivityCollector.Destroy;
+begin
+  Lines.Free;
+  inherited Destroy;
+end;
+
+procedure TToolActivityCollector.OnToolCall(const Name, ArgsJSON: string);
+begin
+  Lines.Add(FormatToolCallLine(Name, ArgsJSON));
+end;
+
+procedure TToolActivityCollector.OnToolResult(const Name, ResultText, Err: string);
+begin
+  Lines.Add(FormatToolResultLine(Name, ResultText, Err));
+end;
+
+function TToolActivityCollector.Transcript: string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 0 to Lines.Count - 1 do
+  begin
+    if i > 0 then Result := Result + #10;
+    Result := Result + Lines[i];
+  end;
+end;
+
+function PrependToolActivity(Collector: TToolActivityCollector;
+                              const Content: string): string;
+{ Stick the tool transcript above the model's content with a blank-line
+  separator, mirroring how the streaming path renders activity as deltas
+  before the final assistant text. Empty transcript or empty collector
+  means Content unchanged. }
+var
+  T: string;
+begin
+  if (Collector = nil) or (Collector.Lines.Count = 0) then
+  begin
+    Result := Content;
+    Exit;
+  end;
+  T := Collector.Transcript;
+  if Trim(Content) = '' then
+    Result := T
+  else
+    Result := T + #10#10 + Content;
+end;
+
 procedure TGatewayServer.HandleChatCompletions(AContext: TIdContext;
                                                 ARequest: TIdHTTPRequestInfo;
                                                 AResp: TIdHTTPResponseInfo;
@@ -721,6 +795,7 @@ var
   ReplyObj: TJsonObject;
   Streamer: TSSEStreamer;
   StreamStarted, StreamClosed: Boolean;
+  ActivityCollector: TToolActivityCollector;
   function SanitizeStreamError(const S: string): string;
   begin
     Result := StringReplace(S, #13, ' ', [rfReplaceAll]);
@@ -733,6 +808,7 @@ begin
   StreamStarted := False;
   StreamClosed := False;
   AWasStreamingRequest := False;
+  ActivityCollector := nil;
   AResponseStarted := False;
   Body := '';
   if ARequest.PostStream <> nil then
@@ -952,6 +1028,15 @@ begin
       Exit;
     end;
 
+    { The non-streaming path collects ToolView-formatted activity lines via
+      OnToolCall/OnToolResult and prepends them above the model's content
+      below — so frontends that buffer the whole JSON reply see the same
+      transcript the streaming path emits as visible deltas through
+      TSSEStreamer. }
+    ActivityCollector := TToolActivityCollector.Create;
+    LoopCfg.OnToolCall   := ActivityCollector.OnToolCall;
+    LoopCfg.OnToolResult := ActivityCollector.OnToolResult;
+
     if not RunToolLoop(LoopCfg, Msgs, Loop) then
     begin
       if FDebugIO then LogDebug('chat/completions -> 502 (tool loop failed)');
@@ -1006,6 +1091,8 @@ begin
                [Loop.Iterations, Loop.LastResp.Usage.InputTokens,
                 Loop.LastResp.Usage.OutputTokens, FinishReason, Loop.Content]);
 
+    Loop.Content := PrependToolActivity(ActivityCollector, Loop.Content);
+
     ReplyObj := BuildOpenAICompletion(CompId, ReqModel, Loop.Content,
                                        Loop.LastResp.Usage, FinishReason);
     try
@@ -1017,6 +1104,7 @@ begin
   finally
     Req.Free;
     if Streamer <> nil then Streamer.Free;
+    if ActivityCollector <> nil then ActivityCollector.Free;
   end;
 end;
 


### PR DESCRIPTION
## Problem

PR #69 wired Claude-Code-style transcripts onto **streamed** `/v1/chat/completions`, so SSE clients now see each tool call render as a visible delta:

```
⏺ fs_read(README.md)
⎿ 312 lines, 12044 bytes — ¶README.md#a1b2
⏺ shell_exec(go test ./...)
⎿ exit=0
```

The **non-streaming** JSON path stayed silent — `BuildOpenAICompletion` only emits the model's final assistant text, so frontends that buffer the whole reply (or that just don't consume SSE) had no record that any tool ran. Same gap your original feedback called out, on the other branch of the dispatch.

## Change

One file: `src/pkg/gateway/PasClaw.Gateway.Server.pas`.

- New `TToolActivityCollector` per request. Owns a `TStringList`; its `OnToolCall` / `OnToolResult` methods match `TToolLoopConfig`'s callback signatures and push each event through ToolView's existing `FormatToolCallLine` / `FormatToolResultLine`.
- `HandleChatCompletions` non-streaming branch now creates the collector before `RunToolLoop`, wires `LoopCfg.OnToolCall := ActivityCollector.OnToolCall` and `LoopCfg.OnToolResult := ActivityCollector.OnToolResult`.
- After the loop completes (and after the existing cap / empty-content handling), `PrependToolActivity` sticks the transcript above `Loop.Content` with a blank-line separator and that string flows into `BuildOpenAICompletion`.
- Owned + freed in the outer `finally` next to `Streamer` and `Req`.

Same line format as PR #69's streaming path — by design, both delivery modes show identical activity.

## Scope

- Only the non-streaming branch is touched. Streaming, `/v1/chat`, `/v1/responses`, `/v1/models` etc. are untouched.
- Only the friendly per-tool labels reach the client. Full args + results still gate behind `--debug` in the server log.
- ToolView already exists from PR #69; this PR just reuses its public functions, no new units, no test changes.

## Verification

`make` (FPC 3.2.2) — clean build, `Linking build/pasclaw`. The brace-comment issues from earlier PRs were already fixed in `main` via `(* *)` form, so no comment changes are needed here.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_