### PR TITLE
search: web_search + web_fetch tools with DDG/Brave/Tavily providers (Wave 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ UNIT_DIRS = \
 	src/pkg/gateway \
 	src/pkg/channels \
 	src/pkg/crypto \
+	src/pkg/search \
 	src/pkg/cron \
 	src/pkg/skills \
 	src/pkg/agent \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Environment variables:
 | `PASCLAW_WHATSAPP_PHONE_ID` | WhatsApp phone-number ID (the numeric ID, not the phone number itself). |
 | `PASCLAW_WHATSAPP_VERIFY_TOKEN` | User-chosen string used to verify Meta's `GET /webhooks/whatsapp` subscription handshake. |
 | `PASCLAW_WHATSAPP_APP_SECRET` | Meta App Secret used to validate `X-Hub-Signature-256` on inbound events. |
+| `PASCLAW_BRAVE_API_KEY` | Brave Search API key for the `web_search` tool when `web_search.provider = brave`. |
+| `PASCLAW_TAVILY_API_KEY` | Tavily API key for the `web_search` tool when `web_search.provider = tavily`. |
 | `NO_COLOR` | Disables ANSI color output. |
 
 Useful config commands:
@@ -160,6 +162,33 @@ pasclaw cron remove daily-summary
 ```
 
 Each cron entry persists its last successful fire time to `$PASCLAW_HOME/workspace/cron/state.json` so a missed slot (gateway down, laptop closed) fires exactly once on the next tick instead of either silently skipping or double-firing. Skill output is appended to `workspace/memory/<today>.md` for the model to recall on subsequent turns, and — if `--channel <kind>:<target>` was set — posted to the configured channel. Channel kinds: `discord`, `slack`, `teams`, `webhook` (URL is the target), `line` (target is userId, token from `$PASCLAW_LINE_TOKEN`), `whatsapp` (target is phone number, credentials from `$PASCLAW_WHATSAPP_TOKEN` + `$PASCLAW_WHATSAPP_PHONE_ID`).
+
+### Web search
+
+Two tools, both registered automatically alongside the filesystem and shell tools:
+
+- **`web_search(query, k?)`** — returns up to k results as title + URL + snippet. Dispatches to the configured provider; defaults to DuckDuckGo when nothing is set.
+- **`web_fetch(url, max_chars?)`** — fetches an `http://` or `https://` URL and returns the response body as readable plain text (HTML tags stripped, entities decoded, whitespace collapsed, capped at 50 KB by default).
+
+Provider is set under `web_search` in `~/.pasclaw/config.json`:
+
+```json
+{
+  "web_search": {
+    "provider":    "brave",
+    "api_key":     "",
+    "max_results": 5
+  }
+}
+```
+
+| Provider | API key needed? | Source |
+|---|---|---|
+| `duckduckgo` (default) | no | HTML scrape of `html.duckduckgo.com/html/` |
+| `brave` | yes — `$PASCLAW_BRAVE_API_KEY` overrides `api_key` | `api.search.brave.com/res/v1/web/search` |
+| `tavily` | yes — `$PASCLAW_TAVILY_API_KEY` overrides `api_key` | `api.tavily.com/search` |
+
+Env-var values win over the `api_key` field so secrets can stay out of `config.json`.
 
 ### Skills
 
@@ -319,7 +348,8 @@ argument, followed by a short result summary on the next line:
 ```
 
 Known tools (`fs_read`, `fs_write`, `fs_list`, `fs_grep`,
-`fs_edit_hashline`, `shell_exec`) surface their most meaningful argument;
+`fs_edit_hashline`, `shell_exec`, `memory_search`, `web_search`, `web_fetch`)
+surface their most meaningful argument;
 MCP and other tools fall back to a compact one-line dump of the raw
 arguments. The full argument and result text also go to the SSE comment
 lines (`: tool_call ...` / `: tool_result ...`) for consumers that log
@@ -519,6 +549,7 @@ src/
     memory/         Memory log storage
     platform/       Platform helpers
     providers/      Provider catalog and LLM HTTP clients
+    search/         Web-search providers (DuckDuckGo, Brave, Tavily) + HTML→text
     skills/         Skill manifest loading and tool registration
     tokenizer/      Token counting helpers
     tools/          Built-in tool registry, filesystem, shell, and tool loop

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -28,6 +28,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.WebSearch,
+  PasClaw.Tools.WebFetch,
   PasClaw.Tools.ToolLoop,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -135,6 +137,8 @@ begin
   RegisterFSTools(Result, UseHashline);
   RegisterShellTool(Result);
   RegisterMemoryTools(Result);
+  RegisterWebSearchTool(Result);
+  RegisterWebFetchTool(Result);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(Result, Skills);
 end;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -27,6 +27,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.WebSearch,
+  PasClaw.Tools.WebFetch,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -128,6 +130,8 @@ begin
       RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
       RegisterMemoryTools(Reg);
+      RegisterWebSearchTool(Reg);
+      RegisterWebFetchTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -40,6 +40,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.WebSearch,
+  PasClaw.Tools.WebFetch,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -118,6 +120,8 @@ begin
       RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
       RegisterMemoryTools(Reg);
+      RegisterWebSearchTool(Reg);
+      RegisterWebFetchTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -25,6 +25,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.WebSearch,
+  PasClaw.Tools.WebFetch,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -86,6 +88,8 @@ begin
       RegisterFSTools(Reg, not A.NoHashline);
       RegisterShellTool(Reg);
       RegisterMemoryTools(Reg);
+      RegisterWebSearchTool(Reg);
+      RegisterWebFetchTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
     end;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -170,6 +170,8 @@
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.FS.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Shell.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Memory.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.WebSearch.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.WebFetch.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.ToolLoop.pas"/>
 
         <!-- pkg/mcp -->
@@ -196,6 +198,14 @@
 
         <!-- pkg/crypto -->
         <DCCReference Include="..\pkg\crypto\PasClaw.Crypto.HMAC.pas"/>
+
+        <!-- pkg/search -->
+        <DCCReference Include="..\pkg\search\PasClaw.Search.Types.pas"/>
+        <DCCReference Include="..\pkg\search\PasClaw.Search.HTMLText.pas"/>
+        <DCCReference Include="..\pkg\search\PasClaw.Search.DuckDuckGo.pas"/>
+        <DCCReference Include="..\pkg\search\PasClaw.Search.Brave.pas"/>
+        <DCCReference Include="..\pkg\search\PasClaw.Search.Tavily.pas"/>
+        <DCCReference Include="..\pkg\search\PasClaw.Search.Factory.pas"/>
 
         <!-- pkg/cron -->
         <DCCReference Include="..\pkg\cron\PasClaw.Cron.Expr.pas"/>

--- a/src/pkg/component/PasClaw.Component.pas
+++ b/src/pkg/component/PasClaw.Component.pas
@@ -154,6 +154,8 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.WebSearch,
+  PasClaw.Tools.WebFetch,
   PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
@@ -236,6 +238,8 @@ begin
   RegisterFSTools(FRegistry, FUseHashline);
   RegisterShellTool(FRegistry);
   RegisterMemoryTools(FRegistry);
+  RegisterWebSearchTool(FRegistry);
+  RegisterWebFetchTool(FRegistry);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(FRegistry, Skills);
   if FUseMCP then
@@ -463,6 +467,8 @@ begin
     RegisterFSTools(FRegistry, FEnableHashline);
     RegisterShellTool(FRegistry);
     RegisterMemoryTools(FRegistry);
+  RegisterWebSearchTool(FRegistry);
+  RegisterWebFetchTool(FRegistry);
     Skills := LoadSkillManifests(GetHome);
     RegisterSkills(FRegistry, Skills);
   end;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -114,6 +114,17 @@ type
     Enabled: Boolean;
   end;
 
+  (* TWebSearchConfig - web_search tool provider selection.
+       Provider:   'duckduckgo' (default, no key) | 'brave' | 'tavily'
+       APIKey:     fallback if no $PASCLAW_<KIND>_API_KEY env var.
+       MaxResults: cap on hits per query; the tool caps further at 25
+                   so a runaway model arg can't pull megabytes. *)
+  TWebSearchConfig = record
+    Provider:   string;
+    APIKey:     string;
+    MaxResults: Integer;
+  end;
+
   TConfig = class
   public
     DefaultProvider: string;
@@ -124,6 +135,7 @@ type
     MCPServers: array of TMCPServer;
     Crons:      array of TCronEntry;
     Skills:     array of TSkillEntry;
+    WebSearch:  TWebSearchConfig;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -160,6 +172,9 @@ begin
   Sandbox.AllowReadOutsideWorkspace := False;
   Sandbox.Workspace                 := '';
   Sandbox.ShellDenyEnabled          := True;
+  WebSearch.Provider   := '';   { empty = duckduckgo fallback }
+  WebSearch.APIKey     := '';
+  WebSearch.MaxResults := 5;
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -234,6 +249,16 @@ begin
     for i := 0 to High(Sandbox.CustomShellDeny) do Arr.AddStr(Sandbox.CustomShellDeny[i]);
     Tmp.PutArray('custom_shell_deny', Arr);
     Root.PutObject('sandbox', Tmp);
+
+    if (WebSearch.Provider <> '') or (WebSearch.APIKey <> '')
+       or (WebSearch.MaxResults <> 5) then
+    begin
+      Tmp := TJsonObject.Create;
+      Tmp.PutStr('provider',    WebSearch.Provider);
+      Tmp.PutStr('api_key',     WebSearch.APIKey);
+      Tmp.PutInt('max_results', WebSearch.MaxResults);
+      Root.PutObject('web_search', Tmp);
+    end;
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -327,6 +352,16 @@ begin
       finally
         Arr.Free;
       end;
+    finally
+      Obj.Free;
+    end;
+
+    Obj := Root.ChildObject('web_search');
+    if Obj <> nil then
+    try
+      WebSearch.Provider   := Obj.GetStr('provider',    WebSearch.Provider);
+      WebSearch.APIKey     := Obj.GetStr('api_key',     WebSearch.APIKey);
+      WebSearch.MaxResults := Obj.GetInt('max_results', WebSearch.MaxResults);
     finally
       Obj.Free;
     end;

--- a/src/pkg/search/PasClaw.Search.Brave.pas
+++ b/src/pkg/search/PasClaw.Search.Brave.pas
@@ -1,0 +1,174 @@
+(*
+  PasClaw.Search.Brave - Brave Search API adapter.
+
+  Endpoint: GET https://api.search.brave.com/res/v1/web/search
+            ?q=<query>&count=<n>
+  Auth:     X-Subscription-Token: <api-key>
+  Response: { "web": { "results": [
+              { "title": "...", "url": "...",
+                "description": "..." }, ... ] } }
+
+  Brave returns rich metadata (favicon, age, type) we don't need —
+  pick title / url / description and move on.
+
+  Docs: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
+*)
+unit PasClaw.Search.Brave;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Search.Types;
+
+function NewBraveProvider(const APIKey: string): ISearchProvider;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+type
+  TBraveProvider = class(TInterfacedObject, ISearchProvider)
+  private
+    FAPIKey: string;
+  public
+    constructor Create(const APIKey: string);
+    function Name: string;
+    function Search(const Query: string; Count: Integer;
+                    out Hits: TSearchResultArray; out ErrMsg: string): Boolean;
+  end;
+
+function UrlEncode(const S: string): string;
+var
+  i: Integer;
+  C: Char;
+begin
+  Result := '';
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if ((C >= 'A') and (C <= 'Z')) or
+       ((C >= 'a') and (C <= 'z')) or
+       ((C >= '0') and (C <= '9')) or
+       (C = '-') or (C = '_') or (C = '.') or (C = '~') then
+      Result := Result + C
+    else
+      Result := Result + '%' + IntToHex(Byte(C), 2);
+  end;
+end;
+
+constructor TBraveProvider.Create(const APIKey: string);
+begin
+  inherited Create;
+  FAPIKey := APIKey;
+end;
+
+function TBraveProvider.Name: string;
+begin
+  Result := 'brave';
+end;
+
+function TBraveProvider.Search(const Query: string; Count: Integer;
+                                out Hits: TSearchResultArray;
+                                out ErrMsg: string): Boolean;
+var
+  URL: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  Root, Web, Item: TJsonObject;
+  Results: TJsonArray;
+  i, Cap: Integer;
+begin
+  SetLength(Hits, 0);
+  ErrMsg := '';
+  Result := False;
+
+  if FAPIKey = '' then
+  begin
+    ErrMsg := 'brave: missing API key (set $PASCLAW_BRAVE_API_KEY)';
+    Exit;
+  end;
+
+  URL := 'https://api.search.brave.com/res/v1/web/search?q=' +
+         UrlEncode(Query) + '&count=' + IntToStr(Count);
+  SetLength(Headers, 2);
+  Headers[0] := MakeHeader('X-Subscription-Token', FAPIKey);
+  Headers[1] := MakeHeader('Accept-Encoding',      'identity');
+
+  Resp := GetJSONURL(URL, Headers, 20);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    ErrMsg := Format('brave: status=%d body=%s',
+                     [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit;
+  end;
+
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(Resp.Body);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'brave: bad JSON: ' + E.Message;
+      Exit;
+    end;
+  end;
+  if Root = nil then begin ErrMsg := 'brave: empty JSON'; Exit; end;
+
+  try
+    Web := Root.ChildObject('web');
+    if Web = nil then
+    begin
+      LogWarn('brave: response has no "web" block (body=%s)',
+              [Copy(Resp.Body, 1, 200)]);
+      Result := True;   { empty hits, not an error }
+      Exit;
+    end;
+    try
+      Results := Web.ChildArray('results');
+      if Results = nil then
+      begin
+        Result := True;
+        Exit;
+      end;
+      try
+        Cap := Results.Count;
+        if Cap > Count then Cap := Count;
+        SetLength(Hits, Cap);
+        for i := 0 to Cap - 1 do
+        begin
+          Item := Results.ItemObject(i);
+          if Item = nil then Continue;
+          try
+            Hits[i].Title   := Item.GetStr('title',       '');
+            Hits[i].URL     := Item.GetStr('url',         '');
+            Hits[i].Snippet := Item.GetStr('description', '');
+          finally
+            Item.Free;
+          end;
+        end;
+      finally
+        Results.Free;
+      end;
+    finally
+      Web.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+
+  Result := True;
+end;
+
+function NewBraveProvider(const APIKey: string): ISearchProvider;
+begin
+  Result := TBraveProvider.Create(APIKey);
+end;
+
+end.

--- a/src/pkg/search/PasClaw.Search.DuckDuckGo.pas
+++ b/src/pkg/search/PasClaw.Search.DuckDuckGo.pas
@@ -1,0 +1,270 @@
+(*
+  PasClaw.Search.DuckDuckGo - HTML-scrape adapter against
+  https://html.duckduckgo.com/html/.
+
+  DuckDuckGo doesn't ship a public API so picoclaw scrapes the no-JS
+  "html" endpoint and pulls results out of the rendered HTML. Same
+  approach here, with the substring/Pos parsing kept deliberately
+  conservative — we look for the well-known result block markers
+  ("result__a" anchor class, "result__snippet" snippet div) and
+  extract title / URL / snippet. Failed parsing returns whatever
+  block did extract cleanly instead of erroring; partial results
+  beat no results when the model is asking.
+
+  Zero-config: this is what the web_search tool falls back to when
+  no provider is configured, so DuckDuckGo's reliability is the
+  floor of the whole feature.
+
+  Some notes on the URL extraction: DuckDuckGo wraps each result URL
+  in their own redirector
+    href="//duckduckgo.com/l/?uddg=<percent-encoded-real-url>&..."
+  We unwrap the uddg param and percent-decode it so the model gets
+  the real URL it'd recognize. If the wrapper shape changes the
+  unwrap is a best-effort — we return whatever's in href as a
+  fallback.
+*)
+unit PasClaw.Search.DuckDuckGo;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Search.Types;
+
+function NewDuckDuckGoProvider: ISearchProvider;
+
+implementation
+
+uses
+  StrUtils,
+  IdHTTP,
+  IdGlobal,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+type
+  TDuckDuckGoProvider = class(TInterfacedObject, ISearchProvider)
+  public
+    function Name: string;
+    function Search(const Query: string; Count: Integer;
+                    out Hits: TSearchResultArray; out ErrMsg: string): Boolean;
+  end;
+
+function PercentDecode(const S: string): string;
+var
+  i: Integer;
+  Hex: string;
+  B: Byte;
+begin
+  Result := '';
+  i := 1;
+  while i <= Length(S) do
+  begin
+    if (S[i] = '%') and (i + 2 <= Length(S)) then
+    begin
+      Hex := Copy(S, i + 1, 2);
+      try
+        B := StrToInt('$' + Hex);
+        Result := Result + Chr(B);
+        Inc(i, 3);
+        Continue;
+      except
+        { fall through to verbatim copy }
+      end;
+    end;
+    if S[i] = '+' then Result := Result + ' '
+    else Result := Result + S[i];
+    Inc(i);
+  end;
+end;
+
+function UnwrapDuckDuckGoURL(const Href: string): string;
+var
+  Marker: string;
+  Start, Stop: Integer;
+begin
+  Marker := 'uddg=';
+  Start := Pos(Marker, Href);
+  if Start = 0 then
+  begin
+    { Already a real URL, or a shape we don't recognise. Return as-is. }
+    if Pos('//', Href) = 1 then Result := 'https:' + Href
+    else                         Result := Href;
+    Exit;
+  end;
+  Inc(Start, Length(Marker));
+  Stop := Start;
+  while (Stop <= Length(Href)) and (Href[Stop] <> '&') do Inc(Stop);
+  Result := PercentDecode(Copy(Href, Start, Stop - Start));
+end;
+
+function StripTags(const S: string): string;
+var
+  i: Integer;
+  InTag: Boolean;
+begin
+  Result := '';
+  InTag := False;
+  for i := 1 to Length(S) do
+  begin
+    if S[i] = '<' then InTag := True
+    else if S[i] = '>' then InTag := False
+    else if not InTag then Result := Result + S[i];
+  end;
+  { Compress runs of whitespace. }
+  Result := Trim(StringReplace(StringReplace(StringReplace(
+              Result, #10, ' ', [rfReplaceAll]),
+              #13, ' ',         [rfReplaceAll]),
+              #9,  ' ',          [rfReplaceAll]));
+  while Pos('  ', Result) > 0 do
+    Result := StringReplace(Result, '  ', ' ', [rfReplaceAll]);
+end;
+
+function DecodeEntities(const S: string): string;
+begin
+  Result := S;
+  Result := StringReplace(Result, '&amp;',  '&', [rfReplaceAll]);
+  Result := StringReplace(Result, '&lt;',   '<', [rfReplaceAll]);
+  Result := StringReplace(Result, '&gt;',   '>', [rfReplaceAll]);
+  Result := StringReplace(Result, '&quot;', '"', [rfReplaceAll]);
+  Result := StringReplace(Result, '&#39;',  '''', [rfReplaceAll]);
+  Result := StringReplace(Result, '&nbsp;', ' ', [rfReplaceAll]);
+end;
+
+function ExtractBetween(const Hay, StartMark, EndMark: string;
+                        var Cursor: Integer): string;
+var
+  S, E: Integer;
+begin
+  Result := '';
+  S := PosEx(StartMark, Hay, Cursor);
+  if S = 0 then begin Cursor := MaxInt; Exit; end;
+  Inc(S, Length(StartMark));
+  E := PosEx(EndMark, Hay, S);
+  if E = 0 then begin Cursor := MaxInt; Exit; end;
+  Result := Copy(Hay, S, E - S);
+  Cursor := E + Length(EndMark);
+end;
+
+function UrlEncode(const S: string): string;
+var
+  i: Integer;
+  C: Char;
+begin
+  Result := '';
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if ((C >= 'A') and (C <= 'Z')) or
+       ((C >= 'a') and (C <= 'z')) or
+       ((C >= '0') and (C <= '9')) or
+       (C = '-') or (C = '_') or (C = '.') or (C = '~') then
+      Result := Result + C
+    else if C = ' ' then
+      Result := Result + '+'
+    else
+      Result := Result + '%' + IntToHex(Byte(C), 2);
+  end;
+end;
+
+function TDuckDuckGoProvider.Name: string;
+begin
+  Result := 'duckduckgo';
+end;
+
+function TDuckDuckGoProvider.Search(const Query: string; Count: Integer;
+                                     out Hits: TSearchResultArray;
+                                     out ErrMsg: string): Boolean;
+const
+  AnchorOpen  = '<a rel="nofollow" class="result__a"';
+  HrefOpen    = 'href="';
+  AnchorEnd   = '</a>';
+  SnippetOpen = '<a class="result__snippet"';
+  SnippetEnd  = '</a>';
+var
+  HTML, Body, Block, RawTitle, RawSnippet, Href: string;
+  HTTP: TIdHTTP;
+  Cursor, HrefStart, HrefEnd, BlockStart, TitleClose: Integer;
+  N: Integer;
+begin
+  SetLength(Hits, 0);
+  ErrMsg := '';
+  Result := False;
+
+  HTTP := TIdHTTP.Create(nil);
+  try
+    HTTP.HandleRedirects := True;
+    HTTP.Request.UserAgent := 'Mozilla/5.0 (PasClaw web_search)';
+    HTTP.Request.Accept := 'text/html';
+    HTTP.ConnectTimeout := 15000;
+    HTTP.ReadTimeout    := 15000;
+    Body := 'q=' + UrlEncode(Query) + '&kl=us-en';
+    try
+      HTML := HTTP.Post('https://html.duckduckgo.com/html/', Body);
+    except
+      on E: Exception do
+      begin
+        ErrMsg := 'duckduckgo: HTTP error: ' + E.Message;
+        Exit;
+      end;
+    end;
+  finally
+    HTTP.Free;
+  end;
+
+  if Trim(HTML) = '' then
+  begin
+    ErrMsg := 'duckduckgo: empty response';
+    Exit;
+  end;
+
+  N := 0;
+  Cursor := 1;
+  while (N < Count) and (Cursor < Length(HTML)) do
+  begin
+    BlockStart := PosEx(AnchorOpen, HTML, Cursor);
+    if BlockStart = 0 then Break;
+
+    { Extract href first — bound to the same anchor open tag. }
+    HrefStart := PosEx(HrefOpen, HTML, BlockStart);
+    if HrefStart = 0 then Break;
+    Inc(HrefStart, Length(HrefOpen));
+    HrefEnd := PosEx('"', HTML, HrefStart);
+    if HrefEnd = 0 then Break;
+    Href := Copy(HTML, HrefStart, HrefEnd - HrefStart);
+
+    { Title: everything between the anchor's > and the matching </a>. }
+    TitleClose := PosEx('>', HTML, HrefEnd);
+    if TitleClose = 0 then Break;
+    Cursor := TitleClose + 1;
+    RawTitle := ExtractBetween(HTML, '', AnchorEnd, Cursor);
+    if Cursor = MaxInt then Break;
+    RawTitle := Copy(HTML, TitleClose + 1, Cursor - Length(AnchorEnd) - (TitleClose + 1));
+
+    { Snippet: the next result__snippet block — best-effort. If we
+      can't find one, leave Snippet empty rather than skipping the
+      whole result. }
+    RawSnippet := ExtractBetween(HTML, SnippetOpen, SnippetEnd, Cursor);
+    Block := RawSnippet;
+
+    SetLength(Hits, N + 1);
+    Hits[N].Title   := DecodeEntities(StripTags(RawTitle));
+    Hits[N].URL     := UnwrapDuckDuckGoURL(Href);
+    Hits[N].Snippet := DecodeEntities(StripTags(Block));
+    Inc(N);
+  end;
+
+  if N = 0 then
+    LogWarn('duckduckgo: parsed 0 hits from %d-byte response', [Length(HTML)]);
+  Result := True;
+end;
+
+function NewDuckDuckGoProvider: ISearchProvider;
+begin
+  Result := TDuckDuckGoProvider.Create;
+end;
+
+end.

--- a/src/pkg/search/PasClaw.Search.Factory.pas
+++ b/src/pkg/search/PasClaw.Search.Factory.pas
@@ -1,0 +1,92 @@
+(*
+  PasClaw.Search.Factory - resolves the configured ISearchProvider
+  from TConfig + env vars.
+
+  Resolution order:
+    1. cfg.WebSearch.Provider explicitly set: use that adapter, fail
+       fast if a key is required but missing.
+    2. Empty / unset: fall back to DuckDuckGo (no key needed).
+
+  Env overrides win over cfg fields, matching how `pasclaw post` and
+  the channel bots read $PASCLAW_* — keeps secrets out of
+  config.json for users who'd rather not commit them.
+
+  Wave-1 providers: duckduckgo, brave, tavily.
+  Wave 2: searxng, perplexity.
+  Wave 3 (deferred): gemini, glm, baidu, sogou.
+*)
+unit PasClaw.Search.Factory;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Search.Types;
+
+function NewSearchProvider(const Cfg: TConfig; out ErrMsg: string): ISearchProvider;
+
+implementation
+
+uses
+  PasClaw.Logger,
+  PasClaw.Search.DuckDuckGo,
+  PasClaw.Search.Brave,
+  PasClaw.Search.Tavily;
+
+function PickKey(const FromCfg, EnvName: string): string;
+var
+  Env: string;
+begin
+  Env := GetEnvironmentVariable(EnvName);
+  if Env <> '' then Result := Env
+  else              Result := FromCfg;
+end;
+
+function NewSearchProvider(const Cfg: TConfig; out ErrMsg: string): ISearchProvider;
+var
+  Kind, Key: string;
+begin
+  ErrMsg := '';
+  Kind := LowerCase(Trim(Cfg.WebSearch.Provider));
+
+  if (Kind = '') or (Kind = 'duckduckgo') or (Kind = 'ddg') then
+  begin
+    Result := NewDuckDuckGoProvider;
+    Exit;
+  end;
+
+  if Kind = 'brave' then
+  begin
+    Key := PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_BRAVE_API_KEY');
+    if Key = '' then
+    begin
+      ErrMsg := 'brave: api key missing (set $PASCLAW_BRAVE_API_KEY)';
+      Result := nil;
+      Exit;
+    end;
+    Result := NewBraveProvider(Key);
+    Exit;
+  end;
+
+  if Kind = 'tavily' then
+  begin
+    Key := PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_TAVILY_API_KEY');
+    if Key = '' then
+    begin
+      ErrMsg := 'tavily: api key missing (set $PASCLAW_TAVILY_API_KEY)';
+      Result := nil;
+      Exit;
+    end;
+    Result := NewTavilyProvider(Key);
+    Exit;
+  end;
+
+  LogWarn('search.factory: unknown provider %s — falling back to duckduckgo', [Kind]);
+  Result := NewDuckDuckGoProvider;
+end;
+
+end.

--- a/src/pkg/search/PasClaw.Search.HTMLText.pas
+++ b/src/pkg/search/PasClaw.Search.HTMLText.pas
@@ -1,0 +1,137 @@
+(*
+  PasClaw.Search.HTMLText - "good enough for the model" HTML to plain
+  text conversion for web_fetch.
+
+  Strip <script> and <style> bodies entirely, drop every other tag,
+  decode the common entities, collapse whitespace runs to single
+  spaces, normalise line breaks. The output isn't pretty-printed
+  Markdown — picoclaw bothers with that for human display, the
+  model doesn't need it — but it preserves the readable text from
+  most modern HTML pages without dragging in a real HTML parser.
+
+  Limited intentionally:
+    - no <li> bullet preservation
+    - no anchor href extraction (URLs go to the model via web_search)
+    - no <table> alignment
+  Fancier conversion is out of scope; the model can re-fetch with a
+  tighter selector via shell + curl + html2text if that ever matters.
+*)
+unit PasClaw.Search.HTMLText;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, StrUtils;
+
+function HTMLToText(const HTML: string; MaxChars: Integer): string;
+
+implementation
+
+function StripBlock(const S, OpenLower, CloseLower: string): string;
+var
+  i, Hit, EndPos: Integer;
+  Lower: string;
+begin
+  Lower := LowerCase(S);
+  Result := '';
+  i := 1;
+  while i <= Length(S) do
+  begin
+    Hit := PosEx(OpenLower, Lower, i);
+    if Hit = 0 then
+    begin
+      Result := Result + Copy(S, i, MaxInt);
+      Break;
+    end;
+    Result := Result + Copy(S, i, Hit - i);
+    EndPos := PosEx(CloseLower, Lower, Hit + Length(OpenLower));
+    if EndPos = 0 then Break;
+    i := EndPos + Length(CloseLower);
+  end;
+end;
+
+function StripTags(const S: string): string;
+var
+  i: Integer;
+  InTag: Boolean;
+begin
+  Result := '';
+  InTag := False;
+  for i := 1 to Length(S) do
+  begin
+    if S[i] = '<' then InTag := True
+    else if S[i] = '>' then InTag := False
+    else if not InTag then Result := Result + S[i];
+  end;
+end;
+
+function DecodeEntities(const S: string): string;
+begin
+  Result := S;
+  Result := StringReplace(Result, '&amp;',  '&', [rfReplaceAll]);
+  Result := StringReplace(Result, '&lt;',   '<', [rfReplaceAll]);
+  Result := StringReplace(Result, '&gt;',   '>', [rfReplaceAll]);
+  Result := StringReplace(Result, '&quot;', '"', [rfReplaceAll]);
+  Result := StringReplace(Result, '&#39;',  '''', [rfReplaceAll]);
+  Result := StringReplace(Result, '&apos;', '''', [rfReplaceAll]);
+  Result := StringReplace(Result, '&nbsp;', ' ', [rfReplaceAll]);
+  Result := StringReplace(Result, '&mdash;', '-', [rfReplaceAll]);
+  Result := StringReplace(Result, '&ndash;', '-', [rfReplaceAll]);
+  Result := StringReplace(Result, '&hellip;', '...', [rfReplaceAll]);
+end;
+
+function CollapseWhitespace(const S: string): string;
+var
+  i: Integer;
+  PrevSpace: Boolean;
+  C: Char;
+begin
+  Result := '';
+  PrevSpace := True;   { suppress leading whitespace }
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if (C = #13) or (C = #10) then
+    begin
+      { Preserve paragraph breaks: keep a single \n, swallow runs. }
+      if (Length(Result) > 0) and (Result[Length(Result)] <> #10) then
+        Result := Result + #10;
+      PrevSpace := True;
+    end
+    else if (C = ' ') or (C = #9) then
+    begin
+      if not PrevSpace then
+      begin
+        Result := Result + ' ';
+        PrevSpace := True;
+      end;
+    end
+    else
+    begin
+      Result := Result + C;
+      PrevSpace := False;
+    end;
+  end;
+  Result := Trim(Result);
+end;
+
+function HTMLToText(const HTML: string; MaxChars: Integer): string;
+var
+  S: string;
+begin
+  if Trim(HTML) = '' then Exit('');
+  S := StripBlock(HTML, '<script', '</script>');
+  S := StripBlock(S,    '<style',  '</style>');
+  S := StripBlock(S,    '<!--',    '-->');
+  S := StripTags(S);
+  S := DecodeEntities(S);
+  S := CollapseWhitespace(S);
+  if (MaxChars > 0) and (Length(S) > MaxChars) then
+    S := Copy(S, 1, MaxChars) + #10 + '…(truncated)';
+  Result := S;
+end;
+
+end.

--- a/src/pkg/search/PasClaw.Search.Tavily.pas
+++ b/src/pkg/search/PasClaw.Search.Tavily.pas
@@ -1,0 +1,153 @@
+(*
+  PasClaw.Search.Tavily - Tavily Search API adapter.
+
+  Tavily is purpose-built for LLM augmentation — the response is
+  pre-summarised and short. Lower-friction than Brave for "drop
+  this into the model" use cases.
+
+  Endpoint: POST https://api.tavily.com/search
+  Body:     { "api_key": "<key>", "query": "<q>",
+              "max_results": <n>, "search_depth": "basic" }
+  Response: { "results": [
+              { "title": "...", "url": "...",
+                "content": "...", "score": ... }, ... ] }
+
+  Docs: https://docs.tavily.com/docs/rest-api/api-reference
+*)
+unit PasClaw.Search.Tavily;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Search.Types;
+
+function NewTavilyProvider(const APIKey: string): ISearchProvider;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+type
+  TTavilyProvider = class(TInterfacedObject, ISearchProvider)
+  private
+    FAPIKey: string;
+  public
+    constructor Create(const APIKey: string);
+    function Name: string;
+    function Search(const Query: string; Count: Integer;
+                    out Hits: TSearchResultArray; out ErrMsg: string): Boolean;
+  end;
+
+constructor TTavilyProvider.Create(const APIKey: string);
+begin
+  inherited Create;
+  FAPIKey := APIKey;
+end;
+
+function TTavilyProvider.Name: string;
+begin
+  Result := 'tavily';
+end;
+
+function TTavilyProvider.Search(const Query: string; Count: Integer;
+                                 out Hits: TSearchResultArray;
+                                 out ErrMsg: string): Boolean;
+var
+  Req: TJsonObject;
+  Body: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  Root, Item: TJsonObject;
+  Results: TJsonArray;
+  i, Cap: Integer;
+begin
+  SetLength(Hits, 0);
+  ErrMsg := '';
+  Result := False;
+
+  if FAPIKey = '' then
+  begin
+    ErrMsg := 'tavily: missing API key (set $PASCLAW_TAVILY_API_KEY)';
+    Exit;
+  end;
+
+  Req := TJsonObject.Create;
+  try
+    Req.PutStr('api_key',      FAPIKey);
+    Req.PutStr('query',        Query);
+    Req.PutInt('max_results',  Count);
+    Req.PutStr('search_depth', 'basic');
+    Body := Req.ToJSON;
+  finally
+    Req.Free;
+  end;
+
+  SetLength(Headers, 0);
+  Resp := PostJSON('https://api.tavily.com/search', Body, Headers, 30);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    ErrMsg := Format('tavily: status=%d body=%s',
+                     [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit;
+  end;
+
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(Resp.Body);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'tavily: bad JSON: ' + E.Message;
+      Exit;
+    end;
+  end;
+  if Root = nil then begin ErrMsg := 'tavily: empty JSON'; Exit; end;
+
+  try
+    Results := Root.ChildArray('results');
+    if Results = nil then
+    begin
+      LogWarn('tavily: response has no "results" array (body=%s)',
+              [Copy(Resp.Body, 1, 200)]);
+      Result := True;
+      Exit;
+    end;
+    try
+      Cap := Results.Count;
+      if Cap > Count then Cap := Count;
+      SetLength(Hits, Cap);
+      for i := 0 to Cap - 1 do
+      begin
+        Item := Results.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          Hits[i].Title   := Item.GetStr('title',   '');
+          Hits[i].URL     := Item.GetStr('url',     '');
+          Hits[i].Snippet := Item.GetStr('content', '');
+        finally
+          Item.Free;
+        end;
+      end;
+    finally
+      Results.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+
+  Result := True;
+end;
+
+function NewTavilyProvider(const APIKey: string): ISearchProvider;
+begin
+  Result := TTavilyProvider.Create(APIKey);
+end;
+
+end.

--- a/src/pkg/search/PasClaw.Search.Types.pas
+++ b/src/pkg/search/PasClaw.Search.Types.pas
@@ -1,0 +1,41 @@
+(*
+  PasClaw.Search.Types - shared types for web-search providers.
+
+  Mirrors picoclaw's SearchProvider interface but Pascal-flavoured:
+  every adapter implements ISearchProvider and returns a uniform
+  TSearchResultArray. The web_search tool dispatches to the
+  configured adapter via PasClaw.Search.Factory, so adding a new
+  provider is a single new unit plus a case-branch in the factory.
+
+  Result records are flat — title + URL + snippet. picoclaw's richer
+  shape (favicons, dates, scores) is provider-specific and not worth
+  the abstraction tax for what the model actually reads.
+*)
+unit PasClaw.Search.Types;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TSearchResult = record
+    Title:   string;
+    URL:     string;
+    Snippet: string;
+  end;
+  TSearchResultArray = array of TSearchResult;
+
+  ISearchProvider = interface
+    ['{E3A4D1F0-5B62-4C8E-9F03-7A1B2C5D8E40}']
+    function Name: string;
+    function Search(const Query: string; Count: Integer;
+                    out Hits: TSearchResultArray; out ErrMsg: string): Boolean;
+  end;
+
+implementation
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -1,0 +1,203 @@
+(*
+  PasClaw.Tools.WebFetch - registers the web_fetch tool.
+
+  Fetches an arbitrary HTTP/HTTPS URL with TIdHTTP, follows redirects
+  (capped at 5), and converts the response body to plain text via
+  PasClaw.Search.HTMLText. Default text cap is 50 KB to keep one
+  page from blowing the model's context; an explicit `max_chars`
+  argument can raise or lower it.
+
+  Schema:
+    {
+      "url":       "<string, required>",
+      "max_chars": <integer, optional, default 50000>
+    }
+
+  Safety: refuses non-http/https schemes (no file://, ftp://,
+  data://) so a misbehaving model can't read local files via this
+  path — it would have to go through fs_read which is sandbox-
+  governed.
+
+  Out of scope for Wave 1 (deferred to a later PR):
+    - SSRF protection (block requests to RFC1918 / loopback /
+      link-local) — picoclaw does this; PasClaw will when somebody
+      actually deploys a public-facing agent.
+    - Markdown conversion. The current strip-tags output is enough
+      for the model to read.
+    - User-Agent overrides per-request.
+*)
+unit PasClaw.Tools.WebFetch;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterWebFetchTool(R: TToolRegistry);
+
+implementation
+
+uses
+  Classes,
+  IdHTTP, IdSSLOpenSSL,
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Search.HTMLText;
+
+const
+  DEFAULT_MAX_CHARS = 50000;
+  HARD_MAX_CHARS    = 200000;
+
+function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      V := Obj.GetStr(Field, '');
+      Result := V <> '';
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function ParseIntArg(const ArgsJSON, Field: string; Default: Integer): Integer;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      if Obj.Has(Field) then Result := Obj.GetInt(Field, Default);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := Default;
+  end;
+end;
+
+function LowerStartsWith(const S, Prefix: string): Boolean;
+begin
+  Result := (Length(S) >= Length(Prefix)) and
+            SameText(Copy(S, 1, Length(Prefix)), Prefix);
+end;
+
+function Tool_WebFetch(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  URL: string;
+  MaxChars: Integer;
+  HTTP: TIdHTTP;
+  SSLHandler: TIdSSLIOHandlerSocketOpenSSL;
+  Body: string;
+  ContentType: string;
+begin
+  ErrMsg := '';
+  Result := '';
+
+  if not ParseStringArg(ArgsJSON, 'url', URL) then
+  begin
+    ErrMsg := 'missing required argument: url';
+    Exit;
+  end;
+  if not (LowerStartsWith(URL, 'http://') or LowerStartsWith(URL, 'https://')) then
+  begin
+    ErrMsg := 'web_fetch only supports http:// and https:// URLs';
+    Exit;
+  end;
+
+  MaxChars := ParseIntArg(ArgsJSON, 'max_chars', DEFAULT_MAX_CHARS);
+  if MaxChars < 100           then MaxChars := 100;
+  if MaxChars > HARD_MAX_CHARS then MaxChars := HARD_MAX_CHARS;
+
+  HTTP := TIdHTTP.Create(nil);
+  SSLHandler := nil;
+  try
+    HTTP.HandleRedirects   := True;
+    HTTP.RedirectMaximum   := 5;
+    HTTP.ConnectTimeout    := 20000;
+    HTTP.ReadTimeout       := 30000;
+    HTTP.Request.UserAgent := 'Mozilla/5.0 (PasClaw web_fetch)';
+    HTTP.Request.Accept    := 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5';
+
+    if LowerStartsWith(URL, 'https://') then
+    begin
+      SSLHandler := TIdSSLIOHandlerSocketOpenSSL.Create(nil);
+      SSLHandler.SSLOptions.SSLVersions := [sslvTLSv1_2];
+      HTTP.IOHandler := SSLHandler;
+    end;
+
+    try
+      Body := HTTP.Get(URL);
+    except
+      on E: Exception do
+      begin
+        ErrMsg := 'web_fetch: HTTP error: ' + E.Message;
+        Exit;
+      end;
+    end;
+
+    ContentType := LowerCase(HTTP.Response.ContentType);
+    if (Pos('text/html',             ContentType) > 0) or
+       (Pos('application/xhtml+xml', ContentType) > 0) or
+       (ContentType = '') then
+      Result := HTMLToText(Body, MaxChars)
+    else if Pos('text/', ContentType) = 1 then
+    begin
+      Result := Body;
+      if Length(Result) > MaxChars then
+        Result := Copy(Result, 1, MaxChars) + #10 + '…(truncated)';
+    end
+    else
+    begin
+      ErrMsg := Format('web_fetch: unsupported content-type %s', [ContentType]);
+      Exit;
+    end;
+  finally
+    HTTP.Free;
+    if SSLHandler <> nil then SSLHandler.Free;
+  end;
+
+  LogDebug('web_fetch url=%s bytes_in=%d chars_out=%d',
+           [URL, Length(Body), Length(Result)]);
+end;
+
+procedure RegisterWebFetchTool(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if R = nil then Exit;
+  T.Name        := 'web_fetch';
+  T.Description :=
+    'Fetch the contents of an HTTP/HTTPS URL and return readable plain text. ' +
+    'Strips HTML tags, decodes entities, collapses whitespace. Useful after ' +
+    'web_search to read a specific result page. Caps the output at 50 KB ' +
+    'by default; pass max_chars to override (range 100–200000).';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"url":{"type":"string","description":"http:// or https:// URL."},' +
+    '"max_chars":{"type":"integer","minimum":100,"maximum":200000,"description":"Output char cap (default 50000)."}' +
+    '},"required":["url"]}';
+  T.Handler     := Tool_WebFetch;
+  T.IsCore      := True;
+  R.Register(T);
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.WebSearch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebSearch.pas
@@ -1,0 +1,180 @@
+(*
+  PasClaw.Tools.WebSearch - registers the web_search tool.
+
+  The tool dispatches to the configured provider via
+  PasClaw.Search.Factory. Schema:
+    {
+      "query": "<string, required>",
+      "k":     <integer, optional, default cfg.WebSearch.MaxResults>
+    }
+  Returns up to k hits as:
+    1. <title>
+       <url>
+       <snippet>
+
+    2. ...
+  with hits separated by blank lines so the model can scan them
+  quickly. Empty result list returns "(no hits for <query>)" so the
+  model doesn't mistake silence for "tool broke".
+
+  No provider configured falls through to DuckDuckGo (zero-config
+  fallback). API-key-required providers surface a clear "set
+  $PASCLAW_<KIND>_API_KEY" error so the user knows what's missing.
+*)
+unit PasClaw.Tools.WebSearch;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterWebSearchTool(R: TToolRegistry);
+
+implementation
+
+uses
+  Classes,
+  PasClaw.JSON,
+  PasClaw.Config,
+  PasClaw.Logger,
+  PasClaw.Search.Types,
+  PasClaw.Search.Factory;
+
+function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      V := Obj.GetStr(Field, '');
+      Result := V <> '';
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function ParseIntArg(const ArgsJSON, Field: string; Default: Integer): Integer;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      if Obj.Has(Field) then Result := Obj.GetInt(Field, Default);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := Default;
+  end;
+end;
+
+function Tool_WebSearch(const ArgsJSON: string; out ErrMsg: string): string;
+const
+  HardCap = 25;
+var
+  Query, Err: string;
+  K, i, Default: Integer;
+  Cfg: TConfig;
+  Provider: ISearchProvider;
+  Hits: TSearchResultArray;
+  Lines: TStringList;
+begin
+  ErrMsg := '';
+  Result := '';
+
+  if not ParseStringArg(ArgsJSON, 'query', Query) then
+  begin
+    ErrMsg := 'missing required argument: query';
+    Exit;
+  end;
+
+  Cfg := LoadConfig;
+  try
+    Default := Cfg.WebSearch.MaxResults;
+    if Default <= 0 then Default := 5;
+    K := ParseIntArg(ArgsJSON, 'k', Default);
+    if K < 1       then K := 1;
+    if K > HardCap then K := HardCap;
+
+    Provider := NewSearchProvider(Cfg, Err);
+    if Provider = nil then
+    begin
+      ErrMsg := Err;
+      Exit;
+    end;
+
+    if not Provider.Search(Query, K, Hits, Err) then
+    begin
+      ErrMsg := Err;
+      Exit;
+    end;
+  finally
+    Cfg.Free;
+  end;
+
+  if Length(Hits) = 0 then
+    Exit(Format('(no hits for %s via %s)',
+                [Query, Provider.Name]));
+
+  Lines := TStringList.Create;
+  try
+    Lines.Add(Format('%d hit(s) for %s via %s:',
+                     [Length(Hits), Query, Provider.Name]));
+    Lines.Add('');
+    for i := 0 to High(Hits) do
+    begin
+      Lines.Add(Format('%d. %s', [i + 1, Hits[i].Title]));
+      Lines.Add('   ' + Hits[i].URL);
+      if Hits[i].Snippet <> '' then
+        Lines.Add('   ' + Hits[i].Snippet);
+      if i < High(Hits) then Lines.Add('');
+    end;
+    Result := Lines.Text;
+  finally
+    Lines.Free;
+  end;
+
+  LogDebug('web_search via=%s q=%s hits=%d',
+           [Provider.Name, Query, Length(Hits)]);
+end;
+
+procedure RegisterWebSearchTool(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if R = nil then Exit;
+  T.Name        := 'web_search';
+  T.Description :=
+    'Search the web. Dispatches to the configured provider (DuckDuckGo ' +
+    'when no api key is set; Brave or Tavily when $PASCLAW_BRAVE_API_KEY ' +
+    'or $PASCLAW_TAVILY_API_KEY is set and config.json picks one). ' +
+    'Returns up to k results as title + URL + snippet.';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"query":{"type":"string","description":"Free-text search query."},' +
+    '"k":{"type":"integer","minimum":1,"maximum":25,"description":"Max results (default 5)."}' +
+    '},"required":["query"]}';
+  T.Handler     := Tool_WebSearch;
+  T.IsCore      := True;
+  R.Register(T);
+end;
+
+end.


### PR DESCRIPTION
picoclaw ships 9 web-search providers under a single `SearchProvider` interface and a model-callable `web_search` tool. PasClaw had none. Wave 1 ports the three lowest-friction providers (one no-key fallback + two API-key providers) plus a sibling `web_fetch` tool for reading a specific page after a search returns interesting URLs. The remaining providers plug into the same factory; queued for Wave 2 / Wave 3.

## New unit tree under `src/pkg/search`

| Unit | What it does |
|---|---|
| `Types` | `ISearchProvider`, `TSearchResult`, `TSearchResultArray`. Flat shape — title + URL + snippet — because that's all the model actually reads. |
| `DuckDuckGo` | Zero-config fallback. Scrapes `html.duckduckgo.com/html/`, unwraps the `//duckduckgo.com/l/?uddg=` redirector so the model gets real URLs. |
| `Brave` | GET `api.search.brave.com/res/v1/web/search`, `X-Subscription-Token` header. Parses `web.results[]`. |
| `Tavily` | POST `api.tavily.com/search`, api_key in body. Purpose-built for LLM augmentation. |
| `HTMLText` | `HTMLToText(html, maxChars)` — strips `<script>`/`<style>`/`<!--…-->` wholesale, drops other tags, decodes 9 common entities, collapses whitespace. |
| `Factory` | `NewSearchProvider(cfg) -> ISearchProvider`. Empty/unknown falls back to DuckDuckGo with a warn. Env wins over cfg fields for API keys. |

## New tools under `src/pkg/tools`

```jsonc
// web_search
{ "query": "string (required)", "k": "1..25 (default 5)" }
// → numbered title/url/snippet blocks; "(no hits)" on empty
//   list; clear "set $PASCLAW_<KIND>_API_KEY" errors when a
//   keyed provider is configured without one.

// web_fetch
{ "url": "http:// or https://", "max_chars": "100..200000 (default 50000)" }
// → readable plain text via HTMLToText for text/html, raw +
//   truncation for other text/*, refused for binary types.
//   Refuses non-http/https schemes so the model can't reach
//   file:// or ftp:// via this path.
```

## Config

```pascal
TWebSearchConfig = record
  Provider:   string;   // 'duckduckgo' (default) | 'brave' | 'tavily'
  APIKey:     string;
  MaxResults: Integer;  // default 5
end;
```

Serialised only when non-default so existing `config.json` files round-trip byte-identical; parser defaults `provider=''` (= DuckDuckGo) and `max_results=5`. Env-var values win over the cfg `api_key` so secrets stay out of `config.json`.

```json
{ "web_search": { "provider": "brave", "max_results": 5 } }
```

## Tool registration

`RegisterWebSearchTool` + `RegisterWebFetchTool` wired into `PasClaw.Cmd.Agent` / `Gateway` / `TUI` / `Serve` and both `TPasClawAgent.EnsureToolsRegistered` paths in `PasClaw.Component` — same five sites `RegisterMemoryTools` lives in. Honours `--no-tools`.

## Build

- `Makefile` `UNIT_DIRS` gains `src/pkg/search`.
- `PasClaw.dproj` `DCC_UnitSearchPath` adds `..\pkg\search`; 7 new `DCCReference` entries (6 search units + 2 tools).
- README: env-var table picks up `PASCLAW_BRAVE_API_KEY` + `PASCLAW_TAVILY_API_KEY`; new "### Web search" section under Configuration with the provider table; repo-layout `search/` row.

## Verification

- `make` — clean build under FPC 3.2.2.
- `HTMLToText` smoke test — **13 assertions, all pass**: basic tag strip, entity decode, script+style+comment stripping, whitespace collapse, truncation, empty/whitespace-only input, realistic page fragment.
- `pasclaw status` output byte-identical.
- `pasclaw --help` unchanged.

## Out of scope (intentional)

| Item | Why deferred |
|---|---|
| Wave 2: SearXNG, Perplexity | Same factory + tool surface; ~250 LOC each. |
| Wave 3: Gemini Google Search, GLM (Zhipu), Baidu | LLM-provider-tied or Chinese-ecosystem auth — heavier port. |
| SSRF protection in `web_fetch` | Today's threat model is "the user is the operator". Picoclaw blocks RFC1918/loopback/link-local; PasClaw will when someone deploys a public-facing agent. Called out in the unit's docstring. |
| Markdown conversion in `web_fetch` | The stripped-text output is enough for the model to read. |

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_