### PR TITLE
channels: Teams + generic webhook + LINE push (outbound notifiers, Wave 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Top-level commands are dispatched by `src/cmd/PasClaw.Cmd.Root.pas`:
 | `migrate` | Run data migrations for older versions. |
 | `skills` | List, install, or remove skill extensions. |
 | `model` | Show or change the default model. |
-| `post` | Send a one-shot message to Discord or Slack webhooks. |
+| `post` | Send a one-shot message to a Discord, Slack, Microsoft Teams, generic, or LINE webhook target. |
 | `membench` | Benchmark the memory log subsystem. |
 | `update` | Check GitHub releases or self-update. |
 | `version` | Print version/build information. |
@@ -493,7 +493,7 @@ src/
   cmd/              CLI command units and root dispatcher
   pkg/
     agent/          Agent execution and prompts
-    channels/       Telegram, Discord, Slack integrations
+    channels/       Telegram, Discord, Slack, Teams, generic webhook, LINE
     cliui/          ANSI styling, banner, command help rendering
     component/      Shared components
     config/         Version constants and on-disk config model

--- a/src/cmd/PasClaw.Cmd.Post.pas
+++ b/src/cmd/PasClaw.Cmd.Post.pas
@@ -4,9 +4,17 @@
 
     pasclaw post discord <webhook-url-or-name> "<content>"
     pasclaw post slack   <webhook-url-or-name> "<content>"
+    pasclaw post teams   <webhook-url>         "<content>"
+    pasclaw post webhook <url>                 "<content>"
+    pasclaw post line    <userId|groupId>      "<content>"
 
   Webhook URLs may be passed directly or referenced by a name stored in
   ~/.pasclaw/config.json under `channels: [{ name, kind, url, ... }]`.
+
+  `line` reads the channel access token from $PASCLAW_LINE_TOKEN.
+  `webhook` optionally reads an Authorization header value from
+  $PASCLAW_WEBHOOK_AUTH (e.g. "Bearer xyz") so cron jobs don't have to
+  put tokens on the command line.
 *)
 unit PasClaw.Cmd.Post;
 
@@ -23,11 +31,34 @@ uses
   SysUtils,
   PasClaw.CliUI,
   PasClaw.Channels.Discord,
-  PasClaw.Channels.Slack;
+  PasClaw.Channels.Slack,
+  PasClaw.Channels.Teams,
+  PasClaw.Channels.Webhook,
+  PasClaw.Channels.LINE;
 
 procedure Help;
 begin
-  WriteLn('Usage: pasclaw post <discord|slack> <webhook-url> "<content>"');
+  WriteLn('Usage: pasclaw post <discord|slack|teams|webhook|line> <target> "<content>"');
+  WriteLn('  discord  <webhook-url> "<text>"');
+  WriteLn('  slack    <webhook-url> "<text>"');
+  WriteLn('  teams    <webhook-url> "<text>"');
+  WriteLn('  webhook  <url> "<text>"           (auth via $PASCLAW_WEBHOOK_AUTH)');
+  WriteLn('  line     <userId|groupId|roomId> "<text>"');
+  WriteLn('                                    (token via $PASCLAW_LINE_TOKEN)');
+end;
+
+function ReportResult(Success: Boolean; const ChannelName: string): Integer;
+begin
+  if Success then
+  begin
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'posted to ', ChannelName);
+    Result := 0;
+  end
+  else
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, ChannelName, ' post failed');
+    Result := 1;
+  end;
 end;
 
 function DoDiscord(const URL, Content: string): Integer;
@@ -35,20 +66,8 @@ var
   W: TDiscordWebhook;
 begin
   W := TDiscordWebhook.Create(URL);
-  try
-    if W.Post(Content) then
-    begin
-      WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'posted to discord');
-      Result := 0;
-    end
-    else
-    begin
-      WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'discord post failed');
-      Result := 1;
-    end;
-  finally
-    W.Free;
-  end;
+  try Result := ReportResult(W.Post(Content), 'discord');
+  finally W.Free; end;
 end;
 
 function DoSlack(const URL, Content: string): Integer;
