### PR TITLE
search: Gemini Google Search grounding provider (Wave 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Environment variables:
 | `PASCLAW_TAVILY_API_KEY` | Tavily API key for the `web_search` tool when `web_search.provider = tavily`. |
 | `PASCLAW_SEARXNG_API_KEY` | Bearer token for protected SearXNG instances (most public ones don't need it). |
 | `PASCLAW_PERPLEXITY_API_KEY` | Perplexity API key for the `web_search` tool when `web_search.provider = perplexity`. |
+| `PASCLAW_GEMINI_API_KEY` | Google AI Studio key for the `web_search` tool when `web_search.provider = gemini`. `PASCLAW_GOOGLE_API_KEY` works too. |
 | `NO_COLOR` | Disables ANSI color output. |
 
 Useful config commands:
@@ -191,6 +192,7 @@ Provider is set under `web_search` in `~/.pasclaw/config.json`:
 | `tavily` | yes — `$PASCLAW_TAVILY_API_KEY` overrides `api_key` | `api.tavily.com/search` |
 | `searxng` | no (most public instances); optional `$PASCLAW_SEARXNG_API_KEY` for protected ones | `<web_search.base_url>/search?format=json` |
 | `perplexity` | yes — `$PASCLAW_PERPLEXITY_API_KEY` overrides `api_key` | `api.perplexity.ai/chat/completions` (Sonar model — returns one synthesised answer plus citation URLs) |
+| `gemini` | yes — `$PASCLAW_GEMINI_API_KEY` (or `$PASCLAW_GOOGLE_API_KEY`) overrides `api_key` | `generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent` with `google_search` grounding — returns one synthesised answer plus the ground-truth source URLs Gemini consulted |
 
 Env-var values win over the `api_key` field so secrets can stay out of `config.json`. SearXNG additionally needs `web_search.base_url` set since every instance is self-hosted (e.g. `"base_url": "https://searx.be"`).
 
@@ -553,7 +555,7 @@ src/
     memory/         Memory log storage
     platform/       Platform helpers
     providers/      Provider catalog and LLM HTTP clients
-    search/         Web-search providers (DuckDuckGo, Brave, Tavily, SearXNG, Perplexity) + HTML→text
+    search/         Web-search providers (DuckDuckGo, Brave, Tavily, SearXNG, Perplexity, Gemini) + HTML→text
     skills/         Skill manifest loading and tool registration
     tokenizer/      Token counting helpers
     tools/          Built-in tool registry, filesystem, shell, and tool loop

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -207,6 +207,7 @@
         <DCCReference Include="..\pkg\search\PasClaw.Search.Tavily.pas"/>
         <DCCReference Include="..\pkg\search\PasClaw.Search.SearXNG.pas"/>
         <DCCReference Include="..\pkg\search\PasClaw.Search.Perplexity.pas"/>
+        <DCCReference Include="..\pkg\search\PasClaw.Search.Gemini.pas"/>
         <DCCReference Include="..\pkg\search\PasClaw.Search.Factory.pas"/>
 
         <!-- pkg/cron -->

--- a/src/pkg/search/PasClaw.Search.Factory.pas
+++ b/src/pkg/search/PasClaw.Search.Factory.pas
@@ -13,8 +13,10 @@
 
   Wave 1: duckduckgo, brave, tavily.
   Wave 2: searxng, perplexity.
-  Wave 3 (deferred): gemini google_search; glm + baidu skipped
-                     (Chinese-ecosystem auth, narrower audience).
+  Wave 3: gemini (Google Search grounding via the Gemini Generative
+          Language API). GLM (Zhipu) and Baidu (Qianfan) intentionally
+          skipped — narrower Delphi/FPC audience for those auth
+          ceremonies.
 *)
 unit PasClaw.Search.Factory;
 
@@ -38,7 +40,8 @@ uses
   PasClaw.Search.Brave,
   PasClaw.Search.Tavily,
   PasClaw.Search.SearXNG,
-  PasClaw.Search.Perplexity;
+  PasClaw.Search.Perplexity,
+  PasClaw.Search.Gemini;
 
 function PickKey(const FromCfg, EnvName: string): string;
 var
@@ -113,6 +116,25 @@ begin
       Exit;
     end;
     Result := NewPerplexityProvider(Key);
+    Exit;
+  end;
+
+  if (Kind = 'gemini') or (Kind = 'google_search') then
+  begin
+    Key := PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_GEMINI_API_KEY');
+    if Key = '' then
+    begin
+      ErrMsg := 'gemini: api key missing (set $PASCLAW_GEMINI_API_KEY ' +
+                'or $PASCLAW_GOOGLE_API_KEY)';
+      Result := nil;
+      { Try the Google-branded env var too. Some users have it set
+        from gcloud / aistudio defaults rather than the explicit
+        Gemini key name. }
+      Key := GetEnvironmentVariable('PASCLAW_GOOGLE_API_KEY');
+      if Key = '' then Exit;
+      ErrMsg := '';
+    end;
+    Result := NewGeminiProvider(Key);
     Exit;
   end;
 

--- a/src/pkg/search/PasClaw.Search.Gemini.pas
+++ b/src/pkg/search/PasClaw.Search.Gemini.pas
@@ -1,0 +1,334 @@
+(*
+  PasClaw.Search.Gemini - Google Gemini "Google Search" grounding
+  as a web_search provider.
+
+  Gemini isn't a search engine. It's an LLM with a `google_search`
+  tool the model can invoke during generation, with the response
+  returning both the synthesised answer AND the source URLs it
+  consulted. The adapter calls generateContent with the
+  google_search tool enabled and maps the result into the same
+  ISearchProvider shape Tavily / Perplexity use:
+
+    Hits[0]   = the synthesised answer (title="Gemini summary",
+                URL=first grounding URL if any, snippet=text)
+    Hits[1..] = each remaining grounding chunk as a real
+                {title, url} pair Gemini already supplies
+
+  Caps total hits at `Count`. The synthesised summary plus a few
+  source URLs is usually more useful than 10 raw search hits.
+
+  Endpoint: POST https://generativelanguage.googleapis.com/v1beta/
+                 models/<model>:generateContent?key=<api-key>
+  Body:     { "contents": [
+                { "parts": [ { "text": "<query>" } ] } ],
+              "tools": [ { "google_search": {} } ] }
+  Response: { "candidates": [ {
+                "content": { "parts": [ { "text": "<answer>" } ] },
+                "groundingMetadata": {
+                  "groundingChunks": [
+                    { "web": { "uri": "...", "title": "..." } }, ...
+                  ],
+                  "webSearchQueries": [ "..." ],
+                  ...
+                }
+              } ] }
+
+  Model: hardcoded to gemini-1.5-flash — free-tier-friendly, supports
+  google_search grounding, fast. Users wanting 1.5-pro or 2.0-flash
+  can patch this constant; we don't add another config field for one
+  provider.
+
+  Docs:
+    Grounding   https://ai.google.dev/gemini-api/docs/grounding
+    REST shape  https://ai.google.dev/api/rest/v1beta/models/generateContent
+*)
+unit PasClaw.Search.Gemini;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Search.Types;
+
+function NewGeminiProvider(const APIKey: string): ISearchProvider;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP;
+
+const
+  GEMINI_MODEL       = 'gemini-1.5-flash';
+  ANSWER_SNIPPET_MAX = 1200;
+
+type
+  TGeminiProvider = class(TInterfacedObject, ISearchProvider)
+  private
+    FAPIKey: string;
+  public
+    constructor Create(const APIKey: string);
+    function Name: string;
+    function Search(const Query: string; Count: Integer;
+                    out Hits: TSearchResultArray; out ErrMsg: string): Boolean;
+  end;
+
+constructor TGeminiProvider.Create(const APIKey: string);
+begin
+  inherited Create;
+  FAPIKey := APIKey;
+end;
+
+function TGeminiProvider.Name: string;
+begin
+  Result := 'gemini';
+end;
+
+function BuildRequestBody(const Query: string): string;
+var
+  Root, Content, Part, Tool, GS: TJsonObject;
+  ContentsArr, PartsArr, ToolsArr: TJsonArray;
+begin
+  Root := TJsonObject.Create;
+  try
+    ContentsArr := TJsonArray.Create;
+    Content     := TJsonObject.Create;
+    PartsArr    := TJsonArray.Create;
+    Part        := TJsonObject.Create;
+    Part.PutStr('text', Query);
+    PartsArr.AddObject(Part);
+    Content.PutArray('parts', PartsArr);
+    ContentsArr.AddObject(Content);
+    Root.PutArray('contents', ContentsArr);
+
+    ToolsArr := TJsonArray.Create;
+    Tool     := TJsonObject.Create;
+    GS       := TJsonObject.Create;   { empty object — the tool config }
+    Tool.PutObject('google_search', GS);
+    ToolsArr.AddObject(Tool);
+    Root.PutArray('tools', ToolsArr);
+
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function ExtractAnswer(Root: TJsonObject): string;
+var
+  Candidates: TJsonArray;
+  Candidate, Content: TJsonObject;
+  Parts: TJsonArray;
+  Part: TJsonObject;
+  i: Integer;
+begin
+  Result := '';
+  Candidates := Root.ChildArray('candidates');
+  if Candidates = nil then Exit;
+  try
+    if Candidates.Count = 0 then Exit;
+    Candidate := Candidates.ItemObject(0);
+    if Candidate = nil then Exit;
+    try
+      Content := Candidate.ChildObject('content');
+      if Content = nil then Exit;
+      try
+        Parts := Content.ChildArray('parts');
+        if Parts = nil then Exit;
+        try
+          for i := 0 to Parts.Count - 1 do
+          begin
+            Part := Parts.ItemObject(i);
+            if Part = nil then Continue;
+            try
+              { Parts may carry text, function_call, etc. We only
+                want the model's prose answer. }
+              if Result <> '' then Result := Result + #10;
+              Result := Result + Part.GetStr('text', '');
+            finally
+              Part.Free;
+            end;
+          end;
+        finally
+          Parts.Free;
+        end;
+      finally
+        Content.Free;
+      end;
+    finally
+      Candidate.Free;
+    end;
+  finally
+    Candidates.Free;
+  end;
+end;
+
+procedure ExtractGroundingURLs(Root: TJsonObject;
+                                var Titles, URLs: array of string;
+                                var ChunkCount: Integer);
+(* Walks candidates[0].groundingMetadata.groundingChunks[].web and
+   appends each title/uri pair into the parallel Titles/URLs arrays
+   up to their declared length. ChunkCount returns how many were
+   populated. *)
+var
+  Candidates: TJsonArray;
+  Candidate, GM, Web: TJsonObject;
+  Chunks: TJsonArray;
+  Chunk: TJsonObject;
+  i, Cap: Integer;
+begin
+  ChunkCount := 0;
+  Cap := Length(Titles);   { same as Length(URLs) by contract }
+  if Cap = 0 then Exit;
+  Candidates := Root.ChildArray('candidates');
+  if Candidates = nil then Exit;
+  try
+    if Candidates.Count = 0 then Exit;
+    Candidate := Candidates.ItemObject(0);
+    if Candidate = nil then Exit;
+    try
+      GM := Candidate.ChildObject('groundingMetadata');
+      if GM = nil then Exit;
+      try
+        Chunks := GM.ChildArray('groundingChunks');
+        if Chunks = nil then Exit;
+        try
+          for i := 0 to Chunks.Count - 1 do
+          begin
+            if ChunkCount >= Cap then Break;
+            Chunk := Chunks.ItemObject(i);
+            if Chunk = nil then Continue;
+            try
+              Web := Chunk.ChildObject('web');
+              if Web = nil then Continue;
+              try
+                URLs[ChunkCount]   := Web.GetStr('uri',   '');
+                Titles[ChunkCount] := Web.GetStr('title', '');
+                if URLs[ChunkCount] <> '' then Inc(ChunkCount);
+              finally
+                Web.Free;
+              end;
+            finally
+              Chunk.Free;
+            end;
+          end;
+        finally
+          Chunks.Free;
+        end;
+      finally
+        GM.Free;
+      end;
+    finally
+      Candidate.Free;
+    end;
+  finally
+    Candidates.Free;
+  end;
+end;
+
+function TGeminiProvider.Search(const Query: string; Count: Integer;
+                                 out Hits: TSearchResultArray;
+                                 out ErrMsg: string): Boolean;
+var
+  URL, Body, Answer: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  Root: TJsonObject;
+  Titles, URLs: array of string;
+  ChunkCount, N, FirstCite, i: Integer;
+begin
+  SetLength(Hits, 0);
+  ErrMsg := '';
+  Result := False;
+
+  if FAPIKey = '' then
+  begin
+    ErrMsg := 'gemini: missing API key (set $PASCLAW_GEMINI_API_KEY)';
+    Exit;
+  end;
+
+  URL := 'https://generativelanguage.googleapis.com/v1beta/models/' +
+         GEMINI_MODEL + ':generateContent?key=' + FAPIKey;
+  Body := BuildRequestBody(Query);
+  SetLength(Headers, 0);
+  Resp := PostJSON(URL, Body, Headers, 45);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    ErrMsg := Format('gemini: status=%d body=%s',
+                     [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit;
+  end;
+
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(Resp.Body);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'gemini: bad JSON: ' + E.Message;
+      Exit;
+    end;
+  end;
+  if Root = nil then begin ErrMsg := 'gemini: empty JSON'; Exit; end;
+
+  try
+    Answer := ExtractAnswer(Root);
+
+    { Reserve room for up to Count grounding chunks. Pull them in
+      one pass, then fold the answer in as Hits[0]. }
+    SetLength(Titles, Count);
+    SetLength(URLs,   Count);
+    ChunkCount := 0;
+    ExtractGroundingURLs(Root, Titles, URLs, ChunkCount);
+
+    N := 0;
+    FirstCite := 0;
+    if Answer <> '' then
+    begin
+      SetLength(Hits, 1);
+      Hits[0].Title := 'Gemini summary';
+      if ChunkCount > 0 then
+      begin
+        Hits[0].URL := URLs[0];
+        FirstCite := 1;   { first grounding URL already in Hits[0] }
+      end
+      else
+        Hits[0].URL := '';
+      if Length(Answer) > ANSWER_SNIPPET_MAX then
+        Hits[0].Snippet := Copy(Answer, 1, ANSWER_SNIPPET_MAX) + ' …(truncated)'
+      else
+        Hits[0].Snippet := Answer;
+      N := 1;
+    end;
+
+    for i := FirstCite to ChunkCount - 1 do
+    begin
+      if N >= Count then Break;
+      SetLength(Hits, N + 1);
+      Hits[N].Title   := Titles[i];
+      if Hits[N].Title = '' then Hits[N].Title := '(grounding chunk)';
+      Hits[N].URL     := URLs[i];
+      Hits[N].Snippet := '';
+      Inc(N);
+    end;
+
+    if (Answer = '') and (ChunkCount = 0) then
+      LogWarn('gemini: response had neither candidates nor grounding (body=%s)',
+              [Copy(Resp.Body, 1, 200)]);
+  finally
+    Root.Free;
+  end;
+
+  Result := True;
+end;
+
+function NewGeminiProvider(const APIKey: string): ISearchProvider;
+begin
+  Result := TGeminiProvider.Create(APIKey);
+end;
+
+end.


### PR DESCRIPTION
Sixth and (per the maintainer call) final port from picoclaw's web-search lineup. Gemini isn't a traditional search endpoint — it's the Gemini LLM with `google_search` as an enabled tool, so the API returns a synthesised answer plus the source URLs the model consulted. The adapter folds that into `ISearchProvider`'s uniform shape the same way Perplexity does:

- `Hits[0]` — `Title="Gemini summary"`, `URL=` first grounding URL if any, `Snippet=` answer text truncated to 1200 chars.
- `Hits[1..]` — remaining `groundingChunks[].web` entries with real `{title, uri}` pairs Gemini supplies (unlike Perplexity which returns bare URLs).

Caps total hits at the caller's `count`.

## `PasClaw.Search.Gemini`

```
POST https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=<api-key>
{ "contents":[{"parts":[{"text":Q}]}], "tools":[{"google_search":{}}] }
```

Model hardcoded to `gemini-1.5-flash` — free-tier-friendly, supports `google_search` grounding, fast. Switching to 1.5-pro or 2.0-flash is a one-constant patch; not adding a config field for one provider.

Response parsing has two helpers:

| Helper | What it does |
|---|---|
| `ExtractAnswer` | Walks `candidates[0].content.parts[].text` and concatenates non-empty pieces. |
| `ExtractGroundingURLs` | Walks `candidates[0].groundingMetadata.groundingChunks[].web` → fills parallel Titles/URLs arrays up to their declared length. Drops chunks with no `uri`. |

## Factory + env

Two case branches under one `if` — `gemini` or `google_search` both map to the Gemini provider, picoclaw uses the longer label and either works here. Env probe reads `$PASCLAW_GEMINI_API_KEY` first, then falls back to `$PASCLAW_GOOGLE_API_KEY` (some users already have the Google-branded var set from `gcloud` / AI Studio defaults).

## README

- Env-var table picks up `PASCLAW_GEMINI_API_KEY` (with the `_GOOGLE_API_KEY` note).
- Provider table grows a sixth row explaining the `google_search`-grounding shape.
- Repo-layout `search/` line spells out the full set of **six providers**.

## Verification

- `make` — clean build under FPC 3.2.2.
- `pasclaw status` and `--help` byte-identical.

## What's next

Closes the picoclaw web-search catch-up at six providers. Maintainer skipped GLM (Zhipu) and Baidu (Qianfan) — narrower Delphi/FPC audience for the Chinese-ecosystem auth ceremonies; can land later if anyone shows up wanting them.

## PR ordering

This branch stacks on **PR #81** (Wave 2 — SearXNG + Perplexity) so the factory case ladder lands in one coherent shape rather than fighting textual conflicts. **Please merge #81 first**; this PR's base will auto-retarget to `main` after that.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_