### PR TITLE
channels: WhatsApp Cloud bot — webhook receiver mounted on the gateway (Wave 1.5b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Environment variables:
 | `PASCLAW_TELEGRAM_TOKEN` | Default Telegram bot token for `pasclaw gateway --telegram`. |
 | `PASCLAW_LINE_TOKEN` | LINE Messaging API channel access token. Used by `pasclaw post line` and `pasclaw gateway --line`. |
 | `PASCLAW_LINE_SECRET` | LINE channel secret. Required by `pasclaw gateway --line` to verify `X-Line-Signature` on inbound events. |
+| `PASCLAW_WHATSAPP_TOKEN` | WhatsApp Cloud API system-user access token. Used by `pasclaw post whatsapp` and `pasclaw gateway --whatsapp`. |
+| `PASCLAW_WHATSAPP_PHONE_ID` | WhatsApp phone-number ID (the numeric ID, not the phone number itself). |
+| `PASCLAW_WHATSAPP_VERIFY_TOKEN` | User-chosen string used to verify Meta's `GET /webhooks/whatsapp` subscription handshake. |
+| `PASCLAW_WHATSAPP_APP_SECRET` | Meta App Secret used to validate `X-Hub-Signature-256` on inbound events. |
 | `NO_COLOR` | Disables ANSI color output. |
 
 Useful config commands:
@@ -95,7 +99,7 @@ Top-level commands are dispatched by `src/cmd/PasClaw.Cmd.Root.pas`:
 | `migrate` | Run data migrations for older versions. |
 | `skills` | List, install, or remove skill extensions. |
 | `model` | Show or change the default model. |
-| `post` | Send a one-shot message to a Discord, Slack, Microsoft Teams, generic, or LINE webhook target. |
+| `post` | Send a one-shot message to a Discord, Slack, Microsoft Teams, generic, LINE, or WhatsApp webhook target. |
 | `membench` | Benchmark the memory log subsystem. |
 | `update` | Check GitHub releases or self-update. |
 | `version` | Print version/build information. |
@@ -242,6 +246,7 @@ pasclaw gateway
 pasclaw gateway --addr 0.0.0.0 --port 8088
 pasclaw gateway --telegram --token <BOT_TOKEN>
 pasclaw gateway --line                              # also pass $PASCLAW_LINE_TOKEN + $PASCLAW_LINE_SECRET
+pasclaw gateway --whatsapp                          # also pass $PASCLAW_WHATSAPP_{TOKEN,PHONE_ID,VERIFY_TOKEN,APP_SECRET}
 pasclaw gateway --no-tools --no-mcp --no-hashline
 
 pasclaw serve
@@ -496,7 +501,7 @@ src/
   cmd/              CLI command units and root dispatcher
   pkg/
     agent/          Agent execution and prompts
-    channels/       Telegram, Discord, Slack, Teams, generic webhook, LINE
+    channels/       Telegram, Discord, Slack, Teams, generic webhook, LINE, WhatsApp
     cliui/          ANSI styling, banner, command help rendering
     component/      Shared components
     config/         Version constants and on-disk config model

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -33,7 +33,8 @@ uses
   PasClaw.Cron.Scheduler,
   PasClaw.Gateway.Server,
   PasClaw.Channels.Telegram,
-  PasClaw.Channels.LINE;
+  PasClaw.Channels.LINE,
+  PasClaw.Channels.WhatsApp;
 
 type
   TGwArgs = record
@@ -44,6 +45,11 @@ type
     Line:        Boolean;
     LineToken:   string;
     LineSecret:  string;
+    WhatsApp:    Boolean;
+    WAToken:     string;
+    WAPhoneId:   string;
+    WAVerify:    string;
+    WASecret:    string;
     NoMCP:       Boolean;
     NoTools:     Boolean;
     NoHashline:  Boolean;
@@ -60,6 +66,11 @@ begin
   Result.Line       := False;
   Result.LineToken  := GetEnvironmentVariable('PASCLAW_LINE_TOKEN');
   Result.LineSecret := GetEnvironmentVariable('PASCLAW_LINE_SECRET');
+  Result.WhatsApp   := False;
+  Result.WAToken    := GetEnvironmentVariable('PASCLAW_WHATSAPP_TOKEN');
+  Result.WAPhoneId  := GetEnvironmentVariable('PASCLAW_WHATSAPP_PHONE_ID');
+  Result.WAVerify   := GetEnvironmentVariable('PASCLAW_WHATSAPP_VERIFY_TOKEN');
+  Result.WASecret   := GetEnvironmentVariable('PASCLAW_WHATSAPP_APP_SECRET');
   Result.NoMCP      := False;
   Result.NoTools    := False;
   Result.NoHashline := False;
@@ -73,6 +84,11 @@ begin
     if Argv[i] = '--line'         then begin Result.Line       := True; Inc(i); Continue; end;
     if Argv[i] = '--line-token'   then begin if i < High(Argv) then Result.LineToken  := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--line-secret'  then begin if i < High(Argv) then Result.LineSecret := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--whatsapp'         then begin Result.WhatsApp  := True; Inc(i); Continue; end;
+    if Argv[i] = '--whatsapp-token'   then begin if i < High(Argv) then Result.WAToken   := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--whatsapp-phone'   then begin if i < High(Argv) then Result.WAPhoneId := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--whatsapp-verify'  then begin if i < High(Argv) then Result.WAVerify  := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--whatsapp-secret'  then begin if i < High(Argv) then Result.WASecret  := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--no-mcp'       then begin Result.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-tools'     then begin Result.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
@@ -91,6 +107,7 @@ var
   Server: TGatewayServer;
   Telegram: TTelegramChannel;
   Line: TLineBot;
+  WhatsApp: TWhatsAppBot;
   Scheduler: TCronScheduler;
   Skills: TSkillSpecArray;
 begin
@@ -131,6 +148,7 @@ begin
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
     Telegram := nil;
     Line     := nil;
+    WhatsApp := nil;
     try
       if Args.Line then
       begin
@@ -145,6 +163,24 @@ begin
         Server.MountWebhook('/webhooks/line', Line.HandleWebhook);
       end;
 
+      if Args.WhatsApp then
+      begin
+        if (Args.WAToken = '') or (Args.WAPhoneId = '') or
+           (Args.WAVerify = '') or (Args.WASecret = '') then
+        begin
+          LogError('whatsapp: need all four — --whatsapp-token / ' +
+                   '$PASCLAW_WHATSAPP_TOKEN, --whatsapp-phone / ' +
+                   '$PASCLAW_WHATSAPP_PHONE_ID, --whatsapp-verify / ' +
+                   '$PASCLAW_WHATSAPP_VERIFY_TOKEN, --whatsapp-secret / ' +
+                   '$PASCLAW_WHATSAPP_APP_SECRET');
+          Exit(1);
+        end;
+        WhatsApp := TWhatsAppBot.Create(Args.WAToken, Args.WAPhoneId,
+                                         Args.WAVerify, Args.WASecret,
+                                         Cfg, Provider, Reg);
+        Server.MountWebhook('/webhooks/whatsapp', WhatsApp.HandleWebhook);
+      end;
+
       Server.Start(Args.Addr, Args.Port);
 
       WriteLn(Ansi.Bold, 'Gateway up.', Ansi.Reset);
@@ -153,6 +189,8 @@ begin
       WriteLn('  POST http://', Args.Addr, ':', Args.Port, '/v1/chat   {"message":"..."}');
       if Args.Line then
         WriteLn('  POST http://', Args.Addr, ':', Args.Port, '/webhooks/line   (LINE platform)');
+      if Args.WhatsApp then
+        WriteLn('  ANY http://', Args.Addr, ':', Args.Port, '/webhooks/whatsapp   (WhatsApp Cloud)');
       WriteLn(Ansi.Dim, 'Press Ctrl-C to stop.', Ansi.Reset);
 
       if Args.Telegram then
@@ -173,6 +211,7 @@ begin
     finally
       if Telegram <> nil then Telegram.Free;
       if Line     <> nil then Line.Free;
+      if WhatsApp <> nil then WhatsApp.Free;
       Server.Stop;
       Server.Free;
       if Scheduler <> nil then Scheduler.Free;

--- a/src/cmd/PasClaw.Cmd.Post.pas
+++ b/src/cmd/PasClaw.Cmd.Post.pas
@@ -34,17 +34,21 @@ uses
   PasClaw.Channels.Slack,
   PasClaw.Channels.Teams,
   PasClaw.Channels.Webhook,
-  PasClaw.Channels.LINE;
+  PasClaw.Channels.LINE,
+  PasClaw.Channels.WhatsApp;
 
 procedure Help;
 begin
-  WriteLn('Usage: pasclaw post <discord|slack|teams|webhook|line> <target> "<content>"');
+  WriteLn('Usage: pasclaw post <discord|slack|teams|webhook|line|whatsapp> <target> "<content>"');
   WriteLn('  discord  <webhook-url> "<text>"');
   WriteLn('  slack    <webhook-url> "<text>"');
   WriteLn('  teams    <webhook-url> "<text>"');
   WriteLn('  webhook  <url> "<text>"           (auth via $PASCLAW_WEBHOOK_AUTH)');
   WriteLn('  line     <userId|groupId|roomId> "<text>"');
   WriteLn('                                    (token via $PASCLAW_LINE_TOKEN)');
+  WriteLn('  whatsapp <to-phone-number> "<text>"');
+  WriteLn('                                    (token via $PASCLAW_WHATSAPP_TOKEN,');
+  WriteLn('                                     phone-id via $PASCLAW_WHATSAPP_PHONE_ID)');
 end;
 
 function ReportResult(Success: Boolean; const ChannelName: string): Integer;
@@ -115,14 +119,37 @@ begin
   finally L.Free; end;
 end;
 
+function DoWhatsApp(const ToPhone, Content: string): Integer;
+var
+  W: TWhatsAppPush;
+  Token, PhoneId: string;
+begin
+  Token   := GetEnvironmentVariable('PASCLAW_WHATSAPP_TOKEN');
+  PhoneId := GetEnvironmentVariable('PASCLAW_WHATSAPP_PHONE_ID');
+  if Token = '' then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'whatsapp: set PASCLAW_WHATSAPP_TOKEN to a system-user access token');
+    Exit(1);
+  end;
+  if PhoneId = '' then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'whatsapp: set PASCLAW_WHATSAPP_PHONE_ID to your phone-number-id');
+    Exit(1);
+  end;
+  W := TWhatsAppPush.Create(Token, PhoneId);
+  try Result := ReportResult(W.Push(ToPhone, Content), 'whatsapp');
+  finally W.Free; end;
+end;
+
 function Cmd_Post_Run(const Argv: array of string): Integer;
 begin
   if Length(Argv) < 3 then begin Help; Exit(1); end;
   if      Argv[0] = 'discord' then Result := DoDiscord(Argv[1], Argv[2])
   else if Argv[0] = 'slack'   then Result := DoSlack  (Argv[1], Argv[2])
   else if Argv[0] = 'teams'   then Result := DoTeams  (Argv[1], Argv[2])