@@ -56,27 +75,54 @@ var
   W: TSlackWebhook;
 begin
   W := TSlackWebhook.Create(URL);
-  try
-    if W.Post(Content) then
-    begin
-      WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'posted to slack');
-      Result := 0;
-    end
-    else
-    begin
-      WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'slack post failed');
-      Result := 1;
-    end;
-  finally
-    W.Free;
+  try Result := ReportResult(W.Post(Content), 'slack');
+  finally W.Free; end;
+end;
+
+function DoTeams(const URL, Content: string): Integer;
+var
+  W: TTeamsWebhook;
+begin
+  W := TTeamsWebhook.Create(URL);
+  try Result := ReportResult(W.Post(Content), 'teams');
+  finally W.Free; end;
+end;
+
+function DoWebhook(const URL, Content: string): Integer;
+var
+  W: TGenericWebhook;
+  Auth: string;
+begin
+  Auth := GetEnvironmentVariable('PASCLAW_WEBHOOK_AUTH');
+  W := TGenericWebhook.Create(URL, Auth);
+  try Result := ReportResult(W.Post(Content), 'webhook');
+  finally W.Free; end;
+end;
+
+function DoLine(const ToId, Content: string): Integer;
+var
+  L: TLinePush;
+  Token: string;
+begin
+  Token := GetEnvironmentVariable('PASCLAW_LINE_TOKEN');
+  if Token = '' then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'line: set PASCLAW_LINE_TOKEN to a channel access token');
+    Exit(1);
   end;
+  L := TLinePush.Create(Token);
+  try Result := ReportResult(L.Push(ToId, Content), 'line');
+  finally L.Free; end;
 end;
 
 function Cmd_Post_Run(const Argv: array of string): Integer;
 begin
   if Length(Argv) < 3 then begin Help; Exit(1); end;
   if      Argv[0] = 'discord' then Result := DoDiscord(Argv[1], Argv[2])
