### PR TITLE
PR #76 review fix: ack webhook 200 before running the agent (LINE + WhatsApp)

### DIFF
--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -82,6 +82,44 @@ uses
   PasClaw.Tools.ToolLoop,
   PasClaw.Crypto.HMAC;
 
+type
+  (* One-shot worker that calls TLineBot.ProcessEvent off the Indy
+     dispatcher thread. HandleWebhook spawns one of these per event and
+     returns; Indy then flushes the 200 ack within milliseconds instead
+     of holding it open while RunToolLoop chases tools. LINE's webhook
+     timeout is 1s — without async, a slow turn (long tool loop, large
+     model response) blows past it and LINE retries the event up to 3
+     more times, generating 4× duplicate replies even though we set
+     ResponseNo := 200 early. FreeOnTerminate := True so the worker
+     cleans itself up after Execute returns. *)
+  TLineEventWorker = class(TThread)
+  private
+    FBot:       TLineBot;
+    FEventJSON: string;
+  public
+    constructor Create(Bot: TLineBot; const EventJSON: string);
+    procedure Execute; override;
+  end;
+
+constructor TLineEventWorker.Create(Bot: TLineBot; const EventJSON: string);
+begin
+  inherited Create(False);   { CreateSuspended=False — start immediately }
+  FreeOnTerminate := True;
+  FBot       := Bot;
+  FEventJSON := EventJSON;
+end;
+
+procedure TLineEventWorker.Execute;
+begin
+  try
+    FBot.ProcessEvent(FEventJSON);
+  except
+    on E: Exception do
+      LogWarn('line worker: ProcessEvent raised %s: %s',
+              [E.ClassName, E.Message]);
+  end;
+end;
+
 const
   LINE_PUSH_URL  = 'https://api.line.me/v2/bot/message/push';
   LINE_REPLY_URL = 'https://api.line.me/v2/bot/message/reply';
@@ -334,7 +372,12 @@ begin
         EvObj := Events.ItemObject(i);
         if EvObj = nil then Continue;
         try
-          ProcessEvent(EvObj.ToJSON);
+          { Hand the event off to a self-freeing worker thread so the
+            handler can return and Indy can flush the 200 ack inside
+            LINE's 1s timeout window. The worker owns its own copy of
+            the event JSON; FBot fields are read-only after construction
+            so the thread reads them without locking. }
+          TLineEventWorker.Create(Self, EvObj.ToJSON);
         finally
           EvObj.Free;
         end;

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -103,10 +103,16 @@ type
 
 constructor TLineEventWorker.Create(Bot: TLineBot; const EventJSON: string);
 begin
-  inherited Create(False);   { CreateSuspended=False — start immediately }
+  { Construct SUSPENDED, assign state, then Start. With Create(False)
+    the kernel can schedule Execute before the field assignments below
+    finish — FBot would be nil and FEventJSON would be empty when the
+    worker ran. Codex flagged this on PR #78; the cron scheduler's
+    TCronThread uses the same suspended-then-start pattern. }
+  inherited Create(True);
   FreeOnTerminate := True;
   FBot       := Bot;
   FEventJSON := EventJSON;
+  Start;
 end;
 
 procedure TLineEventWorker.Execute;

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -124,11 +124,18 @@ type
 constructor TWhatsAppMessageWorker.Create(Bot: TWhatsAppBot;
                                             const FromNumber, Text: string);
 begin
-  inherited Create(False);   { CreateSuspended=False — start immediately }
+  { Construct SUSPENDED, assign state, then Start. With Create(False)
+    the kernel can schedule Execute before the field assignments below
+    finish — FBot would be nil and FFromNumber/FText would be empty
+    when the worker ran. Codex flagged this on PR #78; the cron
+    scheduler's TCronThread uses the same suspended-then-start
+    pattern. }
+  inherited Create(True);
   FreeOnTerminate := True;
   FBot         := Bot;
   FFromNumber  := FromNumber;
   FText        := Text;
+  Start;
 end;
 
 procedure TWhatsAppMessageWorker.Execute;

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -102,6 +102,46 @@ uses
   PasClaw.Tools.ToolLoop,
   PasClaw.Crypto.HMAC;
 
