### PR TITLE
samples: add Delphi .dproj + dcc32/dcc64.cfg so samples build under Delphi

### DIFF
--- a/samples/component-console/Makefile
+++ b/samples/component-console/Makefile
@@ -27,6 +27,21 @@
 # The first build needs Indy vendored under ../../vendor/Indy; the
 # top-level Makefile's `make get-indy` target handles that. Run it
 # once from the repository root before building the sample.
+#
+# Delphi / RAD Studio users have three project files alongside the
+# .dpr sources:
+#
+#   SampleConsole.dproj   open in RAD Studio or build with msbuild
+#   SampleSimple.dproj
+#   SampleServer.dproj
+#
+# Each one carries the same DCC_UnitSearchPath as the main pasclaw
+# binary, re-rooted at ..\..\src\. The dcc32.cfg / dcc64.cfg files
+# in this directory carry the same paths for cmdline-only builds
+# (dcc32 / dcc64 auto-load *.cfg from the current dir).
+#
+# Indy comes from RAD Studio's bundled packages — no vendoring needed
+# on Delphi; this is the same pattern src/pasclaw/PasClaw.dproj uses.
 
 ROOT     := ../..
 FPC      ?= fpc

--- a/samples/component-console/SampleConsole.dpr
+++ b/samples/component-console/SampleConsole.dpr
@@ -16,13 +16,10 @@
   plus Indy's three. The Makefile spells them out.
 
   Build (Delphi):