-  else if Argv[0] = 'webhook' then Result := DoWebhook(Argv[1], Argv[2])
-  else if Argv[0] = 'line'    then Result := DoLine   (Argv[1], Argv[2])
+  else if Argv[0] = 'webhook'  then Result := DoWebhook (Argv[1], Argv[2])
+  else if Argv[0] = 'line'     then Result := DoLine    (Argv[1], Argv[2])
+  else if Argv[0] = 'whatsapp' then Result := DoWhatsApp(Argv[1], Argv[2])
   else begin Help; Result := 1; end;
 end;
 

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -192,6 +192,7 @@
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Teams.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Webhook.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.LINE.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.WhatsApp.pas"/>
 
         <!-- pkg/crypto -->
         <DCCReference Include="..\pkg\crypto\PasClaw.Crypto.HMAC.pas"/>

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -269,6 +269,18 @@ var
   EvObj: TJsonObject;
   i: Integer;
 begin
+  { Gateway dispatch is path-only (channels like WhatsApp Cloud bind
+    GET and POST to the same URL). LINE only delivers via POST; emit
+    405 on anything else so the platform doesn't silently treat a
+    misconfigured probe as success. }
+  if ARequest.Command <> 'POST' then
+  begin
+    AResponse.ResponseNo  := 405;
+    AResponse.ContentText := '{"error":"method not allowed"}';
+    AResponse.ContentType := 'application/json';
+    Exit;
+  end;
+
   if ARequest.PostStream <> nil then
   begin
     SetLength(Bytes, ARequest.PostStream.Size);

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -1,0 +1,419 @@
+(*
+  PasClaw.Channels.WhatsApp - WhatsApp Cloud API (Meta).
+
+  Two surfaces, matching the LINE shape:
+
+    TWhatsAppPush - outbound send. POST a text message to a phone
+                    number via the Cloud API messages endpoint. Useful
+                    from cron skills via `pasclaw post whatsapp`.
+                    Endpoint: POST /v18.0/<phone-number-id>/messages
+                              on graph.facebook.com.
+                    Body:     {"messaging_product":"whatsapp",
+                                "to":"<phone>","type":"text",
+                                "text":{"body":"<text>"}}
+
+    TWhatsAppBot  - bidirectional webhook receiver + reply. Mounted as
+                    a gateway route via TGatewayServer.MountWebhook.
+                    The same path handles two verbs:
+                      GET  /webhooks/whatsapp  -> subscription
+                           verification. Meta sends
+                             hub.mode=subscribe
+                             hub.verify_token=<configured>
+                             hub.challenge=<random>
+                           we echo hub.challenge as text/plain if the
+                           token matches; 403 otherwise.
+                      POST /webhooks/whatsapp  -> message events.
+                           Header: X-Hub-Signature-256: sha256=<hex>
+                           Body:   JSON envelope with
+                                   entry[].changes[].value.messages[]
+                           Each text message runs through RunToolLoop
+                           and the reply goes out via the same
+                           messages endpoint TWhatsAppPush uses.
+
+  Required configuration:
+    Access token (system user, long-lived): $PASCLAW_WHATSAPP_TOKEN
+    Phone number ID (NOT the phone number): $PASCLAW_WHATSAPP_PHONE_ID
+    User-chosen verify-token string:        $PASCLAW_WHATSAPP_VERIFY_TOKEN
+    Meta App Secret (for HMAC):             $PASCLAW_WHATSAPP_APP_SECRET
+
+  Docs:
+    Webhook setup: https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks
+    Send message:  https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages
+    Signature:     https://developers.facebook.com/docs/graph-api/webhooks/getting-started#validating-payloads
+*)
+unit PasClaw.Channels.WhatsApp;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  IdContext, IdCustomHTTPServer,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TWhatsAppPush = class
+  private
+    FToken:   string;
+    FPhoneId: string;
+  public
+    constructor Create(const AccessToken, PhoneNumberId: string);
+    function Push(const ToPhoneNumber, Text: string): Boolean;
+  end;
+
+  TWhatsAppBot = class
+  private
+    FToken:       string;
+    FPhoneId:     string;
+    FVerifyToken: string;
+    FAppSecret:   string;
+    FCfg:         TConfig;
+    FProvider:    ILLMProvider;
+    FRegistry:    TToolRegistry;
+    FPush:        TWhatsAppPush;
+    function VerifySignature(const Body, SignatureHeader: string): Boolean;
+    procedure HandleVerify(ARequest: TIdHTTPRequestInfo;
+                           AResponse: TIdHTTPResponseInfo);
+    procedure HandleEvents(ARequest: TIdHTTPRequestInfo;
+                           AResponse: TIdHTTPResponseInfo);
+    procedure ProcessMessage(const FromNumber, Text: string);
+  public
+    constructor Create(const AccessToken, PhoneNumberId,
+                       VerifyToken, AppSecret: string;
+                       Cfg: TConfig; Provider: ILLMProvider;
+                       Registry: TToolRegistry);
+    destructor Destroy; override;
+    procedure HandleWebhook(AContext: TIdContext;
+                            ARequest: TIdHTTPRequestInfo;
+                            AResponse: TIdHTTPResponseInfo);
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop,
+  PasClaw.Crypto.HMAC;
+
+const
+  WA_API_BASE = 'https://graph.facebook.com/v18.0';
+
+function BuildSendBody(const ToNumber, Text: string): string;
+var
+  Root, TextObj: TJsonObject;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('messaging_product', 'whatsapp');
+    Root.PutStr('to',                ToNumber);
+    Root.PutStr('type',              'text');
+    TextObj := TJsonObject.Create;
+    TextObj.PutStr('body', Text);
+    Root.PutObject('text', TextObj);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function SendMessage(const Token, PhoneId, ToNumber, Text: string): Boolean;
+var
+  URL: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  URL := WA_API_BASE + '/' + PhoneId + '/messages';
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + Token);
+  Resp := PostJSON(URL, BuildSendBody(ToNumber, Text), Headers, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('whatsapp: send -> status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+constructor TWhatsAppPush.Create(const AccessToken, PhoneNumberId: string);
+begin
+  inherited Create;
+  FToken   := AccessToken;
+  FPhoneId := PhoneNumberId;
+end;
+
+function TWhatsAppPush.Push(const ToPhoneNumber, Text: string): Boolean;
+begin
+  if FToken = '' then
+  begin
+    LogWarn('whatsapp push: no access token configured', []);
+    Exit(False);
+  end;
+  if FPhoneId = '' then
+  begin
+    LogWarn('whatsapp push: no phone-number-id configured', []);
+    Exit(False);
+  end;
+  if Trim(ToPhoneNumber) = '' then
+  begin
+    LogWarn('whatsapp push: empty target phone number', []);
+    Exit(False);
+  end;
+  Result := SendMessage(FToken, FPhoneId, ToPhoneNumber, Text);
+end;
+
+constructor TWhatsAppBot.Create(const AccessToken, PhoneNumberId,
+                                  VerifyToken, AppSecret: string;
+                                  Cfg: TConfig; Provider: ILLMProvider;
+                                  Registry: TToolRegistry);
+begin
+  inherited Create;
+  FToken       := AccessToken;
+  FPhoneId     := PhoneNumberId;
+  FVerifyToken := VerifyToken;
+  FAppSecret   := AppSecret;
+  FCfg         := Cfg;
+  FProvider    := Provider;
+  FRegistry    := Registry;
+  FPush        := TWhatsAppPush.Create(AccessToken, PhoneNumberId);
+end;
+
+destructor TWhatsAppBot.Destroy;
+begin
+  FPush.Free;
+  inherited Destroy;
+end;
+
+function TWhatsAppBot.VerifySignature(const Body, SignatureHeader: string): Boolean;
+var
+  Expected, Got: string;
+const
+  Prefix = 'sha256=';
+begin
+  if FAppSecret = '' then
+  begin
+    LogWarn('whatsapp webhook: no app secret configured; rejecting', []);
+    Exit(False);
+  end;
+  if SignatureHeader = '' then Exit(False);
+  if Pos(Prefix, SignatureHeader) <> 1 then
+  begin
+    LogWarn('whatsapp webhook: malformed signature (no sha256= prefix)', []);
+    Exit(False);
+  end;
+  Got      := Copy(SignatureHeader, Length(Prefix) + 1, MaxInt);
+  Expected := HMACSHA256HexLower(StringToBytes(FAppSecret), StringToBytes(Body));
+  Result   := ConstantTimeEqual(Expected, Got);
+end;
+
+procedure TWhatsAppBot.HandleVerify(ARequest: TIdHTTPRequestInfo;
+                                    AResponse: TIdHTTPResponseInfo);
+var
+  Mode, Token, Challenge: string;
+begin
+  { Meta's subscription verify: GET with query params. If hub.mode is
+    "subscribe" AND hub.verify_token matches what we configured, echo
+    hub.challenge back as plain text with 200. Anything else is 403.
+    The challenge body MUST be the raw value (no JSON wrapping) per
+    Meta's docs — they parse it as text. }
+  Mode      := ARequest.Params.Values['hub.mode'];
+  Token     := ARequest.Params.Values['hub.verify_token'];
+  Challenge := ARequest.Params.Values['hub.challenge'];
+
+  if (Mode = 'subscribe') and (FVerifyToken <> '') and
+     ConstantTimeEqual(Token, FVerifyToken) then
+  begin
+    AResponse.ResponseNo  := 200;
+    AResponse.ContentType := 'text/plain; charset=utf-8';
+    AResponse.ContentText := Challenge;
+    LogInfo('whatsapp: subscription verified', []);
+    Exit;
+  end;
+
+  LogWarn('whatsapp: subscription verify rejected (mode=%s)', [Mode]);
+  AResponse.ResponseNo  := 403;
+  AResponse.ContentType := 'application/json';
+  AResponse.ContentText := '{"error":"verify failed"}';
+end;
+
+procedure TWhatsAppBot.ProcessMessage(const FromNumber, Text: string);
+var
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+  Response: string;
+begin
+  LogInfo('whatsapp: %s msg=%s', [FromNumber, Copy(Text, 1, 80)]);
+
+  if FProvider = nil then
+  begin
+    FPush.Push(FromNumber,
+               '(no provider configured — run `pasclaw onboard`)');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Text);
+
+  LoopCfg.Provider      := FProvider;
+  LoopCfg.Registry      := FRegistry;
+  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.MaxIterations := 6;
+  LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.OnText        := nil;
+  LoopCfg.OnToolCall    := nil;
+  LoopCfg.OnToolResult  := nil;
+
+  if RunToolLoop(LoopCfg, Msgs, Loop) and (Loop.Content <> '') then
+    Response := Loop.Content
+  else
+    Response := '(sorry — model returned no content)';
+
+  FPush.Push(FromNumber, Response);
+end;
+
+procedure TWhatsAppBot.HandleEvents(ARequest: TIdHTTPRequestInfo;
+                                     AResponse: TIdHTTPResponseInfo);
+var
+  Body, Signature: string;
+  Bytes: TBytes;
+  Root, ValueObj, MsgObj, EntryObj, ChangeObj, TextObj: TJsonObject;
+  EntryArr, ChangeArr, MsgArr: TJsonArray;
+  i, j, k: Integer;
+  MsgType, From_, Text: string;
+begin
+  if ARequest.PostStream <> nil then
+  begin
+    SetLength(Bytes, ARequest.PostStream.Size);
+    ARequest.PostStream.Position := 0;
+    if Length(Bytes) > 0 then
+      ARequest.PostStream.ReadBuffer(Bytes[0], Length(Bytes));
+    {$IFDEF FPC}
+    SetString(Body, PAnsiChar(@Bytes[0]), Length(Bytes));
+    {$ELSE}
+    Body := TEncoding.UTF8.GetString(Bytes);
+    {$ENDIF}
+  end
+  else
+    Body := '';
+
+  Signature := ARequest.RawHeaders.Values['X-Hub-Signature-256'];
+
+  if not VerifySignature(Body, Signature) then
+  begin
+    AResponse.ResponseNo  := 401;
+    AResponse.ContentText := '{"error":"signature"}';
+    AResponse.ContentType := 'application/json';
+    LogWarn('whatsapp webhook: signature rejected', []);
+    Exit;
+  end;
+
+  { Meta retries with backoff on non-2xx, so always ack 200 — dispatch
+    errors get logged but don't trigger duplicate-delivery storms. }
+  AResponse.ResponseNo  := 200;
+  AResponse.ContentText := '{}';
+  AResponse.ContentType := 'application/json';
+
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(Body);
+  except
+    on E: Exception do
+    begin
+      LogWarn('whatsapp webhook: bad JSON: %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Root = nil then Exit;
+  try
+    EntryArr := Root.ChildArray('entry');
+    if EntryArr = nil then Exit;
+    try
+      for i := 0 to EntryArr.Count - 1 do
+      begin
+        EntryObj := EntryArr.ItemObject(i);
+        if EntryObj = nil then Continue;
+        try
+          ChangeArr := EntryObj.ChildArray('changes');
+          if ChangeArr = nil then Continue;
+          try
+            for j := 0 to ChangeArr.Count - 1 do
+            begin
+              ChangeObj := ChangeArr.ItemObject(j);
+              if ChangeObj = nil then Continue;
+              try
+                ValueObj := ChangeObj.ChildObject('value');
+                if ValueObj = nil then Continue;
+                try
+                  MsgArr := ValueObj.ChildArray('messages');
+                  if MsgArr = nil then Continue;
+                  try
+                    for k := 0 to MsgArr.Count - 1 do
+                    begin
+                      MsgObj := MsgArr.ItemObject(k);
+                      if MsgObj = nil then Continue;
+                      try
+                        MsgType := MsgObj.GetStr('type', '');
+                        if MsgType <> 'text' then Continue;
+                        From_ := MsgObj.GetStr('from', '');
+                        { Text body lives one level down at
+                          messages[].text.body. }
+                        TextObj := MsgObj.ChildObject('text');
+                        if TextObj = nil then Continue;
+                        try
+                          Text := TextObj.GetStr('body', '');
+                        finally
+                          TextObj.Free;
+                        end;
+                        if (From_ = '') or (Text = '') then Continue;
+                        ProcessMessage(From_, Text);
+                      finally
+                        MsgObj.Free;
+                      end;
+                    end;
+                  finally
+                    MsgArr.Free;
+                  end;
+                finally
+                  ValueObj.Free;
+                end;
+              finally
+                ChangeObj.Free;
+              end;
+            end;
+          finally
+            ChangeArr.Free;
+          end;
+        finally
+          EntryObj.Free;
+        end;
+      end;
+    finally
+      EntryArr.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure TWhatsAppBot.HandleWebhook(AContext: TIdContext;
+                                      ARequest: TIdHTTPRequestInfo;
+                                      AResponse: TIdHTTPResponseInfo);
+begin
+  if ARequest.Command = 'GET' then
+    HandleVerify(ARequest, AResponse)
+  else if ARequest.Command = 'POST' then
+    HandleEvents(ARequest, AResponse)
+  else
+  begin
+    AResponse.ResponseNo  := 405;
+    AResponse.ContentText := '{"error":"method not allowed"}';
+    AResponse.ContentType := 'application/json';
+  end;
+end;
+
+end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -166,8 +166,13 @@ var
   Idx: Integer;
   Handler: TWebhookHandler;
 begin
+  { Dispatch on path only. Handlers self-check the verb because some
+    channels (WhatsApp Cloud) bind both GET — subscription
+    verification with hub.challenge echo — and POST — event delivery
+    — to the same URL. Handlers MUST emit 405 for verbs they don't
+    accept so the dispatcher doesn't silently 404 a legitimate
+    request. LINE's HandleWebhook does that; so does WhatsApp's. }
   Result := False;
-  if ARequest.Command <> 'POST' then Exit;
   Idx := FWebhookPaths.IndexOf(ARequest.Document);
   if Idx < 0 then Exit;
   Handler := FWebhookHandlers[Idx];


### PR DESCRIPTION
Reuses everything Wave 1.5a put in place: `TGatewayServer.MountWebhook`, the pure-Pascal `PasClaw.Crypto.HMAC` helper, and the "hold Cfg/Provider/Registry directly, run `RunToolLoop` inline" bot shape that mirrors `TTelegramChannel` and `TLineBot`. Future channels (Matrix, VK, …) plug in the same way.

## Three concrete differences from LINE that the unit addresses

### 1. Signature header shape

| Channel | Header | Encoding |
|---|---|---|
| LINE | `X-Line-Signature` | base64, no prefix |
| WhatsApp | `X-Hub-Signature-256` | `sha256=<hex>` |

`PasClaw.Crypto.HMAC` already supports both encodings. The bot strips the `sha256=` prefix, recomputes the hex digest with the App Secret, and `ConstantTimeEqual`s against the remainder.

### 2. Same URL serves both verbs

```
GET  /webhooks/whatsapp   →  Meta's subscription verification handshake.
                              Pulls hub.mode, hub.verify_token,
                              hub.challenge from query params; if
                              mode=subscribe and verify_token matches
                              (constant-time), echoes the challenge back
                              as text/plain with 200, otherwise 403.
                              The body MUST be the raw challenge —
                              Meta parses it as text; JSON-wrapping it
                              breaks the verify.

POST /webhooks/whatsapp   →  message events.
```

`DispatchWebhook` used to short-circuit on non-POST. Dropped that guard so handlers self-check the verb; added a defensive 405 to LINE's `HandleWebhook` so a misconfigured GET probe doesn't get a silent 404.

### 3. Deeper event nesting

LINE: `events[].message.text`. WhatsApp:

```
entry[].changes[].value.messages[]{from, type, text.body, …}
```

`ProcessMessage` runs `RunToolLoop` on text-type messages and sends the reply via the same Cloud API messages endpoint `TWhatsAppPush` already uses — no replyToken mechanism, every reply is a fresh send.

## CLI

```sh
pasclaw gateway --whatsapp                      # env vars below
pasclaw gateway --whatsapp \
  --whatsapp-token X --whatsapp-phone Y \
  --whatsapp-verify Z --whatsapp-secret S

pasclaw post whatsapp 15551234567 "build done"
```

| Env var | Role |
|---|---|
| `PASCLAW_WHATSAPP_TOKEN` | System-user access token |
| `PASCLAW_WHATSAPP_PHONE_ID` | Phone-number ID (the numeric ID, not the phone number itself) |
| `PASCLAW_WHATSAPP_VERIFY_TOKEN` | User-chosen verify string for `hub.verify_token` |
| `PASCLAW_WHATSAPP_APP_SECRET` | Meta App Secret used to validate `X-Hub-Signature-256` |

Gateway banner now prints `ANY http://…/webhooks/whatsapp   (WhatsApp Cloud)` — "ANY" instead of "POST" so the user knows the same URL serves the GET subscription handshake.

## Tidy-ups

- `Cmd.Post.Help` grew the `whatsapp` row with env-var hints inline, matching the existing `line` / `webhook` rows; dispatch table aligned.
- README env-var table picks up the four `WHATSAPP_*` entries; gateway example block grows `--whatsapp`; command-surface `post` row mentions WhatsApp; repo-layout `channels/` line spells out the full set.

## Verification

- `make` — clean build under FPC 3.2.2; `dproj` DCCReference added for the new unit; no Makefile change needed (channels dir already on `UNIT_DIRS`).
- `pasclaw post` help lists `whatsapp` with the env-var hints.
- `pasclaw --help`, `pasclaw gateway` (without `--whatsapp`), and `pasclaw post discord/slack/teams/webhook/line` all byte-identical to pre-change.
- Signature primitives identical to PR #76 — `HMACSHA256HexLower` already covered by the openssl smoke test that landed there.

## What's left in picoclaw's catalog

After this PR, PasClaw covers 7 of picoclaw's 20 channels (Discord, Slack, Telegram, Teams, generic webhook, LINE, WhatsApp). Realistic next waves (excluding Chinese-ecosystem auth, hardware-specific, and `*_native` variants):

- Wave 3: Matrix (`/sync` long-poll), IRC (raw TCP via TIdIRC), VK (long-poll bot API).
- Wave 4: MQTT (Indy MQTT components).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_