+type
+  (* One-shot worker that calls TWhatsAppBot.ProcessMessage off the Indy
+     dispatcher thread. HandleEvents spawns one per inbound text message
+     and returns; Indy then flushes the 200 ack right away instead of
+     holding it open while RunToolLoop chases tools. Meta's webhook
+     ingestion times out around 20s and backs off exponentially on
+     retry — without async, a long tool loop tips the request past the
+     timeout and the same event gets re-delivered, duplicating replies.
+     FreeOnTerminate so the worker cleans up after Execute returns. *)
+  TWhatsAppMessageWorker = class(TThread)
+  private
+    FBot:        TWhatsAppBot;
+    FFromNumber: string;
+    FText:       string;
+  public
+    constructor Create(Bot: TWhatsAppBot; const FromNumber, Text: string);
+    procedure Execute; override;
+  end;
+
+constructor TWhatsAppMessageWorker.Create(Bot: TWhatsAppBot;
+                                            const FromNumber, Text: string);
+begin
+  inherited Create(False);   { CreateSuspended=False — start immediately }
+  FreeOnTerminate := True;
+  FBot         := Bot;
+  FFromNumber  := FromNumber;
+  FText        := Text;
+end;
+
+procedure TWhatsAppMessageWorker.Execute;
+begin
+  try
+    FBot.ProcessMessage(FFromNumber, FText);
+  except
+    on E: Exception do
+      LogWarn('whatsapp worker: ProcessMessage raised %s: %s',
+              [E.ClassName, E.Message]);
+  end;
+end;
+
 const
   WA_API_BASE = 'https://graph.facebook.com/v18.0';
 
@@ -370,7 +410,13 @@ begin
                           TextObj.Free;
                         end;
                         if (From_ = '') or (Text = '') then Continue;
-                        ProcessMessage(From_, Text);
+                        { Hand the message off to a self-freeing worker
+                          thread so HandleEvents returns and Indy can
+                          flush the 200 ack before Meta times the
+                          delivery out. FBot fields are read-only after
+                          construction; FromNumber + Text are
+                          per-thread locals. }
+                        TWhatsAppMessageWorker.Create(Self, From_, Text);
                       finally
                         MsgObj.Free;
                       end;


### PR DESCRIPTION
## PR #76 review fix (P2): ack webhook 200 before running the agent

[Codex's review on PR #76](https://github.com/FMXExpress/PasClaw/pull/76) flagged that `TLineBot.HandleWebhook` calls `ProcessEvent` inline — `RunToolLoop` is synchronous and can take 30+ seconds when the model uses tools, but the 200 ack only flushes after the Indy handler returns. **LINE's webhook timeout is 1s**; past that they retry the same event up to 3 times, generating **4× duplicate replies** even though `ResponseNo := 200` was set on the response object early.

PR #77's WhatsApp bot shipped with the identical bug (Meta's webhook ingestion times out around 20s and backs off exponentially on retry), so this PR fixes both.

## Approach

A tiny self-freeing `TThread` per event. `HandleWebhook` spawns the worker(s) and returns; Indy flushes the 200 within milliseconds; the worker runs `RunToolLoop` and sends the reply on the background thread.

| Worker | Calls | Captures |
|---|---|---|
| `TLineEventWorker` | `TLineBot.ProcessEvent(EventJSON)` | the raw event JSON |
| `TWhatsAppMessageWorker` | `TWhatsAppBot.ProcessMessage(From, Text)` | extracted at the `messages[].text.body` parse site so each text message gets its own worker |

Both constructors take their bot reference + the captured data, set `FreeOnTerminate := True`, and start via `inherited Create(False)`. `Execute` wraps the bot call in `try/except` so a handler crash logs and dies cleanly instead of propagating up into Indy's dispatcher.

Worker classes live in the implementation section of their respective units so they can reach `Bot.ProcessEvent` / `Bot.ProcessMessage` through Pascal's unit-private visibility — no public surface change.

## Thread safety

- `FBot` fields (Token, Secret, Cfg, Provider, Registry, internal `TLinePush` / `TWhatsAppPush`) are all set once at construction and never written after, so worker threads read them without locking.
- Each `PostJSON` call creates its own `TIdHTTP` per the existing `PasClaw.Providers.HTTP` pattern, so no shared HTTP client state.
- `LogInfo`/`LogWarn` write `WriteLn`-to-stderr without locking, which is the same behaviour the existing `TTelegramChannel.Run` loop already relies on — log lines may interleave under heavy parallel load but won't crash.

## Verification

`make` builds clean under FPC 3.2.2; both bots compile with the new worker types resolving correctly through unit-private visibility. The fix is localized to the two bot units — 91 lines added across both, no signature or API surface change.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_