-    drop the .dpr into a console project that mirrors PasClaw.dproj's
-    DCC_UnitSearchPath. The list lives in src/pasclaw/PasClaw.dproj
-    near the top of the file — copy-paste it into the sample's
-    project options Search Path, swap the leading `..\` for
-    `..\..\src\`, and the sample compiles. (A dedicated sample
-    .dproj is on the to-do list; until then the main project file
-    is the source of truth.)
+    cd samples/component-console
+    msbuild SampleConsole.dproj   # or open SampleConsole.dproj in RAD Studio
+    dcc32 SampleConsole.dpr       # cmdline only — dcc32.cfg in this dir
+                                  # carries the search paths
 
   Runtime: the agent inherits config from ~/.pasclaw/config.json,
   so run `pasclaw onboard` and `pasclaw auth login <provider>` once

--- a/samples/component-console/SampleConsole.dproj
+++ b/samples/component-console/SampleConsole.dproj
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{4A8B3C1E-7D2F-4B6A-9C0E-1F3A8D5C2B47}</ProjectGuid>
+        <ProjectVersion>20.2</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <MainSource>SampleConsole.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win64</Platform>
+        <TargetedPlatforms>3</TargetedPlatforms>
+        <AppType>Console</AppType>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_DependencyCheckOutputName>SampleConsole.dcc_dep</DCC_DependencyCheckOutputName>
+        <DCC_ExeOutput>..\..\build\delphi\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_DcuOutput>..\..\build\delphi\$(Platform)\$(Config)\dcu</DCC_DcuOutput>
+        <SanitizedProjectName>SampleConsole</SanitizedProjectName>
+
+        <!--
+          Unit search path — every src/pkg/* the main pasclaw binary uses,
+          re-rooted at ..\..\src\. Without this, dcc32 fails on the first
+          PasClaw.* unit the sample's `uses` clause references. The list
+          mirrors src/pasclaw/PasClaw.dproj's DCC_UnitSearchPath.
+        -->
+        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+
+        <!--
+          Namespace prefixes so bare unit names ("SysUtils", "Classes",
+          "Windows") resolve under modern Delphi. Identical to PasClaw.dproj.
+        -->
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UnitAlias>WinTypes=Winapi.Windows;WinProcs=Winapi.Windows;$(DCC_UnitAlias)</DCC_UnitAlias>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>2</DCC_DebugInformation>
+        <DCC_Optimize>false</DCC_Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>true</DCC_Optimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+    </ItemGroup>
+
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>VCLApplication</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">SampleConsole.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+
+    <!-- Post-import override so the namespace list isn't reset by Targets. -->
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix</DCC_Namespace>
+    </PropertyGroup>
+</Project>

--- a/samples/component-console/SampleServer.dpr
+++ b/samples/component-console/SampleServer.dpr
@@ -22,9 +22,15 @@
   signal-handling strategy and don't want a library to fight them
   for it.
 
-  Build:
+  Build (FPC):
     cd samples/component-console
     make server
+
+  Build (Delphi):
+    cd samples/component-console
+    msbuild SampleServer.dproj    # or open SampleServer.dproj in RAD Studio
+    dcc32 SampleServer.dpr        # cmdline only — dcc32.cfg in this dir
+                                  # carries the search paths
 
   Runtime: the server inherits config from ~/.pasclaw/config.json,
   so run `pasclaw onboard` and `pasclaw auth login <provider>` once

--- a/samples/component-console/SampleServer.dproj
+++ b/samples/component-console/SampleServer.dproj
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{B5C2D8E3-4A91-4F76-8E0B-2D4C6A9F1E83}</ProjectGuid>
+        <ProjectVersion>20.2</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <MainSource>SampleServer.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win64</Platform>
+        <TargetedPlatforms>3</TargetedPlatforms>
+        <AppType>Console</AppType>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_DependencyCheckOutputName>SampleServer.dcc_dep</DCC_DependencyCheckOutputName>
+        <DCC_ExeOutput>..\..\build\delphi\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_DcuOutput>..\..\build\delphi\$(Platform)\$(Config)\dcu</DCC_DcuOutput>
+        <SanitizedProjectName>SampleServer</SanitizedProjectName>
+
+        <!--
+          Unit search path — every src/pkg/* the main pasclaw binary uses,
+          re-rooted at ..\..\src\. Without this, dcc32 fails on the first
+          PasClaw.* unit the sample's `uses` clause references. The list
+          mirrors src/pasclaw/PasClaw.dproj's DCC_UnitSearchPath.
+        -->
+        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+
+        <!--
+          Namespace prefixes so bare unit names ("SysUtils", "Classes",
+          "Windows") resolve under modern Delphi. Identical to PasClaw.dproj.
+        -->
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UnitAlias>WinTypes=Winapi.Windows;WinProcs=Winapi.Windows;$(DCC_UnitAlias)</DCC_UnitAlias>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>2</DCC_DebugInformation>
+        <DCC_Optimize>false</DCC_Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>true</DCC_Optimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+    </ItemGroup>
+
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>VCLApplication</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">SampleServer.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+
+    <!-- Post-import override so the namespace list isn't reset by Targets. -->
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix</DCC_Namespace>
+    </PropertyGroup>
+</Project>

--- a/samples/component-console/SampleSimple.dpr
+++ b/samples/component-console/SampleSimple.dpr
@@ -10,9 +10,15 @@
     3. Call Run(prompt): string and let it raise EPasClawRun on
        failure instead of unpacking a Boolean + out-parameter.
 
-  Build:
+  Build (FPC):
     cd samples/component-console
     make simple
+
+  Build (Delphi):
+    cd samples/component-console
+    msbuild SampleSimple.dproj    # or open SampleSimple.dproj in RAD Studio
+    dcc32 SampleSimple.dpr        # cmdline only — dcc32.cfg in this dir
+                                  # carries the search paths
 
   Runtime: the agent inherits config from ~/.pasclaw/config.json,
   so run `pasclaw onboard` and `pasclaw auth login <provider>` once

--- a/samples/component-console/SampleSimple.dproj
+++ b/samples/component-console/SampleSimple.dproj
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{6F2E1A7D-9B43-4C58-A1E2-5F7D2C0B91A8}</ProjectGuid>
+        <ProjectVersion>20.2</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <MainSource>SampleSimple.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win64</Platform>
+        <TargetedPlatforms>3</TargetedPlatforms>
+        <AppType>Console</AppType>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_DependencyCheckOutputName>SampleSimple.dcc_dep</DCC_DependencyCheckOutputName>
+        <DCC_ExeOutput>..\..\build\delphi\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_DcuOutput>..\..\build\delphi\$(Platform)\$(Config)\dcu</DCC_DcuOutput>
+        <SanitizedProjectName>SampleSimple</SanitizedProjectName>
+
+        <!--
+          Unit search path — every src/pkg/* the main pasclaw binary uses,
+          re-rooted at ..\..\src\. Without this, dcc32 fails on the first
+          PasClaw.* unit the sample's `uses` clause references. The list
+          mirrors src/pasclaw/PasClaw.dproj's DCC_UnitSearchPath.
+        -->
+        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+
+        <!--
+          Namespace prefixes so bare unit names ("SysUtils", "Classes",
+          "Windows") resolve under modern Delphi. Identical to PasClaw.dproj.
+        -->
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UnitAlias>WinTypes=Winapi.Windows;WinProcs=Winapi.Windows;$(DCC_UnitAlias)</DCC_UnitAlias>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>2</DCC_DebugInformation>
+        <DCC_Optimize>false</DCC_Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>true</DCC_Optimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+    </ItemGroup>
+
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>VCLApplication</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">SampleSimple.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+
+    <!-- Post-import override so the namespace list isn't reset by Targets. -->
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix</DCC_Namespace>
+    </PropertyGroup>
+</Project>

--- a/samples/component-console/dcc32.cfg
+++ b/samples/component-console/dcc32.cfg
@@ -1,0 +1,53 @@
+# dcc32.cfg — shared cmdline build config for Sample{Console,Simple,Server}.dpr
+#
+# dcc32 auto-loads dcc32.cfg from the current directory, so:
+#
+#   cd samples\component-console
+#   dcc32 SampleSimple.dpr
+#   dcc32 SampleConsole.dpr
+#   dcc32 SampleServer.dpr
+#
+# all pick up the search paths below without any extra flags. dcc64.cfg
+# is a sibling for the 64-bit compiler — the contents are identical.
+#
+# RAD Studio IDE users: open Sample{Simple,Console,Server}.dproj instead;
+# the dproj already has the same search path baked in as DCC_UnitSearchPath
+# and reads more naturally in the Project Manager.
+
+# Unit search paths — every src/pkg/* directory the main pasclaw binary
+# uses, relative to samples/component-console/.
+-U..\..\src\cmd
+-U..\..\src\pkg\cliui
+-U..\..\src\pkg\utils
+-U..\..\src\pkg\logger
+-U..\..\src\pkg\config
+-U..\..\src\pkg\json
+-U..\..\src\pkg\providers
+-U..\..\src\pkg\tokenizer
+-U..\..\src\pkg\tools
+-U..\..\src\pkg\mcp
+-U..\..\src\pkg\gateway
+-U..\..\src\pkg\channels
+-U..\..\src\pkg\crypto
+-U..\..\src\pkg\net
+-U..\..\src\pkg\search
+-U..\..\src\pkg\cron
+-U..\..\src\pkg\skills
+-U..\..\src\pkg\agent
+-U..\..\src\pkg\memory
+-U..\..\src\pkg\updater
+-U..\..\src\pkg\membench
+-U..\..\src\pkg\tui
+-U..\..\src\pkg\platform
+-U..\..\src\pkg\hashline
+-U..\..\src\pkg\component
+-U..\..\src\pkg\vendor\dmvcframework
+
+# Namespace prefixes — mirror PasClaw.dproj so bare unit names ("SysUtils",
+# "Classes", "Windows") resolve to their qualified counterparts. Without
+# this, dcc32 emits F2613 Unit 'SysUtils' not found because the RTL only
+# ships System.SysUtils.dcu on modern Delphi.
+-NSSystem;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix
+
+# Unit aliases — legacy Windows API unit names.
+-AWinTypes=Winapi.Windows;WinProcs=Winapi.Windows

--- a/samples/component-console/dcc64.cfg
+++ b/samples/component-console/dcc64.cfg
@@ -1,0 +1,53 @@
+# dcc32.cfg — shared cmdline build config for Sample{Console,Simple,Server}.dpr
+#
+# dcc32 auto-loads dcc32.cfg from the current directory, so:
+#
+#   cd samples\component-console
+#   dcc32 SampleSimple.dpr
+#   dcc32 SampleConsole.dpr
+#   dcc32 SampleServer.dpr
+#
+# all pick up the search paths below without any extra flags. dcc64.cfg
+# is a sibling for the 64-bit compiler — the contents are identical.
+#
+# RAD Studio IDE users: open Sample{Simple,Console,Server}.dproj instead;
+# the dproj already has the same search path baked in as DCC_UnitSearchPath
+# and reads more naturally in the Project Manager.
+
+# Unit search paths — every src/pkg/* directory the main pasclaw binary
+# uses, relative to samples/component-console/.
+-U..\..\src\cmd
+-U..\..\src\pkg\cliui
+-U..\..\src\pkg\utils
+-U..\..\src\pkg\logger
+-U..\..\src\pkg\config
+-U..\..\src\pkg\json
+-U..\..\src\pkg\providers
+-U..\..\src\pkg\tokenizer
+-U..\..\src\pkg\tools
+-U..\..\src\pkg\mcp
+-U..\..\src\pkg\gateway
+-U..\..\src\pkg\channels
+-U..\..\src\pkg\crypto
+-U..\..\src\pkg\net
+-U..\..\src\pkg\search
+-U..\..\src\pkg\cron
+-U..\..\src\pkg\skills
+-U..\..\src\pkg\agent
+-U..\..\src\pkg\memory
+-U..\..\src\pkg\updater
+-U..\..\src\pkg\membench
+-U..\..\src\pkg\tui
+-U..\..\src\pkg\platform
+-U..\..\src\pkg\hashline
+-U..\..\src\pkg\component
+-U..\..\src\pkg\vendor\dmvcframework
+
+# Namespace prefixes — mirror PasClaw.dproj so bare unit names ("SysUtils",
+# "Classes", "Windows") resolve to their qualified counterparts. Without
+# this, dcc32 emits F2613 Unit 'SysUtils' not found because the RTL only
+# ships System.SysUtils.dcu on modern Delphi.
+-NSSystem;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix
+
+# Unit aliases — legacy Windows API unit names.
+-AWinTypes=Winapi.Windows;WinProcs=Winapi.Windows


### PR DESCRIPTION
## Summary

Building any sample under Delphi fails with:

```
[dcc32 Fatal Error] SampleServer.dpr(52): F2613 Unit 'PasClaw.Agent' not found.
[dcc32 Fatal Error] PasClaw.Tools.WebSearch.pas(45): F2613 Unit 'PasClaw.Search.Types' not found.
```

`samples/component-console/` previously had only `.dpr` source files and an FPC `Makefile`. The Delphi toolchain (`dcc32` / `dcc64` / RAD Studio / `msbuild`) had no search path beyond the sample directory itself, so the first `PasClaw.*` unit in the sample's `uses` clause failed; after a partial fix in user setup, the next failure landed inside the transitive `PasClaw.Tools.WebSearch` path on `PasClaw.Search.Types`.

## Fix — five new files in `samples/component-console/`

```
SampleConsole.dproj
SampleSimple.dproj
SampleServer.dproj
dcc32.cfg
dcc64.cfg
```

Each `.dproj` mirrors `src/pasclaw/PasClaw.dproj`'s structure but with the search path re-rooted at `..\..\src\`:

| Setting | Value |
|---|---|
| `DCC_UnitSearchPath` | every `src/pkg/*` directory the main pasclaw binary uses — cliui, utils, logger, config, json, providers, tokenizer, tools, mcp, gateway, channels, crypto, net, search, cron, skills, agent, memory, updater, membench, tui, platform, hashline, component, vendor/dmvcframework, plus cmd. Same 26 entries as the main dproj. |
| `DCC_Namespace` | `System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix` so bare `SysUtils` etc. resolve under modern Delphi where only `System.SysUtils` ships. |
| `DCC_UnitAlias` | `WinTypes=Winapi.Windows;WinProcs=Winapi.Windows` for legacy Windows API names. |
| `DCC_UsePackage` | `vcl;rtl` on Win32/Win64 — same as `PasClaw.dproj`, so Indy resolves from RAD Studio's bundled package, no vendoring on Delphi. |
| `TargetedPlatforms` | Win32 + Win64. Linux64 omitted on samples since the FPC Makefile covers Linux end-to-end. |
| `DCC_ExeOutput` | `..\..\build\delphi\<Platform>\<Config>` to mirror `PasClaw.dproj`. |

`dcc32.cfg` + `dcc64.cfg` are the cmdline-only complement: `dcc32` auto-loads `dcc32.cfg` from the current directory, so

```
cd samples\component-console
dcc32 SampleSimple.dpr
```

picks up the same `-U` / `-NS` / `-A` flags without going through `msbuild` on the dproj. `dcc64.cfg` is a byte-for-byte copy because search-path semantics are identical for the 64-bit compiler.

GUIDs are unique per dproj. Sample `.dpr` headers now enumerate three build flows: `make` (FPC), `msbuild SampleX.dproj` (Delphi), `dcc32 SampleX.dpr` (Delphi cmdline). Sample `Makefile` header gets a paragraph pointing to the new dprojs and cfgs.

## Verification

- FPC sample build (`make clean && make`) still produces all three binaries (no regression).
- Each new `.dproj` parses as well-formed XML via Python's `ET.parse` — full dcc32 validation requires actual Delphi which this Linux container doesn't ship.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_