### PR TITLE
tools: parallel dispatch of read-only tool calls in RunToolLoop

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -161,6 +161,7 @@ begin
   Result.Registry      := Reg;
   Result.Model         := Model;
   Result.MaxIterations := A.MaxIterations;
+  Result.Parallel := True;
   Result.Options       := DefaultChatOptions;
   { ToolsEnabled tracks the registry we are about to hand RunToolLoop
     so the system prompt stays in sync with what the model can

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -582,6 +582,7 @@ begin
   Cfg.Registry      := FRegistry;
   Cfg.Model         := ModelName;
   Cfg.MaxIterations := FMaxIterations;
+  Cfg.Parallel := True;
   Cfg.Options       := DefaultChatOptions;
   { Derive ToolsEnabled from the registry we are about to hand to
     RunToolLoop, NOT from FUseTools. EnsureRegistry caches FRegistry

--- a/src/pkg/channels/PasClaw.Channels.Discord.pas
+++ b/src/pkg/channels/PasClaw.Channels.Discord.pas
@@ -234,6 +234,7 @@ begin
         LoopCfg.Registry      := FRegistry;
         LoopCfg.Model         := FCfg.DefaultModel;
         LoopCfg.MaxIterations := 6;
+        LoopCfg.Parallel := True;
         LoopCfg.Options       := DefaultChatOptions;
         LoopCfg.OnText        := nil;
         LoopCfg.OnToolCall    := nil;

--- a/src/pkg/channels/PasClaw.Channels.IRC.pas
+++ b/src/pkg/channels/PasClaw.Channels.IRC.pas
@@ -219,6 +219,7 @@ begin
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 6;
+  LoopCfg.Parallel := True;
   LoopCfg.Options       := DefaultChatOptions;
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -285,6 +285,7 @@ begin
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 6;
+  LoopCfg.Parallel := True;
   LoopCfg.Options       := DefaultChatOptions;
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;

--- a/src/pkg/channels/PasClaw.Channels.Matrix.pas
+++ b/src/pkg/channels/PasClaw.Channels.Matrix.pas
@@ -387,6 +387,7 @@ begin
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 6;
+  LoopCfg.Parallel := True;
   LoopCfg.Options       := DefaultChatOptions;
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -158,6 +158,7 @@ begin
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 6;
+  LoopCfg.Parallel := True;
   LoopCfg.Options       := DefaultChatOptions;
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -310,6 +310,7 @@ begin
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 6;
+  LoopCfg.Parallel := True;
   LoopCfg.Options       := DefaultChatOptions;
   LoopCfg.OnText        := nil;
   LoopCfg.OnToolCall    := nil;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -985,6 +985,7 @@ begin
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 8;
+  LoopCfg.Parallel := True;
   LoopCfg.Options       := DefaultChatOptions;
   LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', LoopCfg.Registry <> nil);
   LoopCfg.OnText        := nil;
@@ -1512,6 +1513,7 @@ begin
     LoopCfg.Registry      := FRegistry;
     LoopCfg.Model         := ReqModel;
     LoopCfg.MaxIterations := FMaxIter;
+    LoopCfg.Parallel := True;
     LoopCfg.Options       := DefaultChatOptions;
     { Inject the composed PasClaw system prompt — but only if the client
       didn't already supply one of their own. Third-party tooling calling
@@ -3000,6 +3002,7 @@ begin
       LoopCfg.Registry      := FRegistry;
       LoopCfg.Model         := ReqModel;
       LoopCfg.MaxIterations := FMaxIter;
+      LoopCfg.Parallel := True;
       LoopCfg.Options       := DefaultChatOptions;
       if not HasSystemMessage(Msgs) then
         LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '', LoopCfg.Registry <> nil);

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -513,8 +513,9 @@ begin
     T.Description := 'Read the contents of a file from the local filesystem.';
     T.Schema      := '{"type":"object","properties":{"path":{"type":"string","description":"Absolute or relative path to the file."}},"required":["path"]}';
   end;
-  T.Handler := Tool_FSRead;
-  T.IsCore  := True;
+  T.Handler  := Tool_FSRead;
+  T.IsCore   := True;
+  T.Category := tcReadOnly;
   R.Register(T);
 
   T.Name := 'fs_write';
@@ -523,9 +524,10 @@ begin
                      'Strips hashline LINENO: prefixes from `content` when every non-empty line carries one.'
   else
     T.Description := 'Write a string to a file (overwrites). Creates parent dirs.';
-  T.Schema  := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
-  T.Handler := Tool_FSWrite;
-  T.IsCore  := True;
+  T.Schema   := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
+  T.Handler  := Tool_FSWrite;
+  T.IsCore   := True;
+  T.Category := tcMutating;
   R.Register(T);
 
   T.Name        := 'fs_list';
@@ -533,6 +535,7 @@ begin
   T.Schema      := '{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}';
   T.Handler     := Tool_FSList;
   T.IsCore      := True;
+  T.Category    := tcReadOnly;
   R.Register(T);
 
   { Hashline-only tools: skip registration entirely when UseHashline is False
@@ -549,6 +552,7 @@ begin
     T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
     T.Handler     := Tool_FSEditHashline;
     T.IsCore      := True;
+    T.Category    := tcMutating;
     R.Register(T);
 
     T.Name        := 'fs_grep';
@@ -558,6 +562,7 @@ begin
     T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"pattern":{"type":"string"},"ignore_case":{"type":"boolean"},"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"}},"required":["path","pattern"]}';
     T.Handler     := Tool_FSGrep;
     T.IsCore      := True;
