### PR TITLE
build: Windows-ARM64 via FPC cross-build — updater suffix + Makefile CROSS_TARGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,38 @@ UNAME_S      := $(shell uname -s)
 UNAME_M      := $(shell uname -m)
 FPC_VERSION  ?= 3.2.2
 
-ifeq ($(UNAME_S),Darwin)
+# Cross-target override. Set CROSS_TARGET to one of:
+#
+#   aarch64-win64   Windows on ARM64 (Delphi 13 / FPC 3.2+ with the
+#                   aarch64-win64 cross-build installed). FPC switches
+#                   target via -Twin64 -Paarch64; unit search path
+#                   must point at the aarch64-win64 RTL fcl-db /
+#                   sqlite / iconvenc ppu files via FPC_UNITS_DIR.
+#                   Typical invocation:
+#                     make CROSS_TARGET=aarch64-win64 \
+#                          FPC_UNITS_DIR=/opt/fpc/units/aarch64-win64 \
+#                          FPC='fpc -Twin64 -Paarch64' \
+#                          BIN=build/pasclaw-arm64.exe
+#
+#   x86_64-win64    Windows x64 cross-compile. Set FPC='fpc -Twin64'
+#                   and the corresponding unit dir.
+#
+# When CROSS_TARGET is empty the host-target autodetection below
+# (Darwin / Linux × x86_64 / aarch64) wins, same as before.
+ifneq ($(CROSS_TARGET),)
+  FPC_ARCH ?= $(CROSS_TARGET)
+  # Unit directory layout for cross-targets isn't standardised; the
+  # caller knows where their cross-build's units live. Require
+  # FPC_UNITS_DIR explicitly so the Makefile doesn't blindly hand a
+  # wrong path to fpc.
+  ifndef FPC_UNITS_DIR
+    $(error CROSS_TARGET=$(CROSS_TARGET) requires FPC_UNITS_DIR pointing at the cross-build unit tree)
+  endif
+  # Lazarus's Masks unit (LAZUTILS_DIR) is platform-portable Pascal,
+  # so the host build's lazutils tree works for cross-builds. Empty
+  # disables the include.
+  LAZUTILS_DIR ?=
+else ifeq ($(UNAME_S),Darwin)
   # Homebrew FPC lays units under <prefix>/lib/fpc/<ver>/units/<arch>-darwin/.
   # Prefix is /opt/homebrew on Apple Silicon, /usr/local on Intel.
   ifeq ($(UNAME_M),arm64)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Form-designable with published properties for the VCL/FMX path; code-driven OOP 
 ]
 ```
 
-**Cross-platform** — Linux x86_64 + aarch64 under FPC 3.2+; macOS x86_64 + arm64 under FPC (Homebrew unit paths autodetected); Windows x64 + ARM64 + Linux + macOS under Delphi 12 / 13 / RAD Studio. The Makefile probes `uname` for host targets and accepts `CROSS_TARGET=aarch64-win64` (or any FPC target triple) for cross-builds — pair with `FPC_UNITS_DIR` pointing at the cross-build's unit tree. `PasClaw.dproj` ships `Win64x` (ARM Windows) alongside `Win32` / `Win64` / `Linux64`. The updater's release-binary suffix has the matching `windows_arm64.exe` branch. Three sample binaries under `samples/component-console/` plus matching `.dproj` files for RAD Studio and `dcc32.cfg` / `dcc64.cfg` for cmdline Delphi builds.
+**Cross-platform** — Linux x86_64 + aarch64 under FPC 3.2+; macOS x86_64 + arm64 under FPC (Homebrew unit paths autodetected); Windows x64 + Linux + macOS under Delphi 12 / RAD Studio. Windows-on-ARM64 builds via FPC are supported through the Makefile's `CROSS_TARGET=aarch64-win64` override (pair with `FPC_UNITS_DIR` pointing at the cross-build's unit tree); the updater emits `windows_arm64.exe` as the release-asset suffix on those builds. The `Delphi 13 WinArm64EC` target isn't wired into `PasClaw.dproj` yet — add the platform via the IDE's Project Manager when you're ready to ship for it. Three sample binaries under `samples/component-console/` plus matching `.dproj` files for RAD Studio and `dcc32.cfg` / `dcc64.cfg` for cmdline Delphi builds.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Form-designable with published properties for the VCL/FMX path; code-driven OOP 
 ]
 ```
 
