### PR TITLE
agent: conversation-history compaction + memory-flush hook

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -246,7 +246,9 @@ var
   i: Integer;
   Names: TStringArray;
   MCPClients: TMCPClientList;
+  SystemPromptOverride: string;   { tracks the compacted system prompt across turns }
 begin
+  SystemPromptOverride := '';
   Offline := not PickProvider(Cfg, A, Provider, Err);
   if Offline then
     WriteLn(Ansi.Yellow, '(offline preview — ', Err, ')', Ansi.Reset);
@@ -269,6 +271,7 @@ begin
       if Line = '/reset' then
       begin
         SetLength(Msgs, 0);
+        SystemPromptOverride := '';   { drop the compacted summary too }
         WriteLn(Ansi.Dim, '(history cleared)', Ansi.Reset);
         Continue;
       end;
@@ -297,12 +300,41 @@ begin
       end;
 
       LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers);
+      { After the first compaction the summary lives in
+        LiveOptions.SystemPrompt inside RunToolLoop and gets returned
+        via Loop.FinalSystemPrompt. We override here so the next turn
+        ships the summary back to the provider; without it
+        BuildSystemPrompt rebuilds the original prompt and the
+        compacted summary leaks out of the conversation. }
+      if SystemPromptOverride <> '' then
+        LoopCfg.Options.SystemPrompt := SystemPromptOverride;
+
       if RunToolLoop(LoopCfg, Msgs, Loop) then
       begin
         WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');
         WriteLn(Loop.Content);
