### PR TITLE
gateway: write /v1/logs SSE response headers raw — Content-Type now correct

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -762,25 +762,38 @@ procedure TLogStreamWriter.WriteSSE(const Payload: string);
    write raw text it bypasses chunking and the client sees a
    Content-Length-bounded response that gets cut at the first byte
    chunk. Match the manual framing TSSEStreamer in this same file
-   does for /v1/chat/completions. *)
+   does for /v1/chat/completions.
+
+   Frame holds the bytes as TIdBytes (NOT TBytes) — Delphi's
+   dcc64 enforces the distinction at the Write() call site and
+   refuses TBytes there, while FPC accepts either. Build TIdBytes
+   from the start; the copy loop converts the TEncoding output
+   one byte at a time, the same idiom TSSEStreamer.WriteSocketBytes
+   already uses. Codex flagged the Delphi build error on PR #89. *)
 var
-  Bytes, Header, Frame: TBytes;
+  PayloadBytes, HeaderBytes: TBytes;
+  Frame: TIdBytes;
   HeaderStr: string;
   i, Offset: Integer;
 begin
   if (Conn = nil) or (not Conn.Connected) then Exit;
-  Bytes := TEncoding.UTF8.GetBytes(Payload);
-  if Length(Bytes) = 0 then Exit;
-  HeaderStr := IntToHex(Length(Bytes), 1) + #13#10;
-  Header := TEncoding.ASCII.GetBytes(HeaderStr);
-  SetLength(Frame, Length(Header) + Length(Bytes) + 2);
+  PayloadBytes := TEncoding.UTF8.GetBytes(Payload);
+  if Length(PayloadBytes) = 0 then Exit;
+  HeaderStr := IntToHex(Length(PayloadBytes), 1) + #13#10;
+  HeaderBytes := TEncoding.ASCII.GetBytes(HeaderStr);
+  SetLength(Frame, Length(HeaderBytes) + Length(PayloadBytes) + 2);
   Offset := 0;
-  for i := 0 to High(Header) do begin Frame[Offset] := Header[i]; Inc(Offset); end;
-  for i := 0 to High(Bytes)  do begin Frame[Offset] := Bytes[i];  Inc(Offset); end;
+  for i := 0 to High(HeaderBytes)  do begin Frame[Offset] := HeaderBytes[i];  Inc(Offset); end;
+  for i := 0 to High(PayloadBytes) do begin Frame[Offset] := PayloadBytes[i]; Inc(Offset); end;
   Frame[Offset]     := 13;
   Frame[Offset + 1] := 10;
   try
     Conn.IOHandler.Write(Frame);
+    { Drain Indy's nested WriteBuffer stack so the bytes leave the
+      socket now, not when Indy decides the buffer is full. Same
+      idiom TSSEStreamer.WriteSocketBytes uses. }
+    while Conn.IOHandler.WriteBufferingActive do
+      Conn.IOHandler.WriteBufferClose;
   except
     { Connection dropped — the unsubscribe in HandleLogs's finally
       will tear us down on its next iteration. }
@@ -802,6 +815,8 @@ var
   i: Integer;
   TabPos: Integer;
   Tag, Body, Line, HeaderStr: string;
