### PR TITLE
PR #69 review fix: catch EPasClawJSON in FormatToolCallLine so the SSE stream survives malformed args

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
@@ -138,8 +138,20 @@ var
   Obj: TJsonObject;
   Summary, Pattern, Path, Inc_: string;
 begin
-  Obj := TJsonObject.Parse(ArgsJSON);
+  { TJsonObject.Parse raises EPasClawJSON on malformed input — providers
+    occasionally stream truncated `arguments` (the tool loop tolerates
+    this and surfaces a per-tool error). Swallow the parse failure here
+    and treat Obj as nil so the unknown-tool branch echoes the raw
+    ArgsJSON; the helper must never raise, otherwise an exception
+    propagates through TSSEStreamer and the whole stream dies. }
+  Obj := nil;
   try
+    try
+      Obj := TJsonObject.Parse(ArgsJSON);
+    except
+      on EPasClawJSON do
+        Obj := nil;
+    end;
     if Name = 'fs_read' then
     begin
       Summary := ArgStr(Obj, 'path');

--- a/src/tests/toolview_tests.pas
+++ b/src/tests/toolview_tests.pas
@@ -117,6 +117,29 @@ begin
                  'only line', 'trailing newline kept as single line');
 end;
 
+procedure TestMalformedArgsDoesNotRaise;
+{ Providers occasionally stream truncated `arguments` (think mid-token
+  cut-off in a tool_use block). TJsonObject.Parse raises EPasClawJSON on
+  that input, and FormatToolCallLine sits on the SSE-streamer hot path —
+  if it lets the exception escape, the whole stream tears down with no
+  terminal event. Verify the helper handles malformed JSON by falling
+  back to the raw-args echo. }
+var
+  Line: string;
+begin
+  Line := FormatToolCallLine('fs_read', '{"path":"foo');
+  AssertContains(Line, 'fs_read', 'malformed fs_read still names the tool');
+
+  Line := FormatToolCallLine('shell_exec', 'not json at all');
+  AssertContains(Line, 'shell_exec', 'malformed shell_exec still names the tool');
+
+  Line := FormatToolCallLine('fs_grep', '{"pattern":"x"');
+  AssertContains(Line, 'fs_grep', 'malformed fs_grep still names the tool');
+
+  Line := FormatToolCallLine('web_search', '');
+  AssertContains(Line, 'web_search', 'empty args fall through to the unknown branch');
+end;
+
 begin
   TestFsReadCall;
   TestShellCall;
@@ -129,5 +152,6 @@ begin
   TestResultError;
   TestResultEmpty;
   TestResultTrailingNewline;
+  TestMalformedArgsDoesNotRaise;
   Writeln('PASS');
 end.


### PR DESCRIPTION
## PR #69 review fix (P2): malformed tool-call args tear down the SSE stream

[Codex's review on PR #69](https://github.com/FMXExpress/PasClaw/pull/69#discussion_r3321555178) called out that `FormatToolCallLine` sits on the hot path of `TSSEStreamer.NoteToolCall`, and `TJsonObject.Parse` raises `EPasClawJSON` on malformed input. Providers occasionally stream truncated `arguments` (mid-token cut-off in a `tool_use` block; the tool loop tolerates that and surfaces a per-tool execution error). With the unguarded `Parse`, the exception propagates up through `WriteChunk` and the whole SSE stream tears down with no terminal event — strictly worse than the pre-#69 bare `[tool: <name>]` marker, which never crashed because it only used the tool name.

## Fix

Wrap the `Parse` call in `try/except` inside `FormatToolCallLine`. On `EPasClawJSON`, treat `Obj` as nil so the rest of the function falls through to its existing nil-tolerant paths (`ArgStr` returns `''`; the unknown-tool branch echoes the raw `ArgsJSON`). The formatter must never raise.

```pascal
Obj := nil;
try
  try
    Obj := TJsonObject.Parse(ArgsJSON);
  except
    on EPasClawJSON do
      Obj := nil;
  end;
  ...
finally
  Obj.Free;
end;
```

## Test

Added `TestMalformedArgsDoesNotRaise` to `src/tests/toolview_tests.pas` covering four cases the model can produce:

| Input | Expected |
|---|---|
| `fs_read` `{"path":"foo` (truncated) | line containing `fs_read`, no exception |
| `shell_exec` `not json at all` | line containing `shell_exec`, no exception |
| `fs_grep` `{"pattern":"x"` (truncated) | line containing `fs_grep`, no exception |
| `web_search` `` (empty) | line containing `web_search`, no exception |

Verified locally with a standalone driver:

```
truncated fs_read -> ⏺ fs_read()
not json shell_exec -> ⏺ shell_exec()
truncated fs_grep -> ⏺ fs_grep("")
empty web_search -> ⏺ web_search()
OK: no exception escaped
```

## Coverage

Same fix also covers PR #70 — the non-streaming `TToolActivityCollector` hooks the same `FormatToolCallLine` on `OnToolCall`, so both delivery modes now degrade gracefully when the model streams broken JSON.

## Note

`TestEditHashlineCall` fails in this file due to a pre-existing UTF-8 mojibake on the `¶` pilcrow in the patch-header argument. That failure is unrelated and reproduces on `origin/main` without this change; not addressed here.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_