-**Cross-platform** — Linux x86_64 + aarch64 under FPC 3.2+; macOS x86_64 + arm64 under FPC (Homebrew unit paths autodetected); Windows + Linux + macOS under Delphi 12 / RAD Studio. The Makefile probes `uname` and picks the right `fcl-db` / `sqlite` / `iconvenc` / `lazutils` paths automatically. Three sample binaries under `samples/component-console/` plus matching `.dproj` files for RAD Studio and `dcc32.cfg` / `dcc64.cfg` for cmdline Delphi builds.
+**Cross-platform** — Linux x86_64 + aarch64 under FPC 3.2+; macOS x86_64 + arm64 under FPC (Homebrew unit paths autodetected); Windows x64 + ARM64 + Linux + macOS under Delphi 12 / 13 / RAD Studio. The Makefile probes `uname` for host targets and accepts `CROSS_TARGET=aarch64-win64` (or any FPC target triple) for cross-builds — pair with `FPC_UNITS_DIR` pointing at the cross-build's unit tree. `PasClaw.dproj` ships `Win64x` (ARM Windows) alongside `Win32` / `Win64` / `Linux64`. The updater's release-binary suffix has the matching `windows_arm64.exe` branch. Three sample binaries under `samples/component-console/` plus matching `.dproj` files for RAD Studio and `dcc32.cfg` / `dcc64.cfg` for cmdline Delphi builds.
 
 ## Requirements
 

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -26,11 +26,6 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='Win64x' and '$(Base)'=='true') or '$(Base_Win64x)'!=''">
-        <Base_Win64x>true</Base_Win64x>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Linux64' and '$(Base)'=='true') or '$(Base_Linux64)'!=''">
         <Base_Linux64>true</Base_Linux64>
         <CfgParent>Base</CfgParent>
@@ -92,10 +87,6 @@
         <BT_BuildType>Debug</BT_BuildType>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
-        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
-        <BT_BuildType>Debug</BT_BuildType>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
         <BT_BuildType>Debug</BT_BuildType>
     </PropertyGroup>
@@ -327,7 +318,6 @@
             <Platforms>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
-                <Platform value="Win64x">True</Platform>
                 <Platform value="Linux64">True</Platform>
             </Platforms>
         </BorlandProject>

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -26,6 +26,11 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64x' and '$(Base)'=='true') or '$(Base_Win64x)'!=''">
+        <Base_Win64x>true</Base_Win64x>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Linux64' and '$(Base)'=='true') or '$(Base_Linux64)'!=''">
         <Base_Linux64>true</Base_Linux64>
         <CfgParent>Base</CfgParent>
@@ -87,6 +92,10 @@
         <BT_BuildType>Debug</BT_BuildType>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>
         <BT_BuildType>Debug</BT_BuildType>
     </PropertyGroup>
@@ -318,6 +327,7 @@
             <Platforms>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
+                <Platform value="Win64x">True</Platform>
                 <Platform value="Linux64">True</Platform>
             </Platforms>
         </BorlandProject>

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -61,7 +61,9 @@ uses
 function HostPlatformSuffix: string;
 begin
   {$IF DEFINED(MSWINDOWS) OR DEFINED(WINDOWS)}
-    {$IF DEFINED(CPUX86_64) OR DEFINED(CPU_X64) OR DEFINED(CPU64)}
+    {$IF DEFINED(CPUAARCH64) OR DEFINED(CPU_ARM64)}
+      Result := 'windows_arm64.exe';
+    {$ELSEIF DEFINED(CPUX86_64) OR DEFINED(CPU_X64) OR DEFINED(CPU64)}
       Result := 'windows_amd64.exe';
     {$ELSE}
       Result := 'windows_386.exe';

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -61,9 +61,17 @@ uses
 function HostPlatformSuffix: string;
 begin
   {$IF DEFINED(MSWINDOWS) OR DEFINED(WINDOWS)}
