### PR TITLE
net: SSRF guard for web_fetch (IPv4 blocklist + redirect re-check)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ UNIT_DIRS = \
 	src/pkg/gateway \
 	src/pkg/channels \
 	src/pkg/crypto \
+	src/pkg/net \
 	src/pkg/search \
 	src/pkg/cron \
 	src/pkg/skills \

--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ PasClaw's filesystem and shell tools are guarded by an opt-in workspace boundary
 | `allow_write_paths` | `[]` | Same for writes. |
 | `custom_shell_deny` | `[]` | Extra substrings appended to the built-in shell denylist. Case-insensitive. |
 | `shell_deny_enabled` | `true` | Master switch for the shell denylist. Set `false` only for trusted automation — doing so re-enables `sudo`, `rm`, `dd`, `mkfs`, `$( )`, `curl \| sh`, `format c:`, PowerShell `-EncodedCommand`, etc. |
+| `block_private_networks` | `true` | When `true`, `web_fetch` refuses URLs whose host resolves to a private / loopback / link-local IPv4 address (RFC1918, `127.0.0.0/8`, `169.254.0.0/16` — including the cloud-metadata endpoint `169.254.169.254`, CGNAT, IETF-reserved). Initial URL and every redirect hop are both checked. Flip to `false` only when you actually need the model to reach private addresses. See `PasClaw.Net.SSRF` for the full blocklist. |
 
 **Cross-target regex**: `PasClaw.Tools.Regex` wraps FPC's `RegExpr` and Delphi's `System.RegularExpressions` behind one call, so `allow_*_paths` patterns are full PCRE on either toolchain. Invalid patterns return False (the sandbox falls through to the workspace boundary) rather than crashing.
 
@@ -553,6 +554,7 @@ src/
     mcp/            MCP stdio/HTTP clients and tool bridge
     membench/       Memory benchmark helpers
     memory/         Memory log storage
+    net/            SSRF guard (IPv4 blocklist + DNS re-resolution)
     platform/       Platform helpers
     providers/      Provider catalog and LLM HTTP clients
     search/         Web-search providers (DuckDuckGo, Brave, Tavily, SearXNG, Perplexity, Gemini) + HTML→text

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -198,6 +198,9 @@
 
         <!-- pkg/crypto -->
         <DCCReference Include="..\pkg\crypto\PasClaw.Crypto.HMAC.pas"/>
+
+        <!-- pkg/net -->
+        <DCCReference Include="..\pkg\net\PasClaw.Net.SSRF.pas"/>
 
         <!-- pkg/search -->
         <DCCReference Include="..\pkg\search\PasClaw.Search.Types.pas"/>

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -71,7 +71,19 @@ type
         Master switch for the shell denylist. Default True. Set
         False only for trusted automation; doing so re-enables
         `sudo`, `rm -rf`, `dd`, `mkfs`, command-substitution,
-        `curl | sh`, and every other pattern in the list.    *)
+        `curl | sh`, and every other pattern in the list.
+
+      BlockPrivateNetworks
+        When True (default), web_fetch refuses URLs whose host
+        resolves to a private / loopback / link-local IPv4
+        address. Protects against the cloud-metadata SSRF (e.g.
+        169.254.169.254 on AWS / GCP / Azure), against probes
+        of internal LAN services (RFC1918 ranges), and against
+        localhost service enumeration. See
+        PasClaw.Net.SSRF for the full blocklist.
+        Flip to False only when you actually need the model to
+        reach private addresses (local dev mode, intranet
+        scraping) and have weighed the credentials-leak risk.   *)
   TSandboxPolicy = record
     RestrictToWorkspace:       Boolean;
     AllowReadOutsideWorkspace: Boolean;
@@ -80,6 +92,7 @@ type
     AllowWritePaths:           array of string;
     CustomShellDeny:           array of string;
     ShellDenyEnabled:          Boolean;