+    T.Category    := tcReadOnly;
     R.Register(T);
   end;
 end;

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -175,6 +175,7 @@ begin
     '},"required":["query"]}';
   T.Handler     := Tool_MemorySearch;
   T.IsCore      := True;
+  T.Category    := tcReadOnly;  { SQLite SELECT only }
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.Obj.pas
+++ b/src/pkg/tools/PasClaw.Tools.Obj.pas
@@ -59,6 +59,13 @@ type
     function Description: string; virtual;
     function Schema:      string; virtual;
     function Run(const ArgsJSON: string; out ErrMsg: string): string; virtual;
+
+    { Override to tcReadOnly if your Run does no shared-state mutation
+      — that lets the agent loop fan out concurrent calls to your tool
+      alongside other read-only tools in the same model turn. Default is
+      tcMutating for safety: a custom tool author who forgets to set
+      Category gets serial dispatch, never an accidental race. }
+    function Category: TToolCategory; virtual;
   end;
 
 implementation
@@ -73,12 +80,14 @@ begin
   T.Handler     := nil;
   T.HandlerObj  := Self.Run;
   T.IsCore      := False;
+  T.Category    := Category;
   R.Register(T);
 end;
 
 function TPasClawTool.Name:        string; begin Result := ''; end;
 function TPasClawTool.Description: string; begin Result := ''; end;
 function TPasClawTool.Schema:      string; begin Result := '{"type":"object"}'; end;
+function TPasClawTool.Category:    TToolCategory; begin Result := tcMutating; end;
 
 function TPasClawTool.Run(const ArgsJSON: string; out ErrMsg: string): string;
 begin

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -97,6 +97,7 @@ begin
   T.Schema      := '{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute."}},"required":["command"]}';
   T.Handler     := Tool_Shell;
   T.IsCore      := True;
+  T.Category    := tcMutating;  { spawns subprocesses; default-mutating is correct }
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -37,6 +37,15 @@ type
        and the OnBefore memory-flush hook). *)
     CompactEnabled: Boolean;
     CompactOpts:    TCompactOptions;
+    (* Parallel tool dispatch. When True, RunToolLoop partitions each
+       round's tool calls into batches: consecutive tcReadOnly calls
+       (see PasClaw.Tools.Types.TToolCategory) form one parallel batch
+       and run on dedicated worker threads; each tcMutating call is a
+       batch of one and runs serially. When False, every call runs
+       serially in array order — same as the pre-parallel behaviour.
+       Default False on the record (zero-init); the CLI and the
+       built-in components flip it on explicitly. *)
+    Parallel:       Boolean;
   end;
 
   TToolLoopResult = record
@@ -64,7 +73,37 @@ implementation
 uses
   PasClaw.Logger,
   PasClaw.JSON,
