### PR TITLE
agent/server: code-driven provider config via SetProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ var
 begin
   Agent := TPasClawAgent.Create('claude-opus-4-7');
   try
+    Agent.SetProvider('anthropic', GetEnvironmentVariable('ANTHROPIC_API_KEY'));
     Agent.RegisterTool(TWebSearchTool.Create);
     Agent.RegisterTool(TWebFetchTool.Create);
     Agent.RegisterTool(TFileSystemTool.Create);
@@ -448,6 +449,8 @@ begin
   end;
 end;
 ```
+
+`SetProvider(Kind, APIKey)` builds a `TProviderConfig` in-memory from the catalog entry for `Kind` (`anthropic`, `openai`, `gemini`, `groq`, `ollama`, etc. — see `PasClaw.Providers.Catalog`) plus the API key the caller hands in. The catalog supplies the default base URL and default model; both can be overridden via the three-arg and four-arg `SetProvider` overloads. This lets an embedded binary run without ever touching `~/.pasclaw/config.json` — set the env var, ship the binary, done.
 
 `Run` raises `EPasClawRun` on failure; use `Chat(prompt, reply, err): Boolean` when you'd rather not unwind exceptions. `RegisterTool` takes ownership of the `TPasClawTool` instance and frees it with the agent.
 
@@ -473,6 +476,7 @@ var
 begin
   Server := TPasClawServer.Create('0.0.0.0', 8088);
   try
+    Server.SetProvider('anthropic', GetEnvironmentVariable('ANTHROPIC_API_KEY'));
     Server.RegisterTool(TWebSearchTool.Create);
     Server.Run;  { blocks until Stop is signalled from another thread }
   finally
@@ -480,6 +484,8 @@ begin
   end;
 end;
 ```
+
+`SetProvider` works the same way as on `TPasClawAgent` — call it before `Start` and the gateway boots with the in-memory provider config.
 
 `Run` does `Start + WaitForStop` in one call and raises `EPasClawRun` if startup fails. Use `Start` / `WaitForStop` / `Stop` separately when you need to do something between binding the socket and entering the wait. SIGINT handling is the embedder's problem — most hosting apps already have their own signal-handling strategy, so the component doesn't install one.
 

--- a/samples/component-console/SampleServer.dpr
+++ b/samples/component-console/SampleServer.dpr
@@ -32,13 +32,20 @@
     dcc32 SampleServer.dpr        # cmdline only — dcc32.cfg in this dir
                                   # carries the search paths
 
-  Runtime: the server inherits config from ~/.pasclaw/config.json,
-  so run `pasclaw onboard` and `pasclaw auth login <provider>` once
-  first. Then test from another shell:
+  Runtime:
+    export ANTHROPIC_API_KEY=sk-ant-...
+    ./build/SampleServer
+
+  Then test from another shell:
 
     curl http://localhost:8088/v1/chat/completions \
       -H 'content-type: application/json' \
       -d '{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}'
+
+  SetProvider is configured in code below — no ~/.pasclaw/config.json
+  or `pasclaw onboard` required. Swap to "openai" / "gemini" / "groq"
+  / "ollama" via the Kind argument; see PasClaw.Providers.Catalog
+  for the full list.
 *)
 program SampleServer;
 
@@ -59,9 +66,18 @@ uses
 
 var
   Server: TPasClawServer;
+  ApiKey: string;
 begin
+  ApiKey := GetEnvironmentVariable('ANTHROPIC_API_KEY');
+  if ApiKey = '' then
+  begin
+    WriteLn('ANTHROPIC_API_KEY not set — export it and re-run.');
+    Halt(2);
+  end;
+
   Server := TPasClawServer.Create('0.0.0.0', 8088);
   try
+    Server.SetProvider('anthropic', ApiKey);
     Server.RegisterTool(TWebSearchTool.Create);
     Server.RegisterTool(TWebFetchTool.Create);
     Server.RegisterTool(TFileSystemTool.Create);