+    BlockPrivateNetworks:      Boolean;
   end;
 
   TProviderConfig = record
@@ -177,6 +190,7 @@ begin
   Sandbox.AllowReadOutsideWorkspace := False;
   Sandbox.Workspace                 := '';
   Sandbox.ShellDenyEnabled          := True;
+  Sandbox.BlockPrivateNetworks      := True;
   WebSearch.Provider   := '';   { empty = duckduckgo fallback }
   WebSearch.APIKey     := '';
   WebSearch.BaseURL    := '';
@@ -245,6 +259,7 @@ begin
     Tmp.PutBool('allow_read_outside_workspace', Sandbox.AllowReadOutsideWorkspace);
     Tmp.PutStr ('workspace',                    Sandbox.Workspace);
     Tmp.PutBool('shell_deny_enabled',           Sandbox.ShellDenyEnabled);
+    Tmp.PutBool('block_private_networks',       Sandbox.BlockPrivateNetworks);
     Arr := TJsonArray.Create;
     for i := 0 to High(Sandbox.AllowReadPaths)  do Arr.AddStr(Sandbox.AllowReadPaths[i]);
     Tmp.PutArray('allow_read_paths',  Arr);
@@ -335,6 +350,7 @@ begin
       Sandbox.AllowReadOutsideWorkspace := Obj.GetBool('allow_read_outside_workspace', Sandbox.AllowReadOutsideWorkspace);
       Sandbox.Workspace                 := Obj.GetStr ('workspace',                    Sandbox.Workspace);
       Sandbox.ShellDenyEnabled          := Obj.GetBool('shell_deny_enabled',           Sandbox.ShellDenyEnabled);
+      Sandbox.BlockPrivateNetworks      := Obj.GetBool('block_private_networks',       Sandbox.BlockPrivateNetworks);
       Arr := Obj.ChildArray('allow_read_paths');
       if Arr <> nil then
       try

--- a/src/pkg/net/PasClaw.Net.SSRF.pas
+++ b/src/pkg/net/PasClaw.Net.SSRF.pas
@@ -223,8 +223,8 @@ end;
 
 function ExtractHost(const URL: string): string;
 var
-  S: string;
-  SchemeEnd, HostEnd, BracketEnd: Integer;
+  S, Authority: string;
+  SchemeEnd, AuthEnd, HostEnd, BracketEnd, AtPos: Integer;
   i: Integer;
   C: Char;
 begin
@@ -235,27 +235,54 @@ begin
   S := Copy(S, SchemeEnd + 3, MaxInt);
   if S = '' then Exit;
 
