### PR TITLE
hooks: recover PR #111 + #112 review fixes onto main

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -523,15 +523,15 @@ begin
     Loop.LastResp := Resp;
 
     { Provider failure surfaces to hooks. After the fallback walk
-      above, if the final status code is still non-2xx — every
-      configured fallback also returned a retryable status, or we
-      hit an outright non-retryable 4xx — fire OnError(hsProviderCall)
-      so audit / metrics / alerting hooks can record it. Loop
-      continues so a downstream hook or the existing OnText path
-      gets a chance to surface the error to the embedder. (Codex P2
-      on PR #110 — these helpers existed but nothing called them.) }
+      above, fire OnError(hsProviderCall) whenever the final status
+      isn't a 2xx — including non-positive codes (StatusCode <= 0)
+      which the HTTP helper uses to flag pre-HTTP failures: DNS
+      lookup miss, TLS handshake refusal, socket reset, no
+      OpenSSL IO handler. Earlier this guard required StatusCode > 0
+      and silently skipped exactly those cases — the ones an audit
+      / alerting hook most wants to see. (Codex P2 on PR #111.) }
     if (Length(Cfg.Hooks) > 0) and
-       ((Resp.StatusCode > 0) and ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300))) then
+       ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300)) then
       HooksOnError(Cfg.Hooks, hsProviderCall,
                     Format('provider returned status=%d', [Resp.StatusCode]));
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -522,6 +522,19 @@ begin
     end;
     Loop.LastResp := Resp;
 
+    { Provider failure surfaces to hooks. After the fallback walk
+      above, if the final status code is still non-2xx — every
+      configured fallback also returned a retryable status, or we
+      hit an outright non-retryable 4xx — fire OnError(hsProviderCall)
+      so audit / metrics / alerting hooks can record it. Loop
+      continues so a downstream hook or the existing OnText path
+      gets a chance to surface the error to the embedder. (Codex P2
+      on PR #110 — these helpers existed but nothing called them.) }
+    if (Length(Cfg.Hooks) > 0) and
+       ((Resp.StatusCode > 0) and ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300))) then
+      HooksOnError(Cfg.Hooks, hsProviderCall,
+                    Format('provider returned status=%d', [Resp.StatusCode]));
+
     { Stream the text part to the caller now so they can show progress. }
     if Assigned(Cfg.OnText) and (Resp.Content <> '') then
       Cfg.OnText(Resp.Content);
@@ -634,6 +647,15 @@ begin
           Cfg.OnToolResult(Dispatches[Batch[j]].Call.Func.Name,
                            Dispatches[Batch[j]].ResultText,
                            Dispatches[Batch[j]].Err);