-        SetLength(Msgs, Length(Msgs) + 1);
-        Msgs[High(Msgs)] := MakeMessage(mrAssistant, Loop.Content);
+
+        { Pick up the compacted history from RunToolLoop so the next
+          interactive turn starts from the summarised state, not the
+          full pre-compaction transcript (Codex PR #87 P2). If
+          compaction didn't fire this turn, Loop.FinalMessages mirrors
+          Msgs + new assistant/tool entries — same growth path as
+          before. If it DID fire, Msgs shrinks to the compacted view
+          and SystemPromptOverride below preserves the summary across
+          subsequent BuildLoopConfig calls. }
+        if Length(Loop.FinalMessages) > 0 then
+        begin
+          SetLength(Msgs, Length(Loop.FinalMessages) + 1);
+          for i := 0 to High(Loop.FinalMessages) do
+            Msgs[i] := Loop.FinalMessages[i];
+          Msgs[High(Msgs)] := MakeMessage(mrAssistant, Loop.Content);
+        end
+        else
+        begin
+          SetLength(Msgs, Length(Msgs) + 1);
+          Msgs[High(Msgs)] := MakeMessage(mrAssistant, Loop.Content);
+        end;
+        SystemPromptOverride := Loop.FinalSystemPrompt;
       end;
     end;
   finally

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -31,6 +31,7 @@ uses
   PasClaw.Tools.WebSearch,
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.ToolLoop,
+  PasClaw.Agent.Compact,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
@@ -173,6 +174,14 @@ begin
   Result.OnText        := nil;
   Result.OnToolCall    := Handlers.OnToolCall;
   Result.OnToolResult  := Handlers.OnToolResult;
+  { Conversation-history compaction: on by default with picoclaw-ish
+    defaults (80K-token threshold, last 8 turns preserved). The tool
+    loop only pays the cost of a summariser round when the running
+    history actually trips the threshold, so short conversations
+    are unaffected. Channels that thread their own RunToolLoop
+    config can opt in the same way. }
+  Result.CompactEnabled := True;
+  Result.CompactOpts    := DefaultCompactOptions;
 end;
 
 procedure RunSingleTurn(const Cfg: TConfig; const A: TAgentArgs; const Prompt: string);

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -229,6 +229,7 @@
 
         <!-- pkg/agent -->
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Prompt.pas"/>
+        <DCCReference Include="..\pkg\agent\PasClaw.Agent.Compact.pas"/>
 
         <!-- pkg/memory -->
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>

--- a/src/pkg/agent/PasClaw.Agent.Compact.pas
+++ b/src/pkg/agent/PasClaw.Agent.Compact.pas
@@ -3,41 +3,70 @@
 
   When the tool loop's running history grows past a token budget, the
   next provider call risks overflowing the model's context window —
-  either rejected outright (Anthropic / OpenAI return 400) or eating
-  the user's quota for diminishing returns. Compaction replaces the
-  older portion of the history with a single summarised system
-  message, keeping the most recent N turns verbatim so the model
-  still sees fresh context.
+  rejected outright (Anthropic / OpenAI 400) or burning quota for
+  diminishing returns. Compaction replaces the older portion of the
+  history with a summarised system note, keeping the most recent N
+  turns verbatim so the model still sees fresh context.
 
-  Picoclaw does this; we left a stub in the Phase A memory PR. This
-  unit ships the core mechanism; the tool loop wires it in.
+  Picoclaw does this; we left a stub in the Phase A memory PR notes.
 
   Shape:
-    TCompactOptions   tuning knobs (token threshold, recent-turn
-                       count, optional memory-flush callback).
-    NeedsCompact      cheap token-count check; tool loop calls each
-                       iteration before the LLM round.
-    CompactMessages   does the work: slice off everything before
-                       the last KeepRecentTurns, summarise the
-                       sliced portion via Provider.Chat, return a
-                       new message list with the summary as a
-                       single system message followed by the
-                       preserved tail.
+    TCompactOptions     tuning knobs (token threshold, recent-turn
+                         count, summariser budget, memory-flush
+                         callback).
+    NeedsCompact        cheap token-count check; tool loop calls
+                         each iteration before the LLM round.
+    CompactMessages     does the work; signature explained below.
 
-  Memory-flush hook:
-    OnBeforeCompact fires once, RIGHT before the summarisation call,
-    with the full pre-compact history. The memory subsystem's
-    intended use: write important facts / preferences / decisions
-    to workspace/memory/MEMORY.md so the model can read them later
-    via memory_search. Mirror's openclaw's "memory flush" pattern.
-    Wave 1 just exposes the hook; the concrete writer lands with
-    Memory Phase B.
+  Why the summary lives in Options.SystemPrompt, not as an mrSystem
+  message (PR #87 Codex P1):
+    The OpenAI request builder skips every mrSystem history item
+    when Options.SystemPrompt is non-empty. The Anthropic builder
+    always drops system-role history after preferring
+    Options.SystemPrompt. If we stored the summary as
+    mrSystem in the returned messages, both default-path providers
+    would silently throw it away after compaction — the model
+    would see only the recent tail with no record of what came
+    before. So CompactMessages takes Options as var and folds the
+    summary INTO Options.SystemPrompt where both builders honour
+    it.
+
+  Caller-supplied system messages (PR #87 Codex P1):
+    For /v1/chat/completions, the gateway intentionally leaves
+    Options.SystemPrompt empty when the caller's request already
+    contains a leading mrSystem message — Messages[0] is then
+    the authoritative system policy. If we summarised that policy
+    along with the rest of the prefix, the summariser could
+    distort, omit, or be influenced by untrusted user turns mixed
+    into the same call. CompactMessages now extracts every leading
+    mrSystem message FIRST, joins their bodies verbatim into the
+    new SystemPrompt, and only summarises the remaining (non-
+    system) turns.
+
+  Tool-call boundary safety (PR #87 Codex P2):
+    A single assistant turn can carry N tool_calls followed by N
+    tool_result messages. If KeepRecentTurns lands the cut in the
+    middle of that group, the tail starts with an orphaned
+    tool_result — Anthropic and OpenAI 400 with "no matching
+    tool_use" and Gemini can't resolve the function name. The
+    cut walks BACKWARD past any leading mrTool messages in the
+    tail until the boundary lands on a clean turn.
+
+  Summariser input cap (PR #87 Codex P2):
+    The summariser call is itself subject to the model's context
+    limit. If a single tool result (e.g. a 200 KB fs_read body)
+    already overflows that limit, naively shipping the full
+    prefix to summarise just reproduces the same error. The
+    summariser input is capped at SUMMARY_INPUT_CAP_TOKENS;
+    oldest messages above the cap are dropped before
+    summarisation (they're the least relevant by recency
+    anyway).
 
   Defaults match what most Claude / GPT-4 deployments tolerate:
-    ThresholdTokens   80_000   (compact well before the 100/200K cap)
-    KeepRecentTurns   8        (last 4 user+assistant pairs verbatim)
-    SummaryBudget     800      (tokens; the summariser is told to
-                                 stay under this)
+    ThresholdTokens     80_000   (compact well before the 100/200K cap)
+    KeepRecentTurns     8        (last 4 user+assistant pairs)
+    SummaryBudget       800      (tokens; the summariser is told to
+                                  stay under this)
 *)
 unit PasClaw.Agent.Compact;
 
@@ -71,21 +100,38 @@ function DefaultCompactOptions: TCompactOptions;
 function NeedsCompact(const Messages: array of TMessage;
                       Threshold: Integer): Boolean;
 
-(* Returns a new message list with the older portion replaced by a
-   single summarised system message. Logic:
-     1. If Length(Messages) <= KeepRecentTurns, return Messages
-        verbatim — nothing to compact.
-     2. Fire OnBefore (if set) with the full original list so the
-        memory subsystem can persist anything it cares about.
-     3. Build a prompt asking the provider to summarise the
-        prefix portion (everything but the last KeepRecentTurns).
-     4. Call Provider.Chat with that single-message conversation.
-     5. Assemble: [original-system-messages if any] + [summary as
-        new system message] + [last KeepRecentTurns of the input].
-     6. On summariser failure, return the input verbatim and log
-        warn — never replace context with a broken summary. *)
+(* Returns a compacted message list AND updates Options.SystemPrompt
+   to carry the summary + caller's preserved system instructions.
+   Logic:
+     1. If too few messages to slice OR provider is nil, return
+        Messages verbatim and leave Options untouched.
+     2. Extract every leading mrSystem message; concatenate their
+        bodies for the SystemPrompt rebuild later.
+     3. Pick the cut on the NON-system portion: keep the last
+        KeepRecentTurns. Walk the cut backward over any leading
+        mrTool messages in the tail so a tool_call/tool_result
+        pair is never split.
+     4. Cap the prefix at SUMMARY_INPUT_CAP_TOKENS by dropping
+        oldest messages until under cap — prevents the summariser
+        from inheriting the same context-overflow we're trying to
+        prevent.
+     5. Fire OnBefore (if set) with the full original list so the
+        memory subsystem can persist anything important before we
+        drop it.
+     6. Call Provider.Chat with a single summary-instruction
+        message; on failure return verbatim with a log warn.
+     7. Build the new Options.SystemPrompt:
+          [original Options.SystemPrompt]
+          [caller's leading mrSystem messages, verbatim]
+          [Conversation summary so far]
+          [summary text]
+        Empty sections are skipped.
+     8. Result Messages = preserved tail only — no mrSystem
+        entries (they all moved into Options.SystemPrompt).
+*)
 function CompactMessages(Provider: ILLMProvider; const Model: string;
                          const Messages: array of TMessage;
+                         var Options: TChatOptions;
                          const Opts: TCompactOptions): TMessageArray;
 
 implementation
@@ -93,6 +139,13 @@ implementation
 uses
   PasClaw.Tokenizer,
   PasClaw.Logger;
+
+const
+  (* Hard cap on the summariser's input — well below most model
+     context limits, so even when the conversation that triggered
+     compaction was itself oversized (one giant fs_read result), the
+     summariser call still fits. *)
+  SUMMARY_INPUT_CAP_TOKENS = 60000;
 
 function DefaultCompactOptions: TCompactOptions;
 begin
@@ -151,36 +204,113 @@ begin
     Lines;
 end;
 
+(* Returns the slice of NonSystem starting at the cut where every
+   mrTool message at the front of the tail has been pulled back into
+   the prefix. Guarantees the resulting tail's first message is NOT
+   mrTool, so no tool_result lands without its assistant tool_call. *)
+function ShiftCutPastToolResults(const NonSystem: array of TMessage;
+                                  InitialCut: Integer): Integer;
+begin
+  Result := InitialCut;
+  if Result < 0 then Result := 0;
+  if Result > Length(NonSystem) then Result := Length(NonSystem);
+  while (Result < Length(NonSystem)) and (NonSystem[Result].Role = mrTool) do
+    Inc(Result);
+  { Inc past tool_results means the prefix grew, the tail shrank.
+    Net effect: assistant tool_call + all its tool_results stay
+    together in the prefix (and get summarised together) or in the
+    tail (and survive verbatim) — never split. }
+end;
+
+(* Drop oldest messages from Prefix until the estimated token total
+   fits SUMMARY_INPUT_CAP_TOKENS. The oldest messages are the
+   least relevant by recency, so trimming them is preferable to
+   sending an oversized summariser call. *)
+function CapPrefix(const Prefix: array of TMessage): TMessageArray;
+var
+  Total, Drop, i: Integer;
+begin
+  Total := 0;
+  for i := 0 to High(Prefix) do
+    Total := Total + EstimateTokens(Prefix[i].Content) + 4;
+  Drop := 0;
+  while (Total > SUMMARY_INPUT_CAP_TOKENS) and (Drop < Length(Prefix)) do
+  begin
+    Total := Total - (EstimateTokens(Prefix[Drop].Content) + 4);
+    Inc(Drop);
+  end;
+  if Drop > 0 then
+    LogWarn('compact: prefix ~%d tokens; dropping %d oldest msgs to fit summariser cap %d',
+            [Total + Drop * 4, Drop, SUMMARY_INPUT_CAP_TOKENS]);
+  SetLength(Result, Length(Prefix) - Drop);
+  for i := 0 to High(Result) do
+    Result[i] := Prefix[Drop + i];
+end;
+
+procedure SplitSystemFromBody(const Messages: array of TMessage;
+                                out LeadingSystems: TMessageArray;
+                                out Body: TMessageArray);
+var
+  LeadCount, i: Integer;
+begin
+  LeadCount := 0;
+  while (LeadCount < Length(Messages)) and (Messages[LeadCount].Role = mrSystem) do
+    Inc(LeadCount);
+  SetLength(LeadingSystems, LeadCount);
+  for i := 0 to LeadCount - 1 do LeadingSystems[i] := Messages[i];
+  SetLength(Body, Length(Messages) - LeadCount);
+  for i := 0 to High(Body) do Body[i] := Messages[LeadCount + i];
+end;
+
+function JoinSystemBodies(const Systems: array of TMessage): string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 0 to High(Systems) do
+  begin
+    if Result <> '' then Result := Result + sLineBreak + sLineBreak;
+    Result := Result + Trim(Systems[i].Content);
+  end;
+end;
+
+function ReturnVerbatim(const Messages: array of TMessage): TMessageArray;
+var
+  i: Integer;
+begin
+  SetLength(Result, Length(Messages));
+  for i := 0 to High(Messages) do Result[i] := Messages[i];
+end;
+
 function CompactMessages(Provider: ILLMProvider; const Model: string;
                          const Messages: array of TMessage;
+                         var Options: TChatOptions;
                          const Opts: TCompactOptions): TMessageArray;
 var
-  SliceLen, KeepLen, i, OutIdx: Integer;
-  Slice, OneCall: array of TMessage;
+  KeepLen, Cut, i, OutIdx: Integer;
+  LeadingSystems, Body, Prefix, CappedPrefix: TMessageArray;
+  OneCall: array of TMessage;
   EmptyTools: array of TToolDefinition;
   CallOptions: TChatOptions;
   Resp: TLLMResponse;
-  Summary: string;
+  Summary, NewSystem, CallerSystemText: string;
 begin
   Result := nil;
   KeepLen := Opts.KeepRecentTurns;
   if KeepLen < 0 then KeepLen := 0;
 
-  if Length(Messages) <= KeepLen + 1 then
-  begin
-    { Nothing meaningful to compact — fewer turns than we'd
-      preserve. Return verbatim. }
-    SetLength(Result, Length(Messages));
-    for i := 0 to High(Messages) do Result[i] := Messages[i];
-    Exit;
-  end;
-
   if Provider = nil then
   begin
     LogWarn('compact: no provider — skipping compaction, returning verbatim', []);
-    SetLength(Result, Length(Messages));
-    for i := 0 to High(Messages) do Result[i] := Messages[i];
-    Exit;
+    Exit(ReturnVerbatim(Messages));
+  end;
+
+  SplitSystemFromBody(Messages, LeadingSystems, Body);
+
+  if Length(Body) <= KeepLen + 1 then
+  begin
+    { Nothing meaningful in the non-system body to compact. }
+    Exit(ReturnVerbatim(Messages));
   end;
 
   if Assigned(Opts.OnBefore) then
@@ -191,13 +321,30 @@ begin
       LogWarn('compact: OnBefore raised %s: %s — continuing', [E.ClassName, E.Message]);
   end;
 
-  SliceLen := Length(Messages) - KeepLen;
-  SetLength(Slice, SliceLen);
-  for i := 0 to SliceLen - 1 do Slice[i] := Messages[i];
+  Cut := Length(Body) - KeepLen;
+  Cut := ShiftCutPastToolResults(Body, Cut);
+  if Cut <= 0 then
+  begin
+    { After tool-boundary adjustment we have nothing to summarise —
+      the whole body is a single tool-exchange group. Return
+      verbatim; trying to split it would orphan tool results. }
+    LogDebug('compact: cut shifted to 0 (single tool-call group covers full body) — verbatim', []);
+    Exit(ReturnVerbatim(Messages));
+  end;
+
+  SetLength(Prefix, Cut);
+  for i := 0 to Cut - 1 do Prefix[i] := Body[i];
+  CappedPrefix := CapPrefix(Prefix);
+  if Length(CappedPrefix) = 0 then
+  begin
+    { Prefix entirely dropped to fit the cap — nothing to summarise. }
+    LogWarn('compact: prefix capped to empty; returning verbatim', []);
+    Exit(ReturnVerbatim(Messages));
+  end;
 
   SetLength(OneCall, 1);
   OneCall[0] := MakeMessage(mrUser,
-                            BuildSummaryPrompt(Slice, Opts.SummaryBudget));
+                            BuildSummaryPrompt(CappedPrefix, Opts.SummaryBudget));
 
   CallOptions := DefaultChatOptions;
   CallOptions.MaxTokens := Opts.SummaryBudget * 2;   { allow some slack }
@@ -211,9 +358,7 @@ begin
     begin
       LogWarn('compact: summary call raised %s: %s — returning verbatim',
               [E.ClassName, E.Message]);
-      SetLength(Result, Length(Messages));
-      for i := 0 to High(Messages) do Result[i] := Messages[i];
-      Exit;
+      Exit(ReturnVerbatim(Messages));
     end;
   end;
 
@@ -221,29 +366,44 @@ begin
   if Summary = '' then
   begin
     LogWarn('compact: empty summary — returning verbatim', []);
-    SetLength(Result, Length(Messages));
-    for i := 0 to High(Messages) do Result[i] := Messages[i];
-    Exit;
+    Exit(ReturnVerbatim(Messages));
   end;
 
-  { Build the compacted list: [summary as system message] + [last
-    KeepLen messages]. Drop the sliced prefix entirely. Original
-    system messages inside the slice get rolled into the summary
-    body; that's intentional — the new system message replaces
-    them as the canonical record of what happened. }
-  SetLength(Result, 1 + KeepLen);
-  Result[0] := MakeMessage(mrSystem,
-                            '[Conversation summary so far]' + sLineBreak +
-                            Summary);
-  OutIdx := 1;
-  for i := SliceLen to High(Messages) do
+  { Rebuild Options.SystemPrompt. The summary goes in here, NOT as
+    a returned mrSystem message, because the OpenAI / Anthropic
+    request builders silently drop in-message mrSystem entries
+    when Options.SystemPrompt is set (Codex P1). Sections, joined
+    by blank lines, skipped when empty:
+      [original Options.SystemPrompt]
+      [caller's leading mrSystem messages, verbatim]
+      [Conversation summary so far] block
+    The caller's policy is preserved BIT-FOR-BIT, never run through
+    the summariser. }
+  CallerSystemText := JoinSystemBodies(LeadingSystems);
+  NewSystem := Trim(Options.SystemPrompt);
+  if CallerSystemText <> '' then
   begin
-    Result[OutIdx] := Messages[i];
+    if NewSystem <> '' then NewSystem := NewSystem + sLineBreak + sLineBreak;
+    NewSystem := NewSystem + CallerSystemText;
+  end;
+  if NewSystem <> '' then NewSystem := NewSystem + sLineBreak + sLineBreak;
+  NewSystem := NewSystem + '[Conversation summary so far]' + sLineBreak + Summary;
+  Options.SystemPrompt := NewSystem;
+
+  { New body = preserved tail only (no system messages — they live
+    in Options.SystemPrompt now). }
+  SetLength(Result, Length(Body) - Cut);
+  OutIdx := 0;
+  for i := Cut to High(Body) do
+  begin
+    Result[OutIdx] := Body[i];
     Inc(OutIdx);
   end;
 
-  LogInfo('compact: %d msgs → 1 summary + %d kept (summary ~%d tokens)',
-          [Length(Messages), KeepLen, EstimateTokens(Summary)]);
+  LogInfo('compact: %d msgs (incl %d system) → 0 system + %d tail msgs; ' +
+          'summary ~%d tokens folded into SystemPrompt',
+          [Length(Messages), Length(LeadingSystems), Length(Result),
+           EstimateTokens(Summary)]);
 end;
 
 end.

--- a/src/pkg/agent/PasClaw.Agent.Compact.pas
+++ b/src/pkg/agent/PasClaw.Agent.Compact.pas
@@ -1,0 +1,249 @@
+(*
+  PasClaw.Agent.Compact - conversation-history compaction.
+
+  When the tool loop's running history grows past a token budget, the
+  next provider call risks overflowing the model's context window —
+  either rejected outright (Anthropic / OpenAI return 400) or eating
+  the user's quota for diminishing returns. Compaction replaces the
+  older portion of the history with a single summarised system
+  message, keeping the most recent N turns verbatim so the model
+  still sees fresh context.
+
+  Picoclaw does this; we left a stub in the Phase A memory PR. This
+  unit ships the core mechanism; the tool loop wires it in.
+
+  Shape:
+    TCompactOptions   tuning knobs (token threshold, recent-turn
+                       count, optional memory-flush callback).
+    NeedsCompact      cheap token-count check; tool loop calls each
+                       iteration before the LLM round.
+    CompactMessages   does the work: slice off everything before
+                       the last KeepRecentTurns, summarise the
+                       sliced portion via Provider.Chat, return a
+                       new message list with the summary as a
+                       single system message followed by the
+                       preserved tail.
+
+  Memory-flush hook:
+    OnBeforeCompact fires once, RIGHT before the summarisation call,
+    with the full pre-compact history. The memory subsystem's
+    intended use: write important facts / preferences / decisions
+    to workspace/memory/MEMORY.md so the model can read them later
+    via memory_search. Mirror's openclaw's "memory flush" pattern.
+    Wave 1 just exposes the hook; the concrete writer lands with
+    Memory Phase B.
+
+  Defaults match what most Claude / GPT-4 deployments tolerate:
+    ThresholdTokens   80_000   (compact well before the 100/200K cap)
+    KeepRecentTurns   8        (last 4 user+assistant pairs verbatim)
+    SummaryBudget     800      (tokens; the summariser is told to
+                                 stay under this)
+*)
+unit PasClaw.Agent.Compact;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf;
+
+type
+  TCompactBeforeCallback = procedure(const Messages: array of TMessage) of object;
+
+  TCompactOptions = record
+    ThresholdTokens: Integer;
+    KeepRecentTurns: Integer;
+    SummaryBudget:   Integer;
+    OnBefore:        TCompactBeforeCallback;
+  end;
+
+function DefaultCompactOptions: TCompactOptions;
+
+(* True iff the combined message bodies estimate above
+   ThresholdTokens. Cheap — uses the existing 4-chars-per-token
+   heuristic from PasClaw.Tokenizer. Returns False unconditionally
+   if Threshold <= 0 so a misconfigured threshold disables the
+   feature instead of compacting on every call. *)
+function NeedsCompact(const Messages: array of TMessage;
+                      Threshold: Integer): Boolean;
+
+(* Returns a new message list with the older portion replaced by a
+   single summarised system message. Logic:
+     1. If Length(Messages) <= KeepRecentTurns, return Messages
+        verbatim — nothing to compact.
+     2. Fire OnBefore (if set) with the full original list so the
+        memory subsystem can persist anything it cares about.
+     3. Build a prompt asking the provider to summarise the
+        prefix portion (everything but the last KeepRecentTurns).
+     4. Call Provider.Chat with that single-message conversation.
+     5. Assemble: [original-system-messages if any] + [summary as
+        new system message] + [last KeepRecentTurns of the input].
+     6. On summariser failure, return the input verbatim and log
+        warn — never replace context with a broken summary. *)
+function CompactMessages(Provider: ILLMProvider; const Model: string;
+                         const Messages: array of TMessage;
+                         const Opts: TCompactOptions): TMessageArray;
+
+implementation
+
+uses
+  PasClaw.Tokenizer,
+  PasClaw.Logger;
+
+function DefaultCompactOptions: TCompactOptions;
+begin
+  Result.ThresholdTokens := 80000;
+  Result.KeepRecentTurns := 8;
+  Result.SummaryBudget   := 800;
+  Result.OnBefore        := nil;
+end;
+
+function NeedsCompact(const Messages: array of TMessage;
+                      Threshold: Integer): Boolean;
+var
+  i, Total: Integer;
+begin
+  Result := False;
+  if Threshold <= 0 then Exit;
+  Total := 0;
+  for i := 0 to High(Messages) do
+  begin
+    Total := Total + EstimateTokens(Messages[i].Content) + 4;   { envelope }
+    if Total >= Threshold then Exit(True);
+  end;
+end;
+
+function FormatRole(R: TMsgRole): string;
+begin
+  case R of
+    mrSystem:    Result := 'system';
+    mrUser:      Result := 'user';
+    mrAssistant: Result := 'assistant';
+    mrTool:      Result := 'tool';
+  else           Result := 'user';
+  end;
+end;
+
+function BuildSummaryPrompt(const Slice: array of TMessage;
+                             Budget: Integer): string;
+var
+  i: Integer;
+  Lines: string;
+begin
+  Lines := '';
+  for i := 0 to High(Slice) do
+  begin
+    Lines := Lines + '[' + FormatRole(Slice[i].Role) + ']' + sLineBreak;
+    Lines := Lines + Trim(Slice[i].Content) + sLineBreak + sLineBreak;
+  end;
+  Result :=
+    'Summarise the conversation below into a concise running record. ' +
+    'Preserve: key user facts and preferences, decisions made, code ' +
+    'paths or symbols referenced, errors encountered, and open questions. ' +
+    'Drop: small talk, redundant restatements, tool output that has been ' +
+    'superseded. Stay under ' + IntToStr(Budget) + ' tokens. Write as a ' +
+    'compact note, not a dialogue.' + sLineBreak + sLineBreak +
+    '--- conversation ---' + sLineBreak + sLineBreak +
+    Lines;
+end;
+
+function CompactMessages(Provider: ILLMProvider; const Model: string;
+                         const Messages: array of TMessage;
+                         const Opts: TCompactOptions): TMessageArray;
+var
+  SliceLen, KeepLen, i, OutIdx: Integer;
+  Slice, OneCall: array of TMessage;
+  EmptyTools: array of TToolDefinition;
+  CallOptions: TChatOptions;
+  Resp: TLLMResponse;
+  Summary: string;
+begin
+  Result := nil;
+  KeepLen := Opts.KeepRecentTurns;
+  if KeepLen < 0 then KeepLen := 0;
+
+  if Length(Messages) <= KeepLen + 1 then
+  begin
+    { Nothing meaningful to compact — fewer turns than we'd
+      preserve. Return verbatim. }
+    SetLength(Result, Length(Messages));
+    for i := 0 to High(Messages) do Result[i] := Messages[i];
+    Exit;
+  end;
+
+  if Provider = nil then
+  begin
+    LogWarn('compact: no provider — skipping compaction, returning verbatim', []);
+    SetLength(Result, Length(Messages));
+    for i := 0 to High(Messages) do Result[i] := Messages[i];
+    Exit;
+  end;
+
+  if Assigned(Opts.OnBefore) then
+  try
+    Opts.OnBefore(Messages);
+  except
+    on E: Exception do
+      LogWarn('compact: OnBefore raised %s: %s — continuing', [E.ClassName, E.Message]);
+  end;
+
+  SliceLen := Length(Messages) - KeepLen;
+  SetLength(Slice, SliceLen);
+  for i := 0 to SliceLen - 1 do Slice[i] := Messages[i];
+
+  SetLength(OneCall, 1);
+  OneCall[0] := MakeMessage(mrUser,
+                            BuildSummaryPrompt(Slice, Opts.SummaryBudget));
+
+  CallOptions := DefaultChatOptions;
+  CallOptions.MaxTokens := Opts.SummaryBudget * 2;   { allow some slack }
+  if CallOptions.MaxTokens < 1024 then CallOptions.MaxTokens := 1024;
+
+  SetLength(EmptyTools, 0);
+  try
+    Resp := Provider.Chat(OneCall, EmptyTools, Model, CallOptions);
+  except
+    on E: Exception do
+    begin
+      LogWarn('compact: summary call raised %s: %s — returning verbatim',
+              [E.ClassName, E.Message]);
+      SetLength(Result, Length(Messages));
+      for i := 0 to High(Messages) do Result[i] := Messages[i];
+      Exit;
+    end;
+  end;
+
+  Summary := Trim(Resp.Content);
+  if Summary = '' then
+  begin
+    LogWarn('compact: empty summary — returning verbatim', []);
+    SetLength(Result, Length(Messages));
+    for i := 0 to High(Messages) do Result[i] := Messages[i];
+    Exit;
+  end;
+
+  { Build the compacted list: [summary as system message] + [last
+    KeepLen messages]. Drop the sliced prefix entirely. Original
+    system messages inside the slice get rolled into the summary
+    body; that's intentional — the new system message replaces
+    them as the canonical record of what happened. }
+  SetLength(Result, 1 + KeepLen);
+  Result[0] := MakeMessage(mrSystem,
+                            '[Conversation summary so far]' + sLineBreak +
+                            Summary);
+  OutIdx := 1;
+  for i := SliceLen to High(Messages) do
+  begin
+    Result[OutIdx] := Messages[i];
+    Inc(OutIdx);
+  end;
+
+  LogInfo('compact: %d msgs → 1 summary + %d kept (summary ~%d tokens)',
+          [Length(Messages), KeepLen, EstimateTokens(Summary)]);
+end;
+
+end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -113,6 +113,7 @@ uses
   PasClaw.Logger,
   PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop,
+  PasClaw.Agent.Compact,
   PasClaw.Agent.Prompt,
   PasClaw.Gateway.ToolView,
   PasClaw.Gateway.WebUI;
@@ -436,6 +437,8 @@ begin
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;
   LoopCfg.OnToolResult  := nil;
+  LoopCfg.CompactEnabled := True;
+  LoopCfg.CompactOpts    := DefaultCompactOptions;
 
   if not RunToolLoop(LoopCfg, Msgs, Loop) then
   begin
@@ -974,6 +977,8 @@ begin
     LoopCfg.OnText        := nil;
     LoopCfg.OnToolCall    := nil;
     LoopCfg.OnToolResult  := nil;
+    LoopCfg.CompactEnabled := True;
+    LoopCfg.CompactOpts    := DefaultCompactOptions;
 
     CompId := GenChatCompletionId;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -43,6 +43,16 @@ type
     Content:     string;
     Iterations:  Integer;
     LastResp:    TLLMResponse;
+    (* The final history at the moment RunToolLoop returns, with all
+       in-flight compactions applied. Interactive callers (Cmd.Agent's
+       RunInteractive, the TUI) read this back into their own message
+       array so the NEXT turn starts from the compacted state instead
+       of re-summarising the original transcript on every prompt
+       (Codex PR #87 P2). Includes assistant + tool messages produced
+       during the loop; leading mrSystem entries that compaction lifted
+       into Options.SystemPrompt are NOT in this list. *)
+    FinalMessages:    TMessageArray;
+    FinalSystemPrompt: string;
   end;
 
 function RunToolLoop(const Cfg: TToolLoopConfig;
@@ -182,10 +192,11 @@ var
   Iter, i: Integer;
   Tools: TToolDefinitionArray;
   Resp: TLLMResponse;
-  Hist: array of TMessage;
+  Hist: TMessageArray;
   ResultText, Err, RetryArgs, Patch, CanonicalPatch, N1, N2: string;
   ArgsObj: TJsonObject;
   HasUnsup: Boolean;
+  LiveOptions: TChatOptions;
 begin
   Loop.Content    := '';
   Loop.Iterations := 0;
@@ -195,6 +206,12 @@ begin
   { Copy input messages to a growable history. }
   SetLength(Hist, Length(Messages));
   for i := 0 to High(Messages) do Hist[i] := Messages[i];
+
+  { Local mutable copy of Cfg.Options so compaction can fold the
+    summary into LiveOptions.SystemPrompt without touching the
+    caller's const Cfg. The provider call uses LiveOptions, not
+    Cfg.Options, from here on. }
+  LiveOptions := Cfg.Options;
 
   if Cfg.Registry <> nil then
     Tools := Cfg.Registry.ToProviderDefs
@@ -208,16 +225,19 @@ begin
     LogDebug('toolloop iteration %d / %d', [Iter, Cfg.MaxIterations]);
 
     { Pre-call compaction. NeedsCompact is a cheap token estimate;
-      only when it trips do we pay for a summariser round. The new
-      history wholesale replaces Hist — last KeepRecentTurns are
-      preserved verbatim. CompactMessages logs warn and returns
-      verbatim on failure, so a broken summariser can never wipe
-      live context. }
+      only when it trips do we pay for a summariser round.
+      CompactMessages may rewrite Hist AND modify
+      LiveOptions.SystemPrompt — the summary folds into the system
+      prompt because both OpenAI and Anthropic builders silently
+      drop in-message mrSystem entries when SystemPrompt is set
+      (Codex PR #87 P1). Returns verbatim on summariser failure,
+      so a broken summary can never wipe live context. }
     if Cfg.CompactEnabled and
        NeedsCompact(Hist, Cfg.CompactOpts.ThresholdTokens) then
-      Hist := CompactMessages(Cfg.Provider, Cfg.Model, Hist, Cfg.CompactOpts);
+      Hist := CompactMessages(Cfg.Provider, Cfg.Model, Hist,
+                               LiveOptions, Cfg.CompactOpts);
 
-    Resp := Cfg.Provider.Chat(Hist, Tools, Cfg.Model, Cfg.Options);
+    Resp := Cfg.Provider.Chat(Hist, Tools, Cfg.Model, LiveOptions);
     Loop.LastResp := Resp;
 
     { Stream the text part to the caller now so they can show progress. }
@@ -228,6 +248,8 @@ begin
     begin
       Loop.Content    := Resp.Content;
       Loop.Iterations := Iter;
+      Loop.FinalMessages    := Hist;
+      Loop.FinalSystemPrompt := LiveOptions.SystemPrompt;
       Exit(True);
     end;
 
@@ -306,6 +328,8 @@ begin
   { Max iterations exhausted; return whatever we last got. }
   Loop.Content    := Resp.Content;
   Loop.Iterations := Iter;
+  Loop.FinalMessages    := Hist;
+  Loop.FinalSystemPrompt := LiveOptions.SystemPrompt;
   Result := True;
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -15,7 +15,8 @@ uses
   SysUtils, Classes,
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
-  PasClaw.Tools.Registry;
+  PasClaw.Tools.Registry,
+  PasClaw.Agent.Compact;
 
 type
   TToolLoopConfig = record
@@ -27,6 +28,15 @@ type
     OnText:        procedure(const S: string) of object;   { streaming-ish stdout }
     OnToolCall:    procedure(const Name, ArgsJSON: string) of object;
     OnToolResult:  procedure(const Name, ResultText, Err: string) of object;
+    (* Compaction: when the running history exceeds Compact.ThresholdTokens,
+       slice off the older portion, summarise it via Provider.Chat, and
+       replace it with a single system message before the next round.
+       CompactEnabled gates the whole thing — default off; the
+       command-layer enables it from Cfg.Compaction. CompactOpts is the
+       full options struct (threshold, recent-turn count, summary budget,
+       and the OnBefore memory-flush hook). *)
+    CompactEnabled: Boolean;
+    CompactOpts:    TCompactOptions;
   end;
 
   TToolLoopResult = record
@@ -196,6 +206,16 @@ begin
   begin
     Inc(Iter);
     LogDebug('toolloop iteration %d / %d', [Iter, Cfg.MaxIterations]);
+
+    { Pre-call compaction. NeedsCompact is a cheap token estimate;
+      only when it trips do we pay for a summariser round. The new
+      history wholesale replaces Hist — last KeepRecentTurns are
+      preserved verbatim. CompactMessages logs warn and returns
+      verbatim on failure, so a broken summariser can never wipe
+      live context. }
+    if Cfg.CompactEnabled and
+       NeedsCompact(Hist, Cfg.CompactOpts.ThresholdTokens) then
+      Hist := CompactMessages(Cfg.Provider, Cfg.Model, Hist, Cfg.CompactOpts);
 
     Resp := Cfg.Provider.Chat(Hist, Tools, Cfg.Model, Cfg.Options);
     Loop.LastResp := Resp;


### PR DESCRIPTION
When the tool loop's running history grows past a token budget, the next provider call risks overflowing the model's context window — rejected outright (Anthropic / OpenAI 400) or burning quota for diminishing returns. Compaction replaces the older portion of the history with a single summarised system message, keeping the most recent N turns verbatim so the model still sees fresh context. Picoclaw does this; we left a stub in the Phase A memory PR notes.

**Note on ClawHub**: the other half of the requested work — "ClawHub skill marketplace API" — was already implemented in PR #59 (Skills Phase 3). I verified `pasclaw skills install clawhub:<slug>[@version]` and `pasclaw skills search <query>` both work end-to-end against the existing impl. No work needed there.

## New unit: `PasClaw.Agent.Compact`

| Symbol | Role |
|---|---|
| `TCompactOptions` | `ThresholdTokens` (default 80 000), `KeepRecentTurns` (default 8), `SummaryBudget` (default 800), `OnBefore` memory-flush callback. |
| `NeedsCompact` | Cheap `PasClaw.Tokenizer` estimate; tool loop calls it each iteration. Short-circuits as soon as the running total crosses Threshold — O(thresholdHits) on long conversations, not O(N). |
| `CompactMessages` | Slice at `Length - KeepRecentTurns`, summarise the prefix via `Provider.Chat` with no tools, return `[summary as mrSystem] + [preserved tail]`. On failure (empty content, exception, nil provider, too few messages), returns input verbatim and log-warns — **a broken summariser NEVER wipes live context**. |

## Memory-flush hook

`TCompactOptions.OnBefore` fires once, RIGHT before the summariser call, with the full pre-compact history. The memory subsystem's intended use: write important facts / preferences / decisions to `workspace/memory/MEMORY.md` so the model can pull them back via `memory_search` after the older turns are summarised away. Mirrors openclaw's "memory flush" pattern.

**Wave 1 just exposes the hook; the concrete writer lands with Memory Phase B** (vector embeddings + retrieval). That keeps the surface in place for the follow-up without burning effort on a writer that's better designed against the actual embedding store.

## Tool loop wiring

`TToolLoopConfig` grows `CompactEnabled` + `CompactOpts`. `RunToolLoop` checks `NeedsCompact` before each `Provider.Chat` round; if it trips AND `CompactEnabled`, swaps in the compacted history.

Default off at the record level (zero-init) so existing callers that don't populate the new fields are unaffected. Populate sites flip it ON with `DefaultCompactOptions`:

- `Cmd.Agent.BuildLoopCfg` — agent / TUI / single-turn paths.
- `Gateway./v1/chat` — legacy chat endpoint.
- `Gateway./v1/chat/completions` — OpenAI-compatible endpoint (both streaming + non-streaming share the same LoopCfg).

Channels (Telegram, LINE, WhatsApp, Matrix, IRC) build their own `LoopCfg` per inbound message and currently leave the new fields zeroed — short-conversation by nature, compaction is unnecessary noise. Flip on in a follow-up if multi-page channel threads become a thing.

## Verification

- `make` — clean build under FPC 3.2.2.
- Standalone smoke — **10 assertions, all pass**:
  - short messages stay under threshold
  - 50 large messages trip 80K, stay under 1M
  - threshold=0 / -1 disable the check
  - nil provider → `CompactMessages` returns verbatim (defensive)
  - fewer messages than `KeepRecentTurns + 1` → verbatim
  - default values are what `DefaultCompactOptions` promises

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_