-    {$IF DEFINED(CPUAARCH64) OR DEFINED(CPU_ARM64)}
+    { Delphi 13's Windows-on-ARM target (when it ships) defines
+      CPUARM64; FPC's Windows-aarch64 cross-build defines
+      CPUAARCH64. Check both so the right suffix lands regardless
+      of compiler. For the 64-bit Windows-x64 case, Delphi defines
+      CPU64BITS (the Embarcadero canonical name for "running on a
+      64-bit CPU") and FPC defines CPUX86_64; the older CPU_X64 /
+      CPU64 spellings we used to check aren't standard on either
+      compiler. (Codex P2 on PR #115.) }
+    {$IF DEFINED(CPUARM64) OR DEFINED(CPUAARCH64)}
       Result := 'windows_arm64.exe';
-    {$ELSEIF DEFINED(CPUX86_64) OR DEFINED(CPU_X64) OR DEFINED(CPU64)}
+    {$ELSEIF DEFINED(CPUX86_64) OR DEFINED(CPU64BITS)}
       Result := 'windows_amd64.exe';
     {$ELSE}
       Result := 'windows_386.exe';


### PR DESCRIPTION
## Summary

Two changes preparing PasClaw for Windows-on-ARM64 — scoped down from the original draft after Codex review + the user noting they're on Delphi 12 (which doesn't ship either ARM Windows target).

Two commits on the branch:

1. `30c9e6e` — original draft (updater + dproj + Makefile)
2. `b8dba83` — review fixes: drop dproj changes, correct Delphi conditional symbols

## What's in the final state

### 1. `PasClaw.Updater.HostPlatformSuffix` — canonical Delphi/FPC ARM symbols

`update --repo owner/name` from an ARM Windows binary now looks for the right asset suffix on the release page. Uses Embarcadero's canonical conditional defines (not the made-up `CPU_ARM64` / `CPU64` symbols from the draft):

```pascal
{$IF DEFINED(CPUARM64) OR DEFINED(CPUAARCH64)}
  Result := 'windows_arm64.exe';                   // Delphi 13 ARM / FPC aarch64
{$ELSEIF DEFINED(CPUX86_64) OR DEFINED(CPU64BITS)}
  Result := 'windows_amd64.exe';                   // FPC x86_64 / Delphi 64-bit
{$ELSE}
  Result := 'windows_386.exe';
{$ENDIF}
```

### 2. `Makefile` — `CROSS_TARGET` override

Host autodetection unchanged. New override sits in front for cross-builds:

```sh
make CROSS_TARGET=aarch64-win64 \
     FPC_UNITS_DIR=/opt/fpc/units/aarch64-win64 \
     FPC='fpc -Twin64 -Paarch64' \
     BIN=build/pasclaw-arm64.exe
```

Errors loudly if `FPC_UNITS_DIR` isn't provided when `CROSS_TARGET` is set — different FPC packagings (Debian's `fpc-aarch64-win64`, FPC source build, vendored tree) lay out unit dirs differently.

### What was reverted

The original draft added `Win64x` to the dproj's TargetedPlatforms fan-out, but:

- `Win64x` is the **C++Builder x64 toolchain (BCC64X)**, NOT the Delphi ARM Windows target. (Codex P1.)
- Delphi 13's actual Windows-on-ARM target is **`WinArm64EC`**.
- The user is on **Delphi 12**, which ships neither.

Exposing a platform identifier the IDE doesn't recognise could confuse the Project Manager on dproj reload. Cleanest fix: revert all three dproj edits (Base_Win64x PropertyGroup, Base_Win64x DCC_UsePackage block, `<Platform value="Win64x">`). The dproj is back to Win32 / Win64 / Linux64 — exactly what Delphi 12 ships.

When the user upgrades to Delphi 13 and wants ARM Windows, they can add `WinArm64EC` via the Project Manager (the IDE writes the right XML automatically). README's cross-platform line notes this explicitly.

## Verification

`make clean && make smoke` 11/11 green on host Linux x86_64. The new `CROSS_TARGET` path is a no-op when unset.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_