-  { Strip userinfo: user:pass@host… → host… }
-  HostEnd := Pos('@', S);
-  if HostEnd > 0 then S := Copy(S, HostEnd + 1, MaxInt);
-
-  { Bracketed IPv6 literal: [::1]:port → ::1 (no v6 handling in
-    HostIsLocal — keep it for future, return the bare brackets so
-    a caller can see we extracted SOMETHING). }
-  if (Length(S) > 0) and (S[1] = '[') then
-  begin
-    BracketEnd := Pos(']', S);
-    if BracketEnd <= 1 then Exit;
-    Result := Copy(S, 2, BracketEnd - 2);
-    Exit;
-  end;
-
-  { Up to the first '/', '?', '#', or ':'. }
-  HostEnd := Length(S) + 1;
+  { Slice the authority component out FIRST — everything from the
+    end of '://' to the first '/', '?', or '#'. Codex PR #85 P1
+    caught the bug where Pos('@', S) operated on the WHOLE
+    post-scheme string, so a benign-looking userinfo-shaped
+    fragment inside the path (e.g.
+    http://169.254.169.254/latest/meta-data/@example.com) bypassed
+    the SSRF check by retargeting the host to "example.com" while
+    Indy connected to the real host before the slash. Bounding
+    userinfo parsing to the authority closes that hole. }
+  AuthEnd := Length(S) + 1;
   for i := 1 to Length(S) do
   begin
     C := S[i];
-    if (C = '/') or (C = '?') or (C = '#') or (C = ':') then
+    if (C = '/') or (C = '?') or (C = '#') then
+    begin
+      AuthEnd := i;
+      Break;
+    end;
+  end;
+  Authority := Copy(S, 1, AuthEnd - 1);
+  if Authority = '' then Exit;
+
+  { Now strip userinfo from the authority ONLY. user:pass@host:port
+    → host:port. The @ here is unambiguously the userinfo
+    delimiter because it's still inside the authority. }
+  AtPos := Pos('@', Authority);
+  if AtPos > 0 then Authority := Copy(Authority, AtPos + 1, MaxInt);
+
+  { Bracketed IPv6 literal: [::1]:port → ::1 (no v6 handling in
+    HostIsLocal beyond the symbolic ::1 short-circuit — keep the
+    extraction logic anyway so a caller sees the bare host). }
+  if (Length(Authority) > 0) and (Authority[1] = '[') then
+  begin
+    BracketEnd := Pos(']', Authority);
+    if BracketEnd <= 1 then Exit;
+    Result := Copy(Authority, 2, BracketEnd - 2);
+    Exit;
+  end;
+
+  { Trim the port: host:port → host. Operates on the authority,
+    so a real ':' inside the path or fragment further on can't
+    mask the boundary. Only ':' matters here — '/', '?', '#'
+    were already used to slice the authority. }
+  S := Authority;
+  HostEnd := Length(S) + 1;
+  for i := 1 to Length(S) do
+  begin
+    if S[i] = ':' then
     begin
       HostEnd := i;
       Break;

--- a/src/pkg/net/PasClaw.Net.SSRF.pas
+++ b/src/pkg/net/PasClaw.Net.SSRF.pas
@@ -1,0 +1,290 @@
+(*
+  PasClaw.Net.SSRF - Server-Side Request Forgery guard for outbound
+  URL fetches.
+
+  The model can hand any URL to web_fetch. Without this guard, an
+  agent running on (e.g.) an EC2 instance can be tricked into
+  fetching http://169.254.169.254/latest/meta-data/iam/security-
+  credentials/<role> and leaking the instance's temporary AWS
+  credentials. Same trick works against GCP / Azure metadata, against
+  internal services on the operator's LAN, and against localhost
+  services (Postgres on 5432, Redis on 6379, etc.) that were never
+  meant to be reachable by the model.
+
+  The guard does two things:
+
+    1. Pre-check: parse the URL, resolve the hostname to one or more
+       IPv4 addresses, refuse if ANY of them fall in a blocked range.
+       "Any" so a DNS record with both public and private A records
+       can't smuggle a request through.
+
+    2. Redirect re-check: after a 3xx redirect, the agent's HTTP
+       client re-resolves the new target. The redirect handler in
+       web_fetch wires URLIsLocal in so a public->private redirect
+       gets aborted mid-flight.
+
+  Known gaps (intentional, documented for the security-conscious):
+
+    - IPv6 hosts are not blocklisted. The most common attack
+      vectors (cloud metadata, internal LAN services, localhost
+      ports) all surface on IPv4. Adding v6 ranges (::1, fc00::/7,
+      fe80::/10, ::ffff:0:0/96 IPv4-mapped, etc.) is straightforward
+      when someone reports a v6-specific incident.
+
+    - DNS rebinding: this guard re-resolves at request time, not
+      at every TCP packet. A determined attacker could swap the A
+      record between the pre-check and the actual connect.
+      Mitigation requires pinning the TCP connection to the IP
+      that passed validation, which Indy doesn't make easy.
+      Accepted residual risk; same gap picoclaw ships with.
+
+  Blocked IPv4 ranges (CIDR / decimal):
+    0.0.0.0/8          unspecified / kernel localhost on some BSDs
+    10.0.0.0/8         RFC1918 corporate LAN
+    100.64.0.0/10      RFC6598 carrier-grade NAT
+    127.0.0.0/8        loopback (every localhost variant)
+    169.254.0.0/16     link-local — INCLUDES 169.254.169.254 cloud metadata
+    172.16.0.0/12      RFC1918 corporate LAN
+    192.0.0.0/24       IETF Protocol Assignments
+    192.168.0.0/16     RFC1918 home LAN
+    198.18.0.0/15      RFC2544 benchmark
+    224.0.0.0/4        IPv4 multicast
+    240.0.0.0/4        reserved
+*)
+unit PasClaw.Net.SSRF;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+(* Returns True if Host either parses as an IPv4 literal in a blocked
+   range, or resolves (via DNS) to at least one such address. Reason
+   carries a human-readable explanation when True. False means "safe
+   to fetch" — including the case where DNS resolution failed (the
+   request will likely fail at connect time anyway with a clearer
+   network error). *)
+function HostIsLocal(const Host: string; out Reason: string): Boolean;
+
+(* Extracts the host out of an http/https URL and runs HostIsLocal
+   on it. Refuses (returns True) for malformed URLs, but does not
+   refuse for non-http(s) schemes — the caller (web_fetch) already
+   filters those at its own layer. *)
+function URLIsLocal(const URL: string; out Reason: string): Boolean;
+
+implementation
+
+uses
+  IdStack, IdGlobal;
+
+function ParseIPv4(const S: string; out V: UInt32): Boolean;
+var
+  Parts: array[0..3] of Integer;
+  i, p, len, octet: Integer;
+  C: Char;
+  Got: Integer;
+begin
+  Result := False;
+  V := 0;
+  p := 1;
+  len := Length(S);
+  for i := 0 to 3 do
+  begin
+    if p > len then Exit;
+    octet := 0;
+    Got := 0;
+    while p <= len do
+    begin
+      C := S[p];
+      if (C >= '0') and (C <= '9') then
+      begin
+        octet := octet * 10 + (Ord(C) - Ord('0'));
+        if octet > 255 then Exit;
+        Inc(Got);
+        if Got > 3 then Exit;
+        Inc(p);
+      end
+      else
+        Break;
+    end;
+    if Got = 0 then Exit;
+    Parts[i] := octet;
+    if i < 3 then
+    begin
+      if (p > len) or (S[p] <> '.') then Exit;
+      Inc(p);
+    end;
+  end;
+  if p <= len then Exit;   { trailing junk }
+  V := (UInt32(Parts[0]) shl 24) or
+       (UInt32(Parts[1]) shl 16) or
+       (UInt32(Parts[2]) shl  8) or
+        UInt32(Parts[3]);
+  Result := True;
+end;
+
+function InRange(IP: UInt32; const NetStr: string; PrefixBits: Integer): Boolean;
+var
+  Net: UInt32;
+  Mask: UInt32;
+begin
+  Result := False;
+  if not ParseIPv4(NetStr, Net) then Exit;
+  if PrefixBits <= 0       then Mask := 0
+  else if PrefixBits >= 32 then Mask := $FFFFFFFF
+  else                          Mask := UInt32($FFFFFFFF) shl (32 - PrefixBits);
+  Result := (IP and Mask) = (Net and Mask);
+end;
+
+function IPv4Blocked(IP: UInt32; out Reason: string): Boolean;
+type
+  TBlocked = record
+    Net:    string;
+    Prefix: Integer;
+    Label_: string;
+  end;
+const
+  Ranges: array[0..10] of TBlocked = (
+    (Net: '0.0.0.0';       Prefix: 8;  Label_: 'unspecified / kernel localhost'),
+    (Net: '10.0.0.0';      Prefix: 8;  Label_: 'RFC1918 private (10.0.0.0/8)'),
+    (Net: '100.64.0.0';    Prefix: 10; Label_: 'RFC6598 carrier-grade NAT'),
+    (Net: '127.0.0.0';     Prefix: 8;  Label_: 'loopback (127.0.0.0/8)'),
+    (Net: '169.254.0.0';   Prefix: 16; Label_: 'link-local — cloud metadata endpoint range'),
+    (Net: '172.16.0.0';    Prefix: 12; Label_: 'RFC1918 private (172.16.0.0/12)'),
+    (Net: '192.0.0.0';     Prefix: 24; Label_: 'IETF Protocol Assignments'),
+    (Net: '192.168.0.0';   Prefix: 16; Label_: 'RFC1918 private (192.168.0.0/16)'),
+    (Net: '198.18.0.0';    Prefix: 15; Label_: 'RFC2544 benchmark'),
+    (Net: '224.0.0.0';     Prefix: 4;  Label_: 'IPv4 multicast'),
+    (Net: '240.0.0.0';     Prefix: 4;  Label_: 'reserved')
+  );
+var
+  i: Integer;
+begin
+  Reason := '';
+  for i := 0 to High(Ranges) do
+    if InRange(IP, Ranges[i].Net, Ranges[i].Prefix) then
+    begin
+      Reason := Ranges[i].Label_;
+      Exit(True);
+    end;
+  Result := False;
+end;
+
+function HostIsLocal(const Host: string; out Reason: string): Boolean;
+var
+  IP:  UInt32;
+  Resolved: string;
+begin
+  Reason := '';
+  if Trim(Host) = '' then
+  begin
+    Reason := 'empty host';
+    Exit(True);
+  end;
+
+  { Short-circuit on the symbolic localhost names — DNS-on-some-
+    systems returns 127.0.0.1, on others doesn't resolve at all
+    (no /etc/hosts entry, ResolveHost raises). Either way we want
+    to refuse. ::1 is here too because ExtractHost unwraps
+    bracketed IPv6 literals to their bare form and ::1 is the
+    one IPv6 case where "you should never reach this" matches
+    IPv4 loopback semantics. }
+  if SameText(Host, 'localhost') or SameText(Host, 'localhost.localdomain')
+     or SameText(Host, '::1') then
+  begin
+    Reason := 'symbolic localhost';
+    Exit(True);
+  end;
+
+  { Already-numeric IPv4? No DNS lookup needed. }
+  if ParseIPv4(Host, IP) then
+    Exit(IPv4Blocked(IP, Reason));
+
+  { Otherwise resolve via DNS. Failures (no DNS server, NXDOMAIN,
+    timeout) return False — the request itself will fail at
+    connect time with a clearer network error, no need to
+    pre-mask it as SSRF. }
+  try
+    Resolved := GStack.ResolveHost(Host, Id_IPv4);
+  except
+    on E: Exception do
+    begin
+      Reason := 'dns lookup failed: ' + E.Message;
+      Exit(False);
+    end;
+  end;
+  if Resolved = '' then Exit(False);
+  if not ParseIPv4(Resolved, IP) then Exit(False);
+  Result := IPv4Blocked(IP, Reason);
+end;
+
+function ExtractHost(const URL: string): string;
+var
+  S: string;
+  SchemeEnd, HostEnd, BracketEnd: Integer;
+  i: Integer;
+  C: Char;
+begin
+  Result := '';
+  S := URL;
+  SchemeEnd := Pos('://', S);
+  if SchemeEnd = 0 then Exit;
+  S := Copy(S, SchemeEnd + 3, MaxInt);
+  if S = '' then Exit;
+
+  { Strip userinfo: user:pass@host… → host… }
+  HostEnd := Pos('@', S);
+  if HostEnd > 0 then S := Copy(S, HostEnd + 1, MaxInt);
+
+  { Bracketed IPv6 literal: [::1]:port → ::1 (no v6 handling in
+    HostIsLocal — keep it for future, return the bare brackets so
+    a caller can see we extracted SOMETHING). }
+  if (Length(S) > 0) and (S[1] = '[') then
+  begin
+    BracketEnd := Pos(']', S);
+    if BracketEnd <= 1 then Exit;
+    Result := Copy(S, 2, BracketEnd - 2);
+    Exit;
+  end;
+
+  { Up to the first '/', '?', '#', or ':'. }
+  HostEnd := Length(S) + 1;
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if (C = '/') or (C = '?') or (C = '#') or (C = ':') then
+    begin
+      HostEnd := i;
+      Break;
+    end;
+  end;
+  Result := Copy(S, 1, HostEnd - 1);
+end;
+
+function URLIsLocal(const URL: string; out Reason: string): Boolean;
+var
+  Host: string;
+begin
+  Host := ExtractHost(URL);
+  if Host = '' then
+  begin
+    Reason := 'could not parse host out of URL';
+    Exit(True);   { fail closed }
+  end;
+  Result := HostIsLocal(Host, Reason);
+end;
+
+initialization
+  TIdStack.IncUsage;
+
+finalization
+  try
+    TIdStack.DecUsage;
+  except
+    { Shutting down. }
+  end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -97,6 +97,11 @@ function PathInsideDirectory(const Path, Directory: string): Boolean;
   Tool_Shell consults this to decide whether to pin cwd. }
 function RestrictionActive: Boolean;
 
