### PR TITLE
channels: Matrix (REST /sync long-poll) + IRC (TIdIRC) bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Environment variables:
 | `PASCLAW_SEARXNG_API_KEY` | Bearer token for protected SearXNG instances (most public ones don't need it). |
 | `PASCLAW_PERPLEXITY_API_KEY` | Perplexity API key for the `web_search` tool when `web_search.provider = perplexity`. |
 | `PASCLAW_GEMINI_API_KEY` | Google AI Studio key for the `web_search` tool when `web_search.provider = gemini`. `PASCLAW_GOOGLE_API_KEY` works too. |
+| `PASCLAW_MATRIX_HOMESERVER` | Matrix homeserver base URL (e.g. `https://matrix.org`) for `pasclaw gateway --matrix`. |
+| `PASCLAW_MATRIX_TOKEN` | Matrix access token (provisioned out-of-band via `/login` or the homeserver admin UI). |
+| `PASCLAW_IRC_SERVER` | IRC server hostname (e.g. `irc.libera.chat`) for `pasclaw gateway --irc`. |
+| `PASCLAW_IRC_PORT` | IRC server port (default `6667`). |
+| `PASCLAW_IRC_NICK` | IRC nickname the bot connects with. |
+| `PASCLAW_IRC_CHANNEL` | IRC channel to join on connect (must start with `#`). |
+| `PASCLAW_IRC_PASSWORD` | Optional NickServ / server password. |
 | `NO_COLOR` | Disables ANSI color output. |
 
 Useful config commands:
@@ -286,6 +293,8 @@ pasclaw gateway --addr 0.0.0.0 --port 8088
 pasclaw gateway --telegram --token <BOT_TOKEN>
 pasclaw gateway --line                              # also pass $PASCLAW_LINE_TOKEN + $PASCLAW_LINE_SECRET
 pasclaw gateway --whatsapp                          # also pass $PASCLAW_WHATSAPP_{TOKEN,PHONE_ID,VERIFY_TOKEN,APP_SECRET}
+pasclaw gateway --matrix                            # also pass $PASCLAW_MATRIX_HOMESERVER + $PASCLAW_MATRIX_TOKEN
+pasclaw gateway --irc                               # also pass $PASCLAW_IRC_{SERVER,NICK,CHANNEL}
 pasclaw gateway --no-tools --no-mcp --no-hashline
 
 pasclaw serve
@@ -542,7 +551,7 @@ src/
   cmd/              CLI command units and root dispatcher
   pkg/
     agent/          Agent execution and prompts
-    channels/       Telegram, Discord, Slack, Teams, generic webhook, LINE, WhatsApp
+    channels/       Telegram, Discord, Slack, Teams, generic webhook, LINE, WhatsApp, Matrix, IRC
     cliui/          ANSI styling, banner, command help rendering
     component/      Shared components
     config/         Version constants and on-disk config model

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -36,7 +36,9 @@ uses
   PasClaw.Gateway.Server,
   PasClaw.Channels.Telegram,
   PasClaw.Channels.LINE,
-  PasClaw.Channels.WhatsApp;
+  PasClaw.Channels.WhatsApp,
+  PasClaw.Channels.Matrix,
+  PasClaw.Channels.IRC;
 
 type
   TGwArgs = record
@@ -52,6 +54,15 @@ type
     WAPhoneId:   string;
     WAVerify:    string;
     WASecret:    string;
+    Matrix:      Boolean;
+    MatrixHome:  string;
+    MatrixToken: string;
+    IRC:         Boolean;
+    IRCServer:   string;
+    IRCPort:     Integer;
+    IRCNick:     string;
+    IRCChannel:  string;
+    IRCPassword: string;
     NoMCP:       Boolean;
     NoTools:     Boolean;
     NoHashline:  Boolean;
@@ -73,6 +84,15 @@ begin
   Result.WAPhoneId  := GetEnvironmentVariable('PASCLAW_WHATSAPP_PHONE_ID');
   Result.WAVerify   := GetEnvironmentVariable('PASCLAW_WHATSAPP_VERIFY_TOKEN');
   Result.WASecret   := GetEnvironmentVariable('PASCLAW_WHATSAPP_APP_SECRET');
+  Result.Matrix     := False;
+  Result.MatrixHome := GetEnvironmentVariable('PASCLAW_MATRIX_HOMESERVER');
+  Result.MatrixToken := GetEnvironmentVariable('PASCLAW_MATRIX_TOKEN');
+  Result.IRC        := False;
+  Result.IRCServer  := GetEnvironmentVariable('PASCLAW_IRC_SERVER');
+  Result.IRCPort    := StrToIntDef(GetEnvironmentVariable('PASCLAW_IRC_PORT'), 6667);
+  Result.IRCNick    := GetEnvironmentVariable('PASCLAW_IRC_NICK');
+  Result.IRCChannel := GetEnvironmentVariable('PASCLAW_IRC_CHANNEL');
+  Result.IRCPassword := GetEnvironmentVariable('PASCLAW_IRC_PASSWORD');
   Result.NoMCP      := False;
   Result.NoTools    := False;
   Result.NoHashline := False;
@@ -91,6 +111,15 @@ begin
     if Argv[i] = '--whatsapp-phone'   then begin if i < High(Argv) then Result.WAPhoneId := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--whatsapp-verify'  then begin if i < High(Argv) then Result.WAVerify  := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--whatsapp-secret'  then begin if i < High(Argv) then Result.WASecret  := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--matrix'          then begin Result.Matrix      := True; Inc(i); Continue; end;
+    if Argv[i] = '--matrix-homeserver' then begin if i < High(Argv) then Result.MatrixHome  := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--matrix-token'    then begin if i < High(Argv) then Result.MatrixToken := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--irc'             then begin Result.IRC         := True; Inc(i); Continue; end;
+    if Argv[i] = '--irc-server'      then begin if i < High(Argv) then Result.IRCServer   := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--irc-port'        then begin if i < High(Argv) then Result.IRCPort     := StrToIntDef(Argv[i + 1], Result.IRCPort); Inc(i, 2); Continue; end;
+    if Argv[i] = '--irc-nick'        then begin if i < High(Argv) then Result.IRCNick     := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--irc-channel'     then begin if i < High(Argv) then Result.IRCChannel  := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--irc-password'    then begin if i < High(Argv) then Result.IRCPassword := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--no-mcp'       then begin Result.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-tools'     then begin Result.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
@@ -110,6 +139,8 @@ var
   Telegram: TTelegramChannel;
   Line: TLineBot;
   WhatsApp: TWhatsAppBot;
+  Matrix:   TMatrixBot;
+  IRC:      TIRCBot;
   Scheduler: TCronScheduler;
   Skills: TSkillSpecArray;
 begin
@@ -153,6 +184,8 @@ begin
     Telegram := nil;
     Line     := nil;
     WhatsApp := nil;
+    Matrix   := nil;
+    IRC      := nil;
     try
       if Args.Line then
       begin
@@ -185,6 +218,33 @@ begin
         Server.MountWebhook('/webhooks/whatsapp', WhatsApp.HandleWebhook);
       end;
 
+      if Args.Matrix then
+      begin
+        if (Args.MatrixHome = '') or (Args.MatrixToken = '') then
+        begin
+          LogError('matrix: need --matrix-homeserver / $PASCLAW_MATRIX_HOMESERVER ' +
+                   'and --matrix-token / $PASCLAW_MATRIX_TOKEN');
+          Exit(1);
+        end;
+        Matrix := TMatrixBot.Create(Args.MatrixHome, Args.MatrixToken,
+                                     Cfg, Provider, Reg);
+        Matrix.Start;
+      end;
+
+      if Args.IRC then
+      begin
+        if (Args.IRCServer = '') or (Args.IRCNick = '') then
+        begin
+          LogError('irc: need --irc-server / $PASCLAW_IRC_SERVER and ' +
+                   '--irc-nick / $PASCLAW_IRC_NICK');
+          Exit(1);
+        end;
+        IRC := TIRCBot.Create(Args.IRCServer, Args.IRCPort,
+                               Args.IRCNick, Args.IRCChannel, Args.IRCPassword,
+                               Cfg, Provider, Reg);
+        IRC.Start;
+      end;
+
       Server.Start(Args.Addr, Args.Port);
 
       WriteLn(Ansi.Bold, 'Gateway up.', Ansi.Reset);
@@ -195,6 +255,11 @@ begin
         WriteLn('  POST http://', Args.Addr, ':', Args.Port, '/webhooks/line   (LINE platform)');
       if Args.WhatsApp then
         WriteLn('  ANY http://', Args.Addr, ':', Args.Port, '/webhooks/whatsapp   (WhatsApp Cloud)');
+      if Args.Matrix then
+        WriteLn('  matrix sync ', Args.MatrixHome, '  (Matrix homeserver)');
+      if Args.IRC then
+        WriteLn('  irc ', Args.IRCServer, ':', Args.IRCPort, ' ', Args.IRCNick,
+                ' joining ', Args.IRCChannel);
       WriteLn(Ansi.Dim, 'Press Ctrl-C to stop.', Ansi.Reset);
 
       if Args.Telegram then
@@ -216,6 +281,8 @@ begin
       if Telegram <> nil then Telegram.Free;
       if Line     <> nil then Line.Free;
       if WhatsApp <> nil then WhatsApp.Free;
+      if Matrix   <> nil then begin Matrix.RequestStop; Matrix.WaitForStop; Matrix.Free; end;
+      if IRC      <> nil then IRC.Free;
       Server.Stop;
       Server.Free;
       if Scheduler <> nil then Scheduler.Free;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -195,6 +195,8 @@
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.Webhook.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.LINE.pas"/>
         <DCCReference Include="..\pkg\channels\PasClaw.Channels.WhatsApp.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.Matrix.pas"/>
+        <DCCReference Include="..\pkg\channels\PasClaw.Channels.IRC.pas"/>
 
         <!-- pkg/crypto -->
         <DCCReference Include="..\pkg\crypto\PasClaw.Crypto.HMAC.pas"/>

--- a/src/pkg/channels/PasClaw.Channels.IRC.pas
+++ b/src/pkg/channels/PasClaw.Channels.IRC.pas
@@ -94,6 +94,53 @@ uses
   PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop;
 
+type
+  (* PR #86 Codex P2: RunToolLoop inside OnPrivateMessage blocks
+     Indy's TIdCmdTCPClient listener thread. A slow model turn
+     (tool loop chasing fs_read / shell_exec) keeps the listener
+     from servicing PING from the server, the server kills the
+     connection after its ping-timeout, and the bot drops.
+
+     Fix: hand each inbound message off to a self-freeing worker
+     thread. OnPrivateMessage returns immediately, the listener
+     keeps PONGing on schedule, and the worker drives RunToolLoop +
+     the FClient.Say reply asynchronously. Same suspended-then-
+     Start idiom from PR #78's LINE/WhatsApp worker fix. *)
+  TIRCMessageWorker = class(TThread)
+  private
+    FBot:         TIRCBot;
+    FReplyTarget: string;
+    FUserText:    string;
+    FSenderNick:  string;
+  public
+    constructor Create(Bot: TIRCBot;
+                       const ReplyTarget, UserText, SenderNick: string);
+    procedure Execute; override;
+  end;
+
+constructor TIRCMessageWorker.Create(Bot: TIRCBot;
+                                      const ReplyTarget, UserText, SenderNick: string);
+begin
+  inherited Create(True);   { suspended }
+  FreeOnTerminate := True;
+  FBot         := Bot;
+  FReplyTarget := ReplyTarget;
+  FUserText    := UserText;
+  FSenderNick  := SenderNick;
+  Start;
+end;
+
+procedure TIRCMessageWorker.Execute;
+begin
+  try
+    FBot.RunAgentReply(FReplyTarget, FUserText, FSenderNick);
+  except
+    on E: Exception do
+      LogWarn('irc worker: RunAgentReply raised %s: %s',
+              [E.ClassName, E.Message]);
+  end;
+end;
+
 constructor TIRCBot.Create(const Server: string; Port: Integer;
                             const Nick, Channel, Password: string;
                             Cfg: TConfig; Provider: ILLMProvider;
@@ -205,8 +252,10 @@ begin
 
   if SameText(ATarget, FNick) then
   begin
-    { Direct PM. Reply privately to the sender. }
-    RunAgentReply(ANickname, AMessage, ANickname);
+    { Direct PM. Spawn a worker so RunToolLoop doesn't block the
+      Indy listener (server PINGs would time out and disconnect
+      the bot). Worker frees itself on terminate. }
+    TIRCMessageWorker.Create(Self, ANickname, AMessage, ANickname);
     Exit;
   end;
 
@@ -217,7 +266,7 @@ begin
     if not IsAddressed then Exit;
     if Trim(Text) = '' then Exit;
     ReplyTarget := ATarget;
-    RunAgentReply(ReplyTarget, Text, ANickname);
+    TIRCMessageWorker.Create(Self, ReplyTarget, Text, ANickname);
   end;
 end;
 

--- a/src/pkg/channels/PasClaw.Channels.IRC.pas
+++ b/src/pkg/channels/PasClaw.Channels.IRC.pas
@@ -1,0 +1,293 @@
+(*
+  PasClaw.Channels.IRC - IRC bot client wrapping Indy's TIdIRC.
+
+  Connects to a single server, joins a single channel (extending to
+  multi-channel is a config-loop away), and replies in-channel to
+  any message addressed to the bot — either prefixed with the bot's
+  nickname (e.g. "BotName: tell me about Pascal") or via private
+  message. Mirrors the Telegram/Matrix bot shape: holds Cfg /
+  Provider / Registry and runs RunToolLoop inline on each match.
+
+  TIdIRC handles the wire protocol on its own dispatcher thread, so
+  the bot doesn't need a worker thread of its own — Start blocks
+  only long enough to connect + JOIN, then returns. Reply dispatch
+  runs on the IRC dispatcher's context thread.
+
+  Configuration:
+    Server hostname: $PASCLAW_IRC_SERVER     (e.g. irc.libera.chat)
+    Port:            $PASCLAW_IRC_PORT       (default 6667 plain,
+                                              6697 if TLS; this Wave 1
+                                              adapter ships plaintext —
+                                              users wanting TLS today
+                                              can stunnel locally)
+    Nickname:        $PASCLAW_IRC_NICK
+    Channel:         $PASCLAW_IRC_CHANNEL    (must start with #)
+    NickServ pass:   $PASCLAW_IRC_PASSWORD   (optional, sent at
+                                              connect via PASS)
+
+  Reply addressing:
+    Channel msg starting with "<nick>:" or "<nick>," → bot replies.
+    Direct PM to the bot                              → bot replies.
+    Anything else in the channel is ignored — there's enough chatter
+    on IRC that a code agent yelling at every line is a no-go.
+
+  Out of scope for Wave 1 (documented for future work):
+    - Multi-channel / multi-server support. Add another bot
+      instance if you want both.
+    - TLS. TIdIRC inherits from TIdCmdTCPClient and supports an
+      IOHandler; wiring an OpenSSL SSL handler here is a follow-up.
+    - Flood control. Long bot replies get rate-limited by the
+      server. The current code sends one PRIVMSG per response;
+      split-by-line is a follow-up.
+
+  Docs: https://datatracker.ietf.org/doc/html/rfc2812
+*)
+unit PasClaw.Channels.IRC;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  IdContext, IdIRC,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TIRCBot = class
+  private
+    FServer:   string;
+    FPort:     Integer;
+    FNick:     string;
+    FChannel:  string;
+    FPassword: string;
+    FCfg:      TConfig;
+    FProvider: ILLMProvider;
+    FRegistry: TToolRegistry;
+    FClient:   TIdIRC;
+    procedure HandlePrivMessage(ASender: TIdContext;
+                                 const ANickname, AHost, ATarget, AMessage: string);
+    procedure HandleJoin(ASender: TIdContext;
+                          const ANickname, AHost, AChannel: string);
+    function  ExtractAddressedText(const Message: string;
+                                    out IsAddressed: Boolean): string;
+    procedure RunAgentReply(const ReplyTarget, UserText, SenderNick: string);
+  public
+    constructor Create(const Server: string; Port: Integer;
+                       const Nick, Channel, Password: string;
+                       Cfg: TConfig; Provider: ILLMProvider;
+                       Registry: TToolRegistry);
+    destructor  Destroy; override;
+    procedure Start;
+    procedure RequestStop;
+    procedure WaitForStop;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop;
+
+constructor TIRCBot.Create(const Server: string; Port: Integer;
+                            const Nick, Channel, Password: string;
+                            Cfg: TConfig; Provider: ILLMProvider;
+                            Registry: TToolRegistry);
+begin
+  inherited Create;
+  FServer   := Server;
+  FPort     := Port;
+  if FPort = 0 then FPort := 6667;
+  FNick     := Nick;
+  FChannel  := Channel;
+  FPassword := Password;
+  FCfg      := Cfg;
+  FProvider := Provider;
+  FRegistry := Registry;
+end;
+
+destructor TIRCBot.Destroy;
+begin
+  RequestStop;
+  inherited Destroy;
+end;
+
+function TIRCBot.ExtractAddressedText(const Message: string;
+                                       out IsAddressed: Boolean): string;
+var
+  LowMsg, LowNick: string;
+  Prefix, Sep: string;
+  PrefixLen: Integer;
+begin
+  { Recognise "<nick>:" or "<nick>," followed by space. Tolerates
+    trailing whitespace in the prefix. Case-insensitive on the nick
+    so "BotName" and "botname" both work. }
+  IsAddressed := False;
+  Result := '';
+  LowMsg  := LowerCase(Message);
+  LowNick := LowerCase(FNick);
+  Prefix  := LowNick + ':';
+  PrefixLen := Length(Prefix);
+  if (Length(LowMsg) >= PrefixLen) and (Copy(LowMsg, 1, PrefixLen) = Prefix) then
+    Sep := ':'
+  else
+  begin
+    Prefix := LowNick + ',';
+    if (Length(LowMsg) >= PrefixLen) and (Copy(LowMsg, 1, PrefixLen) = Prefix) then
+      Sep := ','
+    else
+      Exit;
+  end;
+  IsAddressed := True;
+  Result := Trim(Copy(Message, PrefixLen + 1, MaxInt));
+end;
+
+procedure TIRCBot.RunAgentReply(const ReplyTarget, UserText, SenderNick: string);
+var
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+  Response: string;
+begin
+  LogInfo('irc: target=%s from=%s msg=%s',
+          [ReplyTarget, SenderNick, Copy(UserText, 1, 80)]);
+
+  if FProvider = nil then
+  begin
+    if FClient <> nil then
+      FClient.Say(ReplyTarget,
+                   SenderNick + ': (no provider configured — run `pasclaw onboard`)');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, UserText);
+
+  LoopCfg.Provider      := FProvider;
+  LoopCfg.Registry      := FRegistry;
+  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.MaxIterations := 6;
+  LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.OnText        := nil;
+  LoopCfg.OnToolCall    := nil;
+  LoopCfg.OnToolResult  := nil;
+
+  if RunToolLoop(LoopCfg, Msgs, Loop) and (Loop.Content <> '') then
+    Response := Loop.Content
+  else
+    Response := '(sorry — model returned no content)';
+
+  if FClient = nil then Exit;
+
+  { Channel replies prefix with the sender's nick so they know it's
+    aimed at them. PMs don't need that — the conversation context
+    is implicit. }
+  if (Length(ReplyTarget) > 0) and (ReplyTarget[1] = '#') then
+    FClient.Say(ReplyTarget, SenderNick + ': ' + Response)
+  else
+    FClient.Say(ReplyTarget, Response);
+end;
+
+procedure TIRCBot.HandlePrivMessage(ASender: TIdContext;
+                                     const ANickname, AHost, ATarget,
+                                            AMessage: string);
+var
+  Text: string;
+  IsAddressed: Boolean;
+  ReplyTarget: string;
+begin
+  if SameText(ANickname, FNick) then Exit;   { our own echoes — ignore }
+
+  if SameText(ATarget, FNick) then
+  begin
+    { Direct PM. Reply privately to the sender. }
+    RunAgentReply(ANickname, AMessage, ANickname);
+    Exit;
+  end;
+
+  { Channel message. Only respond when addressed by name. }
+  if (Length(ATarget) > 0) and (ATarget[1] = '#') then
+  begin
+    Text := ExtractAddressedText(AMessage, IsAddressed);
+    if not IsAddressed then Exit;
+    if Trim(Text) = '' then Exit;
+    ReplyTarget := ATarget;
+    RunAgentReply(ReplyTarget, Text, ANickname);
+  end;
+end;
+
+procedure TIRCBot.HandleJoin(ASender: TIdContext;
+                              const ANickname, AHost, AChannel: string);
+begin
+  if SameText(ANickname, FNick) then
+    LogInfo('irc: joined %s', [AChannel]);
+end;
+
+procedure TIRCBot.Start;
+begin
+  if FClient <> nil then Exit;
+  if (FServer = '') or (FNick = '') then
+  begin
+    LogError('irc: server or nick missing — bot not started', []);
+    Exit;
+  end;
+
+  FClient := TIdIRC.Create(nil);
+  FClient.Host         := FServer;
+  FClient.Port         := FPort;
+  FClient.Nickname     := FNick;
+  FClient.Username     := FNick;
+  FClient.RealName     := 'PasClaw IRC bot';
+  if FPassword <> '' then FClient.Password := FPassword;
+  FClient.OnPrivateMessage := HandlePrivMessage;
+  FClient.OnJoin           := HandleJoin;
+
+  try
+    FClient.Connect;
+  except
+    on E: Exception do
+    begin
+      LogError('irc: connect to %s:%d failed: %s', [FServer, FPort, E.Message]);
+      FreeAndNil(FClient);
+      Exit;
+    end;
+  end;
+
+  LogInfo('irc: connected to %s:%d as %s', [FServer, FPort, FNick]);
+
+  if FChannel <> '' then
+  begin
+    try
+      FClient.Join(FChannel);
+    except
+      on E: Exception do
+        LogWarn('irc: join %s failed: %s', [FChannel, E.Message]);
+    end;
+  end;
+end;
+
+procedure TIRCBot.RequestStop;
+begin
+  if FClient = nil then Exit;
+  try
+    if FClient.Connected then FClient.Disconnect;
+  except
+    on E: Exception do
+      LogWarn('irc: disconnect error: %s', [E.Message]);
+  end;
+  FreeAndNil(FClient);
+end;
+
+procedure TIRCBot.WaitForStop;
+begin
+  { TIdIRC inherits TIdCmdTCPClient which spawns its own listener
+    thread; Disconnect (called from RequestStop) tears it down
+    synchronously. Nothing left to wait on. }
+end;
+
+end.

--- a/src/pkg/channels/PasClaw.Channels.Matrix.pas
+++ b/src/pkg/channels/PasClaw.Channels.Matrix.pas
@@ -67,6 +67,8 @@ type
     function  GetSync(out RawJSON: string): Boolean;
     function  PostSend(const RoomId, Text: string): Boolean;
     function  WhoAmI(out UserId: string): Boolean;
+    function  WhoAmIWithRetry(out UserId: string; Attempts: Integer): Boolean;
+    function  InitialSyncToken: Boolean;
     procedure ProcessSync(const RawJSON: string);
     procedure ProcessEvent(const RoomId, EventJSON: string);
   public
@@ -209,6 +211,77 @@ begin
   try
     UserId := Root.GetStr('user_id', '');
     Result := UserId <> '';
+  finally
+    Root.Free;
+  end;
+end;
+
+function TMatrixBot.WhoAmIWithRetry(out UserId: string; Attempts: Integer): Boolean;
+var
+  i: Integer;
+begin
+  (* PR #86 Codex P1: starting the sync thread before /whoami
+     succeeds leaves FUserId empty. ProcessEvent's
+     "if Sender = FUserId" then matches Sender='' rather than
+     the bot's actual user_id, so every outbound reply
+     re-enters the loop as a fresh prompt and the bot spam-
+     replies to itself until the server boots it or the API
+     quota dies. Retry a few times with exponential-ish
+     backoff before giving up; if all attempts fail, Start
+     refuses to launch the loop. *)
+  Result := False;
+  UserId := '';
+  for i := 0 to Attempts - 1 do
+  begin
+    if WhoAmI(UserId) then Exit(True);
+    if i = Attempts - 1 then Break;
+    if FStopEvt.WaitFor(1000 * (1 shl i)) = wrSignaled then Break;
+  end;
+end;
+
+function TMatrixBot.InitialSyncToken: Boolean;
+var
+  URL, Body: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  Root: TJsonObject;
+begin
+  (* PR #86 Codex P1: the first /sync without a since=
+     parameter returns whatever recent timeline the homeserver
+     has cached for each joined room. ProcessSync would then
+     reply to every old message and look like the bot just
+     time-travelled. Spec workaround: do a one-shot sync with
+     timeline.limit=0 so we get only the next_batch token and
+     no events; the long-poll loop in TMatrixSyncThread then
+     starts strictly from that token. *)
+  Result := False;
+  URL := ApiURL('/_matrix/client/v3/sync?timeout=0&filter=' +
+                '%7B%22room%22%3A%7B%22timeline%22%3A%7B%22limit%22%3A0%7D%7D%7D');
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FToken);
+  Resp := GetJSONURL(URL, Headers, 30);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    LogWarn('matrix: initial sync status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit;
+  end;
+  try
+    Root := TJsonObject.Parse(Resp.Body);
+  except
+    on E: Exception do
+    begin
+      LogWarn('matrix: initial sync bad JSON: %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Root = nil then Exit;
+  try
+    FNextBatch := Root.GetStr('next_batch', '');
+    Result := FNextBatch <> '';
+    Body := FNextBatch;
+    if Result then
+      LogDebug('matrix: initial sync token len=%d', [Length(Body)]);
   finally
     Root.Free;
   end;
@@ -414,18 +487,27 @@ begin
     Exit;
   end;
 
-  if not WhoAmI(FUserId) then
-    LogWarn('matrix: whoami failed — own messages may echo into the loop', [])
-  else
-    LogInfo('matrix: logged in as %s on %s', [FUserId, FHomeserver]);
+  if not WhoAmIWithRetry(FUserId, 3) then
+  begin
+    LogError('matrix: /whoami failed after retries — refusing to start ' +
+             '(without a confirmed user_id the bot would reply to its own ' +
+             'echoes; check $PASCLAW_MATRIX_TOKEN and homeserver reachability)', []);
+    Exit;
+  end;
+  LogInfo('matrix: logged in as %s on %s', [FUserId, FHomeserver]);
 
-  { Initial sync gets the latest token without delivering history —
-    we set since='' and the first call returns "now". Subsequent
-    calls long-poll for new events only. }
+  if not InitialSyncToken then
+  begin
+    LogError('matrix: initial sync token fetch failed — refusing to start ' +
+             '(without an anchor token, the first long-poll would replay ' +
+             'old timeline events and reply to each)', []);
+    Exit;
+  end;
+
   T := TMatrixSyncThread.Create(Self);
   FThread := T;
   FThread.Start;
-  LogInfo('matrix: sync loop started', []);
+  LogInfo('matrix: sync loop started from token len=%d', [Length(FNextBatch)]);
 end;
 
 procedure TMatrixBot.RequestStop;

--- a/src/pkg/channels/PasClaw.Channels.Matrix.pas
+++ b/src/pkg/channels/PasClaw.Channels.Matrix.pas
@@ -1,0 +1,445 @@
+(*
+  PasClaw.Channels.Matrix - Matrix client/server bot.
+
+  Federated, self-hostable, no token-vendor lock-in. The bot is a
+  regular Matrix user identified by an access token; messages
+  arrive via the standard /sync long-poll and outbound replies go
+  back through /rooms/<roomId>/send.
+
+  Mirrors TTelegramChannel's shape: holds Cfg / Provider / Registry,
+  runs RunToolLoop inline per inbound text event. Difference from
+  Telegram is that Matrix can't block the main thread — the gateway
+  may want to run the HTTP server alongside, so Run launches an
+  internal worker thread and returns; RequestStop / WaitForStop
+  drive the shutdown.
+
+  Configuration:
+    Homeserver URL:  $PASCLAW_MATRIX_HOMESERVER  (e.g. https://matrix.org)
+    Access token:    $PASCLAW_MATRIX_TOKEN       (provisioned once
+                                                  via /login or the
+                                                  homeserver admin UI)
+
+  Endpoints used:
+    GET  /_matrix/client/v3/sync?since=<token>&timeout=30000
+    PUT  /_matrix/client/v3/rooms/<roomId>/send/m.room.message/<txnId>
+    GET  /_matrix/client/v3/account/whoami     (one-shot at startup to
+                                                resolve the bot's user
+                                                id so it can ignore its
+                                                own echoed messages)
+
+  Out of scope for Wave 1 (documented for future work):
+    - End-to-end encryption (E2EE rooms produce m.room.encrypted
+      events the bot can't decrypt; those events are skipped with
+      a debug log).
+    - Login flow. The user provisions an access token out of band.
+    - Room joins / leaves driven by the bot. The bot replies in
+      whatever rooms its account is already joined to.
+
+  Docs: https://spec.matrix.org/v1.11/client-server-api/#syncing
+*)
+unit PasClaw.Channels.Matrix;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.Registry;
+
+type
+  TMatrixBot = class
+  private
+    FHomeserver: string;
+    FToken:      string;
+    FUserId:     string;          { resolved at startup via /whoami }
+    FCfg:        TConfig;
+    FProvider:   ILLMProvider;
+    FRegistry:   TToolRegistry;
+    FThread:     TThread;
+    FStop:       Boolean;
+    FStopEvt:    TEvent;
+    FNextBatch:  string;
+    function  ApiURL(const Path: string): string;
+    function  GetSync(out RawJSON: string): Boolean;
+    function  PostSend(const RoomId, Text: string): Boolean;
+    function  WhoAmI(out UserId: string): Boolean;
+    procedure ProcessSync(const RawJSON: string);
+    procedure ProcessEvent(const RoomId, EventJSON: string);
+  public
+    constructor Create(const Homeserver, AccessToken: string;
+                       Cfg: TConfig; Provider: ILLMProvider;
+                       Registry: TToolRegistry);
+    destructor  Destroy; override;
+    procedure Start;
+    procedure RequestStop;
+    procedure WaitForStop;
+    property StopEvt: TEvent read FStopEvt;
+    property Cfg: TConfig read FCfg;
+    property Provider: ILLMProvider read FProvider;
+    property Registry: TToolRegistry read FRegistry;
+    property UserId: string read FUserId;
+    property NextBatch: string read FNextBatch write FNextBatch;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Providers.HTTP,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop;
+
+const
+  SYNC_TIMEOUT_MS = 30000;
+
+type
+  (* Drives the bot's sync loop on its own TThread. Created
+     suspended, fields populated, then Start'd — same pattern the
+     LINE / WhatsApp event workers used (Codex P2 fix from PR
+     #78). FreeOnTerminate is False because TMatrixBot owns the
+     thread and tears it down explicitly via RequestStop +
+     WaitForStop. *)
+  TMatrixSyncThread = class(TThread)
+  private
+    FBot: TMatrixBot;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(Bot: TMatrixBot);
+  end;
+
+constructor TMatrixSyncThread.Create(Bot: TMatrixBot);
+begin
+  inherited Create(True);   { suspended; caller Start's after assignments }
+  FreeOnTerminate := False;
+  FBot := Bot;
+end;
+
+procedure TMatrixSyncThread.Execute;
+var
+  RawJSON: string;
+begin
+  while not Terminated do
+  begin
+    try
+      if FBot.GetSync(RawJSON) then
+        FBot.ProcessSync(RawJSON)
+      else
+        { Transient network error — back off briefly before retry
+          so a server hiccup doesn't tight-loop. The /sync call
+          itself does a 30 s long-poll under normal operation,
+          so this sleep only kicks in on actual failure. }
+        FBot.StopEvt.WaitFor(2000);
+    except
+      on E: Exception do
+      begin
+        LogError('matrix: sync loop error: %s', [E.Message]);
+        FBot.StopEvt.WaitFor(5000);
+      end;
+    end;
+  end;
+end;
+
+constructor TMatrixBot.Create(const Homeserver, AccessToken: string;
+                               Cfg: TConfig; Provider: ILLMProvider;
+                               Registry: TToolRegistry);
+var
+  Trimmed: string;
+begin
+  inherited Create;
+  Trimmed := Homeserver;
+  while (Length(Trimmed) > 0) and (Trimmed[Length(Trimmed)] = '/') do
+    SetLength(Trimmed, Length(Trimmed) - 1);
+  FHomeserver := Trimmed;
+  FToken      := AccessToken;
+  FCfg        := Cfg;
+  FProvider   := Provider;
+  FRegistry   := Registry;
+  FStopEvt    := TEvent.Create(nil, True, False, '');
+end;
+
+destructor TMatrixBot.Destroy;
+begin
+  RequestStop;
+  WaitForStop;
+  FStopEvt.Free;
+  inherited Destroy;
+end;
+
+function TMatrixBot.ApiURL(const Path: string): string;
+begin
+  if (Length(Path) > 0) and (Path[1] = '/') then
+    Result := FHomeserver + Path
+  else
+    Result := FHomeserver + '/' + Path;
+end;
+
+function TMatrixBot.WhoAmI(out UserId: string): Boolean;
+var
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+  Root: TJsonObject;
+begin
+  Result := False;
+  UserId := '';
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FToken);
+  Resp := GetJSONURL(ApiURL('/_matrix/client/v3/account/whoami'), Headers, 15);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    LogWarn('matrix: whoami status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit;
+  end;
+  try
+    Root := TJsonObject.Parse(Resp.Body);
+  except
+    on E: Exception do
+    begin
+      LogWarn('matrix: whoami bad JSON: %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Root = nil then Exit;
+  try
+    UserId := Root.GetStr('user_id', '');
+    Result := UserId <> '';
+  finally
+    Root.Free;
+  end;
+end;
+
+function TMatrixBot.GetSync(out RawJSON: string): Boolean;
+var
+  URL: string;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  Result := False;
+  RawJSON := '';
+  URL := ApiURL('/_matrix/client/v3/sync?timeout=' + IntToStr(SYNC_TIMEOUT_MS));
+  if FNextBatch <> '' then
+    URL := URL + '&since=' + FNextBatch;
+
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FToken);
+  Resp := GetJSONURL(URL, Headers, (SYNC_TIMEOUT_MS div 1000) + 15);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    LogWarn('matrix: sync status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+    Exit;
+  end;
+  RawJSON := Resp.Body;
+  Result := True;
+end;
+
+function TMatrixBot.PostSend(const RoomId, Text: string): Boolean;
+var
+  Path, TxnId, Body: string;
+  Root: TJsonObject;
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  TxnId := IntToStr(DateTimeToFileDate(Now)) + '_' + IntToStr(Random(1000000));
+  Path  := '/_matrix/client/v3/rooms/' + RoomId +
+           '/send/m.room.message/' + TxnId;
+
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('msgtype', 'm.text');
+    Root.PutStr('body',    Text);
+    Body := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+
+  SetLength(Headers, 1);
+  Headers[0] := MakeHeader('Authorization', 'Bearer ' + FToken);
+  Resp := PutJSON(ApiURL(Path), Body, Headers, 30);
+  Result := (Resp.StatusCode >= 200) and (Resp.StatusCode < 300);
+  if not Result then
+    LogWarn('matrix: send status=%d body=%s',
+            [Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+end;
+
+procedure TMatrixBot.ProcessEvent(const RoomId, EventJSON: string);
+var
+  Obj, Content: TJsonObject;
+  EvType, Sender, MsgType, Body, Response: string;
+  Msgs: array of TMessage;
+  Loop: TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+begin
+  Obj := TJsonObject.Parse(EventJSON);
+  if Obj = nil then Exit;
+  try
+    EvType := Obj.GetStr('type', '');
+    if EvType <> 'm.room.message' then Exit;
+    Sender := Obj.GetStr('sender', '');
+    if (Sender = '') or (Sender = FUserId) then Exit;   { ignore our own echoes }
+
+    Content := Obj.ChildObject('content');
+    if Content = nil then Exit;
+    try
+      MsgType := Content.GetStr('msgtype', '');
+      if MsgType <> 'm.text' then Exit;
+      Body := Content.GetStr('body', '');
+    finally
+      Content.Free;
+    end;
+  finally
+    Obj.Free;
+  end;
+  if Trim(Body) = '' then Exit;
+
+  LogInfo('matrix: room=%s sender=%s msg=%s',
+          [RoomId, Sender, Copy(Body, 1, 80)]);
+
+  if FProvider = nil then
+  begin
+    PostSend(RoomId, '(no provider configured — run `pasclaw onboard`)');
+    Exit;
+  end;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, Body);
+
+  LoopCfg.Provider      := FProvider;
+  LoopCfg.Registry      := FRegistry;
+  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.MaxIterations := 6;
+  LoopCfg.Options       := DefaultChatOptions;
+  LoopCfg.OnText        := nil;
+  LoopCfg.OnToolCall    := nil;
+  LoopCfg.OnToolResult  := nil;
+
+  if RunToolLoop(LoopCfg, Msgs, Loop) and (Loop.Content <> '') then
+    Response := Loop.Content
+  else
+    Response := '(sorry — model returned no content)';
+
+  PostSend(RoomId, Response);
+end;
+
+procedure TMatrixBot.ProcessSync(const RawJSON: string);
+var
+  Root, RoomsObj, JoinedObj, RoomObj, TimelineObj, EvObj: TJsonObject;
+  EventsArr: TJsonArray;
+  i: Integer;
+  RoomIds: TStringList;
+  RoomId: string;
+begin
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(RawJSON);
+  except
+    on E: Exception do
+    begin
+      LogWarn('matrix: bad sync JSON: %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Root = nil then Exit;
+  try
+    FNextBatch := Root.GetStr('next_batch', FNextBatch);
+
+    RoomsObj := Root.ChildObject('rooms');
+    if RoomsObj = nil then Exit;
+    try
+      JoinedObj := RoomsObj.ChildObject('join');
+      if JoinedObj = nil then Exit;
+      try
+        RoomIds := JoinedObj.Keys;
+        if RoomIds = nil then Exit;
+        try
+          for RoomId in RoomIds do
+          begin
+            RoomObj := JoinedObj.ChildObject(RoomId);
+            if RoomObj = nil then Continue;
+            try
+              TimelineObj := RoomObj.ChildObject('timeline');
+              if TimelineObj = nil then Continue;
+              try
+                EventsArr := TimelineObj.ChildArray('events');
+                if EventsArr = nil then Continue;
+                try
+                  for i := 0 to EventsArr.Count - 1 do
+                  begin
+                    EvObj := EventsArr.ItemObject(i);
+                    if EvObj = nil then Continue;
+                    try
+                      ProcessEvent(RoomId, EvObj.ToJSON);
+                    finally
+                      EvObj.Free;
+                    end;
+                  end;
+                finally
+                  EventsArr.Free;
+                end;
+              finally
+                TimelineObj.Free;
+              end;
+            finally
+              RoomObj.Free;
+            end;
+          end;
+        finally
+          RoomIds.Free;
+        end;
+      finally
+        JoinedObj.Free;
+      end;
+    finally
+      RoomsObj.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure TMatrixBot.Start;
+var
+  T: TMatrixSyncThread;
+begin
+  if FThread <> nil then Exit;
+  if (FHomeserver = '') or (FToken = '') then
+  begin
+    LogError('matrix: homeserver or access token missing — bot not started', []);
+    Exit;
+  end;
+
+  if not WhoAmI(FUserId) then
+    LogWarn('matrix: whoami failed — own messages may echo into the loop', [])
+  else
+    LogInfo('matrix: logged in as %s on %s', [FUserId, FHomeserver]);
+
+  { Initial sync gets the latest token without delivering history —
+    we set since='' and the first call returns "now". Subsequent
+    calls long-poll for new events only. }
+  T := TMatrixSyncThread.Create(Self);
+  FThread := T;
+  FThread.Start;
+  LogInfo('matrix: sync loop started', []);
+end;
+
+procedure TMatrixBot.RequestStop;
+begin
+  FStop := True;
+  if FStopEvt <> nil then FStopEvt.SetEvent;
+  if FThread <> nil then FThread.Terminate;
+end;
+
+procedure TMatrixBot.WaitForStop;
+begin
+  if FThread = nil then Exit;
+  FThread.WaitFor;
+  FreeAndNil(FThread);
+end;
+
+end.

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -45,6 +45,7 @@ type
     destructor  Destroy; override;
     class function Parse(const S: string): TJsonObject;
     function Has(const Key: string): Boolean;
+    function Keys: TStringList;   { caller frees; one entry per top-level key }
     function GetStr (const Key: string; const Default: string = ''): string;
     function GetInt (const Key: string; Default: Int64 = 0): Int64;
     function GetBool(const Key: string; Default: Boolean = False): Boolean;
@@ -182,6 +183,17 @@ end;
 function TJsonObject.Has(const Key: string): Boolean;
 begin
   Result := fpjson.TJSONObject(FBacking).IndexOfName(Key) >= 0;
+end;
+
+function TJsonObject.Keys: TStringList;
+var
+  Obj: fpjson.TJSONObject;
+  i: Integer;
+begin
+  Result := TStringList.Create;
+  Obj := fpjson.TJSONObject(FBacking);
+  for i := 0 to Obj.Count - 1 do
+    Result.Add(Obj.Names[i]);
 end;
 
 function TJsonObject.GetStr(const Key: string; const Default: string): string;
@@ -505,6 +517,22 @@ end;
 function TJsonObject.Has(const Key: string): Boolean;
 begin
   Result := System.JSON.TJSONObject(FBacking).GetValue(Key) <> nil;
+end;
+
+function TJsonObject.Keys: TStringList;
+var
+  Obj: System.JSON.TJSONObject;
+  i: Integer;
+  Pair: System.JSON.TJSONPair;
+begin
+  Result := TStringList.Create;
+  Obj := System.JSON.TJSONObject(FBacking);
+  for i := 0 to Obj.Count - 1 do
+  begin
+    Pair := Obj.Pairs[i];
+    if (Pair <> nil) and (Pair.JsonString <> nil) then
+      Result.Add(Pair.JsonString.Value);
+  end;
 end;
 
 function TJsonObject.GetStr(const Key: string; const Default: string): string;

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -37,6 +37,9 @@ type
 function PostJSON(const URL, JSON: string;
                   const Headers: array of THeaderPair;
                   TimeoutSeconds: Integer): THTTPResult;
+function PutJSON(const URL, JSON: string;
+                 const Headers: array of THeaderPair;
+                 TimeoutSeconds: Integer): THTTPResult;
 function GetJSONURL(const URL: string;
                     const Headers: array of THeaderPair;
                     TimeoutSeconds: Integer): THTTPResult;
@@ -215,6 +218,58 @@ begin
     Result := DoRequest(Http, URL, Req, True);
   finally
     Req.Free;
+    Http.Free;
+  end;
+end;
+
+function PutJSON(const URL, JSON: string;
+                 const Headers: array of THeaderPair;
+                 TimeoutSeconds: Integer): THTTPResult;
+var
+  Http: TIdHTTP;
+  Req, Resp: TStringStream;
+  SSLErr: string;
+begin
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  if SSLErr <> '' then
+  begin
+    Result.StatusCode := -1;
+    Result.Body       := '';
+    Result.ErrorMsg   := SSLErr;
+    Http.Free;
+    Exit;
+  end;
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
+  Resp := TStringStream.Create('', TEncoding.UTF8);
+  try
+    Http.Request.ContentType    := 'application/json';
+    Http.Request.ContentEncoding := 'utf-8';
+    Http.Request.Accept         := 'application/json';
+    ApplyHeaders(Http, Headers);
+    Result.StatusCode := 0;
+    Result.Body       := '';
+    Result.ErrorMsg   := '';
+    try
+      Http.Put(URL, Req, Resp);
+      Result.StatusCode := Http.ResponseCode;
+      Result.Body       := Resp.DataString;
+    except
+      on E: EIdHTTPProtocolException do
+      begin
+        Result.StatusCode := E.ErrorCode;
+        Result.Body       := E.ErrorMessage;
+        Result.ErrorMsg   := E.Message;
+      end;
+      on E: Exception do
+      begin
+        Result.StatusCode := Http.ResponseCode;
+        Result.Body       := Resp.DataString;
+        Result.ErrorMsg   := E.Message;
+      end;
+    end;
+  finally
+    Req.Free;
+    Resp.Free;
     Http.Free;
   end;
 end;


### PR DESCRIPTION
Two more picoclaw channels ported. **MQTT split out to its own PR** — Indy doesn't ship MQTT components and a clean port requires writing the MQTT 3.1.1 wire protocol from scratch; that deserves dedicated review attention.

## `PasClaw.Channels.Matrix`

`TMatrixBot` connects to any Matrix homeserver with a pre-provisioned access token, runs the standard `/sync` long-poll, and replies via `/rooms/<id>/send`. Same shape as Telegram (holds `Cfg/Provider/Registry`, runs `RunToolLoop` inline) but the sync loop lives on its own `TThread` (suspended-then-`Start`, the Codex P2 idiom from PR #78) so it coexists with the gateway HTTP server.

```
GET  /_matrix/client/v3/sync?since=<tok>&timeout=30000
PUT  /_matrix/client/v3/rooms/<id>/send/m.room.message/<txn>
GET  /_matrix/client/v3/account/whoami        (one-shot — ignore own echoes)
```

Walks `rooms.join[roomId].timeline.events[]` per sync, filters `type=m.room.message` + `content.msgtype=m.text`, drops sender==self, threads `next_batch` across iterations. E2EE rooms surface as `m.room.encrypted` and skip silently (documented gap).

## `PasClaw.Channels.IRC`

`TIRCBot` wraps Indy's `TIdIRC`. Connects to one server, joins one channel, listens via `OnPrivateMessage`. Reply addressing follows IRC convention: channel messages must be prefixed `<botnick>:` or `<botnick>,` for the bot to respond (anything else is ignored — channel chatter would be loud otherwise); direct PMs always get a reply. Channel replies prefix the user's nick.

`TIdCmdTCPClient` gives us the listener thread for free — no worker thread needed. TLS deferred (TIdIRC accepts an IOHandler; wiring `TIdSSLIOHandlerSocketOpenSSL` is straightforward when needed).

## Supporting additions

- **`TJsonObject.Keys`** — new method on both backends (fpjson `Names[]`, Delphi `Pairs[]`). Returns a caller-owned `TStringList` of top-level keys. Matrix sync needs it to walk `rooms.join`'s dynamic-key map; the cron-state code worked around the missing API with an array-of-objects schema earlier. Future dynamic-key parsers benefit too.
- **`PutJSON`** — sibling of `PostJSON` in `PasClaw.Providers.HTTP`. Same UTF-8 body + JSON content-type + header machinery, routes through `Http.Put`. Matrix's `/rooms/<id>/send` is the first caller.

## CLI

```sh
pasclaw gateway --matrix \
  --matrix-homeserver https://matrix.org \
  --matrix-token <token>

pasclaw gateway --irc \
  --irc-server irc.libera.chat \
  --irc-nick MyBot \
  --irc-channel "#mychannel"
```

Env-var equivalents `PASCLAW_MATRIX_HOMESERVER`/`_TOKEN` and `PASCLAW_IRC_SERVER`/`_PORT`/`_NICK`/`_CHANNEL`/`_PASSWORD` match the existing channel-bot pattern. Gateway banner picks up two more lines when enabled.

## Verification

- `make` — clean build under FPC 3.2.2.
- `pasclaw status` and `--help` byte-identical to pre-change.
- Existing LINE / WhatsApp / Telegram bots unchanged.

## What's still left from picoclaw's channel catalog

| Channel | Status |
|---|---|
| MQTT | Next PR — needs hand-rolled wire protocol (no Indy / FPC components) |
| VK | Long-poll bot API; identical shape to Telegram. Easy follow-up. |
| DingTalk, Feishu, OneBot, QQ, WeCom, Weixin | Skipped per maintainer (Chinese-ecosystem auth) |
| MaixCAM, Pico | Skipped (hardware-specific) |
| WhatsApp Native | Skipped (needs Baileys-style protocol reversing) |

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_