### PR TITLE
memory: SQLite + FTS5 keyword index over workspace/memory/ (Phase A)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,21 @@ INDY_REPO    ?= https://github.com/IndySockets/Indy.git
 # on most distros but not always.
 ICONVENC_DIR ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/iconvenc
 
+# fcl-db + sqlite ship with FPC's standard distribution but live outside the
+# default search path (Debian package: fp-units-db). PasClaw.Memory.Index
+# pulls TSQLite3Connection / TSQLQuery from these. libsqlite3.so must be
+# present at runtime — every modern Linux/Mac has it; Windows builds need
+# sqlite3.dll on PATH.
+FCLDB_DIR    ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/fcl-db
+SQLITE_DIR   ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/sqlite
+
+# PasClaw.Tools.FS uses the Masks unit (case-insensitive glob matching for
+# fs_grep's `include` filter). On Debian, Masks lives in Lazarus's lazutils
+# source tree rather than the fpc rtl, so callers that don't already have it
+# on their unit path can set LAZUTILS_DIR (apt: lazarus-src). Defaults to the
+# Debian path; empty string skips the include.
+LAZUTILS_DIR ?= /usr/lib/lazarus/3.0/components/lazutils
+
 # PasClaw source dirs.
 UNIT_DIRS = \
 	src/pkg/cliui \
@@ -49,6 +64,8 @@ INDY_UNIT_DIRS = \
 INDY_INC_DIRS = $(INDY_UNIT_DIRS)
 
 FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
+	-Fu$(FCLDB_DIR) -Fu$(SQLITE_DIR) \
+	$(if $(LAZUTILS_DIR),-Fu$(LAZUTILS_DIR)) \
 	$(foreach d,$(UNIT_DIRS),-Fu$(d)) \
 	$(foreach d,$(INDY_UNIT_DIRS),-Fu$(d)) \
 	$(foreach d,$(INDY_INC_DIRS),-Fi$(d)) \

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -27,6 +27,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Memory,
   PasClaw.Tools.ToolLoop,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -133,6 +134,7 @@ begin
   Result := TToolRegistry.Create;
   RegisterFSTools(Result, UseHashline);
   RegisterShellTool(Result);
+  RegisterMemoryTools(Result);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(Result, Skills);
 end;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -26,6 +26,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Memory,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -98,6 +99,7 @@ begin
       Reg := TToolRegistry.Create;
       RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