+{ True iff outbound URL fetches should be SSRF-guarded against
+  private / loopback / link-local addresses. web_fetch consults
+  this before each request and inside its redirect handler. }
+function NetworkBlockingActive: Boolean;
+
 implementation
 
 uses
@@ -129,6 +134,11 @@ end;
 function RestrictionActive: Boolean;
 begin
   Result := GPolicy.RestrictToWorkspace;
+end;
+
+function NetworkBlockingActive: Boolean;
+begin
+  Result := GPolicy.BlockPrivateNetworks;
 end;
 
 { -------- path helpers -------- }

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -47,7 +47,38 @@ uses
   IdHTTP, IdSSLOpenSSL,
   PasClaw.JSON,
   PasClaw.Logger,
-  PasClaw.Search.HTMLText;
+  PasClaw.Search.HTMLText,
+  PasClaw.Net.SSRF,
+  PasClaw.Tools.Sandbox;
+
+type
+  (* Indy's OnRedirect callback is `of object`; this tiny holder gives
+     us the method to assign without leaking helper state outside. The
+     redirect handler runs URLIsLocal on every 3xx target so a
+     public→private redirect can't smuggle a request past the
+     pre-check. Raising aborts the redirect chain — the outer
+     try/except in Tool_WebFetch turns it into the same "SSRF
+     blocked" surface as a direct hit. *)
+  TWebFetchRedirectGuard = class
+    procedure OnRedirect(Sender: TObject; var Dest: string;
+                          var NumRedirect: Integer;
+                          var Handled: Boolean;
+                          var VMethod: TIdHTTPMethod);
+  end;
+
+procedure TWebFetchRedirectGuard.OnRedirect(Sender: TObject; var Dest: string;
+                                              var NumRedirect: Integer;
+                                              var Handled: Boolean;
+                                              var VMethod: TIdHTTPMethod);
+var
+  Reason: string;
+begin
+  if not NetworkBlockingActive then Exit;
+  if URLIsLocal(Dest, Reason) then
+    raise Exception.CreateFmt('SSRF: redirect to %s refused (%s; ' +
+      'flip sandbox.block_private_networks=false in config.json to allow)',
+      [Dest, Reason]);
+end;
 
 const
   DEFAULT_MAX_CHARS = 50000;
@@ -105,6 +136,7 @@ var
   MaxChars: Integer;
   HTTP: TIdHTTP;
   SSLHandler: TIdSSLIOHandlerSocketOpenSSL;
+  RedirectGuard: TWebFetchRedirectGuard;
   Body: string;
   ContentType: string;
 begin
@@ -126,7 +158,21 @@ begin
   if MaxChars < 100           then MaxChars := 100;
   if MaxChars > HARD_MAX_CHARS then MaxChars := HARD_MAX_CHARS;
 
+  { SSRF pre-check on the initial URL. The redirect handler covers
+    subsequent hops; both layers must pass for the request to land. }
+  if NetworkBlockingActive then
+  begin
+    if URLIsLocal(URL, ErrMsg) then
+    begin
+      ErrMsg := 'web_fetch: SSRF: ' + URL + ' refused (' + ErrMsg +
+        '; flip sandbox.block_private_networks=false in config.json to allow)';
+      Exit;
+    end;
+    ErrMsg := '';
+  end;
+
   HTTP := TIdHTTP.Create(nil);
+  RedirectGuard := TWebFetchRedirectGuard.Create;
   SSLHandler := nil;
   try
     HTTP.HandleRedirects   := True;
@@ -135,6 +181,7 @@ begin
     HTTP.ReadTimeout       := 30000;
     HTTP.Request.UserAgent := 'Mozilla/5.0 (PasClaw web_fetch)';
     HTTP.Request.Accept    := 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5';
+    HTTP.OnRedirect        := RedirectGuard.OnRedirect;
 
     if LowerStartsWith(URL, 'https://') then
     begin
@@ -171,6 +218,7 @@ begin
     end;
   finally
     HTTP.Free;
+    RedirectGuard.Free;
     if SSLHandler <> nil then SSLHandler.Free;
   end;
 

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -66,6 +66,19 @@ type
                           var VMethod: TIdHTTPMethod);
   end;
 