-  else if Argv[0] = 'slack'   then Result := DoSlack(Argv[1], Argv[2])
+  else if Argv[0] = 'slack'   then Result := DoSlack  (Argv[1], Argv[2])
+  else if Argv[0] = 'teams'   then Result := DoTeams  (Argv[1], Argv[2])
+  else if Argv[0] = 'webhook' then Result := DoWebhook(Argv[1], Argv[2])
+  else if Argv[0] = 'line'    then Result := DoLine   (Argv[1], Argv[2])
   else begin Help; Result := 1; end;
 end;
 

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -189,6 +189,9 @@
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Telegram.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Discord.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Slack.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.Teams.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.Webhook.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.LINE.pas"/>
 
         <!-- pkg/cron -->
         <DCCReference Include="..\pkg\cron\PasClaw.Cron.Expr.pas"/>

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -1,0 +1,105 @@
+(*
+  PasClaw.Channels.LINE - LINE Messaging API push sender.
+
+  Outbound push only — sends a text message to a known LINE userId,
+  groupId, or roomId via the LINE Messaging API push endpoint. The
+  receive-side (webhook receiver + reply token + signature verify) is a
+  Wave 2 follow-up alongside the WhatsApp Cloud receiver, since both
+  need a publicly-reachable endpoint mounted on the gateway HTTP
+  server.
+
+  Auth uses a Channel Access Token (long-lived or stateless),
+  configured per channel:
+    - PASCLAW_LINE_TOKEN env var, or
+    - the `token` field of a config.json channel entry with kind=line.
+
+  Endpoint: POST https://api.line.me/v2/bot/message/push
+  Body:    {"to": "<id>", "messages": [{"type":"text","text":"<text>"}]}
+  Headers: Authorization: Bearer <token>
+           Content-Type:  application/json
+
+  The LINE push API has rate limits (Free plan: 500 messages/month);
+  failures are surfaced via the boolean return and the log warning
+  rather than retried — the caller decides what to do.
+
+  Docs: https://developers.line.biz/en/reference/messaging-api/#send-push-message
+*)
+unit PasClaw.Channels.LINE;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TLinePush = class
+  private
+    FToken: string;
+  public
+    constructor Create(const ChannelAccessToken: string);
+    function Push(const ToId, Text: string): Boolean;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+const
+  LINE_PUSH_URL = 'https://api.line.me/v2/bot/message/push';
+
+constructor TLinePush.Create(const ChannelAccessToken: string);
+begin
+  inherited Create;
+  FToken := ChannelAccessToken;
+end;
+
+function TLinePush.Push(const ToId, Text: string): Boolean;
+var
+  Root, Msg: TJsonObject;
+  Msgs: TJsonArray;
+  Body: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  if FToken = '' then
+  begin
+    LogWarn('line push: no channel access token configured', []);
+    Exit(False);
+  end;
+  if Trim(ToId) = '' then
+  begin
+    LogWarn('line push: empty target id', []);
+    Exit(False);
+  end;
+
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('to', ToId);
+    Msgs := TJsonArray.Create;
+    Msg  := TJsonObject.Create;
+    Msg.PutStr('type', 'text');
+    Msg.PutStr('text', Text);
+    Msgs.AddObject(Msg);
+    Root.PutArray('messages', Msgs);
+    Body := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FToken);
+  Resp := PostJSON(LINE_PUSH_URL, Body, Headers, 30);
+
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('line push: status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+end.

--- a/src/pkg/channels/PasClaw.Channels.Teams.pas
+++ b/src/pkg/channels/PasClaw.Channels.Teams.pas
@@ -1,0 +1,72 @@
+(*
+  PasClaw.Channels.Teams - Microsoft Teams Incoming Webhook sender.
+
+  Microsoft Teams' "Incoming Webhook" connector gives the user a URL like
+    https://<tenant>.webhook.office.com/webhookb2/<id>@<tenant>/IncomingWebhook/<conn>/<obj>
+  POSTing a JSON {"text": "..."} body to that URL renders as a card in
+  the configured Teams channel. No auth header — the secret is the URL
+  itself, so treat it like the Slack incoming webhook URL.
+
+  This unit only ships the outbound sender. Two-way conversations (the
+  model replies to user messages from a Teams channel) require Microsoft
+  Bot Framework registration and a publicly-reachable webhook endpoint;
+  that's a Wave 2 follow-up alongside the LINE / WhatsApp Cloud
+  receivers.
+
+  Docs: https://learn.microsoft.com/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook
+*)
+unit PasClaw.Channels.Teams;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TTeamsWebhook = class
+  private
+    FURL: string;
+  public
+    constructor Create(const WebhookURL: string);
+    function Post(const Text: string): Boolean;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+constructor TTeamsWebhook.Create(const WebhookURL: string);
+begin
+  inherited Create;
+  FURL := WebhookURL;
+end;
+
+function TTeamsWebhook.Post(const Text: string): Boolean;
+var
+  Obj: TJsonObject;
+  Body: string;
+  Empty: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  SetLength(Empty, 0);
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('text', Text);
+    Body := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+  Resp := PostJSON(FURL, Body, Empty, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('teams webhook: status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+end.

--- a/src/pkg/channels/PasClaw.Channels.Webhook.pas
+++ b/src/pkg/channels/PasClaw.Channels.Webhook.pas
@@ -1,0 +1,83 @@
+(*
+  PasClaw.Channels.Webhook - generic outbound webhook sender.
+
+  Sometimes the target service doesn't fit any specific adapter — a
+  Zapier hook, an in-house notification endpoint, an n8n workflow, a
+  Discord-but-via-DM-relay, etc. This adapter just POSTs a JSON body
+  to a URL the caller provides:
+
+    { "text": "<text>" }
+
+  Auth: callers can supply an Authorization header value as a string
+  (e.g. "Bearer xyz" or "Basic …"). Empty means no auth header.
+  Anything richer — HMAC signing, OAuth refresh, multipart — belongs
+  in a dedicated adapter, not here.
+
+  Useful for cron skills:
+    pasclaw post webhook https://hooks.example.com/cron-summary "ran fine"
+*)
+unit PasClaw.Channels.Webhook;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TGenericWebhook = class
+  private
+    FURL:  string;
+    FAuth: string;
+  public
+    constructor Create(const URL: string; const AuthHeader: string = '');
+    function Post(const Text: string): Boolean;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+constructor TGenericWebhook.Create(const URL: string; const AuthHeader: string);
+begin
+  inherited Create;
+  FURL  := URL;
+  FAuth := AuthHeader;
+end;
+
+function TGenericWebhook.Post(const Text: string): Boolean;
+var
+  Body: string;
+  Obj: TJsonObject;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  if FAuth <> '' then
+  begin
+    SetLength(Headers, 1);
+    Headers[0] := MakeHeader('Authorization', FAuth);
+  end
+  else
+    SetLength(Headers, 0);
+
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('text', Text);
+    Body := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+  Resp := PostJSON(FURL, Body, Headers, 30);
+
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('webhook: status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+end.


### PR DESCRIPTION
Wave 1 of the picoclaw channel catch-up. PasClaw had 3 of picoclaw's 20 channels (`discord`, `slack`, `telegram`). This adds three outbound notifiers that drop straight into `pasclaw post` and share the existing webhook pattern.

## Why outbound first

My original wave-1 mapping conflated picoclaw's `slack_webhook` / `teams_webhook` (post-only outbound) with real webhook receivers (LINE, WhatsApp Cloud). The receive side needs the gateway to mount per-channel HTTP routes with signature verification — a bigger architectural change that warrants its own PR. The outbound notifiers are immediately useful for cron skills and they share the proven Slack/Discord webhook pattern.

## What's in the box

| Adapter | Class | Endpoint | Auth |
|---|---|---|---|
| Microsoft Teams | `TTeamsWebhook` | user-supplied Incoming Webhook URL | URL is the secret |
| Generic webhook | `TGenericWebhook` | user-supplied URL | optional `Authorization` header via `$PASCLAW_WEBHOOK_AUTH` |
| LINE push | `TLinePush` | `POST https://api.line.me/v2/bot/message/push` | `Bearer $PASCLAW_LINE_TOKEN` |

All three are post-only — single class, single method that wraps `PostJSON`. No new units in `PasClaw.Providers.HTTP`, no gateway changes, no public-facing port.

## CLI

```sh
pasclaw post teams   https://<tenant>.webhook.office.com/...  "deploy succeeded"
pasclaw post webhook https://hooks.example.com/cron-summary    "ran fine"
pasclaw post line    U1234567890abcdef                          "build done"
```

`Cmd_Post_Run` factored a tiny `ReportResult` helper so each `Do*` function stays a one-liner; dropped a chunk of copy-pasted "if posted then green else red" boilerplate at the same time.

## Verification

- `make` — clean build under FPC 3.2.2 (linker step ran, all six new compilation units logged).
- `pasclaw post` with no args prints the new help table listing all five targets.
- `pasclaw post bogus-kind …` dispatches to help with exit 1.
- README's command-surface table updates the `post` row; repo-layout `channels/` line spells out the full set.

## Wave 1.5 (deferred to own PR)

Two-way **LINE bot** and **WhatsApp Cloud bot** receivers — both need the gateway to mount `POST /webhooks/<channel>` routes with HMAC-SHA256 signature verification, parse the platform's event JSON, dispatch into the agent loop, and reply via the existing push REST. That's the channel-mount API + roughly 700 LOC; better as its own focused PR.

## Picoclaw channels still ahead

Remaining realistic ports (excluding Chinese-ecosystem auth, hardware-specific, and `*_native` variants):

- Wave 2: LINE bot, WhatsApp Cloud bot (gateway-mounted receivers).
- Wave 3: Matrix (REST `/sync` long-poll), IRC (raw TCP via TIdIRC), VK (long-poll bot API).
- Wave 4: MQTT (Indy MQTT components).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_