### PR TITLE
build: cross-platform FPC fixes — Linux ELSEIF + macOS portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,38 @@
 # Indy is required for HTTP client/server (TIdHTTP, TIdHTTPServer). Under FPC
 # we vendor it via `make get-indy` (clones IndySockets/Indy into vendor/Indy).
 # Under Delphi, Indy ships with RAD Studio — no vendoring needed.
+#
+# OS / arch autodetect — picks the default fcl-db / sqlite / iconvenc /
+# lazutils unit paths so `make` works on a fresh Debian or Homebrew install
+# without the user having to override every dir. Override any of them by
+# setting the variable on the make command line, e.g.
+#   make FCLDB_DIR=/opt/fpc/units/x86_64-linux/fcl-db
+UNAME_S      := $(shell uname -s)
+UNAME_M      := $(shell uname -m)
+FPC_VERSION  ?= 3.2.2
+
+ifeq ($(UNAME_S),Darwin)
+  # Homebrew FPC lays units under <prefix>/lib/fpc/<ver>/units/<arch>-darwin/.
+  # Prefix is /opt/homebrew on Apple Silicon, /usr/local on Intel.
+  ifeq ($(UNAME_M),arm64)
+    HOMEBREW_PREFIX ?= /opt/homebrew
+    FPC_ARCH        ?= aarch64-darwin
+  else
+    HOMEBREW_PREFIX ?= /usr/local
+    FPC_ARCH        ?= x86_64-darwin
+  endif
+  FPC_UNITS_DIR ?= $(HOMEBREW_PREFIX)/lib/fpc/$(FPC_VERSION)/units/$(FPC_ARCH)
+  LAZUTILS_DIR  ?= $(HOMEBREW_PREFIX)/share/lazarus/components/lazutils
+else
+  # Debian / Ubuntu default layout (apt: fp-units-db, fp-units-misc, lazarus-src).
+  ifeq ($(UNAME_M),aarch64)
+    FPC_ARCH ?= aarch64-linux
+  else
+    FPC_ARCH ?= x86_64-linux
+  endif
+  FPC_UNITS_DIR ?= /usr/lib/$(UNAME_M)-linux-gnu/fpc/$(FPC_VERSION)/units/$(FPC_ARCH)
+  LAZUTILS_DIR  ?= /usr/lib/lazarus/3.0/components/lazutils
+endif
 
 FPC      ?= fpc
 BUILDDIR ?= build
@@ -13,22 +45,22 @@ INDY_DIR     ?= vendor/Indy
 INDY_REPO    ?= https://github.com/IndySockets/Indy.git
 # iconvenc lives in fp-units-misc on Debian; FPC's default config picks it up
 # on most distros but not always.
-ICONVENC_DIR ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/iconvenc
+ICONVENC_DIR ?= $(FPC_UNITS_DIR)/iconvenc
 
 # fcl-db + sqlite ship with FPC's standard distribution but live outside the
 # default search path (Debian package: fp-units-db). PasClaw.Memory.Index
-# pulls TSQLite3Connection / TSQLQuery from these. libsqlite3.so must be
-# present at runtime — every modern Linux/Mac has it; Windows builds need
+# pulls TSQLite3Connection / TSQLQuery from these. libsqlite3.{so,dylib} must
+# be present at runtime — every modern Linux/Mac has it; Windows builds need
 # sqlite3.dll on PATH.
-FCLDB_DIR    ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/fcl-db
-SQLITE_DIR   ?= /usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/sqlite
+FCLDB_DIR    ?= $(FPC_UNITS_DIR)/fcl-db
+SQLITE_DIR   ?= $(FPC_UNITS_DIR)/sqlite
 
 # PasClaw.Tools.FS uses the Masks unit (case-insensitive glob matching for
 # fs_grep's `include` filter). On Debian, Masks lives in Lazarus's lazutils
-# source tree rather than the fpc rtl, so callers that don't already have it
-# on their unit path can set LAZUTILS_DIR (apt: lazarus-src). Defaults to the
-# Debian path; empty string skips the include.
-LAZUTILS_DIR ?= /usr/lib/lazarus/3.0/components/lazutils
+# source tree rather than the fpc rtl. On macOS the Homebrew lazarus formula
+# drops it under <prefix>/share/lazarus/components/lazutils. Set
+# LAZUTILS_DIR= (empty) to skip the include when Masks is already on the
+# default search path.
 
 # PasClaw source dirs.
 UNIT_DIRS = \

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -93,11 +93,25 @@ begin
   Result := Format('Free Pascal %s on %s/%s',
                    [{$I %FPCVERSION%}, {$I %FPCTARGETOS%}, {$I %FPCTARGETCPU%}]);
   {$ELSE}
-    {$IFDEF WIN64}     Result := 'Delphi on win/x86_64';
-    {$ELSEIF Defined(WIN32)} Result := 'Delphi on win/x86';
-    {$ELSEIF Defined(LINUX64)} Result := 'Delphi on linux/x86_64';
-    {$ELSEIF Defined(MACOS64)} Result := 'Delphi on darwin/x86_64';
-    {$ELSE}            Result := 'Delphi';
+    // Nested IFDEFs only — ELSEIF and "IF Defined(...)" both trip
+    // FPC 3.2.2's preprocessor even when this branch is inactive
+    // there, because FPC still scans the inner directives.
+    {$IFDEF WIN64}
+    Result := 'Delphi on win/x86_64';
+    {$ELSE}
+      {$IFDEF WIN32}
+      Result := 'Delphi on win/x86';
+      {$ELSE}
+        {$IFDEF LINUX64}
+        Result := 'Delphi on linux/x86_64';
+        {$ELSE}
+          {$IFDEF MACOS64}
+          Result := 'Delphi on darwin/x86_64';
+          {$ELSE}
+          Result := 'Delphi';
+          {$ENDIF}
+        {$ENDIF}
+      {$ENDIF}
     {$ENDIF}
   {$ENDIF}
 end;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -318,7 +318,17 @@ end;
 
 {$IFDEF UNIX}
 const
