### PR TITLE
channels: LINE bot — webhook receiver mounted on the gateway (Wave 1.5a)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ UNIT_DIRS = \
 	src/pkg/mcp \
 	src/pkg/gateway \
 	src/pkg/channels \
+	src/pkg/crypto \
 	src/pkg/cron \
 	src/pkg/skills \
 	src/pkg/agent \

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Environment variables:
 | `PASCLAW_CONFIG` | Overrides the config file path. |
 | `PASCLAW_VERSION` | Compile-time FPC version override used by the Makefile. |
 | `PASCLAW_TELEGRAM_TOKEN` | Default Telegram bot token for `pasclaw gateway --telegram`. |
+| `PASCLAW_LINE_TOKEN` | LINE Messaging API channel access token. Used by `pasclaw post line` and `pasclaw gateway --line`. |
+| `PASCLAW_LINE_SECRET` | LINE channel secret. Required by `pasclaw gateway --line` to verify `X-Line-Signature` on inbound events. |
 | `NO_COLOR` | Disables ANSI color output. |
 
 Useful config commands:
@@ -239,6 +241,7 @@ Subsequent phases will add `scripts/` (callable helpers) + `references/` (lazy-l
 pasclaw gateway
 pasclaw gateway --addr 0.0.0.0 --port 8088
 pasclaw gateway --telegram --token <BOT_TOKEN>
+pasclaw gateway --line                              # also pass $PASCLAW_LINE_TOKEN + $PASCLAW_LINE_SECRET
 pasclaw gateway --no-tools --no-mcp --no-hashline
 
 pasclaw serve

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -32,7 +32,8 @@ uses
   PasClaw.Skills.Loader,
   PasClaw.Cron.Scheduler,
   PasClaw.Gateway.Server,
-  PasClaw.Channels.Telegram;
+  PasClaw.Channels.Telegram,
+  PasClaw.Channels.LINE;
 
 type
   TGwArgs = record
@@ -40,6 +41,9 @@ type
     Port:        Integer;
     Telegram:    Boolean;
     Token:       string;
+    Line:        Boolean;
+    LineToken:   string;
+    LineSecret:  string;
     NoMCP:       Boolean;
     NoTools:     Boolean;
     NoHashline:  Boolean;
@@ -53,6 +57,9 @@ begin
   Result.Port       := Cfg.Gateway.Port;
   Result.Telegram   := False;
   Result.Token      := GetEnvironmentVariable('PASCLAW_TELEGRAM_TOKEN');
+  Result.Line       := False;
+  Result.LineToken  := GetEnvironmentVariable('PASCLAW_LINE_TOKEN');
+  Result.LineSecret := GetEnvironmentVariable('PASCLAW_LINE_SECRET');
   Result.NoMCP      := False;
   Result.NoTools    := False;
   Result.NoHashline := False;
@@ -63,6 +70,9 @@ begin
     if Argv[i] = '--port'         then begin if i < High(Argv) then Result.Port     := StrToIntDef(Argv[i + 1], Result.Port); Inc(i, 2); Continue; end;
     if Argv[i] = '--telegram'     then begin Result.Telegram   := True; Inc(i); Continue; end;
     if Argv[i] = '--token'        then begin if i < High(Argv) then Result.Token    := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--line'         then begin Result.Line       := True; Inc(i); Continue; end;
+    if Argv[i] = '--line-token'   then begin if i < High(Argv) then Result.LineToken  := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--line-secret'  then begin if i < High(Argv) then Result.LineSecret := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--no-mcp'       then begin Result.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-tools'     then begin Result.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
@@ -80,6 +90,7 @@ var
   MCPClients: TMCPClientList;
   Server: TGatewayServer;
   Telegram: TTelegramChannel;
+  Line: TLineBot;
   Scheduler: TCronScheduler;
   Skills: TSkillSpecArray;
 begin
@@ -119,13 +130,29 @@ begin
 
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
     Telegram := nil;
+    Line     := nil;
     try
+      if Args.Line then
+      begin
+        if (Args.LineToken = '') or (Args.LineSecret = '') then
+        begin
+          LogError('line: need both --line-token / $PASCLAW_LINE_TOKEN and ' +
+                   '--line-secret / $PASCLAW_LINE_SECRET');
+          Exit(1);
+        end;
+        Line := TLineBot.Create(Args.LineToken, Args.LineSecret,
+                                Cfg, Provider, Reg);
+        Server.MountWebhook('/webhooks/line', Line.HandleWebhook);
+      end;
+
       Server.Start(Args.Addr, Args.Port);
 
       WriteLn(Ansi.Bold, 'Gateway up.', Ansi.Reset);
       WriteLn('  http://', Args.Addr, ':', Args.Port, '/v1/health');
       WriteLn('  http://', Args.Addr, ':', Args.Port, '/v1/tools');
       WriteLn('  POST http://', Args.Addr, ':', Args.Port, '/v1/chat   {"message":"..."}');
+      if Args.Line then
+        WriteLn('  POST http://', Args.Addr, ':', Args.Port, '/webhooks/line   (LINE platform)');
       WriteLn(Ansi.Dim, 'Press Ctrl-C to stop.', Ansi.Reset);
 
       if Args.Telegram then
@@ -145,6 +172,7 @@ begin
         Server.WaitForStop;
     finally
       if Telegram <> nil then Telegram.Free;
+      if Line     <> nil then Line.Free;
       Server.Stop;
       Server.Free;
       if Scheduler <> nil then Scheduler.Free;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -192,6 +192,9 @@
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Teams.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Webhook.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.LINE.pas"/>
+
+        <!-- pkg/crypto -->
+        <DCCReference Include="..\pkg\crypto\PasClaw.Crypto.HMAC.pas"/>
 
         <!-- pkg/cron -->
         <DCCReference Include="..\pkg\cron\PasClaw.Cron.Expr.pas"/>

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -1,28 +1,32 @@
 (*
-  PasClaw.Channels.LINE - LINE Messaging API push sender.
+  PasClaw.Channels.LINE - LINE Messaging API client.
 
-  Outbound push only — sends a text message to a known LINE userId,
-  groupId, or roomId via the LINE Messaging API push endpoint. The
-  receive-side (webhook receiver + reply token + signature verify) is a
-  Wave 2 follow-up alongside the WhatsApp Cloud receiver, since both
-  need a publicly-reachable endpoint mounted on the gateway HTTP
-  server.
+  Two surfaces:
 
-  Auth uses a Channel Access Token (long-lived or stateless),
-  configured per channel:
-    - PASCLAW_LINE_TOKEN env var, or
-    - the `token` field of a config.json channel entry with kind=line.
+    TLinePush - outbound push. Sends a text message to a known userId,
+                groupId, or roomId via POST /v2/bot/message/push with
+                Bearer <token>. Useful from cron skills via
+                `pasclaw post line`.
 
-  Endpoint: POST https://api.line.me/v2/bot/message/push
-  Body:    {"to": "<id>", "messages": [{"type":"text","text":"<text>"}]}
-  Headers: Authorization: Bearer <token>
-           Content-Type:  application/json
+    TLineBot  - bidirectional webhook receiver + reply. Mounted as a
+                gateway route via TGatewayServer.MountWebhook; receives
+                events at POST /webhooks/line, verifies the
+                X-Line-Signature HMAC-SHA256/Base64 against the channel
+                secret, parses the event JSON, and runs each text
+                message through the same RunToolLoop the Telegram bot
+                uses. Replies use the one-shot replyToken (POST
+                /v2/bot/message/reply) for the first response inside
+                the ~30 s window; the bot falls back to push when the
+                handler responds after the reply window closes.
 
-  The LINE push API has rate limits (Free plan: 500 messages/month);
-  failures are surfaced via the boolean return and the log warning
-  rather than retried — the caller decides what to do.
+  Configuration:
+    Channel access token:  $PASCLAW_LINE_TOKEN
+    Channel secret (HMAC): $PASCLAW_LINE_SECRET
 
-  Docs: https://developers.line.biz/en/reference/messaging-api/#send-push-message
+  Docs:
+    Push:    https://developers.line.biz/en/reference/messaging-api/#send-push-message
+    Reply:   https://developers.line.biz/en/reference/messaging-api/#send-reply-message
+    Webhook: https://developers.line.biz/en/reference/messaging-api/#webhooks
 *)
 unit PasClaw.Channels.LINE;
 
@@ -32,7 +36,11 @@ unit PasClaw.Channels.LINE;
 interface
 
 uses
-  SysUtils, Classes;
+  SysUtils, Classes,
+  IdContext, IdCustomHTTPServer,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
 
 type
   TLinePush = class
@@ -43,15 +51,40 @@ type
     function Push(const ToId, Text: string): Boolean;
   end;
 
+  TLineBot = class
+  private
+    FToken:    string;
+    FSecret:   string;
+    FCfg:      TConfig;
+    FProvider: ILLMProvider;
+    FRegistry: TToolRegistry;
+    FPush:     TLinePush;
+    function VerifySignature(const Body, SignatureB64: string): Boolean;
+    function Reply(const ReplyToken, Text: string): Boolean;
+    procedure ProcessEvent(const EventJSON: string);
+  public
+    constructor Create(const ChannelAccessToken, ChannelSecret: string;
+                       Cfg: TConfig; Provider: ILLMProvider;
+                       Registry: TToolRegistry);
+    destructor Destroy; override;
+    procedure HandleWebhook(AContext: TIdContext;
+                            ARequest: TIdHTTPRequestInfo;
+                            AResponse: TIdHTTPResponseInfo);
+  end;
+
 implementation
 
 uses
   PasClaw.JSON,
   PasClaw.Logger,
-  PasClaw.Providers.HTTP;
+  PasClaw.Providers.HTTP,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop,
+  PasClaw.Crypto.HMAC;
 
 const
-  LINE_PUSH_URL = 'https://api.line.me/v2/bot/message/push';
+  LINE_PUSH_URL  = 'https://api.line.me/v2/bot/message/push';
+  LINE_REPLY_URL = 'https://api.line.me/v2/bot/message/reply';
 
 constructor TLinePush.Create(const ChannelAccessToken: string);
 begin
@@ -59,13 +92,41 @@ begin
   FToken := ChannelAccessToken;
 end;
 
-function TLinePush.Push(const ToId, Text: string): Boolean;
+function PushOrReply(const URL, Token, BodyJSON: string): Boolean;
+var
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + Token);
+  Resp := PostJSON(URL, BodyJSON, Headers, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('line: %s -> status=%d body=%s',
+            [URL, Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+function BuildTextMessagesBody(const KeyName, KeyValue, Text: string): string;
 var
   Root, Msg: TJsonObject;
   Msgs: TJsonArray;
-  Body: string;
-  Headers: array of THeaderPair;
-  Resp: THTTPResult;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr(KeyName, KeyValue);
+    Msgs := TJsonArray.Create;
+    Msg  := TJsonObject.Create;
+    Msg.PutStr('type', 'text');
+    Msg.PutStr('text', Text);
+    Msgs.AddObject(Msg);
+    Root.PutArray('messages', Msgs);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TLinePush.Push(const ToId, Text: string): Boolean;
 begin
   if FToken = '' then
   begin
@@ -77,29 +138,201 @@ begin
     LogWarn('line push: empty target id', []);
     Exit(False);
   end;
+  Result := PushOrReply(LINE_PUSH_URL, FToken,
+                        BuildTextMessagesBody('to', ToId, Text));
+end;
 
-  Root := TJsonObject.Create;
+constructor TLineBot.Create(const ChannelAccessToken, ChannelSecret: string;
+                             Cfg: TConfig; Provider: ILLMProvider;
+                             Registry: TToolRegistry);
+begin
+  inherited Create;
+  FToken    := ChannelAccessToken;
+  FSecret   := ChannelSecret;
+  FCfg      := Cfg;
+  FProvider := Provider;
+  FRegistry := Registry;
+  FPush     := TLinePush.Create(ChannelAccessToken);
+end;
+
+destructor TLineBot.Destroy;
+begin
+  FPush.Free;
+  inherited Destroy;
+end;
+
+function TLineBot.VerifySignature(const Body, SignatureB64: string): Boolean;
+var
+  Expected: string;
+begin
+  if FSecret = '' then
+  begin
+    LogWarn('line webhook: no channel secret configured; rejecting', []);
+    Exit(False);
+  end;
+  if SignatureB64 = '' then Exit(False);
+  Expected := HMACSHA256Base64(StringToBytes(FSecret), StringToBytes(Body));
+  Result := ConstantTimeEqual(Expected, SignatureB64);
+end;
+
+function TLineBot.Reply(const ReplyToken, Text: string): Boolean;
+begin
+  if Trim(ReplyToken) = '' then Exit(False);
+  Result := PushOrReply(LINE_REPLY_URL, FToken,
+                        BuildTextMessagesBody('replyToken', ReplyToken, Text));
+end;
+
+procedure TLineBot.ProcessEvent(const EventJSON: string);
+var
+  Obj, MsgObj, SrcObj: TJsonObject;
+  Kind, MsgType, Text, ReplyToken, SourceId, Response: string;
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+begin
+  Obj := TJsonObject.Parse(EventJSON);
+  if Obj = nil then Exit;
   try
-    Root.PutStr('to', ToId);
-    Msgs := TJsonArray.Create;
-    Msg  := TJsonObject.Create;
-    Msg.PutStr('type', 'text');
-    Msg.PutStr('text', Text);
-    Msgs.AddObject(Msg);
-    Root.PutArray('messages', Msgs);
-    Body := Root.ToJSON;
+    Kind := Obj.GetStr('type', '');
+    if Kind <> 'message' then Exit;
+
+    MsgObj := Obj.ChildObject('message');
+    if MsgObj = nil then Exit;
+    try
+      MsgType := MsgObj.GetStr('type', '');
+      if MsgType <> 'text' then Exit;
+      Text := MsgObj.GetStr('text', '');
+    finally
+      MsgObj.Free;
+    end;
+
+    if Trim(Text) = '' then Exit;
+    ReplyToken := Obj.GetStr('replyToken', '');
+
+    SrcObj := Obj.ChildObject('source');
+    if SrcObj <> nil then
+    try
+      { LINE source.type is "user" / "group" / "room"; the matching
+        id field varies. Pick whichever exists for push fallback. }
+      SourceId := SrcObj.GetStr('userId',  '');
+      if SourceId = '' then SourceId := SrcObj.GetStr('groupId', '');
+      if SourceId = '' then SourceId := SrcObj.GetStr('roomId',  '');
+    finally
+      SrcObj.Free;
+    end;
+  finally
+    Obj.Free;
+  end;
+
+  LogInfo('line: %s msg=%s', [SourceId, Copy(Text, 1, 80)]);
+
+  if FProvider = nil then
+  begin
+    Response := '(no provider configured — run `pasclaw onboard`)';
+    if not Reply(ReplyToken, Response) and (SourceId <> '') then
+      FPush.Push(SourceId, Response);
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Text);
+
+  LoopCfg.Provider      := FProvider;
+  LoopCfg.Registry      := FRegistry;
+  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.MaxIterations := 6;
+  LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.OnText        := nil;
+  LoopCfg.OnToolCall    := nil;
+  LoopCfg.OnToolResult  := nil;
+
+  if RunToolLoop(LoopCfg, Msgs, Loop) and (Loop.Content <> '') then
+    Response := Loop.Content
+  else
+    Response := '(sorry — model returned no content)';
+
+  { Try Reply first — free, fast, single-use. If the token expired or
+    was already consumed (RunToolLoop took >30 s) fall back to Push so
+    the user still gets the answer. }
+  if not Reply(ReplyToken, Response) then
+    if SourceId <> '' then FPush.Push(SourceId, Response);
+end;
+
+procedure TLineBot.HandleWebhook(AContext: TIdContext;
+                                  ARequest: TIdHTTPRequestInfo;
+                                  AResponse: TIdHTTPResponseInfo);
+var
+  Body, Signature: string;
+  Bytes: TBytes;
+  Root: TJsonObject;
+  Events: TJsonArray;
+  EvObj: TJsonObject;
+  i: Integer;
+begin
+  if ARequest.PostStream <> nil then
+  begin
+    SetLength(Bytes, ARequest.PostStream.Size);
+    ARequest.PostStream.Position := 0;
+    if Length(Bytes) > 0 then
+      ARequest.PostStream.ReadBuffer(Bytes[0], Length(Bytes));
+    {$IFDEF FPC}
+    SetString(Body, PAnsiChar(@Bytes[0]), Length(Bytes));
+    {$ELSE}
+    Body := TEncoding.UTF8.GetString(Bytes);
+    {$ENDIF}
+  end
+  else
+    Body := '';
+
+  Signature := ARequest.RawHeaders.Values['X-Line-Signature'];
+
+  if not VerifySignature(Body, Signature) then
+  begin
+    AResponse.ResponseNo  := 401;
+    AResponse.ContentText := '{"error":"signature"}';
+    AResponse.ContentType := 'application/json';
+    LogWarn('line webhook: signature rejected', []);
+    Exit;
+  end;
+
+  { LINE retries up to 3 times when we return non-2xx, so respond 200
+    even if dispatch fails internally — the retries would only make
+    duplicate replies. }
+  AResponse.ResponseNo  := 200;
+  AResponse.ContentText := '{}';
+  AResponse.ContentType := 'application/json';
+
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(Body);
+  except
+    on E: Exception do
+    begin
+      LogWarn('line webhook: bad JSON: %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Root = nil then Exit;
+  try
+    Events := Root.ChildArray('events');
+    if Events = nil then Exit;
+    try
+      for i := 0 to Events.Count - 1 do
+      begin
+        EvObj := Events.ItemObject(i);
+        if EvObj = nil then Continue;
+        try
+          ProcessEvent(EvObj.ToJSON);
+        finally
+          EvObj.Free;
+        end;
+      end;
+    finally
+      Events.Free;
+    end;
   finally
     Root.Free;
   end;
-
-  SetLength(Headers, 1);
-  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FToken);
-  Resp := PostJSON(LINE_PUSH_URL, Body, Headers, 30);
-
-  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
-  if not Result then
-    LogWarn('line push: status=%d body=%s',
-            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
 end;
 
 end.

--- a/src/pkg/crypto/PasClaw.Crypto.HMAC.pas
+++ b/src/pkg/crypto/PasClaw.Crypto.HMAC.pas
@@ -1,0 +1,301 @@
+(*
+  PasClaw.Crypto.HMAC - SHA-256 and HMAC-SHA-256 over arbitrary bytes,
+  with Base64 and lowercase-hex encoders for the two main webhook
+  signature shapes (LINE expects Base64 in X-Line-Signature; WhatsApp
+  expects "sha256=" + lowercase hex in X-Hub-Signature-256).
+
+  Pure Pascal implementation of FIPS 180-4 SHA-256 and RFC 2104 HMAC.
+  No OpenSSL, no Indy hash dependency, no platform-specific units —
+  same code path under FPC ({$MODE DELPHI}) and Delphi 12. The Indy
+  HMAC classes are tied to OpenSSL's EVP function pointers and the
+  OpenSSL 3 export changes are flaky to detect at load time; doing the
+  primitive ourselves removes that whole class of failure mode.
+
+  ConstantTimeEqual is a length-checked byte-by-byte XOR — never
+  compare signatures with `=`, the early-out timing leaks one byte at
+  a time.
+*)
+unit PasClaw.Crypto.HMAC;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}{$Q-}{$R-}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+function SHA256Bytes(const Data: TBytes): TBytes;
+function HMACSHA256Bytes(const Key, Data: TBytes): TBytes;
+function HMACSHA256Base64(const Key, Data: TBytes): string;
+function HMACSHA256HexLower(const Key, Data: TBytes): string;
+function StringToBytes(const S: string): TBytes;
+function BytesToHexLower(const B: TBytes): string;
+function ConstantTimeEqual(const A, B: string): Boolean;
+
+implementation
+
+const
+  SHA256_BLOCK = 64;
+  SHA256_HASH  = 32;
+
+  K: array[0..63] of LongWord = (
+    $428a2f98, $71374491, $b5c0fbcf, $e9b5dba5, $3956c25b, $59f111f1, $923f82a4, $ab1c5ed5,
+    $d807aa98, $12835b01, $243185be, $550c7dc3, $72be5d74, $80deb1fe, $9bdc06a7, $c19bf174,
+    $e49b69c1, $efbe4786, $0fc19dc6, $240ca1cc, $2de92c6f, $4a7484aa, $5cb0a9dc, $76f988da,
+    $983e5152, $a831c66d, $b00327c8, $bf597fc7, $c6e00bf3, $d5a79147, $06ca6351, $14292967,
+    $27b70a85, $2e1b2138, $4d2c6dfc, $53380d13, $650a7354, $766a0abb, $81c2c92e, $92722c85,
+    $a2bfe8a1, $a81a664b, $c24b8b70, $c76c51a3, $d192e819, $d6990624, $f40e3585, $106aa070,
+    $19a4c116, $1e376c08, $2748774c, $34b0bcb5, $391c0cb3, $4ed8aa4a, $5b9cca4f, $682e6ff3,
+    $748f82ee, $78a5636f, $84c87814, $8cc70208, $90befffa, $a4506ceb, $bef9a3f7, $c67178f2
+  );
+
+function RotR(X: LongWord; N: Byte): LongWord; inline;
+begin
+  Result := (X shr N) or (X shl (32 - N));
+end;
+
+function Ch(x, y, z: LongWord): LongWord; inline;
+begin
+  Result := (x and y) xor ((not x) and z);
+end;
+
+function Maj(x, y, z: LongWord): LongWord; inline;
+begin
+  Result := (x and y) xor (x and z) xor (y and z);
+end;
+
+function BigSig0(x: LongWord): LongWord; inline;
+begin
+  Result := RotR(x, 2) xor RotR(x, 13) xor RotR(x, 22);
+end;
+
+function BigSig1(x: LongWord): LongWord; inline;
+begin
+  Result := RotR(x, 6) xor RotR(x, 11) xor RotR(x, 25);
+end;
+
+function LilSig0(x: LongWord): LongWord; inline;
+begin
+  Result := RotR(x, 7) xor RotR(x, 18) xor (x shr 3);
+end;
+
+function LilSig1(x: LongWord): LongWord; inline;
+begin
+  Result := RotR(x, 17) xor RotR(x, 19) xor (x shr 10);
+end;
+
+procedure ProcessBlock(var State: array of LongWord; const Block: array of Byte);
+var
+  W: array[0..63] of LongWord;
+  i: Integer;
+  va, vb, vc, vd, ve, vf, vg, vh, T1, T2: LongWord;
+begin
+  for i := 0 to 15 do
+    W[i] := (LongWord(Block[i * 4    ]) shl 24) or
+            (LongWord(Block[i * 4 + 1]) shl 16) or
+            (LongWord(Block[i * 4 + 2]) shl  8) or
+             LongWord(Block[i * 4 + 3]);
+  for i := 16 to 63 do
+    W[i] := LilSig1(W[i - 2]) + W[i - 7] + LilSig0(W[i - 15]) + W[i - 16];
+
+  va := State[0]; vb := State[1]; vc := State[2]; vd := State[3];
+  ve := State[4]; vf := State[5]; vg := State[6]; vh := State[7];
+
+  for i := 0 to 63 do
+  begin
+    T1 := vh + BigSig1(ve) + Ch(ve, vf, vg) + K[i] + W[i];
+    T2 := BigSig0(va) + Maj(va, vb, vc);
+    vh := vg; vg := vf; vf := ve; ve := vd + T1;
+    vd := vc; vc := vb; vb := va; va := T1 + T2;
+  end;
+
+  State[0] := State[0] + va; State[1] := State[1] + vb;
+  State[2] := State[2] + vc; State[3] := State[3] + vd;
+  State[4] := State[4] + ve; State[5] := State[5] + vf;
+  State[6] := State[6] + vg; State[7] := State[7] + vh;
+end;
+
+function SHA256Bytes(const Data: TBytes): TBytes;
+var
+  State: array[0..7] of LongWord;
+  PadLen, Total, i, Pos: Integer;
+  Buf: array of Byte;
+  BitLen: UInt64;
+  Block: array[0..63] of Byte;
+begin
+  State[0] := $6a09e667; State[1] := $bb67ae85; State[2] := $3c6ef372; State[3] := $a54ff53a;
+  State[4] := $510e527f; State[5] := $9b05688c; State[6] := $1f83d9ab; State[7] := $5be0cd19;
+
+  { Pad: original || 0x80 || zero bytes || 8-byte big-endian bit length.
+    Total padded length is a multiple of 64. }
+  PadLen := SHA256_BLOCK - ((Length(Data) + 1 + 8) mod SHA256_BLOCK);
+  if PadLen = SHA256_BLOCK then PadLen := 0;
+  Total := Length(Data) + 1 + PadLen + 8;
+  SetLength(Buf, Total);
+  if Length(Data) > 0 then
+    Move(Data[0], Buf[0], Length(Data));
+  Buf[Length(Data)] := $80;
+  for i := Length(Data) + 1 to Length(Data) + PadLen do
+    Buf[i] := 0;
+
+  BitLen := UInt64(Length(Data)) * 8;
+  for i := 0 to 7 do
+    Buf[Total - 8 + i] := Byte(BitLen shr (8 * (7 - i)));
+
+  Pos := 0;
+  while Pos < Total do
+  begin
+    Move(Buf[Pos], Block[0], SHA256_BLOCK);
+    ProcessBlock(State, Block);
+    Inc(Pos, SHA256_BLOCK);
+  end;
+
+  SetLength(Result, SHA256_HASH);
+  for i := 0 to 7 do
+  begin
+    Result[i * 4    ] := Byte(State[i] shr 24);
+    Result[i * 4 + 1] := Byte(State[i] shr 16);
+    Result[i * 4 + 2] := Byte(State[i] shr  8);
+    Result[i * 4 + 3] := Byte(State[i]);
+  end;
+end;
+
+function HMACSHA256Bytes(const Key, Data: TBytes): TBytes;
+var
+  K0: array[0..SHA256_BLOCK - 1] of Byte;
+  IPadded, OPadded, Inner: TBytes;
+  i: Integer;
+  ShortKey: TBytes;
+begin
+  FillChar(K0, SizeOf(K0), 0);
+  if Length(Key) > SHA256_BLOCK then
+  begin
+    ShortKey := SHA256Bytes(Key);
+    Move(ShortKey[0], K0[0], Length(ShortKey));
+  end
+  else if Length(Key) > 0 then
+    Move(Key[0], K0[0], Length(Key));
+
+  SetLength(IPadded, SHA256_BLOCK + Length(Data));
+  for i := 0 to SHA256_BLOCK - 1 do IPadded[i] := K0[i] xor $36;
+  if Length(Data) > 0 then
+    Move(Data[0], IPadded[SHA256_BLOCK], Length(Data));
+  Inner := SHA256Bytes(IPadded);
+
+  SetLength(OPadded, SHA256_BLOCK + SHA256_HASH);
+  for i := 0 to SHA256_BLOCK - 1 do OPadded[i] := K0[i] xor $5c;
+  Move(Inner[0], OPadded[SHA256_BLOCK], SHA256_HASH);
+  Result := SHA256Bytes(OPadded);
+end;
+
+function StringToBytes(const S: string): TBytes;
+{$IFDEF FPC}
+var
+  Raw: RawByteString;
+{$ENDIF}
+begin
+  if S = '' then
+  begin
+    SetLength(Result, 0);
+    Exit;
+  end;
+  {$IFDEF FPC}
+  Raw := UTF8Encode(S);
+  SetLength(Result, Length(Raw));
+  if Length(Raw) > 0 then
+    Move(Raw[1], Result[0], Length(Raw));
+  {$ELSE}
+  Result := TEncoding.UTF8.GetBytes(S);
+  {$ENDIF}
+end;
+
+function BytesToHexLower(const B: TBytes): string;
+const
+  Hex: array[0..15] of Char =
+    ('0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f');
+var
+  i: Integer;
+  Bt: Byte;
+begin
+  SetLength(Result, Length(B) * 2);
+  for i := 0 to High(B) do
+  begin
+    Bt := B[i];
+    Result[1 + i * 2]     := Hex[Bt shr 4];
+    Result[1 + i * 2 + 1] := Hex[Bt and $F];
+  end;
+end;
+
+function HMACSHA256HexLower(const Key, Data: TBytes): string;
+begin
+  Result := BytesToHexLower(HMACSHA256Bytes(Key, Data));
+end;
+
+function BytesToBase64(const B: TBytes): string;
+const
+  Alphabet: array[0..63] of Char =
+    ('A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P',
+     'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f',
+     'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v',
+     'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/');
+var
+  i, Triplets, Rem, OutLen, OPos: Integer;
+  B1, B2, B3: Byte;
+  N: LongWord;
+begin
+  Triplets := Length(B) div 3;
+  Rem      := Length(B) mod 3;
+  OutLen   := ((Length(B) + 2) div 3) * 4;
+  SetLength(Result, OutLen);
+  OPos := 1;
+  for i := 0 to Triplets - 1 do
+  begin
+    B1 := B[i * 3];
+    B2 := B[i * 3 + 1];
+    B3 := B[i * 3 + 2];
+    N := (LongWord(B1) shl 16) or (LongWord(B2) shl 8) or LongWord(B3);
+    Result[OPos]     := Alphabet[(N shr 18) and $3F];
+    Result[OPos + 1] := Alphabet[(N shr 12) and $3F];
+    Result[OPos + 2] := Alphabet[(N shr  6) and $3F];
+    Result[OPos + 3] := Alphabet[N          and $3F];
+    Inc(OPos, 4);
+  end;
+  if Rem = 1 then
+  begin
+    B1 := B[Triplets * 3];
+    Result[OPos]     := Alphabet[(B1 shr 2) and $3F];
+    Result[OPos + 1] := Alphabet[(B1 shl 4) and $3F];
+    Result[OPos + 2] := '=';
+    Result[OPos + 3] := '=';
+  end
+  else if Rem = 2 then
+  begin
+    B1 := B[Triplets * 3];
+    B2 := B[Triplets * 3 + 1];
+    Result[OPos]     := Alphabet[(B1 shr 2) and $3F];
+    Result[OPos + 1] := Alphabet[((B1 shl 4) or (B2 shr 4)) and $3F];
+    Result[OPos + 2] := Alphabet[(B2 shl 2) and $3F];
+    Result[OPos + 3] := '=';
+  end;
+end;
+
+function HMACSHA256Base64(const Key, Data: TBytes): string;
+begin
+  Result := BytesToBase64(HMACSHA256Bytes(Key, Data));
+end;
+
+function ConstantTimeEqual(const A, B: string): Boolean;
+var
+  Diff: Byte;
+  Len, i: Integer;
+begin
+  if Length(A) <> Length(B) then Exit(False);
+  Len := Length(A);
+  Diff := 0;
+  for i := 1 to Len do
+    Diff := Diff or (Byte(A[i]) xor Byte(B[i]));
+  Result := Diff = 0;
+end;
+
+end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -35,6 +35,15 @@ uses
   PasClaw.Tools.Registry;
 
 type
+  { Method-of-object signature any channel (LINE, WhatsApp, Slack Events
+    API, …) can register on the gateway via MountWebhook so the model
+    can be reached from a public IM platform without spinning a second
+    HTTP server. The handler owns its own response: signature check,
+    parse, run the agent loop, write the reply object. }
+  TWebhookHandler = procedure(AContext: TIdContext;
+                              ARequest: TIdHTTPRequestInfo;
+                              AResponse: TIdHTTPResponseInfo) of object;
+
   { Wraps TIdHTTPServer and dispatches requests to handler methods. Pass a
     provider + tool registry in at construction; ownership stays with the
     caller. Stop() blocks until the listener has fully torn down. }
@@ -48,6 +57,11 @@ type
     FStopFlag: TEvent;
     FDebugIO:  Boolean;
     FMaxIter:  Integer;
+    FWebhookPaths:    TStringList;
+    FWebhookHandlers: array of TWebhookHandler;
+    function DispatchWebhook(AContext: TIdContext;
+                             ARequest: TIdHTTPRequestInfo;
+                             AResponse: TIdHTTPResponseInfo): Boolean;
     procedure OnCommandGet(AContext: TIdContext;
                            ARequest: TIdHTTPRequestInfo;
                            AResponse: TIdHTTPResponseInfo);
@@ -83,6 +97,12 @@ type
     procedure Start(const BindAddr: string; Port: Integer);
     procedure Stop;
     procedure WaitForStop;
+    { Channel webhook registration. Adds an exact-match POST route at Path
+      that runs Handler when a client POSTs to it. Handlers must respond
+      with 401 for unauthenticated requests; the dispatcher does not
+      authenticate on its behalf. Mount must be called before Start so
+      the route is in place when Indy binds. }
+    procedure MountWebhook(const Path: string; Handler: TWebhookHandler);
   end;
 
 implementation
@@ -105,6 +125,9 @@ begin
   FRegistry := Registry;
   FMaxIter  := 25;
   FStopFlag := TEvent.Create(nil, True, False, '');
+  FWebhookPaths := TStringList.Create;
+  FWebhookPaths.CaseSensitive := False;
+  SetLength(FWebhookHandlers, 0);
   FHTTP := TIdHTTPServer.Create(nil);
   FHTTP.OnCommandGet := OnCommandGet;
   FHTTP.KeepAlive    := True;
@@ -116,7 +139,41 @@ begin
   Stop;
   FHTTP.Free;
   FStopFlag.Free;
+  FWebhookPaths.Free;
   inherited Destroy;
+end;
+
+procedure TGatewayServer.MountWebhook(const Path: string; Handler: TWebhookHandler);
+var
+  Idx: Integer;
+begin
+  Idx := FWebhookPaths.IndexOf(Path);
+  if Idx >= 0 then
+  begin
+    FWebhookHandlers[Idx] := Handler;
+    Exit;
+  end;
+  FWebhookPaths.Add(Path);
+  SetLength(FWebhookHandlers, FWebhookPaths.Count);
+  FWebhookHandlers[FWebhookPaths.Count - 1] := Handler;
+  LogInfo('gateway: mounted webhook %s', [Path]);
+end;
+
+function TGatewayServer.DispatchWebhook(AContext: TIdContext;
+                                         ARequest: TIdHTTPRequestInfo;
+                                         AResponse: TIdHTTPResponseInfo): Boolean;
+var
+  Idx: Integer;
+  Handler: TWebhookHandler;
+begin
+  Result := False;
+  if ARequest.Command <> 'POST' then Exit;
+  Idx := FWebhookPaths.IndexOf(ARequest.Document);
+  if Idx < 0 then Exit;
+  Handler := FWebhookHandlers[Idx];
+  if not Assigned(Handler) then Exit;
+  Handler(AContext, ARequest, AResponse);
+  Result := True;
 end;
 
 procedure TGatewayServer.Start(const BindAddr: string; Port: Integer);
@@ -225,7 +282,7 @@ begin
     else if Doc = '/v1' then
       WriteJSON(AResponse, 200,
         '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat","/v1/chat/completions","/v1/responses","/v1/models"]}')
-    else
+    else if not DispatchWebhook(AContext, ARequest, AResponse) then
       WriteJSON(AResponse, 404, '{"error":"not found","path":"' + Doc + '"}');
   except
     on E: Exception do


### PR DESCRIPTION
First two-way IM bot beyond Telegram. PR #75 shipped LINE *push*; this PR closes the loop with a webhook *receiver* that runs the agent and replies. Three things landed together because all three are needed for any future webhook-based channel (WhatsApp Cloud is next).

## 1. Gateway "mount webhook" API

`TGatewayServer.MountWebhook(Path, Handler)` registers an exact-match POST route. The new `DispatchWebhook` is called from `OnCommandGet` just before the 404 fall-through, so the channel piggybacks on the same Indy listener PasClaw already runs for `/v1` — no second TCP port, no second TLS config, no second auth scheme.

```pascal
type
  TWebhookHandler = procedure(AContext: TIdContext;
                              ARequest: TIdHTTPRequestInfo;
                              AResponse: TIdHTTPResponseInfo) of object;
```

Handlers own their own response — signature check, parse, run the agent loop, write the reply. The dispatcher does not authenticate on their behalf.

## 2. Pure-Pascal SHA-256 + HMAC-SHA-256

`src/pkg/crypto/PasClaw.Crypto.HMAC.pas`. Indy's `TIdHMACSHA256` routes through OpenSSL's `EVP_sha256` and OpenSSL 3's export layout is flaky to detect at load time — Indy's `IsAvailable` returned `False` even with `libssl.so.3` fully loaded. Doing the primitive ourselves removes the whole class of failure mode and runs identical under FPC `{$MODE DELPHI}` and Delphi 12. Zero native deps, zero compile-time hash unit picker.

Verified against `openssl dgst -sha256 -hmac`:

```
HMAC-SHA256("key", "The quick brown fox jumps over the lazy dog")
  hex:    f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8
  base64: 97yD9DBThCSxMpjmqm+xQ+9NWaFJRhdZl0edvC0aPNg=
```

Includes `ConstantTimeEqual` for signature compares (never `=` — early-out leaks one byte at a time).

## 3. `TLineBot`

Sits alongside the existing `TLinePush` in `PasClaw.Channels.LINE`. Holds Cfg / Provider / Registry directly (mirrors `TTelegramChannel` — no callback indirection, no abstract bridge). `HandleWebhook`:

1. Reads the raw request body — signature is over bytes, not the parsed JSON.
2. Verifies `X-Line-Signature` via `ConstantTimeEqual(HMACSHA256Base64(secret, body), header)`.
3. Returns `401 {"error":"signature"}` on mismatch.
4. Returns `200` immediately so LINE doesn't retry on internal errors (their retry storms duplicate replies).
5. Parses each event; for `type=message` + `message.type=text`, runs `RunToolLoop` with the user text.
6. Replies via `/v2/bot/message/reply` using the one-shot `replyToken` (free + fast inside ~30 s) and falls back to `/v2/bot/message/push` when the token expired because the tool loop took longer.

Source ID picks `userId` / `groupId` / `roomId` in order — fallback push works for any chat type.

## CLI

```sh
pasclaw gateway --line                                    # env: $PASCLAW_LINE_TOKEN + $PASCLAW_LINE_SECRET
pasclaw gateway --line --line-token X --line-secret Y     # explicit
```

Gateway banner prints `POST http://…/webhooks/line   (LINE platform)` when `--line` is on, so the URL is copy-pasteable straight into LINE Developers Console.

## Build

- `Makefile` `UNIT_DIRS` gains `src/pkg/crypto`.
- `PasClaw.dproj` `DCC_UnitSearchPath` gains `..\pkg\crypto`; `DCCReference` entry for `PasClaw.Crypto.HMAC.pas`.
- README env-var table picks up `LINE_TOKEN` / `LINE_SECRET`; gateway example block grows `--line`.

## Verification

- `make` — clean build under FPC 3.2.2.
- HMAC smoke test against `openssl dgst -sha256 -hmac`: RFC test vector hex + base64, empty-input vector, 4 constant-time equality cases — **all 7 pass**.
- `pasclaw --help` and `pasclaw gateway` (without `--line`) byte-identical to pre-change.

## Wave 1.5b ahead

WhatsApp Cloud receiver lands next on top of this same `MountWebhook` API and HMAC helper. WhatsApp adds a GET subscription-verification handler (hub.challenge echo) and uses `X-Hub-Signature-256` with hex-encoded HMAC + `sha256=` prefix; the HMAC primitive already supports both encodings.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_