### PR TITLE
email: fix PR #103 review — RetrievePeek + bounded shutdown timeouts

### DIFF
--- a/src/pkg/channels/PasClaw.Channels.Email.pas
+++ b/src/pkg/channels/PasClaw.Channels.Email.pas
@@ -102,6 +102,34 @@ uses
   PasClaw.Providers.Factory,
   PasClaw.Tools.ToolLoop;
 
+const
+  { Per-operation IMAP / SMTP timeout. Bounds how long a single
+    Connect / Login / Retrieve / Send can block before raising; in
+    turn bounds Email.Stop's shutdown wait. 30s is generous for
+    healthy mail servers (typical SMTP STARTTLS roundtrip is well
+    under a second) and tight enough that a wedged server doesn't
+    keep the gateway alive for minutes. Tune via constant edit if
+    your environment legitimately needs more. }
+  EmailIOTimeoutMS = 30000;
+
+{ TThread.WaitFor blocks indefinitely — Indy doesn't ship a
+  timeout-aware variant. Poll Finished at 50ms granularity for up
+  to TimeoutMS, return True if the thread exited in time. }
+function WaitForWorkerWithTimeout(W: TThread; TimeoutMS: Cardinal): Boolean;
+var
+  Elapsed: Cardinal;
+const
+  PollMS = 50;
+begin
+  Elapsed := 0;
+  while (not W.Finished) and (Elapsed < TimeoutMS) do
+  begin
+    Sleep(PollMS);
+    Inc(Elapsed, PollMS);
+  end;
+  Result := W.Finished;
+end;
+
 function ParseSMTPMode(const S: string): TEmailSMTPMode;
 var
   L: string;
@@ -232,11 +260,13 @@ begin
       else
         SMTP.UseTLS := utUseExplicitTLS;
     end;
-    SMTP.Host     := FSMTP.Host;
-    SMTP.Port     := FSMTP.Port;
-    SMTP.Username := FSMTP.User;
-    SMTP.Password := FSMTP.Pass;
-    SMTP.AuthType := satDefault;
+    SMTP.Host           := FSMTP.Host;
+    SMTP.Port           := FSMTP.Port;
+    SMTP.Username       := FSMTP.User;
+    SMTP.Password       := FSMTP.Pass;
+    SMTP.AuthType       := satDefault;
+    SMTP.ConnectTimeout := EmailIOTimeoutMS;
+    SMTP.ReadTimeout    := EmailIOTimeoutMS;
 
     Msg.From.Address := FFrom;
     Msg.Recipients.EMailAddresses := Recipient;
@@ -298,6 +328,12 @@ begin
     IMAP.Port := FIMAP.Port;
     IMAP.Username := FIMAP.User;
     IMAP.Password := FIMAP.Pass;
+    { Bounded I/O: if the IMAP server stalls, individual ops fail
+      after 30s instead of blocking the worker forever. Caps the
+      shutdown latency Email.Stop sees at roughly one ReadTimeout
+      cycle. }
+    IMAP.ConnectTimeout := EmailIOTimeoutMS;
+    IMAP.ReadTimeout    := EmailIOTimeoutMS;
 
     try
       IMAP.Connect;
@@ -326,7 +362,13 @@ begin
           SeqNum := Unseen[k];
           Msg := TIdMessage.Create(nil);
           try
-            if not IMAP.Retrieve(Integer(SeqNum), Msg) then Continue;
+            { Peek (BODY.PEEK[]) doesn't set \Seen as a side effect
+              the way Retrieve does — so when SMTP delivery fails
+              below and we skip StoreFlags, the next SEARCH UNSEEN
+              still returns this message and we retry. Retrieve would
+              silently mark Seen on fetch, draining the message from
+              the unseen set even though the reply never went out. }
+            if not IMAP.RetrievePeek(SeqNum, Msg) then Continue;
             FromAddr := Msg.From.Address;
             Subj := Msg.Subject;
             BodyText := Msg.Body.Text;
@@ -464,10 +506,36 @@ begin
 end;
 
 procedure TEmailChannel.Stop;