+  HeaderTmp: TBytes;
+  HeaderIdBytes: TIdBytes;
 begin
   { SSE stream — emit the recent buffer up front, then subscribe
     for live tail. The handler doesn't return until the client
@@ -840,7 +855,17 @@ begin
     'Server: PasClaw/' + FormatVersion + #13#10 +
     #13#10;
   try
-    AContext.Connection.IOHandler.Write(TEncoding.ASCII.GetBytes(HeaderStr));
+    { Convert string -> TBytes (TEncoding) -> TIdBytes (Indy
+      Write expects this exact type — Delphi dcc64 enforces it;
+      FPC happens to accept TBytes here too. Same one-byte-at-a-
+      time copy idiom as TLogStreamWriter.WriteSSE.). }
+    SetLength(HeaderTmp, Length(HeaderStr));   { ASCII safe — header line is ascii-only }
+    HeaderTmp := TEncoding.ASCII.GetBytes(HeaderStr);
+    SetLength(HeaderIdBytes, Length(HeaderTmp));
+    for i := 0 to High(HeaderTmp) do HeaderIdBytes[i] := HeaderTmp[i];
+    AContext.Connection.IOHandler.Write(HeaderIdBytes);
+    while AContext.Connection.IOHandler.WriteBufferingActive do
+      AContext.Connection.IOHandler.WriteBufferClose;
   except
     on E: Exception do
     begin
@@ -888,8 +913,16 @@ begin
     end;
   finally
     UnsubscribeLog(Token);
-    { Best-effort terminator chunk so the client sees a clean end. }
-    try AContext.Connection.IOHandler.Write(TEncoding.ASCII.GetBytes('0'#13#10#13#10)); except end;
+    { Best-effort terminator chunk so the client sees a clean
+      end-of-stream. Same TBytes→TIdBytes conversion as the header
+      write above — Delphi dcc64 enforces the type match. }
+    try
+      HeaderTmp := TEncoding.ASCII.GetBytes('0'#13#10#13#10);
+      SetLength(HeaderIdBytes, Length(HeaderTmp));
+      for i := 0 to High(HeaderTmp) do HeaderIdBytes[i] := HeaderTmp[i];
+      AContext.Connection.IOHandler.Write(HeaderIdBytes);
+    except
+    end;
     Writer.Free;
   end;
 end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -801,25 +801,57 @@ var
   Snapshot: TStringList;
   i: Integer;
   TabPos: Integer;
-  Tag, Body, Line: string;
+  Tag, Body, Line, HeaderStr: string;
 begin
   { SSE stream — emit the recent buffer up front, then subscribe
     for live tail. The handler doesn't return until the client
     disconnects (or we throw); on either path the listener gets
-    unsubscribed. Pattern matches the existing
-    /v1/chat/completions stream path: explicit empty ContentText,
-    ContentLength := -1 to suppress Indy's auto Content-Length,
-    Transfer-Encoding via CustomHeaders (not via AResp.TransferEncoding
-    which on some Indy builds double-frames body writes). }
-  AResp.ResponseNo  := 200;
-  AResp.ContentText := '';
-  AResp.ContentType := 'text/event-stream; charset=utf-8';
-  AResp.CharSet     := 'utf-8';
-  AResp.CustomHeaders.AddValue('Cache-Control', 'no-cache');
-  AResp.CustomHeaders.AddValue('X-Accel-Buffering', 'no');
-  AResp.CustomHeaders.AddValue('Transfer-Encoding', 'chunked');
-  AResp.ContentLength := -1;
-  AResp.WriteHeader;
+    unsubscribed.
+
+    Why bypass AResp.WriteHeader entirely and write the status +
+    headers raw via IOHandler:
+
+      Indy's TIdHTTPResponseInfo.WriteHeader rewrites ContentType
+      to "text/html; charset=utf-8" under conditions that are
+      hard to fully unset from outside the unit (around
+      Content-Length / Transfer-Encoding / ContentText interplay
+      — see IdCustomHTTPServer.pas line ~"if ContentType = ''"
+      block). The result: the response header line said
+      "Content-Type: text/html" even though we set
+      text/event-stream. Strict EventSource implementations
+      (recent Firefox) refuse the stream; lenient ones (Chrome,
+      Safari) tolerate it but the wire is technically wrong.
+
+      The cure is to build the response status line + every
+      header byte ourselves and write them through the underlying
+      IOHandler, then flip AResp.HeaderHasBeenWritten := True so
+      Indy knows to skip its own header emission. The same trick
+      lets us guarantee Content-Type, Transfer-Encoding: chunked,
+      and the SSE-required Cache-Control / X-Accel-Buffering all
+      land verbatim. Chunked body framing (TLogStreamWriter)
+      stays exactly as before. }
+  HeaderStr :=
+    'HTTP/1.1 200 OK'#13#10 +
+    'Content-Type: text/event-stream; charset=utf-8'#13#10 +
+    'Cache-Control: no-cache, no-transform'#13#10 +
+    'Connection: keep-alive'#13#10 +
+    'X-Accel-Buffering: no'#13#10 +
+    'Transfer-Encoding: chunked'#13#10 +
+    'Server: PasClaw/' + FormatVersion + #13#10 +
+    #13#10;
+  try
+    AContext.Connection.IOHandler.Write(TEncoding.ASCII.GetBytes(HeaderStr));
+  except
+    on E: Exception do
+    begin
+      LogWarn('logs SSE: failed to emit headers: %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  AResp.HeaderHasBeenWritten := True;
+  AResp.ContentText  := '';
+  AResp.ContentLength := 0;
+  AResp.ResponseNo   := 200;
 
   Writer := TLogStreamWriter.Create;
   Writer.Conn := AContext.Connection;


### PR DESCRIPTION
PR #88 noted a known limitation: Indy's `TIdHTTPResponseInfo.WriteHeader` rewrote our explicit `text/event-stream` Content-Type back to `text/html; charset=utf-8` on the wire. Lenient browsers (Chrome, Safari) tolerated it; strict EventSource implementations (recent Firefox per spec) refused the stream.

## Root cause

In `IdCustomHTTPServer.pas`, `WriteHeader` has a `if ContentType = ''` defaulting block PLUS additional Content-Length / Transfer-Encoding interplay that, even with our `ContentLength := -1` + `CustomHeaders 'Transfer-Encoding: chunked'` trick, ended up emitting a 39-byte `text/html` response followed by our SSE chunks on the same keep-alive connection. Invalid HTTP and the reason the header was wrong.

## Fix

Bypass `AResp.WriteHeader` entirely for `/v1/logs`. Build the HTTP/1.1 status line + every header byte ourselves, write through `AContext.Connection.IOHandler`, then set `AResp.HeaderHasBeenWritten := True` so Indy's later finalization skips its own header emission.

```
HTTP/1.1 200 OK
Content-Type: text/event-stream; charset=utf-8
Cache-Control: no-cache, no-transform
Connection: keep-alive
X-Accel-Buffering: no
Transfer-Encoding: chunked
Server: PasClaw/<version>
```

No `Content-Length` — chunked is the only framing now, matching SSE spec. The prior response had both `Content-Length: 39` AND `Transfer-Encoding: chunked`, which **RFC 2616 §4.4 explicitly forbids** and which is what Firefox was choking on.

Chunked body framing (`TLogStreamWriter`) is unchanged — it already formatted hex-length chunks manually, the same way `TSSEStreamer` does for `/v1/chat/completions`.

## Verification

```
$ curl -sN -D- http://127.0.0.1:18099/v1/logs
HTTP/1.1 200 OK
Content-Type: text/event-stream; charset=utf-8
Cache-Control: no-cache, no-transform
Connection: keep-alive
X-Accel-Buffering: no
Transfer-Encoding: chunked
Server: PasClaw/9bfa459

data: [warn] gateway: no provider — /v1/chat will return 503 …
data: [info] gateway: listening on http://127.0.0.1:18099
```

## Scope

Intentionally narrow — only `/v1/logs` gets this treatment in this PR. `/v1/chat/completions` streams work in practice because `TSSEStreamer` does the chunked body framing manually too, even though the headers there have the same theoretical issue. Landing a fix on a feature that doesn't have a known consumer complaint is a separate decision. If chat completions ever breaks the same way in a strict browser, this PR is the template.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_