--- a/samples/component-console/SampleSimple.dpr
+++ b/samples/component-console/SampleSimple.dpr
@@ -5,9 +5,13 @@
   property-driven API). This file shows the code-friendly API:
 
     1. Pass the model name directly to Create.
-    2. Register tools as class instances rather than as records
+    2. Configure the provider in code with SetProvider — no
+       ~/.pasclaw/config.json or `pasclaw onboard` required.
+       The API key is read from an env var so the binary doesn't
+       carry secrets.
+    3. Register tools as class instances rather than as records
        full of function pointers.
-    3. Call Run(prompt): string and let it raise EPasClawRun on
+    4. Call Run(prompt): string and let it raise EPasClawRun on
        failure instead of unpacking a Boolean + out-parameter.
 
   Build (FPC):
@@ -20,10 +24,17 @@
     dcc32 SampleSimple.dpr        # cmdline only — dcc32.cfg in this dir
                                   # carries the search paths
 
-  Runtime: the agent inherits config from ~/.pasclaw/config.json,
-  so run `pasclaw onboard` and `pasclaw auth login <provider>` once
-  first. PASCLAW_AUTH_PROVIDER / PASCLAW_AUTH_TOKEN env vars also
-  work if you'd rather not write to disk.
+  Runtime:
+    export ANTHROPIC_API_KEY=sk-ant-...
+    ./build/SampleSimple
+
+  Switch providers by changing the SetProvider() Kind argument —
+  "openai", "gemini", "groq", "ollama" are all in
+  PasClaw.Providers.Catalog. Each has its own default base URL and
+  expected env var name; the catalog one-liner below covers the
+  Anthropic case end-to-end. If ~/.pasclaw/config.json IS present,
+  the SetProvider call overrides whatever provider entry it had
+  for "anthropic".
 *)
 program SampleSimple;
 
@@ -38,9 +49,18 @@ uses
 
 var
   Agent: TPasClawAgent;
+  ApiKey: string;
 begin
+  ApiKey := GetEnvironmentVariable('ANTHROPIC_API_KEY');
+  if ApiKey = '' then
+  begin
+    WriteLn('ANTHROPIC_API_KEY not set — export it and re-run.');
+    Halt(2);
+  end;
+
   Agent := TPasClawAgent.Create('claude-opus-4-7');
   try
+    Agent.SetProvider('anthropic', ApiKey);
     Agent.RegisterTool(TWebSearchTool.Create);
     Agent.RegisterTool(TWebFetchTool.Create);
     Agent.RegisterTool(TFileSystemTool.Create);

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -96,6 +96,12 @@ type
                                     the registry early without skipping
                                     the lazy built-in install on first
                                     Chat. }
+    FProviderOverride:    TProviderConfig;  { populated by SetProvider, then
+                                              folded into FConfig.Providers
+                                              when EnsureConfig runs (if before
+                                              first Chat) or immediately (if
+                                              FConfig is already loaded). }
+    FHasProviderOverride: Boolean;
     FOnText:         TPasClawTextEvent;
     FOnToolCall:     TPasClawToolEvent;
     FOnToolResult:   TPasClawToolResultEvent;
@@ -129,6 +135,30 @@ type
       RegisterTool ensures it exists. }
     procedure RegisterTool(ATool: TPasClawTool);
 
+    { Code-driven provider configuration. Builds a TProviderConfig
+      in-memory from a catalog Kind ("anthropic", "openai", "gemini",
+      etc. — see PasClaw.Providers.Catalog) plus the API key the
+      caller supplies (typically read from an env var). The catalog
+      fills in DefaultBase and DefaultModel; Model/APIBase overloads
+      override either default.
+
+      Effect:
+        * FConfig.Providers gets the new entry appended, or any
+          existing entry with the same Kind replaced.
+        * FConfig.DefaultProvider := Kind.
+        * FConfig.DefaultModel    := (Model or catalog default).
+        * Any cached FProvider is released so the next Chat/Run
+          rebuilds with the new credentials.
+
+      Lets an embedded agent run without a populated
+      ~/.pasclaw/config.json — the binary ships with its own
+      provider config and reads the API key from wherever the
+      embedder chooses. Raises EPasClawRun if Kind isn't in the
+      catalog. }
+    procedure SetProvider(const Kind, APIKey: string); overload;
+    procedure SetProvider(const Kind, APIKey, Model: string); overload;
+    procedure SetProvider(const Kind, APIKey, Model, APIBase: string); overload;
+
     function Chat(const Prompt: string; out Reply, ErrMsg: string): Boolean;
     function ChatHistory(const History: array of TMessage;
                          out Reply, ErrMsg: string): Boolean;