+  { TIOCGWINSZ encoding differs per OS. Linux picked a low number
+    in the legacy unencoded range; Darwin/BSD use the IOCTL macro
+    encoding _IOR('t', 104, struct winsize) = 0x40087468. Passing
+    the wrong magic to ioctl() returns -1 and we silently fall
+    back to the default 80-column width — which is what was
+    happening on macOS before this gate landed. }
+  {$IFDEF DARWIN}
+  TIOCGWINSZ = $40087468;
+  {$ELSE}
   TIOCGWINSZ = $5413;
+  {$ENDIF}
 type
   Twinsize = record
     ws_row, ws_col, ws_xpixel, ws_ypixel: Word;


### PR DESCRIPTION
## Summary

Three follow-on fixes from assessing whether the project compiles on Linux + macOS under FPC. Linux x86_64 works end-to-end after commit 1; commits 2-3 unblock the macOS path the same way.

### 1. `PasClaw.Agent.Prompt` — FPC `{$ELSEIF}` build blocker (commit `fef9c7a`)

`RuntimeString` used `{$IFDEF WIN64}` + `{$ELSEIF Defined(WIN32)}` + ... inside the `{$ELSE}` of the FPC/Delphi guard. FPC 3.2.2 rejects this:

```
PasClaw.Agent.Prompt.pas(97,13) Error: ENDIF without IF(N)DEF
PasClaw.Agent.Prompt.pas(98,13) Error: ENDIF without IF(N)DEF
PasClaw.Agent.Prompt.pas(99,13) Error: ENDIF without IF(N)DEF
```

Three reasons:
1. `{$ELSEIF}` only chains after `{$IF}` in FPC, never after `{$IFDEF}`.
2. Even though the `{$ELSE}` branch is inactive under FPC, the preprocessor still scans the inner directives to find the matching `{$ENDIF}`, so the malformed chain fails the scan.
3. Rewriting to `{$IF Defined(...)}` + `{$ELSEIF Defined(...)}` also failed under FPC 3.2.2 mode delphi.

Switched to nested `{$IFDEF}` / `{$ELSE}` / `{$ENDIF}` — both compilers parse identically. Same per-OS string table.

Without this fix `make` aborts before the agent loop compiles — Linux/macOS builds are blocked entirely. This has bitten on multiple prior PRs and been worked around with transient edit-and-revert; this is the permanent fix.

### 2. `PasClaw.TUI` — TIOCGWINSZ per-OS constant (commit `a167a82`)

`TIOCGWINSZ` was hardcoded to `$5413` (the Linux value). On Darwin/BSD the IOCTL macro encoding gives `$40087468` (`_IOR('t', 104, struct winsize)`). Passing the wrong magic to `ioctl()` returns -1 and `TermWidth` silently falls back to 80 columns — which is what was happening on macOS. Now `{$IFDEF DARWIN}`-gated so the TUI reads real width on both.

### 3. Makefile — `uname`-driven unit-path autodetect (commit `a167a82`)

`FCLDB_DIR`, `SQLITE_DIR`, `ICONVENC_DIR`, `LAZUTILS_DIR` were hardcoded to Debian multiarch (`/usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux/...`), so `make` on a fresh Homebrew FPC install failed to find any of them. Replaced with `uname -s` / `uname -m`-driven autodetect:

| Target | FPC_UNITS_DIR |
|---|---|
| Darwin + arm64 | `/opt/homebrew/lib/fpc/3.2.2/units/aarch64-darwin` |
| Darwin + x86_64 | `/usr/local/lib/fpc/3.2.2/units/x86_64-darwin` |
| Linux + x86_64 | `/usr/lib/x86_64-linux-gnu/fpc/3.2.2/units/x86_64-linux` |
| Linux + aarch64 | `/usr/lib/aarch64-linux-gnu/fpc/3.2.2/units/aarch64-linux` |

`FPC_UNITS_DIR` / `FPC_ARCH` / `HOMEBREW_PREFIX` / `FPC_VERSION` / `LAZUTILS_DIR` all `?=` so anything atypical is still overridable on the make command line.

## Verification

Linux x86_64 (this PR — host build):

```
$ make clean && make
...
Linking build/pasclaw
343846 lines compiled, 5.3 sec

$ make smoke
smoke: home=/tmp/...
  version   OK
  help      OK
  config    OK
  status    OK
  mcp       OK
  cron      OK
  skills    OK
  model     OK
  migrate   OK
  update    OK
  membench  OK
smoke: all commands OK
```

macOS path resolution verified by inspection of the rewritten Makefile + manual check that the Homebrew FPC layout matches the assumed `$(HOMEBREW_PREFIX)/lib/fpc/$(FPC_VERSION)/units/$(FPC_ARCH)/{fcl-db,sqlite,iconvenc}`. **Actual darwin compile will need to happen on a Mac** — this CI container only has FPC for Linux x86_64, no cross-darwin units installed.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_