### PR TITLE
hooks: fix PR #110 review — steering via SystemPrompt + wire OnError

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -523,15 +523,15 @@ begin
     Loop.LastResp := Resp;
 
     { Provider failure surfaces to hooks. After the fallback walk
-      above, if the final status code is still non-2xx — every
-      configured fallback also returned a retryable status, or we
-      hit an outright non-retryable 4xx — fire OnError(hsProviderCall)
-      so audit / metrics / alerting hooks can record it. Loop
-      continues so a downstream hook or the existing OnText path
-      gets a chance to surface the error to the embedder. (Codex P2
-      on PR #110 — these helpers existed but nothing called them.) }
+      above, fire OnError(hsProviderCall) whenever the final status
+      isn't a 2xx — including non-positive codes (StatusCode <= 0)
+      which the HTTP helper uses to flag pre-HTTP failures: DNS
+      lookup miss, TLS handshake refusal, socket reset, no
+      OpenSSL IO handler. Earlier this guard required StatusCode > 0
+      and silently skipped exactly those cases — the ones an audit
+      / alerting hook most wants to see. (Codex P2 on PR #111.) }
     if (Length(Cfg.Hooks) > 0) and
-       ((Resp.StatusCode > 0) and ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300))) then
+       ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300)) then
       HooksOnError(Cfg.Hooks, hsProviderCall,
                     Format('provider returned status=%d', [Resp.StatusCode]));
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -522,6 +522,19 @@ begin
     end;
     Loop.LastResp := Resp;
 
+    { Provider failure surfaces to hooks. After the fallback walk
+      above, if the final status code is still non-2xx — every
+      configured fallback also returned a retryable status, or we
+      hit an outright non-retryable 4xx — fire OnError(hsProviderCall)
+      so audit / metrics / alerting hooks can record it. Loop
+      continues so a downstream hook or the existing OnText path
+      gets a chance to surface the error to the embedder. (Codex P2
+      on PR #110 — these helpers existed but nothing called them.) }
+    if (Length(Cfg.Hooks) > 0) and
+       ((Resp.StatusCode > 0) and ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300))) then
+      HooksOnError(Cfg.Hooks, hsProviderCall,
+                    Format('provider returned status=%d', [Resp.StatusCode]));
+
     { Stream the text part to the caller now so they can show progress. }
     if Assigned(Cfg.OnText) and (Resp.Content <> '') then
       Cfg.OnText(Resp.Content);
@@ -634,6 +647,15 @@ begin
           Cfg.OnToolResult(Dispatches[Batch[j]].Call.Func.Name,
                            Dispatches[Batch[j]].ResultText,
                            Dispatches[Batch[j]].Err);
