### PR TITLE
hooks: fix PR #111 review — OnError fires for status ≤ 0 too

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -523,15 +523,15 @@ begin
     Loop.LastResp := Resp;
 
     { Provider failure surfaces to hooks. After the fallback walk
-      above, if the final status code is still non-2xx — every
-      configured fallback also returned a retryable status, or we
-      hit an outright non-retryable 4xx — fire OnError(hsProviderCall)
-      so audit / metrics / alerting hooks can record it. Loop
-      continues so a downstream hook or the existing OnText path
-      gets a chance to surface the error to the embedder. (Codex P2
-      on PR #110 — these helpers existed but nothing called them.) }
+      above, fire OnError(hsProviderCall) whenever the final status
+      isn't a 2xx — including non-positive codes (StatusCode <= 0)
+      which the HTTP helper uses to flag pre-HTTP failures: DNS
+      lookup miss, TLS handshake refusal, socket reset, no
+      OpenSSL IO handler. Earlier this guard required StatusCode > 0
+      and silently skipped exactly those cases — the ones an audit
+      / alerting hook most wants to see. (Codex P2 on PR #111.) }
     if (Length(Cfg.Hooks) > 0) and
-       ((Resp.StatusCode > 0) and ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300))) then
+       ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300)) then
       HooksOnError(Cfg.Hooks, hsProviderCall,
                     Format('provider returned status=%d', [Resp.StatusCode]));
 


### PR DESCRIPTION
**Stacks on PR #111.** Targets `claude/pr110-review-fixes` so the diff shows just this fix.

## Summary

Codex P2 on PR #111: the `OnError(hsProviderCall)` dispatcher gated on `Resp.StatusCode > 0`, so DNS / TLS / socket / no-OpenSSL failures (the HTTP helper flags those as `StatusCode := -1`) silently slipped past the audit-hook path. Exactly the outage modes an embedder running unattended would want to alert on.

## Fix

Drop the `StatusCode > 0` guard. Condition is now "anything that isn't 2xx" — covers `-1` (network/TLS), `0` (pre-HTTP unclassified failure), `4xx` (auth/bad-request), and `5xx` (server) in one check.

```diff
- if (Resp.StatusCode > 0) and
-    ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300)) then
+ if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
```

## Verification

Probe test (built + run + removed) over five representative status codes:

```
--- probe status=-1  ---  PASS — provider returned status=-1
--- probe status=0   ---  PASS — provider returned status=0
--- probe status=429 ---  PASS — provider returned status=429
--- probe status=502 ---  PASS — provider returned status=502
--- probe status=401 ---  PASS — provider returned status=401

PASS — all non-2xx statuses now reach OnError hooks.
```

`make clean && make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_