@@ -157,6 +187,8 @@ type
     FRegistry:       TToolRegistry;
     FMCPClients:     TMCPClientList;
     FOwnedTools:     TObjectList;     { TPasClawTool instances handed in via RegisterTool }
+    FProviderOverride:    TProviderConfig;  { same purpose as TPasClawAgent's }
+    FHasProviderOverride: Boolean;
     FServer:         TGatewayServer;
     FThread:         TThread;
     FStopSignal:     TEvent;          { lives as long as TPasClawServer itself; WaitForStop
@@ -205,6 +237,18 @@ type
       EnableTools := False the server still installs OOP tools the
       caller hands us, so a custom-only registry is achievable. }
     procedure RegisterTool(ATool: TPasClawTool);
+
+    { Code-driven provider configuration. Same shape as
+      TPasClawAgent.SetProvider — see that method's header for the
+      contract. Must be called BEFORE Start; the override is applied
+      after LoadConfig in Start. Calling after Start is a no-op
+      because TGatewayServer was already constructed with the
+      previous provider; Stop / SetProvider / Start cleanly restarts
+      with the new one. }
+    procedure SetProvider(const Kind, APIKey: string); overload;
+    procedure SetProvider(const Kind, APIKey, Model: string); overload;
+    procedure SetProvider(const Kind, APIKey, Model, APIBase: string); overload;
+
     property Server: TGatewayServer read FServer;
     property LastError: string read FLastError;
   published
@@ -228,6 +272,7 @@ implementation
 
 uses
   PasClaw.Cmd.Root,
+  PasClaw.Providers.Catalog,
   PasClaw.Providers.Factory,
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
@@ -238,6 +283,53 @@ uses
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
   PasClaw.Tools.ToolLoop;
+
+{ ------------------------------ helpers ------------------------------ }
+
+{ Build a TProviderConfig for catalog Kind, filling APIBase and Model
+  from the catalog defaults when the caller didn't override them.
+  Raises EPasClawRun if Kind isn't in the catalog. }
+function BuildProviderOverride(const Kind, APIKey, Model, APIBase: string): TProviderConfig;
+var
+  Spec: TProviderSpec;
+begin
+  if not LookupProvider(Kind, Spec) then
+    raise EPasClawRun.CreateFmt(
+      'unknown provider kind "%s" — see PasClaw.Providers.Catalog ' +
+      'for the canonical list (anthropic / openai / gemini / ...)',
+      [Kind]);
+  Result.Name    := Kind;
+  Result.Kind    := Kind;
+  Result.APIBase := APIBase;
+  if Result.APIBase = '' then Result.APIBase := Spec.DefaultBase;
+  Result.APIKey  := APIKey;
+  Result.Model   := Model;
+  if Result.Model = '' then Result.Model := Spec.DefaultModel;
+end;
+
+{ Fold the override into Cfg: replace any existing Provider with the
+  same Kind, or append; promote to default. Used by both
+  TPasClawAgent.EnsureConfig and TPasClawServer.Start. }
+procedure ApplyProviderOverride(var Cfg: TConfig; const Override: TProviderConfig);
+var
+  i, Idx: Integer;
+begin
+  Idx := -1;
+  for i := 0 to High(Cfg.Providers) do
+    if SameText(Cfg.Providers[i].Kind, Override.Kind) then
+    begin
+      Idx := i;
+      Break;
+    end;
+  if Idx < 0 then
+  begin
+    SetLength(Cfg.Providers, Length(Cfg.Providers) + 1);
+    Idx := High(Cfg.Providers);
+  end;
+  Cfg.Providers[Idx] := Override;
+  Cfg.DefaultProvider := Override.Kind;
+  if Override.Model <> '' then Cfg.DefaultModel := Override.Model;
+end;
 
 var
   { Tracks the live instance of each component class. Set in the
@@ -291,6 +383,12 @@ begin
       The component sits next to the CLI in one process so this is
       the same global state Cmd.Agent / Cmd.Serve seed at startup. }
     ConfigureSandbox(FConfig.Sandbox, '');
+    { Fold in any provider configured in code via SetProvider. Has
+      to land AFTER LoadConfig so a code-supplied entry wins over
+      whatever ~/.pasclaw/config.json had, and BEFORE
+      EnsureProvider runs so NewProviderFromConfig sees it. }
+    if FHasProviderOverride then
+      ApplyProviderOverride(FConfig, FProviderOverride);
   end;
 end;
 
@@ -370,6 +468,37 @@ begin
     FRegistry := TToolRegistry.Create;
   FOwnedTools.Add(ATool);
   ATool.Install(FRegistry);
+end;
+
+procedure TPasClawAgent.SetProvider(const Kind, APIKey: string);
+begin
+  SetProvider(Kind, APIKey, '', '');
+end;
+
+procedure TPasClawAgent.SetProvider(const Kind, APIKey, Model: string);
+begin
+  SetProvider(Kind, APIKey, Model, '');
+end;
+
+procedure TPasClawAgent.SetProvider(const Kind, APIKey, Model, APIBase: string);
+begin
+  FProviderOverride    := BuildProviderOverride(Kind, APIKey, Model, APIBase);
+  FHasProviderOverride := True;
+  { If FConfig is already loaded (later SetProvider calls after a
+    first Chat), apply now so subsequent Chats see the change.
+    Otherwise EnsureConfig will pick it up when it first loads. }
+  if FConfig <> nil then
+    ApplyProviderOverride(FConfig, FProviderOverride);
+  { Drop any cached provider so EnsureProvider rebuilds with the
+    new credentials on the next Chat. }
+  FProvider := nil;
+  { If the caller didn't pick a model on TPasClawAgent, mirror the
+    catalog default into FModel so EnsureProvider's model lookup
+    sees it. ChatHistory falls back to FConfig.DefaultModel when
+    FModel is empty so this is technically redundant, but keeping
+    the two in sync matches what a user typing it manually expects. }
+  if (FModel = '') and (FProviderOverride.Model <> '') then
+    FModel := FProviderOverride.Model;
 end;
 
 procedure TPasClawAgent.ForwardText(const S: string);
@@ -600,6 +729,11 @@ begin
 
   FConfig := LoadConfig;
   ConfigureSandbox(FConfig.Sandbox, '');
+  { Fold in the code-supplied provider (from SetProvider) AFTER
+    LoadConfig and BEFORE the NewProviderFromConfig block below,
+    so the synthetic entry is the one the gateway boots with. }
+  if FHasProviderOverride then
+    ApplyProviderOverride(FConfig, FProviderOverride);
   if FModel <> '' then
     FConfig.DefaultModel := FModel;
 
@@ -739,6 +873,30 @@ begin
   FOwnedTools.Add(ATool);
   if FRegistry <> nil then
     ATool.Install(FRegistry);
+end;
+
+procedure TPasClawServer.SetProvider(const Kind, APIKey: string);
+begin
+  SetProvider(Kind, APIKey, '', '');
+end;
+
+procedure TPasClawServer.SetProvider(const Kind, APIKey, Model: string);
+begin
+  SetProvider(Kind, APIKey, Model, '');
+end;
+
+procedure TPasClawServer.SetProvider(const Kind, APIKey, Model, APIBase: string);
+begin
+  FProviderOverride    := BuildProviderOverride(Kind, APIKey, Model, APIBase);
+  FHasProviderOverride := True;
+  { Mirror the catalog default into FModel so Start's
+    `if FModel <> '' then FConfig.DefaultModel := FModel` picks
+    it up. The Start path also calls ApplyProviderOverride which
+    re-applies the same DefaultModel, so the assignment here is
+    belt-and-suspenders for the case where the embedder later
+    sets FModel manually before Start. }
+  if (FModel = '') and (FProviderOverride.Model <> '') then
+    FModel := FProviderOverride.Model;
 end;
 
 { ============================== Registration ============================== }


### PR DESCRIPTION
## Summary

Closes the gap that made the samples awkward: you couldn't fully configure an embedded `TPasClawAgent` or `TPasClawServer` without running `pasclaw onboard` + `pasclaw auth login <provider>` on the same machine first, because `LoadConfig` was the only path to a populated `TConfig.Providers`.

Now you can:

```pascal
Agent := TPasClawAgent.Create('claude-opus-4-7');
Agent.SetProvider('anthropic', GetEnvironmentVariable('ANTHROPIC_API_KEY'));
Agent.RegisterTool(TWebSearchTool.Create);
WriteLn(Agent.Run('hi'));
```

No `~/.pasclaw/config.json` required. Same shape on `TPasClawServer`.

## What's new

Three overloads on each component:

```pascal
procedure SetProvider(const Kind, APIKey: string);
procedure SetProvider(const Kind, APIKey, Model: string);
procedure SetProvider(const Kind, APIKey, Model, APIBase: string);
```

`Kind` is a catalog identifier (`anthropic`, `openai`, `gemini`, `groq`, `ollama`, ...) — anything `LookupProvider` in `PasClaw.Providers.Catalog` recognises. The catalog supplies the default base URL and default model; `Model` and `APIBase` overloads override either.

## Implementation pattern (mirrors `pasclaw auth login`)

1. **`SetProvider` builds a `TProviderConfig` in-memory** via `BuildProviderOverride`. Raises `EPasClawRun` if `Kind` isn't a catalog entry — caught early so embedders see a clear error instead of "provider unavailable" at first `Chat`.

2. **Stashed in `FProviderOverride` / `FHasProviderOverride`**. Folded into `FConfig.Providers` at the right point in the lifecycle:
   - `TPasClawAgent.EnsureConfig`: after `LoadConfig`, before `EnsureProvider` runs.
   - `TPasClawServer.Start`: after `LoadConfig`, before the `NewProviderFromConfig` block.

   Works whether or not `~/.pasclaw/config.json` exists.

3. **`ApplyProviderOverride`** finds an existing same-`Kind` entry and replaces it, or appends. Promotes `Kind` to `DefaultProvider` and the override's `Model` to `DefaultModel`. Same shape `pasclaw auth login` writes when it updates credentials in place.

4. **`TPasClawAgent`** calls `ApplyProviderOverride` immediately when `SetProvider` is invoked after `Chat` has already run (`FConfig` already loaded), and drops `FProvider` so the next `Chat` picks up new credentials.

## Sample updates

Both `SampleSimple.dpr` and `SampleServer.dpr` now:
- Read `ANTHROPIC_API_KEY` from the env (`Halt(2)` with a clear "not set — export and re-run" message when missing)
- Call `SetProvider('anthropic', ApiKey)`
- Proceed normally — no `~/.pasclaw/config.json` required

README "Embedding in your own app" section rewritten to show `SetProvider` in both snippets, with a one-sentence explanation that the catalog supplies defaults and embedders override only what they need.

## Verification

| Check | Result |
|---|---|
| `make clean && make smoke` | 11/11 OK |
| `cd samples/component-console && make` | All three sample binaries (Console, Simple, Server) build clean |
| `./build/SampleSimple` (no env) | Prints "ANTHROPIC_API_KEY not set — export it and re-run.", halts cleanly |
| `ANTHROPIC_API_KEY=sk-ant-fake ./build/SampleSimple` | Runs all the way through `SetProvider → ApplyProviderOverride → NewProviderFromConfig` and reaches the actual HTTPS call — only stops at TLS (libcrypto not in build dir, unrelated to this PR) |

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_