+        { Tool failure surfaces to hooks. Fires whether the handler
+          raised (worker caught it into Err) or PreflightToolCall
+          rejected the args. Hooks see Stage = hsDuringToolCall.
+          (Codex P2 on PR #110.) }
+        if (Length(Cfg.Hooks) > 0) and (Dispatches[Batch[j]].Err <> '') then
+          HooksOnError(Cfg.Hooks, hsDuringToolCall,
+                        Format('tool "%s": %s',
+                               [Dispatches[Batch[j]].Call.Func.Name,
+                                Dispatches[Batch[j]].Err]));
         SetLength(Hist, Length(Hist) + 1);
         if Dispatches[Batch[j]].Err <> '' then
           Hist[High(Hist)] := MakeToolResult(Dispatches[Batch[j]].Call.Id,
@@ -643,15 +665,35 @@ begin
                                               Dispatches[Batch[j]].ResultText);
       end;
 
-      { Phase 3: if any hook contributed a steering note, append one
-        consolidated system-role message so the next iteration's LLM
-        round-trip sees it. Picoclaw's steering pattern — lets the
-        embedder inject "based on the file you just read, also check X"
-        without restructuring the loop. }
+      { Phase 3: if any hook contributed a steering note, fold it
+        into LiveOptions.SystemPrompt so the next iteration's LLM
+        round-trip sees it.
+
+        WHY THE SYSTEM PROMPT, NOT mrSystem IN HISTORY:
+          The PasClaw.Providers.OpenAI / Anthropic / Gemini builders
+          explicitly DROP in-history mrSystem entries whenever the
+          ChatOptions.SystemPrompt slot is non-empty — they ship one
+          consolidated system prompt via that slot, not via the
+          messages array, so an mrSystem appended to Hist gets
+          silently dropped on the next provider call. TPasClawAgent.
+          ChatHistory always populates Cfg.Options.SystemPrompt via
+          BuildSystemPrompt, so the default component path always
+          hits this case. Routing steering through SystemPrompt
+          keeps it visible on every provider. (Codex P1 on PR #110.)
+
+          Side effect: steering accumulates across iterations, which
+          is the picoclaw semantic — each new tool result can add
+          context that the model carries through to the end of the
+          loop. If an embedder wants ephemeral per-batch steering
+          they can reset SystemPrompt in BeforeTurn. }
       if BatchSteering <> '' then
       begin
-        SetLength(Hist, Length(Hist) + 1);
-        Hist[High(Hist)] := MakeMessage(mrSystem, BatchSteering);
+        if LiveOptions.SystemPrompt <> '' then
+          LiveOptions.SystemPrompt := LiveOptions.SystemPrompt
+                                      + sLineBreak + sLineBreak
+                                      + BatchSteering
+        else
+          LiveOptions.SystemPrompt := BatchSteering;
       end;
     end;
   end;


### PR DESCRIPTION
## Recovery — bring PR #111 + #112 review fixes into main

PR #110 merged to `main` before its review-fix PRs (#111, #112) existed. When those landed they each targeted the PR #110 / PR #111 branches respectively, so the four resulting commits ended up stranded on `claude/hooks-and-steering` without ever reaching `main`.

This PR fast-forwards the four stranded commits across:

| Commit | Origin |
|---|---|
| `4382019` | PR #111 — steering folds into `LiveOptions.SystemPrompt` (not in-history `mrSystem`) + wire `HooksOnError(hsProviderCall, hsDuringToolCall)` |
| `3ad3436` | PR #112 — drop `StatusCode > 0` guard so DNS/TLS/socket failures (status -1) also fire `OnError` |
| `8cad3b0` | merge of #112 into the #111 branch |
| `a795363` | merge of #111 into the hooks branch |

## Why the merge order matters

- **Provider-config users** (the default `TPasClawAgent` path with `Cfg.Options.SystemPrompt` populated) currently see steering messages silently dropped because PR #110 routes them through in-history `mrSystem` which the OpenAI/Anthropic/Gemini builders skip when `SystemPrompt` is non-empty. PR #111 fixes this.
- **Audit hooks** registered to observe failures currently never fire — `HooksOnError` was declared but unused. PR #111 wires it; PR #112 widens the trigger to include non-HTTP failures (TLS handshake refusal, DNS misses, OpenSSL absent).

Without this recovery, both fixes stay in the branch graveyard and `main` ships hooks that don't actually deliver steering or error notifications for the common case.

## Verification

Tests run against `claude/hooks-and-steering` HEAD when PR #111 / #112 were opened:

```
=== Test 1: steering folds into SystemPrompt ===
  PASS — steering in SystemPrompt, no stray mrSystem
=== Test 2a: hsDuringToolCall fires ===
  PASS — fired 1 time(s), last msg: tool "fail_tool": simulated tool failure
=== Test 2b: hsProviderCall fires ===
  PASS — fired 1 time(s), last msg: provider returned status=502

--- probe status=-1  ---  PASS — provider returned status=-1
--- probe status=0   ---  PASS — provider returned status=0
--- probe status=429 ---  PASS — provider returned status=429
--- probe status=502 ---  PASS — provider returned status=502
--- probe status=401 ---  PASS — provider returned status=401
```

`make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_