+function IsAbsoluteHttpURL(const S: string): Boolean;
+{ True iff S has an http:// or https:// scheme. Anything else is
+  either path-relative ("/login", "next.html") or protocol-relative
+  ("//cdn.example.com/a"). Indy hands TIdHTTP.OnRedirect whatever
+  the server's Location header said — which is frequently a bare
+  path, NOT a full URL. Codex PR #85 P2 caught that we were
+  rejecting "/login" as malformed. }
+begin
+  Result := (Length(S) >= 7) and
+            (SameText(Copy(S, 1, 7),  'http://')  or
+             (Length(S) >= 8) and SameText(Copy(S, 1, 8), 'https://'));
+end;
+
 procedure TWebFetchRedirectGuard.OnRedirect(Sender: TObject; var Dest: string;
                                               var NumRedirect: Integer;
                                               var Handled: Boolean;
@@ -74,6 +87,34 @@ var
   Reason: string;
 begin
   if not NetworkBlockingActive then Exit;
+
+  { Same-origin redirects retain the host that already passed the
+    pre-check. Two flavours:
+      "/path/next"     — path-relative; same scheme, host, port.
+      "next.html"      — path-relative without leading slash; same.
+    A protocol-relative URL ("//cdn.example.com/a") DOES change
+    host so we still pass it through URLIsLocal — ExtractHost
+    handles those since "//" parses as an authority without a
+    scheme, and a bare authority is enough to read the host. }
+  if not IsAbsoluteHttpURL(Dest) then
+  begin
+    if (Length(Dest) >= 2) and (Dest[1] = '/') and (Dest[2] = '/') then
+    begin
+      { Protocol-relative. Synthesise an http:// prefix purely for
+        the parse — Indy itself will re-prefix with the current
+        URL's scheme before connecting. }
+      if URLIsLocal('http:' + Dest, Reason) then
+        raise Exception.CreateFmt(
+          'SSRF: protocol-relative redirect to %s refused (%s; ' +
+          'flip sandbox.block_private_networks=false in config.json to allow)',
+          [Dest, Reason]);
+      Exit;
+    end;
+    { Path-relative — same host as the request that just passed
+      the check. Let Indy proceed. }
+    Exit;
+  end;
+
   if URLIsLocal(Dest, Reason) then
     raise Exception.CreateFmt('SSRF: redirect to %s refused (%s; ' +
       'flip sandbox.block_private_networks=false in config.json to allow)',


### PR DESCRIPTION
picoclaw documents "SSRF protection via DNS re-resolution and private IP blocking" on their `WebFetchTool`; PasClaw shipped `web_fetch` without it. Closing the gap before someone runs the gateway exposed — without this, an agent on (e.g.) an EC2 instance can be tricked into fetching `http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>` and leaking the instance's IAM credentials.

## `PasClaw.Net.SSRF` (new unit)

`HostIsLocal(host) → bool`: parses host as IPv4 literal (no DNS) or resolves via Indy's `GStack`, checks each result against an 11-entry CIDR blocklist:

| Range | What |
|---|---|
| `0.0.0.0/8` | unspecified / kernel localhost on some BSDs |
| `10.0.0.0/8` | RFC1918 corporate LAN |
| `100.64.0.0/10` | RFC6598 carrier-grade NAT |
| `127.0.0.0/8` | loopback |
| `169.254.0.0/16` | link-local — **includes `169.254.169.254` cloud metadata** |
| `172.16.0.0/12` | RFC1918 corporate LAN |
| `192.0.0.0/24` | IETF Protocol Assignments |
| `192.168.0.0/16` | RFC1918 home LAN |
| `198.18.0.0/15` | RFC2544 benchmark |
| `224.0.0.0/4` | IPv4 multicast |
| `240.0.0.0/4` | reserved |

Symbolic-name short-circuit: `localhost`, `localhost.localdomain`, and IPv6 `::1` refuse without DNS so systems with no resolver still fail closed.

`URLIsLocal(url) → bool`: strips scheme + userinfo + bracketed IPv6 + port and calls `HostIsLocal`. Failed URL parsing returns True (fail closed); failed DNS resolution returns False (let connect fail with a clearer network error).

## `sandbox.block_private_networks` (new, default `true`)

Toggle on `TSandboxPolicy`. Existing configs that don't mention the field get the guard on — opt-out, not opt-in.

## `web_fetch` two-layer wiring

1. **Pre-check** on the URL the model handed us — refused requests return a clear `web_fetch: SSRF: <url> refused (<reason>; flip sandbox.block_private_networks=false in config.json to allow)` so the model knows it's a policy refusal, not a transient network error.
2. **`TWebFetchRedirectGuard.OnRedirect`** runs `URLIsLocal` on every 3xx target. A public→private redirect raises from inside the callback, gets caught by the existing `try/except` around `HTTP.Get`, surfaces as the same SSRF error. Both layers must pass for the request to land.

## Verification

`make` builds clean under FPC 3.2.2. Standalone smoke — **33 assertions, all pass**:

- 17 IP literals — every blocked range edge **plus** samples just OUTSIDE the range (`172.32`, `192.0.1`, `100.128`) confirming the mask math is right.
- 3 symbolic localhost variants (`localhost`, `LOCALHOST`, `localhost.localdomain`).
- 9 URLs (loopback, with port, AWS metadata path, userinfo stripped, localhost name, IPv6 `::1`, two public IPs allowed, malformed).
- 4 public passthroughs (`8.8.8.8`, `1.1.1.1`, public-IP URLs).

## Known gaps (intentional, documented in the unit's docstring)

| Gap | Why deferred |
|---|---|
| IPv6 blocklist beyond `::1` (`fc00::/7`, `fe80::/10`, `::ffff:0:0/96` IPv4-mapped) | Most attack vectors surface on IPv4. Add when reported. |
| DNS rebinding | The guard re-resolves at request and redirect time, not per TCP packet. Closing this requires pinning the connection to the validated IP, which Indy doesn't make easy. Same residual risk picoclaw ships with. |

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_