### PR TITLE
agent: subagents via spawn() tool (with PR #107 review fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Form-designable with published properties for the VCL/FMX path; code-driven OOP 
 
 **Interactive chat** — `pasclaw agent` and `pasclaw tui` ship slash commands: `/help` lists them; `/status` shows model + provider + message count + thinking state; `/new` and `/reset` clear history; `/compact` forces a summariser pass; `/think` toggles extended-thinking mode for the next turn (Anthropic Claude); `/tools` lists registered tools; `/quit` exits.
 
+**Subagents** — fan-out to focused specialists via a `spawn(agent, prompt)` tool. Declare them in `config.json`'s `subagents:` array (name + description + system prompt + tool allowlist + optional model / max-iterations override). Each spawn runs a short `RunToolLoop` against the parent's provider + fallback chain with a registry filtered to the named tools and a specialist system prompt; result lands back as the parent's `tool_result`. Implementation in `src/pkg/agent/PasClaw.Agent.Subagent.pas` — picoclaw's `SubTurn` pattern, nanobot's `subagent` module, openclaw's multi-agent routing, ~300 LOC.
+
+```json
+"subagents": [
+  { "name": "researcher",
+    "description": "Web search + summary specialist",
+    "system_prompt": "You search the web and produce a 3-bullet summary...",
+    "tools": ["web_search", "web_fetch"],
+    "max_iterations": 4 },
+  { "name": "coder",
+    "description": "Code editor",
+    "system_prompt": "You edit code precisely using hashline patches...",
+    "tools": ["fs_read", "fs_write", "fs_grep", "fs_edit_hashline"] }
+]
+```
+
 **Cross-platform** — Linux x86_64 + aarch64 under FPC 3.2+; macOS x86_64 + arm64 under FPC (Homebrew unit paths autodetected); Windows + Linux + macOS under Delphi 12 / RAD Studio. The Makefile probes `uname` and picks the right `fcl-db` / `sqlite` / `iconvenc` / `lazutils` paths automatically. Three sample binaries under `samples/component-console/` plus matching `.dproj` files for RAD Studio and `dcc32.cfg` / `dcc64.cfg` for cmdline Delphi builds.
 
 ## Requirements

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -227,6 +227,14 @@ begin
     Exit;
   end;
 
+  { Resolve the effective model BEFORE registering the spawn tool.
+    MaybeRegisterSpawnTool captures Model into the TSubagentContext
+    by value; if we hand it an empty string the child subagent loop
+    will fall back to the provider's GetDefaultModel instead of the
+    user's --model selection. RunInteractive already does this in the
+    right order — fixing the asymmetry here. (Codex P2 on PR #107.) }
+  if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
+
   Reg := nil;
   if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
@@ -236,7 +244,6 @@ begin
     SetLength(Msgs, 1);
     Msgs[0] := MakeMessage(mrUser, Prompt);
 
-    if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
     LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers);
 
     WriteLn(Ansi.Cyan, 'assistant', Ansi.Reset, ' (', Provider.GetName, '/', Model, '):');

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -35,6 +35,7 @@ uses
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
+  PasClaw.Agent.Subagent,
   PasClaw.Tools.Sandbox;
 
 type
@@ -144,6 +145,25 @@ begin
   RegisterSkills(Result, Skills);
 end;
 
+{ When the operator declared subagents in config.json, install the
+  `spawn` tool into the registry — once MCP tools have already been
+  bridged in so subagents can include them in their allowlist.
+  Returns the created spawn tool so the caller can `Free` it during
+  cleanup; nil when no subagents are configured. }
+function MaybeRegisterSpawnTool(Cfg: TConfig; Provider: ILLMProvider;
+                                 Reg: TToolRegistry; const Model: string): TSpawnTool;
+var
+  Ctx: TSubagentContext;
+begin
+  Result := nil;
+  if (Reg = nil) or (Length(Cfg.Subagents) = 0) then Exit;
+  Ctx.Provider       := Provider;
+  Ctx.Fallbacks      := ResolveFallbacks(Cfg);
+  Ctx.ParentRegistry := Reg;
+  Ctx.DefaultModel   := Model;
+  Result := RegisterSpawnTool(Reg, Ctx, Cfg.Subagents);
+end;
+
 function ConnectMCP(Cfg: TConfig; Reg: TToolRegistry; NoMCP: Boolean): TMCPClientList;
 begin
   SetLength(Result, 0);
@@ -197,6 +217,7 @@ var
   LoopCfg: TToolLoopConfig;
   Model: string;
   MCPClients: TMCPClientList;
+  Spawn: TSpawnTool;
 begin
   if not PickProvider(Cfg, A, Provider, Err) then
   begin
@@ -209,6 +230,7 @@ begin
   Reg := nil;
   if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
+  Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;
   try
     SetLength(Msgs, 1);
@@ -229,6 +251,7 @@ begin
   finally
     Handlers.Free;
     FreeMCPClients(MCPClients);
+    if Spawn <> nil then Spawn.Free;
     Reg.Free;
   end;
 end;
@@ -248,6 +271,7 @@ var
   i: Integer;
   Names: TStringArray;
   MCPClients: TMCPClientList;
+  Spawn: TSpawnTool;
   SystemPromptOverride: string;   { tracks the compacted system prompt across turns }
   ThinkingOn: Boolean;             { toggled by /think; cleared each turn after sending }
   CompactOptsLocal: TCompactOptions;
@@ -263,6 +287,7 @@ begin
   Reg := nil;
   if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
+  Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;
   try
     SetLength(Msgs, 0);
@@ -427,6 +452,7 @@ begin
   finally
     Handlers.Free;
     FreeMCPClients(MCPClients);
+    if Spawn <> nil then Spawn.Free;
     Reg.Free;
   end;
 end;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -234,6 +234,7 @@
         <!-- pkg/agent -->
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Prompt.pas"/>
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Compact.pas"/>
+        <DCCReference Include="..\pkg\agent\PasClaw.Agent.Subagent.pas"/>
 
         <!-- pkg/memory -->
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>

--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -79,6 +79,14 @@ type
     function Schema:      string; override;
     function Category:    TToolCategory; override;
     function Run(const ArgsJSON: string; out ErrMsg: string): string; override;
+    { Refresh the captured TSubagentContext. Embedders that swap
+      providers mid-session (TPasClawAgent.SetProvider after the
+      first Chat) call this so the next spawn() dispatch picks up
+      the new ILLMProvider / Fallbacks / DefaultModel — without it
+      the spawn tool would keep using the stale provider that was
+      live when the registry was first installed. (Codex P2 on
+      PR #107.) }
+    procedure SetContext(const ACtx: TSubagentContext);
   end;
 
 (* Build a TToolRegistry holding a subset of the source registry,
@@ -150,6 +158,11 @@ begin
   FCtx := ACtx;
   SetLength(FSpecs, Length(ASpecs));
   for i := 0 to High(ASpecs) do FSpecs[i] := ASpecs[i];
+end;
+
+procedure TSpawnTool.SetContext(const ACtx: TSubagentContext);
+begin
+  FCtx := ACtx;
 end;
 
 function TSpawnTool.Name: string;

--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -1,0 +1,352 @@
+(*
+  PasClaw.Agent.Subagent — `spawn` tool for fan-out to specialist
+  subagents.
+
+  When the model calls `spawn(agent="researcher", prompt="...")`,
+  TSpawnTool runs a focused RunToolLoop against:
+
+    * the parent's provider + fallback chain (no new HTTPS handshake
+      to a different API)
+    * a filtered registry holding only the tools the named subagent
+      is allowed to use (per TSubagentSpec.Tools — and never the
+      `spawn` tool itself, so nested sub-subagents aren't a thing
+      in v1)
+    * the subagent's specialisation system prompt instead of the
+      parent's
+    * the subagent's model override or, when empty, the parent's
+      default
+
+  This is intentionally NOT a child TPasClawAgent instance — the
+  parent's "single live instance per process" constraint (rooted in
+  PasClaw.MCP.Bridge / PasClaw.Skills.Loader holding their state
+  in module-level arrays) would otherwise have to be lifted. By
+  running a bare RunToolLoop call instead, the subagent pays no
+  startup cost (no MCP reconnect, no skills reload) and shares the
+  parent's already-built provider + registry foundations.
+
+  Mirrors picoclaw's SubTurn coordination, nanobot's subagent
+  module, and openclaw's multi-agent routing — same "planner agent
+  fans out to specialists" pattern, smaller surface.
+
+  Configuration: TConfig.Subagents (config.json "subagents": [...]).
+*)
+unit PasClaw.Agent.Subagent;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.Obj;
+
+type
+  TSubagentSpecArray = array of TSubagentSpec;
+
+  { Everything the spawn tool needs from its parent — captured at
+    registration time so the tool handler can run a child loop
+    without reaching back into the parent's TPasClawAgent state. }
+  TSubagentContext = record
+    Provider:       ILLMProvider;
+    Fallbacks:      TLLMProviderArray;
+    ParentRegistry: TToolRegistry;
+    DefaultModel:   string;
+  end;
+
+  { The spawn tool itself. Subclasses TPasClawTool so the OOP
+    Install path (set up in PR #93) handles registration; the model
+    sees one tool named `spawn` whose schema enumerates the
+    available subagent names. }
+  TSpawnTool = class(TPasClawTool)
+  private
+    FCtx:   TSubagentContext;
+    FSpecs: TSubagentSpecArray;
+    function BuildSchema: string;
+    function BuildDescription: string;
+    function FindSpec(const N: string; out S: TSubagentSpec): Boolean;
+    function JoinSpecNames: string;
+  public
+    constructor Create(const ACtx: TSubagentContext;
+                       const ASpecs: TSubagentSpecArray);
+    function Name:        string; override;
+    function Description: string; override;
+    function Schema:      string; override;
+    function Category:    TToolCategory; override;
+    function Run(const ArgsJSON: string; out ErrMsg: string): string; override;
+  end;
+
+(* Build a TToolRegistry holding a subset of the source registry,
+   keyed by name. Tools not present in the source are silently
+   skipped (logged as a warning so the operator notices a typo).
+   The 'spawn' tool is always excluded so the subagent can't recurse
+   into another spawn. Caller owns the returned registry and must
+   free it. *)
+function BuildFilteredRegistry(Source: TToolRegistry;
+                               const Names: array of string): TToolRegistry;
+
+(* Convenience for the standard registration flow: when Specs is
+   non-empty, create a TSpawnTool against the given context+specs
+   and Install it into Reg. The tool's lifetime is tied to Reg
+   (the spawn tool holds a method-pointer handler into itself; the
+   registry's RunTool dispatches through it). For callers that
+   already manage their own OOP-tool ownership via FOwnedTools,
+   pass the result up to register ownership; otherwise the leaked
+   tool is reaped at process exit, which is fine for the CLI / one-
+   shot path. Returns the created tool (or nil when Specs is empty)
+   so the caller can take ownership. *)
+function RegisterSpawnTool(Reg: TToolRegistry;
+                            const Ctx: TSubagentContext;
+                            const Specs: TSubagentSpecArray): TSpawnTool;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Tools.ToolLoop;
+
+function RegisterSpawnTool(Reg: TToolRegistry;
+                            const Ctx: TSubagentContext;
+                            const Specs: TSubagentSpecArray): TSpawnTool;
+begin
+  Result := nil;
+  if (Reg = nil) or (Length(Specs) = 0) then Exit;
+  Result := TSpawnTool.Create(Ctx, Specs);
+  Result.Install(Reg);
+end;
+
+function BuildFilteredRegistry(Source: TToolRegistry;
+                               const Names: array of string): TToolRegistry;
+var
+  i: Integer;
+  T: TTool;
+begin
+  Result := TToolRegistry.Create;
+  if Source = nil then Exit;
+  for i := 0 to High(Names) do
+  begin
+    if Names[i] = 'spawn' then Continue;  { no nested sub-subagents }
+    if not Source.Find(Names[i], T) then
+    begin
+      LogWarn('subagent: source registry has no tool named "%s" — skipping', [Names[i]]);
+      Continue;
+    end;
+    Result.Register(T);
+  end;
+end;
+
+constructor TSpawnTool.Create(const ACtx: TSubagentContext;
+                              const ASpecs: TSubagentSpecArray);
+var
+  i: Integer;
+begin
+  inherited Create;
+  FCtx := ACtx;
+  SetLength(FSpecs, Length(ASpecs));
+  for i := 0 to High(ASpecs) do FSpecs[i] := ASpecs[i];
+end;
+
+function TSpawnTool.Name: string;
+begin
+  Result := 'spawn';
+end;
+
+function TSpawnTool.Description: string;
+begin
+  Result := BuildDescription;
+end;
+
+function TSpawnTool.Schema: string;
+begin
+  Result := BuildSchema;
+end;
+
+function TSpawnTool.Category: TToolCategory;
+begin
+  { Mutating in the parallel-batching sense — a spawn call drives
+    another LLM round trip + tool dispatch, has its own side
+    effects, and shouldn't run in parallel with the parent's other
+    tool calls. The agent loop treats it as a batch of one. }
+  Result := tcMutating;
+end;
+
+function TSpawnTool.BuildDescription: string;
+var
+  i: Integer;
+begin
+  Result := 'Fan out to a focused specialist subagent. Pass the agent name '
+          + 'and the prompt; the subagent runs its own short tool loop and '
+          + 'returns its reply as the tool_result.';
+  if Length(FSpecs) > 0 then
+  begin
+    Result := Result + ' Available subagents:';
+    for i := 0 to High(FSpecs) do
+    begin
+      Result := Result + ' "' + FSpecs[i].Name + '"';
+      if FSpecs[i].Description <> '' then
+        Result := Result + ' (' + FSpecs[i].Description + ')';
+      if i < High(FSpecs) then Result := Result + ',';
+    end;
+    Result := Result + '.';
+  end;
+end;
+
+function TSpawnTool.BuildSchema: string;
+var
+  Obj, Props, Agent, Prompt: TJsonObject;
+  Enum: TJsonArray;
+  Req: TJsonArray;
+  i: Integer;
+begin
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutStr('type', 'object');
+
+    Props := TJsonObject.Create;
+    try
+      Agent := TJsonObject.Create;
+      try
+        Agent.PutStr('type', 'string');
+        Agent.PutStr('description', 'Name of the subagent to spawn.');
+        if Length(FSpecs) > 0 then
+        begin
+          Enum := TJsonArray.Create;
+          for i := 0 to High(FSpecs) do
+            Enum.AddStr(FSpecs[i].Name);
+          Agent.PutArray('enum', Enum);
+        end;
+      finally
+        Props.PutObject('agent', Agent);
+      end;
+
+      Prompt := TJsonObject.Create;
+      try
+        Prompt.PutStr('type', 'string');
+        Prompt.PutStr('description', 'The prompt to hand the subagent.');
+      finally
+        Props.PutObject('prompt', Prompt);
+      end;
+    finally
+      Obj.PutObject('properties', Props);
+    end;
+
+    Req := TJsonArray.Create;
+    Req.AddStr('agent');
+    Req.AddStr('prompt');
+    Obj.PutArray('required', Req);
+
+    Result := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+end;
+
+function TSpawnTool.FindSpec(const N: string; out S: TSubagentSpec): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to High(FSpecs) do
+    if SameText(FSpecs[i].Name, N) then
+    begin
+      S := FSpecs[i];
+      Exit(True);
+    end;
+  Result := False;
+end;
+
+function TSpawnTool.Run(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Args: TJsonObject;
+  AgentName, Prompt: string;
+  Spec: TSubagentSpec;
+  ChildCfg: TToolLoopConfig;
+  ChildReg: TToolRegistry;
+  ChildHist: TMessageArray;
+  Loop: TToolLoopResult;
+  Model: string;
+  MaxIter: Integer;
+begin
+  Result := '';
+  ErrMsg := '';
+  Args := TJsonObject.Parse(ArgsJSON);
+  if Args = nil then
+  begin
+    ErrMsg := 'spawn: invalid arguments JSON';
+    Exit;
+  end;
+  try
+    AgentName := Args.GetStr('agent', '');
+    Prompt    := Args.GetStr('prompt', '');
+  finally
+    Args.Free;
+  end;
+  if AgentName = '' then
+  begin
+    ErrMsg := 'spawn: agent name required';
+    Exit;
+  end;
+  if Prompt = '' then
+  begin
+    ErrMsg := 'spawn: prompt required';
+    Exit;
+  end;
+  if not FindSpec(AgentName, Spec) then
+  begin
+    ErrMsg := Format('spawn: no subagent named "%s" — available: %s',
+                     [AgentName, JoinSpecNames]);
+    Exit;
+  end;
+
+  Model := Spec.Model;
+  if Model = '' then Model := FCtx.DefaultModel;
+  MaxIter := Spec.MaxIter;
+  if MaxIter <= 0 then MaxIter := 4;
+
+  ChildReg := BuildFilteredRegistry(FCtx.ParentRegistry, Spec.Tools);
+  try
+    ChildCfg.Provider      := FCtx.Provider;
+    ChildCfg.Registry      := ChildReg;
+    ChildCfg.Model         := Model;
+    ChildCfg.MaxIterations := MaxIter;
+    ChildCfg.Parallel      := True;
+    ChildCfg.Fallbacks     := FCtx.Fallbacks;
+    ChildCfg.Options       := DefaultChatOptions;
+    ChildCfg.Options.SystemPrompt := Spec.SystemPrompt;
+    ChildCfg.OnText        := nil;
+    ChildCfg.OnToolCall    := nil;
+    ChildCfg.OnToolResult  := nil;
+
+    SetLength(ChildHist, 1);
+    ChildHist[0] := MakeMessage(mrUser, Prompt);
+
+    LogInfo('subagent spawn: name=%s model=%s tools=%d',
+            [AgentName, Model, ChildReg.Count]);
+    if RunToolLoop(ChildCfg, ChildHist, Loop) then
+      Result := Loop.Content
+    else
+      ErrMsg := Format('spawn: subagent "%s" failed', [AgentName]);
+  finally
+    ChildReg.Free;
+  end;
+end;
+
+function TSpawnTool.JoinSpecNames: string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 0 to High(FSpecs) do
+  begin
+    if Result <> '' then Result := Result + ', ';
+    Result := Result + FSpecs[i].Name;
+  end;
+  if Result = '' then Result := '(none configured)';
+end;
+
+end.

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -96,6 +96,12 @@ type
                                     the registry early without skipping
                                     the lazy built-in install on first
                                     Chat. }
+    FSubagentCtx: TSubagentContext;  { populated in EnsureRegistry when
+                                       FConfig.Subagents is non-empty;
+                                       captured by value into the TSpawnTool
+                                       instance so the tool can run a child
+                                       loop against the parent's provider
+                                       + fallbacks + registry. }
     FProviderOverride:    TProviderConfig;  { populated by SetProvider, then
                                               folded into FConfig.Providers
                                               when EnsureConfig runs (if before
@@ -282,6 +288,7 @@ uses
   PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
+  PasClaw.Agent.Subagent,
   PasClaw.Tools.ToolLoop;
 
 { ------------------------------ helpers ------------------------------ }
@@ -446,6 +453,22 @@ begin
   RegisterSkills(FRegistry, Skills);
   if FUseMCP then
     FMCPClients := ConnectMCPServers(FConfig, FRegistry);
+  { Subagent spawn tool — installs only when the operator declared
+    subagents in config.json. Needs FProvider already resolved so
+    the spawn tool's context captures the live ILLMProvider; in
+    the ChatHistory path EnsureProvider runs before EnsureRegistry,
+    so by here FProvider is non-nil. }
+  if (Length(FConfig.Subagents) > 0) and (FProvider <> nil) then
+  begin
+    FSubagentCtx.Provider       := FProvider;
+    FSubagentCtx.Fallbacks      := ResolveFallbacks(FConfig);
+    FSubagentCtx.ParentRegistry := FRegistry;
+    if FModel <> '' then
+      FSubagentCtx.DefaultModel := FModel
+    else
+      FSubagentCtx.DefaultModel := FConfig.DefaultModel;
+    FOwnedTools.Add(RegisterSpawnTool(FRegistry, FSubagentCtx, FConfig.Subagents));
+  end;
   FBuiltinsInstalled := True;
   { Re-install OOP tools that were registered before this point so
     user names override the built-ins on conflict. TToolRegistry.

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -102,6 +102,13 @@ type
                                        instance so the tool can run a child
                                        loop against the parent's provider
                                        + fallbacks + registry. }
+    FSpawnTool:   TSpawnTool;         { borrowed reference into FOwnedTools.
+                                       Non-nil when EnsureRegistry installed
+                                       a spawn tool; lets RefreshSubagentContext
+                                       update the captured ctx when an
+                                       embedder swaps providers mid-session
+                                       (SetProvider after first Chat). Set
+                                       to nil in Destroy / not freed here. }
     FProviderOverride:    TProviderConfig;  { populated by SetProvider, then
                                               folded into FConfig.Providers
                                               when EnsureConfig runs (if before
@@ -115,6 +122,7 @@ type
     procedure EnsureConfig;
     procedure EnsureProvider;
     procedure EnsureRegistry;
+    procedure RefreshSubagentContext;
     procedure ForwardText      (const S: string);
     procedure ForwardToolCall  (const Name, ArgsJSON: string);
     procedure ForwardToolResult(const Name, ResultText, Err: string);
@@ -467,7 +475,8 @@ begin
       FSubagentCtx.DefaultModel := FModel
     else
       FSubagentCtx.DefaultModel := FConfig.DefaultModel;
-    FOwnedTools.Add(RegisterSpawnTool(FRegistry, FSubagentCtx, FConfig.Subagents));
+    FSpawnTool := RegisterSpawnTool(FRegistry, FSubagentCtx, FConfig.Subagents);
+    FOwnedTools.Add(FSpawnTool);
   end;
   FBuiltinsInstalled := True;
   { Re-install OOP tools that were registered before this point so
@@ -478,6 +487,26 @@ begin
     and skip this re-pass. }
   for i := 0 to FOwnedTools.Count - 1 do
     TPasClawTool(FOwnedTools[i]).Install(FRegistry);
+end;
+
+procedure TPasClawAgent.RefreshSubagentContext;
+begin
+  { Called by ChatHistory after EnsureProvider so the spawn tool's
+    captured TSubagentContext reflects the live provider, fallback
+    chain, and model. Without this, an embedder that calls
+    SetProvider after the first Chat would leave the spawn tool
+    pointing at the old ILLMProvider — EnsureRegistry early-exits
+    on FBuiltinsInstalled and never refreshes the tool. (Codex P2
+    on PR #107.) }
+  if (FSpawnTool = nil) or (FProvider = nil) then Exit;
+  FSubagentCtx.Provider       := FProvider;
+  FSubagentCtx.Fallbacks      := ResolveFallbacks(FConfig);
+  FSubagentCtx.ParentRegistry := FRegistry;
+  if FModel <> '' then
+    FSubagentCtx.DefaultModel := FModel
+  else
+    FSubagentCtx.DefaultModel := FConfig.DefaultModel;
+  FSpawnTool.SetContext(FSubagentCtx);
 end;
 
 procedure TPasClawAgent.RegisterTool(ATool: TPasClawTool);
@@ -595,6 +624,12 @@ begin
     Exit;
   end;
   EnsureRegistry;
+  { After EnsureProvider rebuilt FProvider (e.g. because SetProvider
+    was called post-Chat), the spawn tool may be holding a stale
+    captured context. Refresh it now so the next spawn dispatch
+    uses the live provider + fallbacks. No-op when there's no
+    subagent tool installed. }
+  RefreshSubagentContext;
 
   SetLength(Msgs, Length(History));
   for i := 0 to High(History) do Msgs[i] := History[i];

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -127,6 +127,41 @@ type
     Enabled: Boolean;
   end;
 
+  (* TSubagentSpec - declaration of a named subagent the parent agent
+     can fan out to via the `spawn` tool. Each spec is a focused
+     "specialist" — its own system prompt, an allowlist of tools
+     inherited from the parent's registry, an optional model
+     override, and an iteration cap. The spawned subagent runs as a
+     standalone RunToolLoop call (not a separate TPasClawAgent) so it
+     piggybacks on the parent's provider + fallback chain without
+     paying the MCP / skill / registry-rebuild cost.
+
+       Name         caller-facing name (lowercase, kebab-case)
+       Description  one-line summary surfaced to the parent model
+                    in the `spawn` tool's description so it can pick
+                    the right specialist
+       SystemPrompt the subagent's specialisation prompt — replaces
+                    the parent's prompt for this child turn
+       Tools        names of parent-registry tools the subagent is
+                    allowed to call. Empty means "no tools" (a
+                    prompt-driven specialist). 'spawn' is always
+                    excluded — no nested sub-subagents in v1.
+       Model        empty = inherit parent's model. Cross-provider
+                    model names go through the fallback chain (same
+                    as the parent's loop).
+       MaxIter      iteration cap for the subagent's tool loop. 0
+                    means default (4). Keep this tight — the
+                    subagent should produce a focused answer, not
+                    nest into a long conversation. *)
+  TSubagentSpec = record
+    Name:          string;
+    Description:   string;
+    SystemPrompt:  string;
+    Tools:         array of string;
+    Model:         string;
+    MaxIter:       Integer;
+  end;
+
   (* TWebSearchConfig - web_search tool provider selection.
        Provider:   'duckduckgo' (default, no key) | 'brave' | 'tavily' |
                    'searxng'    | 'perplexity'
@@ -160,6 +195,7 @@ type
     MCPServers: array of TMCPServer;
     Crons:      array of TCronEntry;
     Skills:     array of TSkillEntry;
+    Subagents:  array of TSubagentSpec;
     WebSearch:  TWebSearchConfig;
     constructor Create;
     function  ToJSON: string;
@@ -242,6 +278,26 @@ begin
   Result.PutStr ('name',    S.Name);
   Result.PutStr ('source',  S.Source);
   Result.PutBool('enabled', S.Enabled);
+end;
+
+function SubagentToJSON(const S: TSubagentSpec): TJsonObject;
+var
+  ToolsArr: TJsonArray;
+  i: Integer;
+begin
+  Result := TJsonObject.Create;
+  Result.PutStr('name',          S.Name);
+  Result.PutStr('description',   S.Description);
+  Result.PutStr('system_prompt', S.SystemPrompt);
+  if Length(S.Tools) > 0 then
+  begin
+    ToolsArr := TJsonArray.Create;
+    for i := 0 to High(S.Tools) do
+      ToolsArr.AddStr(S.Tools[i]);
+    Result.PutArray('tools', ToolsArr);
+  end;
+  if S.Model <> '' then Result.PutStr('model', S.Model);
+  if S.MaxIter > 0 then Result.PutInt('max_iterations', S.MaxIter);
 end;
 
 function TConfig.ToJSON: string;
@@ -328,6 +384,17 @@ begin
     end;
     Root.PutArray('skills', Arr);
 
+    if Length(Subagents) > 0 then
+    begin
+      Arr := TJsonArray.Create;
+      for i := 0 to High(Subagents) do
+      begin
+        Tmp := SubagentToJSON(Subagents[i]);
+        Arr.AddObject(Tmp);
+      end;
+      Root.PutArray('subagents', Arr);
+    end;
+
     Result := Root.ToJSON;
   finally
     Root.Free;
@@ -337,8 +404,8 @@ end;
 procedure TConfig.FromJSON(const S: string);
 var
   Root, Obj, Item: TJsonObject;
-  Arr: TJsonArray;
-  i: Integer;
+  Arr, ToolsArr: TJsonArray;
+  i, j: Integer;
 begin
   if Trim(S) = '' then Exit;
   Root := TJsonObject.Parse(S);
@@ -496,6 +563,37 @@ begin
           Skills[i].Name    := Item.GetStr ('name',    '');
           Skills[i].Source  := Item.GetStr ('source',  '');
           Skills[i].Enabled := Item.GetBool('enabled', True);
+        finally
+          Item.Free;
+        end;
+      end;
+    finally
+      Arr.Free;
+    end;
+
+    Arr := Root.ChildArray('subagents');
+    if Arr <> nil then
+    try
+      SetLength(Subagents, Arr.Count);
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          Subagents[i].Name         := Item.GetStr('name',          '');
+          Subagents[i].Description  := Item.GetStr('description',   '');
+          Subagents[i].SystemPrompt := Item.GetStr('system_prompt', '');
+          Subagents[i].Model        := Item.GetStr('model',         '');
+          Subagents[i].MaxIter      := Item.GetInt('max_iterations', 0);
+          ToolsArr := Item.ChildArray('tools');
+          if ToolsArr <> nil then
+          try
+            SetLength(Subagents[i].Tools, ToolsArr.Count);
+            for j := 0 to ToolsArr.Count - 1 do
+              Subagents[i].Tools[j] := ToolsArr.ItemStr(j);
+          finally
+            ToolsArr.Free;
+          end;
         finally
           Item.Free;
         end;


### PR DESCRIPTION
## Summary

Sub-agents (`spawn(agent, prompt)` tool) **plus** the two Codex P2 review fixes against the original draft. Two commits:

1. `5cae0eb` — original subagent implementation (was PR #107)
2. `80f0d7b` — review fixes on top

## What's in commit 1 (`5cae0eb`)

New `PasClaw.Agent.Subagent` unit ships a `spawn(agent, prompt)` tool that lets the model fan out to focused specialist subagents declared in `config.json`. Mirrors picoclaw's `SubTurn`, nanobot's `subagent`, and openclaw's multi-agent routing.

```json
"subagents": [
  { "name": "researcher",
    "description": "Web search + summary specialist",
    "system_prompt": "You search the web and produce a 3-bullet summary...",
    "tools": ["web_search", "web_fetch"],
    "max_iterations": 4 },
  { "name": "coder",
    "description": "Code editor",
    "system_prompt": "You edit code precisely using hashline patches...",
    "tools": ["fs_read", "fs_write", "fs_grep", "fs_edit_hashline"] }
]
```

- `TSubagentSpec` in `PasClaw.Config` + JSON load/save under `"subagents": [...]`
- `TSubagentContext` bundles `Provider` / `Fallbacks` / `ParentRegistry` / `DefaultModel`
- `BuildFilteredRegistry` produces a registry filtered to allowlisted tools (always excludes `spawn` — no nested sub-subagents in v1)
- `TSpawnTool: TPasClawTool` — Schema is a JSON object with required `{agent, prompt}` and an `enum` of available agent names; `Category = tcMutating` so it stays serial in the parallel-batch dispatch
- Runs a bare `RunToolLoop` against the filtered registry instead of spawning a child `TPasClawAgent` — avoids lifting the single-instance MCP/Skills constraint and pays no startup cost per spawn
- Wired in `Cmd.Agent.MaybeRegisterSpawnTool` (CLI) and `TPasClawAgent.EnsureRegistry` (embedder API)

## What's in commit 2 (`80f0d7b`) — Codex review fixes

### P2 #1 — `RunSingleTurn` captured `Model` before assigning it

The CLI's single-turn path called `MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model)` before the line that resolves `Model` from `A.Model` / `Cfg.DefaultModel`. So `Model` was `''` when the spawn tool's `TSubagentContext.DefaultModel` was captured — a `pasclaw agent -m claude-opus-4-7 "prompt"` that called `spawn()` ignored the user's `--model` selection. `RunInteractive` had the right order; this brings `RunSingleTurn` into line.

### P2 #2 — Stale provider in spawn tool after embedder `SetProvider`

`TPasClawAgent.SetProvider` drops `FProvider := nil` so `EnsureProvider` rebuilds on the next `Chat`, but `EnsureRegistry` short-circuits on `FBuiltinsInstalled = True` — the spawn tool installed during the first `Chat` was still holding a captured `TSubagentContext` pointing at the old `ILLMProvider`. Fix in three pieces:

1. **`TSpawnTool.SetContext(const ACtx: TSubagentContext)`** — trivial, `FCtx := ACtx`.
2. **`TPasClawAgent.FSpawnTool: TSpawnTool`** borrowed-reference field, set in `EnsureRegistry`'s subagent-install block.
3. **`TPasClawAgent.RefreshSubagentContext`** rebuilds `FSubagentCtx` from current `FProvider` / `FConfig` / `FModel` and calls `FSpawnTool.SetContext`. `ChatHistory` calls it after `EnsureProvider` + `EnsureRegistry`, so every `Chat` refreshes — even when the registry was already populated.

## Verification

End-to-end test (built + run + removed, not committed): stub `TFakeProvider` returns one round of `spawn(echo, "hello sub")` on the parent then `"subagent saw: hello sub"` on the subagent turn. Output:

```
parent final content: parent done
parent iterations:    2
parent message count: 3
PASS
```

`make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_