### PR TITLE
cmd/toolloop: fix dcc64 E2010 on Fallbacks + Msgs — named-type matches

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -238,7 +238,7 @@ var
   Line: string;
   Provider: ILLMProvider;
   Err: string;
-  Msgs: array of TMessage;
+  Msgs: TMessageArray;
   Reg: TToolRegistry;
   Handlers: TLoopHandlers;
   Loop: TToolLoopResult;

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -15,8 +15,10 @@ uses
   PasClaw.Config,
   PasClaw.Providers.Intf;
 
-type
-  TLLMProviderArray = array of ILLMProvider;
+{ TLLMProviderArray moved to PasClaw.Providers.Intf so both this unit
+  and PasClaw.Tools.ToolLoop reference the same named type — dcc64
+  rejects cross-unit assignments between inline `array of ILLMProvider`
+  declarations even when structurally identical. }
 
 function NewProviderFromConfig(Cfg: TConfig; const ProviderName: string;
                                out Provider: ILLMProvider; out ErrMsg: string): Boolean;

--- a/src/pkg/providers/PasClaw.Providers.Intf.pas
+++ b/src/pkg/providers/PasClaw.Providers.Intf.pas
@@ -34,6 +34,16 @@ type
                         OnChunk: TStreamCallback): TLLMResponse;
   end;
 
+  { Named alias for `array of ILLMProvider`. Used by TToolLoopConfig.
+    Fallbacks and PasClaw.Providers.Factory.ResolveFallbacks. Declared
+    here (not in Factory) so PasClaw.Tools.ToolLoop can reference the
+    named type without picking up the whole factory dependency, which
+    matters under dcc64 — Delphi 12 enforces strict named-type matching
+    on dynamic-array assignments, so an inline `array of ILLMProvider`
+    on TToolLoopConfig.Fallbacks would reject the named-type return of
+    ResolveFallbacks with E2010. }
+  TLLMProviderArray = array of ILLMProvider;
+
 implementation
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -52,8 +52,12 @@ type
        until one succeeds (StatusCode 2xx) or all fail. Empty
        array — same as the old behaviour, primary failure surfaces
        directly. Callers populate from TConfig.Fallbacks by
-       resolving each name through NewProviderFromConfig. *)
-    Fallbacks:      array of ILLMProvider;
+       resolving each name through NewProviderFromConfig (see
+       PasClaw.Providers.Factory.ResolveFallbacks). The named
+       TLLMProviderArray type — not an inline `array of ILLMProvider`
+       — is required because dcc64 enforces strict named-type matching
+       on dynamic-array assignments. *)
+    Fallbacks:      TLLMProviderArray;
   end;
 
   TToolLoopResult = record


### PR DESCRIPTION
## Summary

Delphi 12 dcc64 reported two E2010 errors from merged PR #101:

```
[dcc64 Error] PasClaw.Cmd.Agent.pas(165): E2010 Incompatible types: 'Dynamic array' and 'TLLMProviderArray'
[dcc64 Error] PasClaw.Cmd.Agent.pas(362): E2010 Incompatible types: 'Dynamic array' and 'TMessageArray'
[dcc64 Fatal Error] PasClaw.Cmd.Root.pas(32): F2063 Could not compile used unit 'PasClaw.Cmd.Agent.pas'
```

Same root cause as PR #99: dcc64 enforces strict named-type matching on dynamic-array assignments, while FPC's mode-Delphi is looser and accepts structurally-equivalent inline forms.

| Line | Assignment | LHS type | RHS type |
|---|---|---|---|
| 165 | `Result.Fallbacks := ResolveFallbacks(Cfg);` | inline `array of ILLMProvider` | `TLLMProviderArray` |
| 362 | `Msgs := CompactMessages(Provider, Model, Msgs, …);` | inline `array of TMessage` | `TMessageArray` |

## Fixes

1. **Promote `TLLMProviderArray`** from `PasClaw.Providers.Factory` (where it lived since PR #101) to `PasClaw.Providers.Intf`. `ToolLoop` already imports `Intf`, so the named type is visible without pulling in the factory's transitive dependencies (SysUtils + Anthropic + OpenAI + Gemini). `TToolLoopConfig.Fallbacks` now uses the named type directly.

2. **Change `Msgs` declaration** in `RunInteractive` from `array of TMessage` to `TMessageArray` (already exported by `PasClaw.Providers.Types`). Assignment from `CompactMessages`'s return now matches. Also aligned `Msgs` in `RunSingleTurn` for consistency, even though that procedure doesn't call `CompactMessages`.

## When to apply which fix

The PR #99 case (`PartitionToolBatches`) used the open-array escape hatch (`const Calls: array of TToolCall`) — the right fix for a **parameter** whose source might be a record field. For a **record field** (Fallbacks) or a **local var** that needs to receive a named-type return (Msgs), the right fix is to align the lhs type with the named-type return value, which is what this PR does.

## Verification

`make clean && make smoke` 11/11 green under FPC. Delphi verification needs an actual dcc64 install.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_