+const
+  { Worst-case shutdown latency the gateway is willing to absorb.
+    The worker may currently be blocked in IMAP.Retrieve or
+    SMTP.Send, both of which now carry EmailIOTimeoutMS read
+    timeouts — so the actual wait is bounded by one ReadTimeout
+    plus the post-op return path. EmailStopWatchdogMS gives that
+    a generous ceiling; the WaitFor fallback below catches the
+    pathological "server stops responding mid-TLS handshake"
+    case so gateway shutdown doesn't hang forever. }
+  EmailStopWatchdogMS = EmailIOTimeoutMS + 5000;
 begin
   if FWorker = nil then Exit;
   FStop := True;
-  FWorker.WaitFor;
+  { Indy's TThread.WaitFor doesn't take a timeout argument, so we
+    poll. Cheap — Sleep(50ms) until Finished or timeout. The
+    worker sets Finished := True the moment Execute returns. }
+  if not WaitForWorkerWithTimeout(FWorker, EmailStopWatchdogMS) then
+  begin
+    LogWarn('email worker did not exit within %d ms — leaking thread (IMAP/SMTP socket likely wedged)',
+            [EmailStopWatchdogMS]);
+    { Detach: set FreeOnTerminate so the thread cleans itself up
+      whenever it does eventually exit. Better than blocking the
+      gateway shutdown forever. NB: if FProvider / FRegistry /
+      FCfg get torn down before the thread exits the worker may
+      hit a UAF on its next access — that's the lesser evil vs.
+      a wedged gateway. }
+    FWorker.FreeOnTerminate := True;
+    FWorker := nil;
+    Exit;
+  end;
   FreeAndNil(FWorker);
 end;
 


### PR DESCRIPTION
## Summary

Two Codex P2 findings on merged PR #103, both legitimate.

### P2 — `IMAP.Retrieve` auto-marks Seen, defeating the failed-SMTP retry logic

PR #103 introduced a `ReplySent` / `ReplyAttempted` truth table that intentionally skipped `StoreFlags(mfSeen)` when SMTP delivery failed, on the theory that the next `SEARCH UNSEEN` would re-list the message. But `Retrieve` sends `FETCH BODY[]`, which the IMAP RFC defines as a Seen-setting fetch — so the message left the unseen set the moment we read it, regardless of whether the `StoreFlags` later ran. Failed replies were silently dropped.

**Fix**: switched to `IMAP.RetrievePeek` (`FETCH BODY.PEEK[]`), which doesn't set Seen as a side effect. The explicit `StoreFlags` now becomes the only place `mfSeen` is added, so the PR #103 truth table actually works end-to-end:

| ReplyAttempted | ReplySent | StoreFlags? | Result |
|---|---|---|---|
| False (no reply) | — | Yes | Don't loop on poison |
| True | True | Yes | Delivered |
| True | False | No | **Now actually retried next poll** |

### P2 — `TThread.WaitFor` blocks indefinitely on shutdown

If the worker was inside a wedged `IMAP.Retrieve` or `SMTP.Send` when the gateway called `Email.Stop`, `FStop` got set but the worker never returned from the syscall — so `WaitFor` blocked the gateway indefinitely. User-facing symptom was Ctrl-C requiring a second SIGKILL.

**Fix in two halves**:

1. **Bound the I/O at the source.** `TIdIMAP4` and `TIdSMTP` both inherit `ConnectTimeout` / `ReadTimeout` from `TIdTCPClient`; set both to `EmailIOTimeoutMS` (30s). After `Stop` signals `FStop`, the worst-case worker exit is one `ReadTimeout` plus the post-op return path — bounded.

2. **Bound the `WaitFor` too.** New `WaitForWorkerWithTimeout` helper polls `Worker.Finished` at 50ms granularity for up to `EmailStopWatchdogMS` (= `EmailIOTimeoutMS + 5s`). If the worker hasn't exited in that window — e.g. server stopped responding mid-TLS handshake before `ReadTimeout` could trigger — `Email.Stop` sets `FreeOnTerminate := True` and detaches the thread. The gateway shuts down on schedule; the detached worker cleans itself up if/when it eventually unblocks.

## Verification

`make clean && make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_