### PR TITLE
sandbox: stop banning cd/pushd in unrestricted mode

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -245,11 +245,15 @@ const
       tokenizer splits on whitespace + shell metacharacters, so only
       stand-alone tokens trigger the match.
 
-      cd / chdir / pushd / popd are in here because the workspace
-      restriction below binds the shell's cwd to GWorkspace and runs
-      the abs-path scanner on the rest of the command; letting the
-      model chdir would defeat both. *)
-  ForbiddenTokens: array[0..27] of string = (
+      cd / chdir / pushd / popd are NOT in here — they live in
+      WorkspaceEscapeTokens below, which is checked only when the
+      workspace restriction is active. Banning the cd-family
+      unconditionally broke legitimate compile-and-build flows
+      ("cmd /c cd <proj> && dcc32 …") in unrestricted mode for no
+      additional safety — the workspace boundary is what they were
+      ever meant to protect, so they only matter when that boundary
+      exists. *)
+  ForbiddenTokens: array[0..23] of string = (
     'sudo',
     'su',
     'rm',          { all rm — too easy to escape -rf detection }
@@ -265,10 +269,6 @@ const
     'eval',
     'mkfs',
     'diskpart',
-    'cd',          { workspace-escape via cwd change }
-    'chdir',
-    'pushd',
-    'popd',
     { Windows additions } 'del',
     'erase',
     'rd',
@@ -278,6 +278,20 @@ const
     'takeown',
     'icacls',
     'runas'
+  );
+
+  (*  Tokens that would let the model escape the workspace cwd pin —
+      the workspace restriction binds the shell's cwd to GWorkspace
+      and runs the abs-path scanner on the rest of the command;
+      letting the model chdir would defeat both. Only enforced when
+      sandbox.restrict_to_workspace is True. In unrestricted mode
+      the model can change directories freely (regular CLI use, no
+      cwd pin to defeat). *)
+  WorkspaceEscapeTokens: array[0..3] of string = (
+    'cd',
+    'chdir',
+    'pushd',
+    'popd'
   );
 
   { Substrings that, when present anywhere in the lowercased command,
@@ -405,6 +419,31 @@ begin
         if T = ForbiddenTokens[j] then
         begin
           Hit := ForbiddenTokens[j];
+          Exit(True);
+        end;
+    end;
+  finally
+    Tokens.Free;
+  end;
+end;
+
+function MatchesAnyWorkspaceEscape(const Cmd: string; out Hit: string): Boolean;
+var
+  Tokens: TStringList;
+  i, j: Integer;
+  T: string;
+begin
+  Result := False;
+  Hit := '';
+  Tokens := TokenizeCommand(Cmd);
+  try
+    for i := 0 to Tokens.Count - 1 do
+    begin
+      T := LowerCase(Tokens[i]);
+      for j := 0 to High(WorkspaceEscapeTokens) do
+        if T = WorkspaceEscapeTokens[j] then
+        begin
+          Hit := WorkspaceEscapeTokens[j];
           Exit(True);
         end;
     end;
@@ -542,6 +581,21 @@ begin
 
   if GPolicy.RestrictToWorkspace then
   begin
+    { cd / chdir / pushd / popd only matter when restriction is on —
+      they'd let the model escape the workspace cwd pin. In
+      unrestricted mode the model can chdir freely (regular CLI use,
+      no cwd to pin). Gating these here, rather than in the
+      always-on ForbiddenTokens above, fixes the "cmd /c cd <proj> &&
+      dcc32 …" Delphi/Windows compile flow that worked before
+      sandbox landed. }
+    if GPolicy.ShellDenyEnabled and MatchesAnyWorkspaceEscape(Cmd, Hit) then
+    begin
+      Reason := 'refused: command contains workspace-escape token "' + Hit +
+                '" (sandbox.restrict_to_workspace=true pins shell cwd to "' +
+                GWorkspace + '"; cd would defeat that). Use absolute paths ' +
+                'inside the workspace instead.';
+      Exit(False);
+    end;
     if HasOutsideAbsolutePath(Cmd, Path) then
     begin
       Reason := 'refused: command references absolute path "' + Path +


### PR DESCRIPTION
## The bug

The shell denylist short-circuited `cd` / `chdir` / `pushd` / `popd` unconditionally whenever `shell_deny_enabled` was True, regardless of whether `restrict_to_workspace` was on. That broke legitimate compile-and-build flows like the Delphi/Windows one:

```bat
cmd /c "C:\…\rsvars.bat && cd C:\proj && dcc32.exe probe.dpr"
```

For users whose `config.json` had **no `sandbox` section at all** — because `TConfig` defaults to `restrict_to_workspace=false` + `shell_deny_enabled=true`, which silently combined to ban `cd` in unrestricted mode for no actual security benefit. The cd-family only matters when a workspace cwd pin exists; without a pin to defeat, banning them is pure friction.

## The fix

Split `ForbiddenTokens` into two arrays:

| Array | Size | Gated by | Examples |
|---|---|---|---|
| `ForbiddenTokens` | 24 (was 28) | `shell_deny_enabled` alone | sudo, rm, chmod, chown, kill family, mkfs, diskpart, del, format, … |
| `WorkspaceEscapeTokens` | 4 (new) | `restrict_to_workspace AND shell_deny_enabled` | cd, chdir, pushd, popd |

The new check lives in the existing `RestrictToWorkspace` branch in `ShellAllowed`, right next to the absolute-path scanner and the traversal-token check. Refusal message names the actual reason ("workspace-escape token … `restrict_to_workspace=true` pins shell cwd to …") so the model can rewrite with absolute paths inside the workspace instead of bouncing off a generic "forbidden token" error and getting stuck — which is what was happening in the transcript that surfaced this regression.

## Verification

Standalone smoke covering all four policy combinations × 11 commands. All 11 assertions pass:

| Policy | Outcome |
|---|---|
| unrestricted + deny on (the user's default) | `cd` / `chdir` / `pushd` **allowed** (regression fix); `sudo` / `rm` / `curl \| sh` **still blocked** |
| restricted + deny on | `cd` / `pushd` **blocked** with the new clearer message; `sudo` still blocked |
| restricted + deny off | `cd` (relative path) allowed — new gate requires both flags |
| unrestricted + deny off | full passthrough (existing behaviour) |

Behaviour preserved verbatim for every non-cd-family entry in the original list. The `restrict_to_workspace=true` operator loses nothing: the workspace cwd pin, the absolute-path scanner, and the traversal-token check all still fire as before, and the new `WorkspaceEscape` check joins them inside the same branch.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_