### PR TITLE
email: fix dcc64 E2010 — TStringArray + TUInt32Array named types

### DIFF
--- a/src/pkg/channels/PasClaw.Channels.Email.pas
+++ b/src/pkg/channels/PasClaw.Channels.Email.pas
@@ -63,7 +63,10 @@ type
     FSMTP:      TEmailAuth;
     FIMAP:      TEmailAuth;
     FFrom:      string;
-    FAllow:     array of string;
+    FAllow:     TStringArray;   { named type, not `array of string`, so Delphi 12
+                                  dcc64 accepts the SplitCSV(...) assignment
+                                  result without an E2010 — same pattern as
+                                  PR #104 fixed for TLLMProviderArray. }
     FPollSec:   Integer;
     FStop:      Boolean;
     FWorker:    TThread;
@@ -97,6 +100,10 @@ uses
   DateUtils,
   IdSMTP, IdIMAP4, IdMessage, IdSSLOpenSSL, IdExplicitTLSClientServerBase,
   IdMessageBuilder, IdMessageParts, IdAttachmentFile,
+  IdMailBox,  { TUInt32Array — needed for the Unseen local in ProcessInbox
+                because IMAP.MailBox.SearchResult is declared as
+                TUInt32Array; dcc64 won't assign it into an inline
+                `array of UInt32` (PR #104 same pattern). }
   PasClaw.Logger,
   PasClaw.Providers.Types,
   PasClaw.Providers.Factory,
@@ -302,7 +309,7 @@ var
   IMAP: TIdIMAP4;
   SSL:  TIdSSLIOHandlerSocketOpenSSL;
   Msg:  TIdMessage;
-  Unseen: array of UInt32;
+  Unseen: TUInt32Array;
   Search: array of TIdIMAP4SearchRec;
   SeqNum: UInt32;
   k: Integer;


### PR DESCRIPTION
## Summary

Delphi 12 dcc64 reported two more E2010 errors on the email channel from merged PR #103:

```
[dcc64 Error] PasClaw.Channels.Email.pas(217): E2010 Incompatible types: 'Dynamic array' and 'TStringArray'
[dcc64 Error] PasClaw.Channels.Email.pas(355): E2010 Incompatible types: 'Dynamic array' and 'TUInt32Array'
[dcc64 Fatal Error] PasClaw.Cmd.Gateway.pas(42): F2063 Could not compile used unit 'PasClaw.Channels.Email.pas'
```

Same root cause as PRs #99 and #104. Two sites:

| Line | Assignment | LHS type | RHS type | Source of RHS named type |
|---|---|---|---|---|
| 217 | `FAllow := SplitCSV(...)` | inline `array of string` | `TStringArray` | `PasClaw.Tools.Registry` |
| 355 | `Unseen := Copy(IMAP.MailBox.SearchResult)` | inline `array of UInt32` | `TUInt32Array` | Indy `IdMailBox` |

## Fixes

1. **`FAllow` declared as `TStringArray`** — already in scope, the interface uses clause imports `PasClaw.Tools.Registry` which exports it. Drop-in change to the class field.

2. **`Unseen` declared as `TUInt32Array`** — `IdIMAP4` uses `IdMailBox` internally but doesn't re-export the named type, so added `IdMailBox` to the implementation uses clause.

Each named type gets an inline comment pointing back to this PR pattern so the next person to touch this file doesn't reintroduce the inline form.

## Verification

`make clean && make smoke` 11/11 green on FPC. Delphi verification needs an actual dcc64 install.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_