-  PasClaw.Hashline;
+  PasClaw.Hashline,
+  PasClaw.Tools.Types;
+
+type
+  { Per-call work unit. The same record is filled in by a worker thread
+    (parallel) or by an inline call (serial), then read by the main
+    loop to append the tool_result to history. Workers never touch the
+    history array directly — race-free by construction. }
+  TToolCallDispatch = record
+    Call:       TToolCall;
+    ResultText: string;
+    Err:        string;
+  end;
+  PToolCallDispatch = ^TToolCallDispatch;
+
+  { Worker thread that runs one tool call's PreflightToolCall +
+    Registry.RunTool + hashline retry logic, writes the result back
+    into a TToolCallDispatch slot, exits. FreeOnTerminate is False —
+    the main thread WaitFor's then Free's each worker in array order. }
+  TToolCallWorker = class(TThread)
+  private
+    FCfg:  TToolLoopConfig;
+    FSlot: PToolCallDispatch;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(const ACfg: TToolLoopConfig; ASlot: PToolCallDispatch);
+  end;
+
+  TToolBatch      = array of Integer;        { indices into Resp.ToolCalls }
+  TToolBatchArray = array of TToolBatch;
 
 function IsPatchFormatError(const Err: string): Boolean;
 var
@@ -185,18 +224,162 @@ begin
   Result.ToolCallId := ToolCallId;
 end;
 
