### PR TITLE
tools: fix dcc64 E2010 on PartitionToolBatches — open-array param

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -322,8 +322,16 @@ end;
   default — applies to skill / MCP tools and to any handler that
   forgot to set the Category field). Order is preserved across
   batches, so the agent loop appends tool_results in the same order
-  the model emitted tool_use blocks. }
-function PartitionToolBatches(const Calls: TToolCallArray;
+  the model emitted tool_use blocks.
+
+  Calls is declared as an open array rather than `TToolCallArray`
+  because the source is `TLLMResponse.ToolCalls`, which the providers
+  record as an inline `array of TToolCall` — Delphi 12 dcc64 enforces
+  strict named-type matching on dynamic-array parameters and rejects
+  the bare-array → TToolCallArray pass-through with E2010. FPC happens
+  to accept it either way, but the open-array form compiles cleanly
+  under both. }
+function PartitionToolBatches(const Calls: array of TToolCall;
                               Reg: TToolRegistry): TToolBatchArray;
 var
   i: Integer;


### PR DESCRIPTION
## Summary

Delphi 12 dcc64 reported on PR #98 (already merged):

```
[dcc64 Error] PasClaw.Tools.ToolLoop.pas(458): E2010 Incompatible
types: 'TToolCallArray' and 'Dynamic array'
```

`PartitionToolBatches` declared its formal parameter as `const Calls: TToolCallArray`, but the only caller passes `Resp.ToolCalls` which `TLLMResponse` records as an inline `array of TToolCall` (not the `TToolCallArray` alias). Delphi 12 enforces strict named-type matching on dynamic-array parameters — the two are structurally identical but live in different named-type slots, so dcc64 refuses the conversion. FPC's mode-Delphi is looser and accepted it, which is why PR #98 built green on Linux but tripped the Delphi build.

## Fix

Change the formal to `const Calls: array of TToolCall` (open-array parameter). Open arrays are name-agnostic — they accept any source whose element type matches, including bare-array record fields. Compiles cleanly under both FPC and dcc64. No callers change because there's only one and it already passes the bare array.

## Verification

`make clean && make smoke` still 11/11 green under FPC. The open-array form is the same pattern `PasClaw.Tools.ToolLoop` already uses for other `TMessage` / `TToolDefinition` signatures, so the syntax is known good. Delphi 12 dcc64 verification needs an actual Delphi install.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_