+        { Tool failure surfaces to hooks. Fires whether the handler
+          raised (worker caught it into Err) or PreflightToolCall
+          rejected the args. Hooks see Stage = hsDuringToolCall.
+          (Codex P2 on PR #110.) }
+        if (Length(Cfg.Hooks) > 0) and (Dispatches[Batch[j]].Err <> '') then
+          HooksOnError(Cfg.Hooks, hsDuringToolCall,
+                        Format('tool "%s": %s',
+                               [Dispatches[Batch[j]].Call.Func.Name,
+                                Dispatches[Batch[j]].Err]));
         SetLength(Hist, Length(Hist) + 1);
         if Dispatches[Batch[j]].Err <> '' then
           Hist[High(Hist)] := MakeToolResult(Dispatches[Batch[j]].Call.Id,
@@ -643,15 +665,35 @@ begin
                                               Dispatches[Batch[j]].ResultText);
       end;
 
-      { Phase 3: if any hook contributed a steering note, append one
-        consolidated system-role message so the next iteration's LLM
-        round-trip sees it. Picoclaw's steering pattern — lets the
-        embedder inject "based on the file you just read, also check X"
-        without restructuring the loop. }
+      { Phase 3: if any hook contributed a steering note, fold it
+        into LiveOptions.SystemPrompt so the next iteration's LLM
+        round-trip sees it.
+
+        WHY THE SYSTEM PROMPT, NOT mrSystem IN HISTORY:
+          The PasClaw.Providers.OpenAI / Anthropic / Gemini builders
+          explicitly DROP in-history mrSystem entries whenever the
+          ChatOptions.SystemPrompt slot is non-empty — they ship one
+          consolidated system prompt via that slot, not via the
+          messages array, so an mrSystem appended to Hist gets
+          silently dropped on the next provider call. TPasClawAgent.
+          ChatHistory always populates Cfg.Options.SystemPrompt via
+          BuildSystemPrompt, so the default component path always
+          hits this case. Routing steering through SystemPrompt
+          keeps it visible on every provider. (Codex P1 on PR #110.)
+
+          Side effect: steering accumulates across iterations, which
+          is the picoclaw semantic — each new tool result can add
+          context that the model carries through to the end of the
+          loop. If an embedder wants ephemeral per-batch steering
+          they can reset SystemPrompt in BeforeTurn. }
       if BatchSteering <> '' then
       begin
-        SetLength(Hist, Length(Hist) + 1);
-        Hist[High(Hist)] := MakeMessage(mrSystem, BatchSteering);
+        if LiveOptions.SystemPrompt <> '' then
+          LiveOptions.SystemPrompt := LiveOptions.SystemPrompt
+                                      + sLineBreak + sLineBreak
+                                      + BatchSteering
+        else
+          LiveOptions.SystemPrompt := BatchSteering;
       end;
     end;
   end;


### PR DESCRIPTION
**Stacks on PR #110.** Targets `claude/hooks-and-steering` so the diff is just the review fixes; once #110 merges, GitHub will auto-retarget to `main`.

## Summary

Two Codex findings on PR #110.

### P1 — Steering messages invisible under the default component config

PR #110 appended each batch's `SteeringMessages` as an `mrSystem` entry in `Hist` before the next LLM round. But the OpenAI / Anthropic / Gemini provider builders **explicitly drop in-history `mrSystem` entries whenever `ChatOptions.SystemPrompt` is non-empty** — they ship one consolidated system prompt via that slot, not via the messages array. `TPasClawAgent.ChatHistory` always populates `Cfg.Options.SystemPrompt` via `BuildSystemPrompt`, so the default component path always hit this case. Steering was silently dropped before reaching the model.

**Fix**: fold `BatchSteering` into `LiveOptions.SystemPrompt` (which **does** get shipped to the model on the next `Provider.Chat`) instead of appending an `mrSystem` to `Hist`. Two newlines as a separator preserves the original `BuildSystemPrompt` content's formatting.

**Side effect**: steering accumulates across iterations through end of loop — the picoclaw semantic (each new tool result builds on prior steering). Embedders wanting ephemeral per-batch steering can reset `SystemPrompt` in `BeforeTurn`.

### P2 — `HooksOnError` dispatcher declared but never invoked

The helper existed in `PasClaw.Agent.Hooks`; nothing in `RunToolLoop` called it. None of the documented stages could reach an embedder's audit hook.

**Fix**: wired `HooksOnError` into two failure paths:

| Stage | Trigger |
|---|---|
| `hsProviderCall` | After the fallback walk, if the final response carries non-2xx (every fallback failed, or a non-retryable 4xx came back). |
| `hsDuringToolCall` | Per batch slot in phase 3, if `Dispatches[j].Err` is non-empty after dispatch. Covers both `PreflightToolCall` rejections and worker-caught handler exceptions. |

The other stages (`hsBeforeTurn`, `hsBeforeToolCall`, `hsAfterToolResult`) currently have no failure modes `RunToolLoop` catches — hook methods that raise propagate up since hooks run on the main thread. Those stages stay in the API for future use.

## Verification

Three-part end-to-end test (built + run + removed):

```
=== Test 1: steering folds into SystemPrompt ===
  PASS — steering in SystemPrompt, no stray mrSystem
=== Test 2a: hsDuringToolCall fires ===
  PASS — fired 1 time(s), last msg: tool "fail_tool": simulated tool failure
=== Test 2b: hsProviderCall fires ===
  PASS — fired 1 time(s), last msg: provider returned status=502

all PR #110 review-fix tests passed.
```

Test 1 asserts the steering text appears in `Loop.FinalSystemPrompt` **and** that no `mrSystem` message with the steering text leaked into `Loop.FinalMessages`. Tests 2a/2b register an audit hook + a deliberately-failing tool / provider and check the audit hook recorded the right stage + message.

`make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_