+{ Run one tool call: PreflightToolCall → Registry.RunTool → fs_edit_hashline
+  retry on format errors. Writes ResultText / Err into the dispatch slot.
+  Pure with respect to shared state (uses per-call HTTP clients, reads
+  the registry's name table read-only, calls thread-safe LogWarn), so it
+  is safe to call from a worker thread alongside other DispatchOneToolCall
+  invocations against different ToolCall inputs. Callers fire
+  OnToolCall / OnToolResult on the main thread before / after; we
+  deliberately don't invoke them in here to keep the worker stateless
+  with respect to the embedder's event-handler thread affinity. }
+procedure DispatchOneToolCall(const Cfg: TToolLoopConfig;
+                               var D: TToolCallDispatch);
+var
+  RetryArgs, Patch, CanonicalPatch, N1, N2: string;
+  ArgsObj: TJsonObject;
+  HasUnsup: Boolean;
+begin
+  D.Err        := '';
+  D.ResultText := '';
+  RetryArgs    := D.Call.Func.Arguments;
+  if not PreflightToolCall(D.Call.Func.Name, RetryArgs, D.Err) then
+    D.ResultText := ''
+  else if Cfg.Registry <> nil then
+    D.ResultText := Cfg.Registry.RunTool(D.Call.Func.Name, RetryArgs, D.Err)
+  else
+    D.Err := 'no tool registry';
+
+  if (D.Call.Func.Name = 'fs_edit_hashline') and IsPatchFormatError(D.Err) then
+  begin
+    LogWarn('tool-retry attempt=1 strategy=raw_hashline normalized_patch_len=%d has_unsupported_tokens=%s class=format_error',
+      [Length(NormalizePatchForCompare(RetryArgs)), BoolToStr(False, True)]);
+    ArgsObj := TJsonObject.Parse(RetryArgs);
+    Patch := '';
+    if ArgsObj <> nil then
+    begin
+      try
+        Patch := ArgsObj.GetStr('patch', '');
+      finally
+        ArgsObj.Free;
+      end;
+    end;
+    if (Patch <> '') and CanonicalizeHashlinePatch(Patch, CanonicalPatch, HasUnsup) then
+    begin
+      ArgsObj := TJsonObject.Create;
+      try
+        ArgsObj.PutStr('patch', CanonicalPatch);
+        RetryArgs := ArgsObj.ToJSON;
+      finally
+        ArgsObj.Free;
+      end;
+      N1 := NormalizePatchForCompare(Patch);
+      N2 := NormalizePatchForCompare(CanonicalPatch);
+      LogWarn('tool-retry attempt=2 strategy=strict_hashline_formatter normalized_patch_len=%d has_unsupported_tokens=%s class=format_error',
+        [Length(N2), BoolToStr(HasUnsup, True)]);
+      D.Err := '';
+      if not PreflightToolCall(D.Call.Func.Name, RetryArgs, D.Err) then
+        D.ResultText := ''
+      else if Cfg.Registry <> nil then
+        D.ResultText := Cfg.Registry.RunTool(D.Call.Func.Name, RetryArgs, D.Err)
+      else
+        D.Err := 'no tool registry';
+      if IsPatchFormatError(D.Err) and (N1 = N2) then
+        D.Err := 'format_error: deterministic fallback exhausted; two consecutive retries had equivalent normalized patch content. ' +
+                 'Regenerate patch intent or use safer apply-patch/unified-diff edit path.';
+    end
+    else
+      D.Err := 'format_error: unable to canonicalize patch for deterministic retry; regenerate patch intent or use safer apply-patch/unified-diff edit path. original=' + D.Err;
+  end;
+end;
+
+constructor TToolCallWorker.Create(const ACfg: TToolLoopConfig;
+                                    ASlot: PToolCallDispatch);
+begin
+  inherited Create(True);  { suspended; main thread calls Start after all workers in the batch are constructed }
+  FreeOnTerminate := False;
+  FCfg  := ACfg;
+  FSlot := ASlot;
+end;
+
+procedure TToolCallWorker.Execute;
+begin
+  try
+    DispatchOneToolCall(FCfg, FSlot^);
+  except
+    on E: Exception do
+    begin
+      FSlot^.ResultText := '';
+      FSlot^.Err        := 'worker exception: ' + E.ClassName + ': ' + E.Message;
+    end;
+  end;
+end;
+
+{ Partition a round's tool calls into batches that are safe to run in
+  parallel within each batch. Read-only tools (Category = tcReadOnly)
+  coalesce into one batch; each mutating tool is its own batch of one.
+  Tools not found in the registry are treated as tcMutating (safe
+  default — applies to skill / MCP tools and to any handler that
+  forgot to set the Category field). Order is preserved across
+  batches, so the agent loop appends tool_results in the same order
+  the model emitted tool_use blocks. }
+function PartitionToolBatches(const Calls: TToolCallArray;
+                              Reg: TToolRegistry): TToolBatchArray;
+var
+  i: Integer;
+  IsRO: Boolean;
+  T: TTool;
+  Cur: TToolBatch;
+
+  procedure FlushCur;
+  begin
+    if Length(Cur) > 0 then
+    begin
+      SetLength(Result, Length(Result) + 1);
+      Result[High(Result)] := Cur;
+      SetLength(Cur, 0);
+    end;
+  end;
+
+begin
+  SetLength(Result, 0);
+  SetLength(Cur, 0);
+  for i := 0 to High(Calls) do
+  begin
+    IsRO := False;
+    if (Reg <> nil) and Reg.Find(Calls[i].Func.Name, T) and (T.Category = tcReadOnly) then
+      IsRO := True;
+    if IsRO then
+    begin
+      SetLength(Cur, Length(Cur) + 1);
+      Cur[High(Cur)] := i;
+    end
+    else
+    begin
+      { Flush the in-flight read-only batch (if any), then emit a
+        batch-of-one for the mutating call. }
+      FlushCur;
+      SetLength(Cur, 1);
+      Cur[0] := i;
+      FlushCur;
+    end;
+  end;
+  FlushCur;
+end;
+
 function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
 var
-  Iter, i: Integer;
+  Iter, i, bi, j: Integer;
   Tools: TToolDefinitionArray;
   Resp: TLLMResponse;
   Hist: TMessageArray;
-  ResultText, Err, RetryArgs, Patch, CanonicalPatch, N1, N2: string;
-  ArgsObj: TJsonObject;
-  HasUnsup: Boolean;
   LiveOptions: TChatOptions;
+  Dispatches: array of TToolCallDispatch;
+  Batches: TToolBatchArray;
+  Batch: TToolBatch;
+  Workers: array of TToolCallWorker;
 begin
   Loop.Content    := '';
   Loop.Iterations := 0;
@@ -257,71 +440,79 @@ begin
     SetLength(Hist, Length(Hist) + 1);
     Hist[High(Hist)] := MakeAssistantWithToolCalls(Resp.Content, Resp.ToolCalls);
 
+    { Allocate one dispatch slot per tool call upfront so workers can hold
+      a pointer to a slot without worrying about array reallocation. }
+    SetLength(Dispatches, Length(Resp.ToolCalls));
     for i := 0 to High(Resp.ToolCalls) do
     begin
-      if Assigned(Cfg.OnToolCall) then
-        Cfg.OnToolCall(Resp.ToolCalls[i].Func.Name, Resp.ToolCalls[i].Func.Arguments);
+      Dispatches[i].Call       := Resp.ToolCalls[i];
+      Dispatches[i].ResultText := '';
+      Dispatches[i].Err        := '';
+    end;
 
-      Err := '';
-      ResultText := '';
-      RetryArgs := Resp.ToolCalls[i].Func.Arguments;
-      if not PreflightToolCall(Resp.ToolCalls[i].Func.Name, RetryArgs, Err) then
-        ResultText := ''
-      else if Cfg.Registry <> nil then
-        ResultText := Cfg.Registry.RunTool(Resp.ToolCalls[i].Func.Name, RetryArgs, Err)
-      else
-        Err := 'no tool registry';
+    { Partition into batches: read-only calls fan out concurrently
+      within a batch when Cfg.Parallel is on; mutating calls each
+      get a batch of one and stay serial. Order across batches is
+      preserved, so tool_results land in Hist in the same order the
+      model emitted them. }
+    Batches := PartitionToolBatches(Resp.ToolCalls, Cfg.Registry);
 
-      if (Resp.ToolCalls[i].Func.Name = 'fs_edit_hashline') and IsPatchFormatError(Err) then
+    for bi := 0 to High(Batches) do
+    begin
+      Batch := Batches[bi];
+
+      { Fire OnToolCall for every call in the batch on the main thread,
+        in array order, before any worker starts. Embedders rely on
+        OnToolCall firing before its matching OnToolResult and on the
+        announcements appearing in the same order the model produced
+        the tool_use blocks. }
+      for j := 0 to High(Batch) do
+        if Assigned(Cfg.OnToolCall) then
+          Cfg.OnToolCall(Dispatches[Batch[j]].Call.Func.Name,
+                          Dispatches[Batch[j]].Call.Func.Arguments);
+
+      if Cfg.Parallel and (Length(Batch) > 1) then
       begin
-        LogWarn('tool-retry attempt=1 strategy=raw_hashline normalized_patch_len=%d has_unsupported_tokens=%s class=format_error',
-          [Length(NormalizePatchForCompare(RetryArgs)), BoolToStr(False, True)]);
-        ArgsObj := TJsonObject.Parse(RetryArgs);
-        Patch := '';
-        if ArgsObj <> nil then
+        { Parallel batch: spawn one TThread per call, suspended; Start
+          all in array order; WaitFor all in array order; Free each
+          worker after WaitFor. }
+        SetLength(Workers, Length(Batch));
+        for j := 0 to High(Batch) do
+          Workers[j] := TToolCallWorker.Create(Cfg, @Dispatches[Batch[j]]);
+        for j := 0 to High(Workers) do
+          Workers[j].Start;
+        for j := 0 to High(Workers) do
         begin
-          try
-            Patch := ArgsObj.GetStr('patch', '');
-          finally
-            ArgsObj.Free;
-          end;
+          Workers[j].WaitFor;
+          Workers[j].Free;
         end;
-        if (Patch <> '') and CanonicalizeHashlinePatch(Patch, CanonicalPatch, HasUnsup) then
-        begin
-          ArgsObj := TJsonObject.Create;
-          try
-            ArgsObj.PutStr('patch', CanonicalPatch);
-            RetryArgs := ArgsObj.ToJSON;
-          finally
-            ArgsObj.Free;
-          end;
-          N1 := NormalizePatchForCompare(Patch);
-          N2 := NormalizePatchForCompare(CanonicalPatch);
-          LogWarn('tool-retry attempt=2 strategy=strict_hashline_formatter normalized_patch_len=%d has_unsupported_tokens=%s class=format_error',
-            [Length(N2), BoolToStr(HasUnsup, True)]);
-          Err := '';
-          if not PreflightToolCall(Resp.ToolCalls[i].Func.Name, RetryArgs, Err) then
-            ResultText := ''
-          else if Cfg.Registry <> nil then
-            ResultText := Cfg.Registry.RunTool(Resp.ToolCalls[i].Func.Name, RetryArgs, Err)
-          else
-            Err := 'no tool registry';
-          if IsPatchFormatError(Err) and (N1 = N2) then
-            Err := 'format_error: deterministic fallback exhausted; two consecutive retries had equivalent normalized patch content. ' +
-                   'Regenerate patch intent or use safer apply-patch/unified-diff edit path.';
-        end
-        else
-          Err := 'format_error: unable to canonicalize patch for deterministic retry; regenerate patch intent or use safer apply-patch/unified-diff edit path. original=' + Err;
+        SetLength(Workers, 0);
+      end
+      else
+      begin
+        { Serial batch (or Parallel disabled): just run inline on the
+          main thread. Same DispatchOneToolCall the workers use, so
+          fs_edit_hashline retry semantics are identical. }
+        for j := 0 to High(Batch) do
+          DispatchOneToolCall(Cfg, Dispatches[Batch[j]]);
       end;
 
-      if Assigned(Cfg.OnToolResult) then
-        Cfg.OnToolResult(Resp.ToolCalls[i].Func.Name, ResultText, Err);
-
-      SetLength(Hist, Length(Hist) + 1);
-      if Err <> '' then
-        Hist[High(Hist)] := MakeToolResult(Resp.ToolCalls[i].Id, 'ERROR: ' + Err)
-      else
-        Hist[High(Hist)] := MakeToolResult(Resp.ToolCalls[i].Id, ResultText);
+      { Fire OnToolResult and append tool_result messages on the main
+        thread, in array order, AFTER the whole batch has joined. }
+      for j := 0 to High(Batch) do
+      begin
+        if Assigned(Cfg.OnToolResult) then
+          Cfg.OnToolResult(Dispatches[Batch[j]].Call.Func.Name,
+                           Dispatches[Batch[j]].ResultText,
+                           Dispatches[Batch[j]].Err);
+        SetLength(Hist, Length(Hist) + 1);
+        if Dispatches[Batch[j]].Err <> '' then
+          Hist[High(Hist)] := MakeToolResult(Dispatches[Batch[j]].Call.Id,
+                                              'ERROR: ' + Dispatches[Batch[j]].Err)
+        else
+          Hist[High(Hist)] := MakeToolResult(Dispatches[Batch[j]].Call.Id,
+                                              Dispatches[Batch[j]].ResultText);
+      end;
     end;
   end;
 

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -24,6 +24,25 @@ type
     a top-level function pointer. }
   TToolHandlerObj = function(const ArgsJSON: string; out ErrMsg: string): string of object;
 
+  { Tool category — drives parallel dispatch in PasClaw.Tools.ToolLoop.
+
+    tcMutating: the tool can mutate shared state (filesystem writes,
+                shell subprocesses, MCP-stdio handshakes that share a
+                single stdin pipe, memory writes). MUST run serially —
+                a batch containing one mutating call has size 1, never
+                gets parallelized with siblings.
+
+    tcReadOnly: the tool only reads. Filesystem reads, HTTP GETs,
+                grep / search / list. Multiple read-only calls from a
+                single model turn can fan out concurrently.
+
+    tcMutating is the first (= zero-init) value on purpose: a freshly-
+    allocated TTool record on the stack with the Category field left
+    untouched defaults to "treat as mutating", which is the safe choice
+    when a tool author forgets to set it. Built-in tools and TPasClawTool
+    subclasses explicitly opt into tcReadOnly. }
+  TToolCategory = (tcMutating, tcReadOnly);
+
   TTool = record
     Name:        string;
     Description: string;
@@ -31,6 +50,7 @@ type
     Handler:     TToolHandler;
     HandlerObj:  TToolHandlerObj;
     IsCore:      Boolean;
+    Category:    TToolCategory;
   end;
 
   TToolList = array of TTool;

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -286,6 +286,7 @@ begin
     '},"required":["url"]}';
   T.Handler     := Tool_WebFetch;
   T.IsCore      := True;
+  T.Category    := tcReadOnly;  { HTTP GET only, no shared state }
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.WebSearch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebSearch.pas
@@ -174,6 +174,7 @@ begin
     '},"required":["query"]}';
   T.Handler     := Tool_WebSearch;
   T.IsCore      := True;
+  T.Category    := tcReadOnly;  { HTTP GETs only, no shared state }
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.pas
+++ b/src/pkg/tools/PasClaw.Tools.pas
@@ -31,6 +31,7 @@ unit PasClaw.Tools;
 interface
 
 uses
+  PasClaw.Tools.Types,
   PasClaw.Tools.Obj,
   PasClaw.Tools.Registry;
 
@@ -38,21 +39,26 @@ type
   TWebSearchTool = class(TPasClawTool)
   public
     procedure Install(R: TToolRegistry); override;
+    function Category: TToolCategory; override;
   end;
 
   TWebFetchTool = class(TPasClawTool)
   public
     procedure Install(R: TToolRegistry); override;
+    function Category: TToolCategory; override;
   end;
 
   TShellTool = class(TPasClawTool)
   public
     procedure Install(R: TToolRegistry); override;
+    { Category stays tcMutating from the base class — shell spawns
+      subprocesses, can't safely parallelize. }
   end;
 
   TMemoryTool = class(TPasClawTool)
   public
     procedure Install(R: TToolRegistry); override;
+    function Category: TToolCategory; override;
   end;
 
   TFileSystemTool = class(TPasClawTool)
@@ -61,6 +67,11 @@ type
   public
     constructor Create(UseHashline: Boolean = True); reintroduce;
     procedure Install(R: TToolRegistry); override;
+    { Per-sub-tool categories are set by RegisterFSTools (fs_read /
+      fs_grep / fs_list = tcReadOnly; fs_write / fs_edit = tcMutating).
+      The bundle's own Category isn't used since Install delegates
+      directly to RegisterFSTools rather than going through the
+      default Install path. }
     property UseHashline: Boolean read FUseHashline write FUseHashline;
   end;
 
@@ -78,9 +89,19 @@ begin
   RegisterWebSearchTool(R);
 end;
 
+function TWebSearchTool.Category: TToolCategory;
+begin
+  Result := tcReadOnly;
+end;
+
 procedure TWebFetchTool.Install(R: TToolRegistry);
 begin
   RegisterWebFetchTool(R);
+end;
+
+function TWebFetchTool.Category: TToolCategory;
+begin
+  Result := tcReadOnly;
 end;
 
 procedure TShellTool.Install(R: TToolRegistry);
@@ -91,6 +112,11 @@ end;
 procedure TMemoryTool.Install(R: TToolRegistry);
 begin
   RegisterMemoryTools(R);
+end;
+
+function TMemoryTool.Category: TToolCategory;
+begin
+  Result := tcReadOnly;
 end;
 
 constructor TFileSystemTool.Create(UseHashline: Boolean);

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -237,6 +237,7 @@ begin
   Cfg.Registry      := FRegistry;
   Cfg.Model         := FModel;
   Cfg.MaxIterations := 6;
+  Cfg.Parallel := True;
   Cfg.Options       := DefaultChatOptions;
   Cfg.OnText        := nil;
   Cfg.OnToolCall    := nil;
@@ -422,6 +423,7 @@ begin
   Cfg.Registry      := FRegistry;
   Cfg.Model         := FModel;
   Cfg.MaxIterations := 6;
+  Cfg.Parallel := True;
   Cfg.Options       := DefaultChatOptions;
   Cfg.OnText        := nil;
   Cfg.OnToolCall    := nil;


### PR DESCRIPTION
## Summary

When the model returns multiple `tool_use` blocks in one turn, `RunToolLoop` now runs the read-only ones concurrently on worker threads instead of one-at-a-time. Mutating tools (`fs_write`, `shell`, `fs_edit_hashline`) still serialise — each lands in its own batch of one — so race-prone tools never share the wire.

**Picoclaw** is fully serial (`pkg/agent/pipeline_execute.go`, plain `for-range` loop). **Nanobot** has it as an opt-in flag on `AgentRunSpec` (`nanobot/agent/runner.py`, batched `asyncio.gather`). This PR brings PasClaw to nanobot parity, using the same "categorise tools first, batch by category" insight.

## Implementation

### Tool category metadata

- `PasClaw.Tools.Types.TToolCategory = (tcMutating, tcReadOnly)` — `tcMutating` is the first/zero-init value so a forgotten `Category` on any record-built tool fails closed (never accidentally parallel).
- `TTool.Category` field on the record.
- `TPasClawTool.Category: TToolCategory` virtual, default `tcMutating`. OOP tool authors override to `tcReadOnly` when their `Run` does no shared-state mutation. `Install` propagates `Self.Category` into the TTool record.
- Built-in OOP wrappers in `PasClaw.Tools`: `TWebSearchTool`, `TWebFetchTool`, `TMemoryTool` override → `tcReadOnly`. `TShellTool` stays `tcMutating`. `TFileSystemTool` is a bundle that delegates to `RegisterFSTools` (per-sub-tool category set there).
- Built-in record-based tools explicitly set `Category` on each `Register*` call:
  - **Read-only**: `web_search`, `web_fetch`, `memory_search`, `fs_read`, `fs_grep`, `fs_list`
  - **Mutating**: `fs_write`, `fs_edit_hashline`, `shell_exec`

### Loop dispatch

- `TToolLoopConfig.Parallel: Boolean` (default False on the record — caller opts in).
- `DispatchOneToolCall` function extracted from the old inline for-loop body. Single source of truth for preflight + `Registry.RunTool` + `fs_edit_hashline` retry logic. Pure with respect to shared state (per-call HTTP clients, thread-safe `LogWarn`, read-only sandbox globals).
- `TToolCallWorker: TThread` runs `DispatchOneToolCall` on one `TToolCallDispatch` slot. Suspended on construct, main thread `Start`s + `WaitFor`s + `Free`s in array order.
- `PartitionToolBatches` walks `Resp.ToolCalls`, coalesces consecutive `tcReadOnly` calls into one batch, emits a batch-of-one for every `tcMutating`. Order preserved across batches so `tool_result` history append order matches the model's `tool_use` emit order (Anthropic pairs by id, OpenAI/Gemini pair positionally — both work).
- Rewrote the dispatch block: for each batch, fire all `OnToolCall` in array order on the main thread, then run the batch (parallel if `Cfg.Parallel` and size > 1; serial otherwise), then fire all `OnToolResult` and append `tool_result` messages in array order on the main thread. **Callbacks stay on the main thread** — avoids threading the embedder's Indy/TUI/Form across.

### Opt-in by 12 callers

- `Cmd.Agent` (CLI agent loop)
- `TPasClawAgent.ChatHistory`
- `Gateway.Server` (3 sites — gateway, chat/completions, responses endpoint)
- `TUI.PasClaw.TUI` (interactive TUI)
- 6 channel handlers (Telegram, Discord, LINE, WhatsApp, Matrix, IRC) — same one-line pattern

## Verification

Wall-clock test (built + run + removed; not committed): two `TPasClawTool` subclasses each `Sleep(500ms)`, `tcReadOnly`. Stub `TFakeProvider` returns one round of two `tool_use` blocks then loop-exit. `RunToolLoop` timed both ways:

```
serial   (Parallel=False): 1000 ms
parallel (Parallel=True):   501 ms
speedup: 49.9%
PASS
```

Matches the theoretical max — `max(500, 500) = 500ms` parallel vs `500 + 500 = 1000ms` serial.

`make smoke` 11/11 green. All three samples (Console / Simple / Server) still build.

## Future work

- **MCP-stdio tools** default to `tcMutating` (registered without `Category` set → zero-init falls through to mutating). Correct for now — they share a single stdin/stdout pipe per server. Adding a request-mux lock would let them parallelize too.
- **`max_parallel_tools` cap**: not bounded today. If a runaway agent ever fans out 20+ concurrent web fetches and trips a resource limit, add a queue.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_