+      RegisterMemoryTools(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -39,6 +39,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Memory,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -116,6 +117,7 @@ begin
       Reg := TToolRegistry.Create;
       RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
+      RegisterMemoryTools(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -24,6 +24,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Memory,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -84,6 +85,7 @@ begin
       Reg := TToolRegistry.Create;
       RegisterFSTools(Reg, not A.NoHashline);
       RegisterShellTool(Reg);
+      RegisterMemoryTools(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
     end;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -169,6 +169,7 @@
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Sandbox.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.FS.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Shell.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Memory.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.ToolLoop.pas"/>
 
         <!-- pkg/mcp -->
@@ -204,6 +205,7 @@
 
         <!-- pkg/memory -->
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>
+        <DCCReference Include="..\pkg\memory\PasClaw.Memory.Index.pas"/>
 
         <!-- pkg/updater -->
         <DCCReference Include="..\pkg\updater\PasClaw.Updater.pas"/>

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -136,19 +136,45 @@ begin
 end;
 
 function BuildMemorySection: string;
+{ Inject up to three markdown files into the system prompt:
+    workspace/memory/MEMORY.md         — durable user-owned notes
+    workspace/memory/<today>.md        — today's daily note, if it exists
+    workspace/memory/<yesterday>.md    — yesterday's daily note, for fresh context
+  Mirrors openclaw's bootstrap loading. Older notes stay on disk and reach
+  the model only when memory_search returns them. Each file is wrapped in
+  a subsection so the model can tell durable from dated material apart. }
 var
-  Path, Body: string;
+  MemoryDir, TodayStr, YesterdayStr: string;
+
+  procedure AppendFile(const SubHeader, FilePath: string);
+  var
+    SubBody: string;
+  begin
+    if not FileExists(FilePath) then Exit;
+    try
+      SubBody := Trim(ReadFileText(FilePath));
+    except
+      SubBody := '';
+    end;
+    if SubBody = '' then Exit;
+    if Result = '' then
+      Result := '## Memory'
+    else
+      Result := Result + sLineBreak + sLineBreak;
+    Result := Result + sLineBreak + sLineBreak +
+              '### ' + SubHeader + sLineBreak + sLineBreak + SubBody;
+  end;
+
 begin
   Result := '';
-  Path := JoinPath(GetHome, 'workspace/memory/MEMORY.md');
-  if not FileExists(Path) then Exit;
-  try
-    Body := Trim(ReadFileText(Path));
-    if Body = '' then Exit;
-    Result := '## Memory' + sLineBreak + sLineBreak + Body;
-  except
-    Result := '';
-  end;
+  MemoryDir := JoinPath(GetHome, 'workspace/memory');
+
+  AppendFile('MEMORY.md (durable)', JoinPath(MemoryDir, 'MEMORY.md'));
+
+  TodayStr     := FormatDateTime('yyyy-mm-dd', Now);
+  YesterdayStr := FormatDateTime('yyyy-mm-dd', Now - 1);
+  AppendFile('Today (' + TodayStr + ')',         JoinPath(MemoryDir, TodayStr + '.md'));
+  AppendFile('Yesterday (' + YesterdayStr + ')', JoinPath(MemoryDir, YesterdayStr + '.md'));
 end;
 
 function BuildSkillsSection: string;
@@ -269,7 +295,12 @@ begin
     sLineBreak +
     '5. **Memory** — when the user mentions something worth keeping across ' +
     'sessions (preferences, project facts, conventions), update ' +
-    MemPath + '. Treat it as a long-lived notes file the user owns.';
+    MemPath + ' for durable notes the user owns, or append a dated ' +
+    'entry to ' + JoinPath(GetHome, 'workspace/memory') +
+    '/{today}.md (e.g. ' + FormatDateTime('yyyy-mm-dd', Now) +
+    '.md) for episodic context. Use `memory_search` before answering ' +
+    'questions about prior conversations or project facts you might ' +
+    'have written down on an earlier turn.';
 end;
 
 function AppendSection(const Acc, Section: string): string;

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -153,6 +153,7 @@ uses
   PasClaw.Providers.Factory,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
+  PasClaw.Tools.Memory,
   PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
@@ -234,6 +235,7 @@ begin
   FRegistry := TToolRegistry.Create;
   RegisterFSTools(FRegistry, FUseHashline);
   RegisterShellTool(FRegistry);
+  RegisterMemoryTools(FRegistry);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(FRegistry, Skills);
   if FUseMCP then
@@ -460,6 +462,7 @@ begin
     FRegistry := TToolRegistry.Create;
     RegisterFSTools(FRegistry, FEnableHashline);
     RegisterShellTool(FRegistry);
+    RegisterMemoryTools(FRegistry);
     Skills := LoadSkillManifests(GetHome);
     RegisterSkills(FRegistry, Skills);
   end;

--- a/src/pkg/memory/PasClaw.Memory.Index.pas
+++ b/src/pkg/memory/PasClaw.Memory.Index.pas
@@ -80,6 +80,79 @@ uses
   PasClaw.Utils,
   PasClaw.Logger;
 
+function SanitizeFtsQuery(const Raw: string): string;
+(* Turn a natural-language query string into an FTS5-safe MATCH
+   expression. FTS5 treats unquoted ASCII punctuation (?, +, :, /,
+   unbalanced quotes, etc.) as syntax, so a conversational query like
+   "what did we discuss?" or a code token like "C++", "foo/bar", or
+   "skill_<name>" raises a parse error that bubbles up as "no matches"
+   even when the indexed content is right there.
+
+   Strategy: split the input on every non-token byte and reassemble as
+   OR-ed quoted phrases. Bytes >= $80 are treated as token bytes so
+   UTF-8 multi-byte sequences survive intact (the porter unicode61
+   tokenizer FTS5 was created with will fold them properly at index
+   time). The empty-string result signals the caller to early-exit.
+
+   OR over AND: natural-language queries include filler words
+   ("what", "did", "we") that won't appear in terse notes. AND would
+   require every token to match and silently return zero hits the
+   moment any filler is missing. OR returns matches as soon as ANY
+   token lands, and BM25 ranks documents that match more tokens
+   higher — so the top-K results are still the most relevant ones,
+   and "what did we discuss authentication?" still finds the note
+   that mentions "discussed authentication tokens".
+
+   Examples (arrow is the produced MATCH expression):
+     what did we discuss?  ->  "what" OR "did" OR "we" OR "discuss"
+     C++                   ->  "C"
+     foo/bar baz           ->  "foo" OR "bar" OR "baz"
+     authentication        ->  "authentication"
+     ?!?                   ->  (empty — all-separator input)
+*)
+
+  function IsTokenByte(B: Byte): Boolean;
+  begin
+    Result := ((B >= Ord('a')) and (B <= Ord('z'))) or
+              ((B >= Ord('A')) and (B <= Ord('Z'))) or
+              ((B >= Ord('0')) and (B <= Ord('9'))) or
+              (B = Ord('_')) or
+              (B >= $80);
+  end;
+
+var
+  i: Integer;
+  Cur: string;
+  Tokens: TStringList;
+begin
+  Result := '';
+  if Trim(Raw) = '' then Exit;
+
+  Tokens := TStringList.Create;
+  try
+    Cur := '';
+    for i := 1 to Length(Raw) do
+    begin
+      if IsTokenByte(Byte(Raw[i])) then
+        Cur := Cur + Raw[i]
+      else if Cur <> '' then
+      begin
+        Tokens.Add(Cur);
+        Cur := '';
+      end;
+    end;
+    if Cur <> '' then Tokens.Add(Cur);
+
+    for i := 0 to Tokens.Count - 1 do
+    begin
+      if Result <> '' then Result := Result + ' OR ';
+      Result := Result + '"' + Tokens[i] + '"';
+    end;
+  finally
+    Tokens.Free;
+  end;
+end;
+
 type
   TMemoryIndexImpl = class(TInterfacedObject, IMemoryIndex)
   private
@@ -483,12 +556,14 @@ end;
 function TMemoryIndexImpl.Search(const Query: string; K: Integer): TMemoryHitArray;
 {$IFDEF FPC}
 var
-  Q: TSQLQuery;
-  N: Integer;
+  Q:         TSQLQuery;
+  N:         Integer;
+  Sanitized: string;
 begin
   SetLength(Result, 0);
   if not FOpen then Exit;
-  if Trim(Query) = '' then Exit;
+  Sanitized := SanitizeFtsQuery(Query);
+  if Sanitized = '' then Exit;
   if K <= 0 then K := 5;
 
   Q := TSQLQuery.Create(nil);
@@ -498,7 +573,7 @@ begin
       'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', 24), bm25(memory_fts) ' +
       'FROM memory_fts WHERE memory_fts MATCH :q ' +
       'ORDER BY bm25(memory_fts) LIMIT :k';
-    Q.Params.ParamByName('q').AsString := Query;
+    Q.Params.ParamByName('q').AsString := Sanitized;
     Q.Params.ParamByName('k').AsInteger := K;
     try
       Q.Open;
@@ -526,12 +601,14 @@ begin
 end;
 {$ELSE}
 var
-  Q: TFDQuery;
-  N: Integer;
+  Q:         TFDQuery;
+  N:         Integer;
+  Sanitized: string;
 begin
   SetLength(Result, 0);
   if not FOpen then Exit;
-  if Trim(Query) = '' then Exit;
+  Sanitized := SanitizeFtsQuery(Query);
+  if Sanitized = '' then Exit;
   if K <= 0 then K := 5;
 
   Q := TFDQuery.Create(nil);
@@ -541,7 +618,7 @@ begin
       'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', 24), bm25(memory_fts) ' +
       'FROM memory_fts WHERE memory_fts MATCH :q ' +
       'ORDER BY bm25(memory_fts) LIMIT :k';
-    Q.ParamByName('q').AsString  := Query;
+    Q.ParamByName('q').AsString  := Sanitized;
     Q.ParamByName('k').AsInteger := K;
     try
       Q.Open;

--- a/src/pkg/memory/PasClaw.Memory.Index.pas
+++ b/src/pkg/memory/PasClaw.Memory.Index.pas
@@ -1,0 +1,572 @@
+(*
+  PasClaw.Memory.Index - SQLite + FTS5 keyword index over the workspace
+  memory directory.
+
+  PasClaw's memory model follows openclaw: durable notes live as
+  Markdown files (MEMORY.md, workspace/memory/YYYY-MM-DD.md). This unit
+  builds a derived FTS5 index over those files so the model can search
+  past memories with BM25 ranking via the memory_search tool. Files
+  remain the source of truth; the DB is a lazy-rebuilt cache.
+
+  Lifecycle:
+    1. NewMemoryIndex returns an IMemoryIndex with no resources held.
+    2. Open(DbPath) opens (or creates) the SQLite file and ensures the
+       schema. Returns False and logs a warning if libsqlite3 can't be
+       loaded; memory_search then degrades to "index unavailable".
+    3. SyncDir walks the directory's *.md files, compares mtimes against
+       the memory_files table, and reindexes whatever changed. Files
+       that disappeared from disk are dropped from the index. Called at
+       the start of every Search.
+    4. Search runs an FTS5 MATCH query and returns up to K hits, each
+       with the source path, a snippet around the matched term, and the
+       BM25 score (smaller = better).
+    5. Close releases the connection. Destructor calls Close.
+
+  Cross-target split:
+    - {$IFDEF FPC}: TSQLite3Connection + TSQLQuery from sqldb. Needs
+      fcl-db at build time; libsqlite3 at runtime.
+    - {$ELSE}: FireDAC's TFDConnection + TFDQuery. Needs FireDAC at
+      build time (ships with Delphi); sqlite3.dll at runtime.
+
+  Schema:
+    memory_files(rowid INTEGER PK, path TEXT UNIQUE, mtime INTEGER,
+                 indexed_at INTEGER)
+    memory_fts USING fts5(path UNINDEXED, content,
+                          tokenize='porter unicode61')
+
+    Each indexed file is one FTS5 row, sharing rowid with memory_files.
+    The reindex path deletes the file row in memory_files (CASCADE-like
+    via explicit DELETE on memory_fts first) and re-inserts. Avoids
+    rowid-sync drift across updates.
+*)
+unit PasClaw.Memory.Index;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TMemoryHit = record
+    Path:    string;
+    Snippet: string;
+    Score:   Double;
+  end;
+  TMemoryHitArray = array of TMemoryHit;
+
+  IMemoryIndex = interface
+    ['{6A4B9F2C-3D1E-4A50-9C8B-7F1A2D3E4B91}']
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    procedure SyncDir(const Dir: string);
+    function  Search(const Query: string; K: Integer): TMemoryHitArray;
+  end;
+
+function NewMemoryIndex: IMemoryIndex;
+
+implementation
+
+uses
+  DateUtils,
+  {$IFDEF FPC}
+  sqldb, sqlite3conn,
+  {$ELSE}
+  FireDAC.Comp.Client, FireDAC.Phys.SQLite, FireDAC.Stan.Def,
+  FireDAC.Stan.Async, FireDAC.DApt,
+  {$ENDIF}
+  PasClaw.Utils,
+  PasClaw.Logger;
+
+type
+  TMemoryIndexImpl = class(TInterfacedObject, IMemoryIndex)
+  private
+    {$IFDEF FPC}
+    FConn:  TSQLite3Connection;
+    FTx:    TSQLTransaction;
+    {$ELSE}
+    FConn:  TFDConnection;
+    {$ENDIF}
+    FOpen:  Boolean;
+    procedure ExecSQL(const SQL: string);
+    procedure EnsureSchema;
+    function  FileMtime(const Path: string): Int64;
+    function  IndexedMtime(const Path: string; out Mtime: Int64): Boolean;
+    procedure ReindexFile(const Path: string; Mtime: Int64);
+    procedure DropMissingFiles(const KnownPaths: TStringList);
+  public
+    destructor Destroy; override;
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    procedure SyncDir(const Dir: string);
+    function  Search(const Query: string; K: Integer): TMemoryHitArray;
+  end;
+
+function NewMemoryIndex: IMemoryIndex;
+begin
+  Result := TMemoryIndexImpl.Create;
+end;
+
+destructor TMemoryIndexImpl.Destroy;
+begin
+  Close;
+  inherited Destroy;
+end;
+
+procedure TMemoryIndexImpl.ExecSQL(const SQL: string);
+{$IFDEF FPC}
+begin
+  FConn.ExecuteDirect(SQL);
+  FTx.CommitRetaining;
+end;
+{$ELSE}
+begin
+  FConn.ExecSQL(SQL);
+end;
+{$ENDIF}
+
+procedure TMemoryIndexImpl.EnsureSchema;
+begin
+  ExecSQL(
+    'CREATE TABLE IF NOT EXISTS memory_files (' +
+    '  rowid INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  path TEXT UNIQUE NOT NULL,' +
+    '  mtime INTEGER NOT NULL,' +
+    '  indexed_at INTEGER NOT NULL)');
+  ExecSQL(
+    'CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(' +
+    '  path UNINDEXED, content,' +
+    '  tokenize=''porter unicode61'')');
+end;
+
+function TMemoryIndexImpl.Open(const DbPath: string): Boolean;
+begin
+  Result := False;
+  if FOpen then Exit(True);
+
+  try
+    {$IFDEF FPC}
+    FConn := TSQLite3Connection.Create(nil);
+    FTx   := TSQLTransaction.Create(nil);
+    FConn.DatabaseName := DbPath;
+    FConn.Transaction  := FTx;
+    FTx.Database       := FConn;
+    FConn.Open;
+    FTx.StartTransaction;
+    {$ELSE}
+    FConn := TFDConnection.Create(nil);
+    FConn.DriverName := 'SQLite';
+    FConn.Params.Values['Database'] := DbPath;
+    FConn.LoginPrompt := False;
+    FConn.Connected := True;
+    {$ENDIF}
+    EnsureSchema;
+    FOpen := True;
+    Result := True;
+    LogDebug('memory.index: opened %s', [DbPath]);
+  except
+    on E: Exception do
+    begin
+      LogWarn('memory.index: failed to open %s (%s) — memory_search disabled',
+              [DbPath, E.Message]);
+      {$IFDEF FPC}
+      FreeAndNil(FTx);
+      FreeAndNil(FConn);
+      {$ELSE}
+      FreeAndNil(FConn);
+      {$ENDIF}
+      FOpen := False;
+    end;
+  end;
+end;
+
+procedure TMemoryIndexImpl.Close;
+begin
+  if not FOpen then Exit;
+  try
+    {$IFDEF FPC}
+    if (FTx <> nil) and FTx.Active then FTx.Commit;
+    if (FConn <> nil) and FConn.Connected then FConn.Close;
+    FreeAndNil(FTx);
+    FreeAndNil(FConn);
+    {$ELSE}
+    if (FConn <> nil) and FConn.Connected then FConn.Connected := False;
+    FreeAndNil(FConn);
+    {$ENDIF}
+  except
+    on E: Exception do
+      LogWarn('memory.index: close error: %s', [E.Message]);
+  end;
+  FOpen := False;
+end;
+
+function TMemoryIndexImpl.FileMtime(const Path: string): Int64;
+var
+  Age: Integer;
+  Dt:  TDateTime;
+begin
+  Result := 0;
+  Age := FileAge(Path);
+  if Age = -1 then Exit;
+  Dt := FileDateToDateTime(Age);
+  Result := DateTimeToUnix(Dt, False);
+end;
+
+function TMemoryIndexImpl.IndexedMtime(const Path: string; out Mtime: Int64): Boolean;
+{$IFDEF FPC}
+var
+  Q: TSQLQuery;
+begin
+  Result := False;
+  Mtime  := 0;
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text := 'SELECT mtime FROM memory_files WHERE path = :p';
+    Q.Params.ParamByName('p').AsString := Path;
+    Q.Open;
+    if not Q.EOF then
+    begin
+      Mtime  := Q.Fields[0].AsLargeInt;
+      Result := True;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ELSE}
+var
+  Q: TFDQuery;
+begin
+  Result := False;
+  Mtime  := 0;
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := 'SELECT mtime FROM memory_files WHERE path = :p';
+    Q.ParamByName('p').AsString := Path;
+    Q.Open;
+    if not Q.Eof then
+    begin
+      Mtime  := Q.Fields[0].AsLargeInt;
+      Result := True;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ENDIF}
+
+procedure TMemoryIndexImpl.ReindexFile(const Path: string; Mtime: Int64);
+var
+  Content: string;
+  Now_:    Int64;
+{$IFDEF FPC}
+  Q: TSQLQuery;
+{$ELSE}
+  Q: TFDQuery;
+{$ENDIF}
+begin
+  try
+    Content := ReadFileText(Path);
+  except
+    on E: Exception do
+    begin
+      LogWarn('memory.index: read %s failed (%s) — skipping', [Path, E.Message]);
+      Exit;
+    end;
+  end;
+  Now_ := DateTimeToUnix(Now, False);
+
+  { Delete existing rows for this path so we don't accumulate
+    duplicates on rewrite. memory_fts rowid is linked to
+    memory_files.rowid via the explicit INSERT below. }
+  {$IFDEF FPC}
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text :=
+      'DELETE FROM memory_fts WHERE rowid IN (SELECT rowid FROM memory_files WHERE path = :p)';
+    Q.Params.ParamByName('p').AsString := Path;
+    Q.ExecSQL;
+
+    Q.SQL.Text := 'DELETE FROM memory_files WHERE path = :p';
+    Q.Params.ParamByName('p').AsString := Path;
+    Q.ExecSQL;
+
+    Q.SQL.Text :=
+      'INSERT INTO memory_files (path, mtime, indexed_at) VALUES (:p, :m, :i)';
+    Q.Params.ParamByName('p').AsString    := Path;
+    Q.Params.ParamByName('m').AsLargeInt  := Mtime;
+    Q.Params.ParamByName('i').AsLargeInt  := Now_;
+    Q.ExecSQL;
+
+    Q.SQL.Text :=
+      'INSERT INTO memory_fts (rowid, path, content) ' +
+      'VALUES ((SELECT rowid FROM memory_files WHERE path = :p), :p, :c)';
+    Q.Params.ParamByName('p').AsString := Path;
+    Q.Params.ParamByName('c').AsString := Content;
+    Q.ExecSQL;
+
+    FTx.CommitRetaining;
+  finally
+    Q.Free;
+  end;
+  {$ELSE}
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text :=
+      'DELETE FROM memory_fts WHERE rowid IN (SELECT rowid FROM memory_files WHERE path = :p)';
+    Q.ParamByName('p').AsString := Path;
+    Q.ExecSQL;
+
+    Q.SQL.Text := 'DELETE FROM memory_files WHERE path = :p';
+    Q.ParamByName('p').AsString := Path;
+    Q.ExecSQL;
+
+    Q.SQL.Text :=
+      'INSERT INTO memory_files (path, mtime, indexed_at) VALUES (:p, :m, :i)';
+    Q.ParamByName('p').AsString   := Path;
+    Q.ParamByName('m').AsLargeInt := Mtime;
+    Q.ParamByName('i').AsLargeInt := Now_;
+    Q.ExecSQL;
+
+    Q.SQL.Text :=
+      'INSERT INTO memory_fts (rowid, path, content) ' +
+      'VALUES ((SELECT rowid FROM memory_files WHERE path = :p), :p, :c)';
+    Q.ParamByName('p').AsString := Path;
+    Q.ParamByName('c').AsString := Content;
+    Q.ExecSQL;
+  finally
+    Q.Free;
+  end;
+  {$ENDIF}
+end;
+
+procedure TMemoryIndexImpl.DropMissingFiles(const KnownPaths: TStringList);
+{$IFDEF FPC}
+var
+  Q:      TSQLQuery;
+  Stale:  TStringList;
+  Path:   string;
+begin
+  Stale := TStringList.Create;
+  try
+    Q := TSQLQuery.Create(nil);
+    try
+      Q.Database := FConn;
+      Q.SQL.Text := 'SELECT path FROM memory_files';
+      Q.Open;
+      while not Q.EOF do
+      begin
+        Path := Q.Fields[0].AsString;
+        if KnownPaths.IndexOf(Path) < 0 then
+          Stale.Add(Path);
+        Q.Next;
+      end;
+      Q.Close;
+
+      for Path in Stale do
+      begin
+        Q.SQL.Text :=
+          'DELETE FROM memory_fts WHERE rowid IN (SELECT rowid FROM memory_files WHERE path = :p)';
+        Q.Params.ParamByName('p').AsString := Path;
+        Q.ExecSQL;
+        Q.SQL.Text := 'DELETE FROM memory_files WHERE path = :p';
+        Q.Params.ParamByName('p').AsString := Path;
+        Q.ExecSQL;
+        LogDebug('memory.index: dropped stale %s', [Path]);
+      end;
+      if Stale.Count > 0 then FTx.CommitRetaining;
+    finally
+      Q.Free;
+    end;
+  finally
+    Stale.Free;
+  end;
+end;
+{$ELSE}
+var
+  Q:     TFDQuery;
+  Stale: TStringList;
+  Path:  string;
+begin
+  Stale := TStringList.Create;
+  try
+    Q := TFDQuery.Create(nil);
+    try
+      Q.Connection := FConn;
+      Q.SQL.Text := 'SELECT path FROM memory_files';
+      Q.Open;
+      while not Q.Eof do
+      begin
+        Path := Q.Fields[0].AsString;
+        if KnownPaths.IndexOf(Path) < 0 then
+          Stale.Add(Path);
+        Q.Next;
+      end;
+      Q.Close;
+
+      for Path in Stale do
+      begin
+        Q.SQL.Text :=
+          'DELETE FROM memory_fts WHERE rowid IN (SELECT rowid FROM memory_files WHERE path = :p)';
+        Q.ParamByName('p').AsString := Path;
+        Q.ExecSQL;
+        Q.SQL.Text := 'DELETE FROM memory_files WHERE path = :p';
+        Q.ParamByName('p').AsString := Path;
+        Q.ExecSQL;
+        LogDebug('memory.index: dropped stale %s', [Path]);
+      end;
+    finally
+      Q.Free;
+    end;
+  finally
+    Stale.Free;
+  end;
+end;
+{$ENDIF}
+
+procedure TMemoryIndexImpl.SyncDir(const Dir: string);
+var
+  Sr:     TSearchRec;
+  Path:   string;
+  Mtime:  Int64;
+  Idx:    Int64;
+  Found:  Boolean;
+  Known:  TStringList;
+  MemoryMd: string;
+begin
+  if not FOpen then Exit;
+
+  Known := TStringList.Create;
+  try
+    Known.Sorted := False;
+
+    { workspace/memory/MEMORY.md — durable note, top-of-tree. }
+    MemoryMd := JoinPath(Dir, 'MEMORY.md');
+    if FileExists(MemoryMd) then Known.Add(MemoryMd);
+
+    { workspace/memory/*.md — daily notes and ad-hoc files. }
+    if FindFirst(JoinPath(Dir, '*.md'), faAnyFile, Sr) = 0 then
+    try
+      repeat
+        if (Sr.Attr and faDirectory) <> 0 then Continue;
+        if SameText(Sr.Name, 'MEMORY.md') then Continue;
+        Path := JoinPath(Dir, Sr.Name);
+        Known.Add(Path);
+      until FindNext(Sr) <> 0;
+    finally
+      FindClose(Sr);
+    end;
+
+    for Path in Known do
+    begin
+      Mtime := FileMtime(Path);
+      if Mtime = 0 then Continue;
+      Found := IndexedMtime(Path, Idx);
+      if (not Found) or (Idx < Mtime) then
+        ReindexFile(Path, Mtime);
+    end;
+
+    DropMissingFiles(Known);
+  finally
+    Known.Free;
+  end;
+end;
+
+function TMemoryIndexImpl.Search(const Query: string; K: Integer): TMemoryHitArray;
+{$IFDEF FPC}
+var
+  Q: TSQLQuery;
+  N: Integer;
+begin
+  SetLength(Result, 0);
+  if not FOpen then Exit;
+  if Trim(Query) = '' then Exit;
+  if K <= 0 then K := 5;
+
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text :=
+      'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', 24), bm25(memory_fts) ' +
+      'FROM memory_fts WHERE memory_fts MATCH :q ' +
+      'ORDER BY bm25(memory_fts) LIMIT :k';
+    Q.Params.ParamByName('q').AsString := Query;
+    Q.Params.ParamByName('k').AsInteger := K;
+    try
+      Q.Open;
+    except
+      on E: Exception do
+      begin
+        LogWarn('memory.index: search %s failed (%s)', [Query, E.Message]);
+        Exit;
+      end;
+    end;
+    N := 0;
+    while (not Q.EOF) and (N < K) do
+    begin
+      SetLength(Result, N + 1);
+      Result[N].Path    := Q.Fields[0].AsString;
+      Result[N].Snippet := Q.Fields[1].AsString;
+      Result[N].Score   := Q.Fields[2].AsFloat;
+      Inc(N);
+      Q.Next;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ELSE}
+var
+  Q: TFDQuery;
+  N: Integer;
+begin
+  SetLength(Result, 0);
+  if not FOpen then Exit;
+  if Trim(Query) = '' then Exit;
+  if K <= 0 then K := 5;
+
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text :=
+      'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', 24), bm25(memory_fts) ' +
+      'FROM memory_fts WHERE memory_fts MATCH :q ' +
+      'ORDER BY bm25(memory_fts) LIMIT :k';
+    Q.ParamByName('q').AsString  := Query;
+    Q.ParamByName('k').AsInteger := K;
+    try
+      Q.Open;
+    except
+      on E: Exception do
+      begin
+        LogWarn('memory.index: search %s failed (%s)', [Query, E.Message]);
+        Exit;
+      end;
+    end;
+    N := 0;
+    while (not Q.Eof) and (N < K) do
+    begin
+      SetLength(Result, N + 1);
+      Result[N].Path    := Q.Fields[0].AsString;
+      Result[N].Snippet := Q.Fields[1].AsString;
+      Result[N].Score   := Q.Fields[2].AsFloat;
+      Inc(N);
+      Q.Next;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ENDIF}
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -1,0 +1,181 @@
+(*
+  PasClaw.Tools.Memory - registers the memory_search tool.
+
+  Workflow (openclaw-style):
+    - The model writes durable notes by editing MEMORY.md or a daily
+      file workspace/memory/YYYY-MM-DD.md with the existing fs_write
+      tool. There is intentionally NO memory_add tool — files are the
+      source of truth, the index follows.
+    - memory_search opens the lazy FTS5 index over workspace/memory/,
+      syncs it against the current files (rebuilding rows for any file
+      whose mtime moved), and runs an FTS5 MATCH against the user's
+      query. Returns up to K hits as
+        path | bm25 score | highlighted snippet
+      one per line, smallest score first.
+
+  The DB lives at <home>/workspace/memory/.index.db. Missing / corrupt
+  / unloadable libsqlite3 degrades to "memory_search: index
+  unavailable" — the rest of the agent continues to function.
+*)
+unit PasClaw.Tools.Memory;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterMemoryTools(R: TToolRegistry);
+
+implementation
+
+uses
+  Classes,
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Logger,
+  PasClaw.Memory.Index;
+
+function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      V := Obj.GetStr(Field, '');
+      Result := V <> '';
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function ParseIntArg(const ArgsJSON, Field: string; Default: Integer): Integer;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      if Obj.Has(Field) then Result := Obj.GetInt(Field, Default);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := Default;
+  end;
+end;
+
+function MemoryDir: string;
+begin
+  Result := JoinPath(GetHome, 'workspace/memory');
+end;
+
+function IndexDbPath: string;
+begin
+  Result := JoinPath(MemoryDir, '.index.db');
+end;
+
+function Tool_MemorySearch(const ArgsJSON: string; out ErrMsg: string): string;
+const
+  DefaultK = 5;
+  MaxK     = 25;
+var
+  Query: string;
+  K, i:  Integer;
+  Idx:   IMemoryIndex;
+  Hits:  TMemoryHitArray;
+  Lines: TStringList;
+  Dir:   string;
+begin
+  ErrMsg := '';
+  Result := '';
+
+  if not ParseStringArg(ArgsJSON, 'query', Query) then
+  begin
+    ErrMsg := 'missing required argument: query';
+    Exit;
+  end;
+  K := ParseIntArg(ArgsJSON, 'k', DefaultK);
+  if K < 1   then K := 1;
+  if K > MaxK then K := MaxK;
+
+  Dir := MemoryDir;
+  if not DirectoryExists(Dir) then
+    Exit('(no memory directory yet — write to ' + JoinPath(Dir, 'MEMORY.md') +
+         ' first)');
+
+  Idx := NewMemoryIndex;
+  try
+    if not Idx.Open(IndexDbPath) then
+    begin
+      ErrMsg := 'memory index unavailable (libsqlite3 missing or unreadable)';
+      Exit;
+    end;
+    Idx.SyncDir(Dir);
+    Hits := Idx.Search(Query, K);
+  finally
+    Idx := nil;  { IInterface release closes the DB }
+  end;
+
+  if Length(Hits) = 0 then
+    Exit(Format('(no matches for %s in %s)', [Query, Dir]));
+
+  Lines := TStringList.Create;
+  try
+    Lines.Add(Format('%d match(es) for %s:', [Length(Hits), Query]));
+    Lines.Add('');
+    for i := 0 to High(Hits) do
+    begin
+      Lines.Add(Format('%s  (bm25=%.3f)', [Hits[i].Path, Hits[i].Score]));
+      Lines.Add('  ' + Hits[i].Snippet);
+      if i < High(Hits) then Lines.Add('');
+    end;
+    Result := Lines.Text;
+  finally
+    Lines.Free;
+  end;
+
+  LogDebug('memory_search query=%s k=%d hits=%d', [Query, K, Length(Hits)]);
+end;
+
+procedure RegisterMemoryTools(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if R = nil then Exit;
+  T.Name        := 'memory_search';
+  T.Description :=
+    'Search the workspace memory directory (MEMORY.md + workspace/memory/*.md) ' +
+    'with SQLite FTS5 BM25 ranking. Use this before answering questions about ' +
+    'prior conversations, the user''s preferences, or project facts you might ' +
+    'have written down on an earlier turn. Returns up to k matches as path + ' +
+    'snippet + score (smaller score = stronger match).';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"query":{"type":"string","description":"FTS5 query string. Supports plain words, AND/OR/NOT, ' +
+                '\"phrase\" quoting, and prefix^ matching."},' +
+    '"k":{"type":"integer","minimum":1,"maximum":25,"description":"Max results (default 5)."}' +
+    '},"required":["query"]}';
+  T.Handler     := Tool_MemorySearch;
+  T.IsCore      := True;
+  R.Register(T);
+end;
+
+end.


### PR DESCRIPTION
Phase A of the hybrid memory system. Mirrors openclaw's model: durable notes live as Markdown files (`MEMORY.md`, `workspace/memory/<date>.md`) that the model edits with the existing `fs_write` tool. SQLite is a derived index — never the source of truth, lazy-rebuilt on each `memory_search` call by walking mtimes. No embeddings, no `memory_add` tool, no `ILLMProvider.Embed` — all deferred to Phase B.

## What's in the box

### 1. `PasClaw.Memory.Index` — cross-target SQLite + FTS5 index

`IMemoryIndex` interface with `Open / Close / SyncDir / Search`. Two backends gated by IFDEF:

| Target | Driver | Build dep | Runtime dep |
|---|---|---|---|
| FPC | `TSQLite3Connection` + `TSQLQuery` (`sqldb` / `sqlite3conn`) | `fcl-db` (apt: `fp-units-db`) | `libsqlite3.so` |
| Delphi | `TFDConnection` + `TFDQuery` (FireDAC SQLite) | ships with Delphi | `sqlite3.dll` |

If `libsqlite3` can't be loaded, `Open` returns `False` and `memory_search` degrades to "index unavailable" — the rest of the agent keeps running.

Schema:

```sql
CREATE TABLE memory_files (
  rowid INTEGER PRIMARY KEY AUTOINCREMENT,
  path TEXT UNIQUE NOT NULL,
  mtime INTEGER NOT NULL,
  indexed_at INTEGER NOT NULL
);
CREATE VIRTUAL TABLE memory_fts USING fts5(
  path UNINDEXED, content,
  tokenize='porter unicode61'
);
```

Each file is one FTS5 row sharing rowid with `memory_files`. The reindex path deletes both rows by path and reinserts, so rowids stay in sync across edits.

`SyncDir` walks `workspace/memory/MEMORY.md` + `workspace/memory/*.md`, compares mtimes, reindexes whatever's newer, and drops rows for files that disappeared from disk.

`Search` runs `MATCH` and returns up to K hits with the FTS5 `snippet()` excerpt and `bm25()` score (smaller = better).

### 2. `PasClaw.Tools.Memory` — `memory_search` tool

```json
{
  "name": "memory_search",
  "description": "Search the workspace memory directory (MEMORY.md + workspace/memory/*.md) with SQLite FTS5 BM25 ranking…",
  "parameters": {
    "type": "object",
    "properties": {
      "query": {"type": "string"},
      "k":     {"type": "integer", "minimum": 1, "maximum": 25}
    },
    "required": ["query"]
  }
}
```

Opens `$PASCLAW_HOME/workspace/memory/.index.db`, syncs against the filesystem, runs the FTS5 query, returns up to 25 hits as `path (bm25=N.NNN)` + snippet. Missing memory dir surfaces a friendly `(no memory directory yet — write to MEMORY.md first)` instead of an error.

**No `memory_add` tool by design.** Model writes durable memories by editing files with `fs_write` — same convention openclaw uses.

### 3. `BuildMemorySection` extension

The system prompt's `## Memory` section used to inject only `MEMORY.md`. It now also injects today's and yesterday's daily notes (if either exists), wrapped under `### Today (<date>)` / `### Yesterday (<date>)` subsections. Mirrors openclaw's bootstrap loading; older daily notes stay on disk and reach the model only when `memory_search` returns them.

### 4. Rules update (rule 5)

Teaches the model to:
- write **durable** preferences/project facts to `MEMORY.md`,
- write **episodic** session context to `workspace/memory/<today>.md`,
- call `memory_search` before answering questions about prior conversations.

### 5. Tool registration wired into every site

`RegisterMemoryTools` added to `PasClaw.Cmd.Agent` / `Gateway` / `TUI` / `Serve` and both `TPasClawAgent.EnsureToolsRegistered` paths in `PasClaw.Component`. Honours `--no-tools` (no registry → no memory_search).

## Build

`Makefile` adds `FCLDB_DIR` / `SQLITE_DIR` (defaulting to Debian `fp-units-db` paths) plus an optional `LAZUTILS_DIR` so `Tools.FS.Masks` keeps resolving on environments where it lives in Lazarus rather than fcl-base. `PasClaw.dproj` gets DCCReference entries for the two new units.

## Verification

- `make` — clean build under FPC 3.2.2.
- Standalone smoke test: open / SyncDir / Search hits "pascal" → top hit is `MEMORY.md` / FTS5 search hits "FTS5" / reindex picks up new term after rewrite / removed file drops from index. 7 assertions, all pass.
- `pasclaw --help` still lists every existing command unchanged.

## Deferred to Phase B

- `vec0` + embeddings + hybrid RRF retrieval (sqlite-vec loadable extension + `ILLMProvider.Embed`).
- openclaw's "memory flush" pre-compaction prompt (PasClaw has no compaction yet).
- "Dreaming" consolidation pass.
- Eviction / decay / importance scoring.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_