### PR TITLE
build: dcc64 cleanup — 1 error + 5 hints + 1 warning from PR #108

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -254,7 +254,12 @@ begin
     Result := Lines.Text;
     { Strip trailing newline TStringList.Text adds, so the SectionSep
       below doesn't end up with an extra blank line. }
-    while (Result <> '') and (Result[Length(Result)] in [#10, #13]) do
+    { CharInSet (vs the `in` shorthand) — under Delphi 12 dcc64 the
+      string is UnicodeString so Result[i] is WideChar; `in [#10,#13]`
+      coerces it back to AnsiChar and emits W1050. CharInSet keeps
+      the WideChar without the truncation warning; FPC's SysUtils
+      ships the same helper so no per-compiler gate is needed. }
+    while (Result <> '') and CharInSet(Result[Length(Result)], [#10, #13]) do
       SetLength(Result, Length(Result) - 1);
   finally
     Lines.Free;

--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -47,7 +47,9 @@ uses
   PasClaw.Tools.Obj;
 
 type
-  TSubagentSpecArray = array of TSubagentSpec;
+  { TSubagentSpecArray now lives in PasClaw.Config alongside
+    TSubagentSpec — see comment there for the dcc64 named-type
+    rationale. The use clause above pulls it in. }
 
   { Everything the spawn tool needs from its parent — captured at
     registration time so the tool handler can run a child loop

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -161,6 +161,15 @@ type
     Model:         string;
     MaxIter:       Integer;
   end;
+  { Named-type alias for dcc64 strict-array compatibility — assigning
+    Cfg.Subagents into a `TSubagentSpecArray` parameter (which
+    PasClaw.Agent.Subagent.RegisterSpawnTool / TSpawnTool.Create take)
+    used to E2010 because TConfig.Subagents was declared as an inline
+    `array of TSubagentSpec`. Same pattern as TLLMProviderArray
+    (PR #104) and TStringArray / TUInt32Array (PR #106). Owning the
+    alias here means callers in higher layers pick it up by importing
+    PasClaw.Config — they don't have to re-declare. }
+  TSubagentSpecArray = array of TSubagentSpec;
 
   (* TWebSearchConfig - web_search tool provider selection.
        Provider:   'duckduckgo' (default, no key) | 'brave' | 'tavily' |
@@ -195,7 +204,7 @@ type
     MCPServers: array of TMCPServer;
     Crons:      array of TCronEntry;
     Skills:     array of TSkillEntry;
-    Subagents:  array of TSubagentSpec;
+    Subagents:  TSubagentSpecArray;  { see comment on the type alias }
     WebSearch:  TWebSearchConfig;
     constructor Create;
     function  ToJSON: string;

--- a/src/pkg/search/PasClaw.Search.Brave.pas
+++ b/src/pkg/search/PasClaw.Search.Brave.pas
@@ -109,7 +109,6 @@ begin
     Exit;
   end;
 
-  Root := nil;
   try
     Root := TJsonObject.Parse(Resp.Body);
   except

--- a/src/pkg/search/PasClaw.Search.Gemini.pas
+++ b/src/pkg/search/PasClaw.Search.Gemini.pas
@@ -263,7 +263,6 @@ begin
     Exit;
   end;
 
-  Root := nil;
   try
     Root := TJsonObject.Parse(Resp.Body);
   except

--- a/src/pkg/search/PasClaw.Search.Perplexity.pas
+++ b/src/pkg/search/PasClaw.Search.Perplexity.pas
@@ -90,7 +90,6 @@ begin
   ErrMsg := '';
   Result := False;
 
-  Root := nil;
   try
     Root := TJsonObject.Parse(JSONBody);
   except

--- a/src/pkg/search/PasClaw.Search.SearXNG.pas
+++ b/src/pkg/search/PasClaw.Search.SearXNG.pas
@@ -134,7 +134,6 @@ begin
     Exit;
   end;
 
-  Root := nil;
   try
     Root := TJsonObject.Parse(Resp.Body);
   except

--- a/src/pkg/search/PasClaw.Search.Tavily.pas
+++ b/src/pkg/search/PasClaw.Search.Tavily.pas
@@ -98,7 +98,6 @@ begin
     Exit;
   end;
 
-  Root := nil;
   try
     Root := TJsonObject.Parse(Resp.Body);
   except


### PR DESCRIPTION
Delphi 12 dcc64 reported one error and six advisories on the subagents code that landed via PR #108 plus pre-existing search- provider noise:

  PR-introduced:
    PasClaw.Cmd.Agent.pas(164): E2010 Incompatible types:
      'TSubagentSpecArray' and 'Dynamic array'

  Pre-existing (now also cleaned up):
    PasClaw.Search.Brave.pas(112):      H2077 Value assigned to 'Root' never used
    PasClaw.Search.Tavily.pas(101):     H2077 Value assigned to 'Root' never used
    PasClaw.Search.SearXNG.pas(137):    H2077 Value assigned to 'Root' never used
    PasClaw.Search.Perplexity.pas(93):  H2077 Value assigned to 'Root' never used
    PasClaw.Search.Gemini.pas(266):     H2077 Value assigned to 'Root' never used
    PasClaw.Agent.Prompt.pas(257):      W1050 WideChar reduced to byte char in set expressions

E2010 — same dcc64 strict-named-type pattern as PRs #99 / #104 / #106. TConfig.Subagents was declared inline as `array of TSubagentSpec`; RegisterSpawnTool takes `const Specs: TSubagentSpecArray`. Under FPC mode-Delphi the structurally- identical inline form is accepted; dcc64 rejects with E2010.

Fix: promoted TSubagentSpecArray from PasClaw.Agent.Subagent up to PasClaw.Config (alongside TSubagentSpec). TConfig.Subagents now uses the named alias; both callers point at the same type. Comment notes the pattern so the next contributor doesn't re-introduce an inline declaration.

W1050 — Result[Length(Result)] is WideChar under modern Delphi (UnicodeString), so `Result[i] in [#10, #13]` truncates to AnsiChar. Replaced with CharInSet from SysUtils — same helper ships under both FPC and Delphi, no per-compiler gate needed.

H2077 — each search-provider unit had a pattern like:

    Root := nil;
    try
      Root := TJsonObject.Parse(Resp.Body);
    except
      ...
    end;

The `Root := nil;` is dead: TJsonObject.Parse either returns a value (used immediately) or raises (jumps to except which doesn't read Root). dcc64 flagged the wasted assignment; FPC silently ignored it. Dropped the line in Brave / Tavily / SearXNG / Perplexity / Gemini (5 sites). Behaviour unchanged.

Verified `make clean && make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon