### PR TITLE
hooks: fix PR #114 review — exception out-of-band + non-destructive policy copy

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -63,6 +63,17 @@ type
     function SupportsStreaming: Boolean;
   end;
 
+{ Exported for test fixtures — given a TLLMResponse-shaped input,
+  returns the JSON body that would be POSTed to generateContent.
+  Used by the Codex PR #116 review-fix test to assert SystemPrompt
+  / in-history mrSystem dedup without spinning up a real HTTPS
+  round-trip. Tools / ToolIds / ToolNames are normally constructed
+  inside the request flow; tests pass empty arrays. }
+function BuildRequest(const Messages: array of TMessage;
+                      const Tools:    array of TToolDefinition;
+                      const Model:    string;
+                      const Options:  TChatOptions): string;
+
 implementation
 
 uses
@@ -120,16 +131,28 @@ begin
   try
     Contents := TJsonArray.Create;
 
-    { First pass: collect every system prompt for systemInstruction. }
+    { First pass: collect system prompt for systemInstruction.
+
+      Precedence matches the OpenAI / Anthropic builders: when
+      Options.SystemPrompt is non-empty, that wins and in-history
+      mrSystem entries are skipped. When SystemPrompt is empty,
+      fold every in-history mrSystem into Sys. Earlier this
+      builder concatenated BOTH, which double-shipped the policy
+      when the ToolLoop's steering fold copied in-history
+      mrSystem into LiveOptions.SystemPrompt (the original entries
+      stay in Hist for ephemeral-reset recovery — see
+      CopyHistorySystem in PasClaw.Tools.ToolLoop). Codex P2 on
+      PR #116. }
     Sys := Options.SystemPrompt;
-    for i := 0 to High(Messages) do
-      if (Messages[i].Role = mrSystem) and (Trim(Messages[i].Content) <> '') then
-      begin
-        if Sys = '' then
-          Sys := Messages[i].Content
-        else
-          Sys := Sys + sLineBreak + Messages[i].Content;
-      end;
+    if Sys = '' then
+      for i := 0 to High(Messages) do
+        if (Messages[i].Role = mrSystem) and (Trim(Messages[i].Content) <> '') then
+        begin
+          if Sys = '' then
+            Sys := Messages[i].Content
+          else
+            Sys := Sys + sLineBreak + Messages[i].Content;
+        end;
 
     { Pre-scan assistant turns so tool-result messages can resolve a
       function name from their tool_call_id. Gemini's functionResponse

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -374,33 +374,38 @@ end;
   to accept it either way, but the open-array form compiles cleanly
   under both. }
 
-{ Drain every mrSystem entry from Hist (in array order), return their
-  concatenated content separated by blank lines. Hist is rewritten in
-  place to skip those entries. Used by the steering fold so an
-  embedder's in-history system policy doesn't silently disappear the
-  moment LiveOptions.SystemPrompt becomes non-empty: the OpenAI /
-  Anthropic builders drop in-history mrSystem when the option is set,
-  so we lift them into the option slot first. Codex P2 on PR #113. }
-function DrainHistorySystem(var Hist: TMessageArray): string;
+{ Collect every mrSystem entry's content from Hist (in array order),
+  return them concatenated with blank-line separators. Read-only —
+  does NOT modify Hist.
+
+  Used by the steering fold so an embedder's in-history system
+  policy is visible through LiveOptions.SystemPrompt (which the
+  provider builders DO ship) when steering makes that slot non-empty.
+  An earlier draft drained Hist destructively, but that made the
+  policy unrecoverable if a BeforeTurn hook later reset
+  SystemPrompt to '' for ephemeral-steering semantics (Codex P2 on
+  PR #114). Keeping mrSystem in Hist means: when SystemPrompt is
+  set, the provider drops in-history mrSystem (using the consolidated
+  SystemPrompt); when SystemPrompt is empty, the provider includes
+  the in-history mrSystem (so the policy still ships). Either way
+  the policy reaches the model.
+
+  Caller responsibility: read CopyHistorySystem ONLY when
+  LiveOptions.SystemPrompt is empty. Once SystemPrompt has the
+  policy embedded (after the first fold), subsequent folds should
+  append steering without re-reading Hist to avoid duplicating the
+  policy text. }
+function CopyHistorySystem(const Hist: TMessageArray): string;
 var
-  i, dst: Integer;
+  i: Integer;
 begin
   Result := '';
-  dst := 0;
   for i := 0 to High(Hist) do
-  begin
     if Hist[i].Role = mrSystem then
     begin
       if Result <> '' then Result := Result + sLineBreak + sLineBreak;
       Result := Result + Hist[i].Content;
-    end
-    else
-    begin
-      if dst <> i then Hist[dst] := Hist[i];
-      Inc(dst);
     end;
-  end;
-  if dst < Length(Hist) then SetLength(Hist, dst);
 end;
 
 function PartitionToolBatches(const Calls: array of TToolCall;
@@ -461,7 +466,7 @@ var
   Batches: TToolBatchArray;
   Batch: TToolBatch;
   Workers: array of TToolCallWorker;
-  Steering, BatchSteering, HistSystem: string;
+  Steering, BatchSteering, HistSystem, LastProviderErrText: string;
 begin
   Loop.Content    := '';
   Loop.Iterations := 0;
@@ -524,7 +529,16 @@ begin
       the OnError hook entirely. Now any raised exception turns
       into a synthetic -1 response — the fallback walk continues
       and the post-walk HooksOnError check fires with the
-      exception text in Resp.Content. (Codex P2 on PR #113.) }
+      diagnostic text out-of-band. (Codex P2 on PR #113.)
+
+      Diagnostic text goes into LastProviderErrText (local),
+      NOT into Resp.Content. If we stashed exception text in
+      Resp.Content, the outer "no tool calls, exit cleanly" path
+      would surface it as Loop.Content — i.e. as the assistant's
+      reply to the user, leaking internal parser / socket / TLS
+      details through to the caller. Hook embedders that want the
+      diagnostic still get it via OnError. (Codex P2 on PR #114.) }
+    LastProviderErrText := '';
     try
       Resp := Cfg.Provider.Chat(Hist, Tools, Cfg.Model, LiveOptions);
     except
@@ -533,7 +547,8 @@ begin
         LogWarn('provider Chat raised: %s: %s', [E.ClassName, E.Message]);
         Resp := Default(TLLMResponse);
         Resp.StatusCode := -1;
-        Resp.Content := E.ClassName + ': ' + E.Message;
+        LastProviderErrText := Cfg.Provider.GetName + ': '
+                               + E.ClassName + ': ' + E.Message;
       end;
     end;
     { Provider fallback. Retryable conditions: HTTP 408 / 429 / 5xx,
@@ -563,6 +578,9 @@ begin
                  [fbi, Cfg.Fallbacks[fbi].GetName, FallbackModel]);
         try
           Resp := Cfg.Fallbacks[fbi].Chat(Hist, Tools, FallbackModel, LiveOptions);
+          { Successful call clears the diagnostic — only the LAST failed
+            attempt's text should surface to hooks. }
+          LastProviderErrText := '';
         except
           on E: Exception do
           begin
@@ -570,7 +588,8 @@ begin
                     [Cfg.Fallbacks[fbi].GetName, E.ClassName, E.Message]);
             Resp := Default(TLLMResponse);
             Resp.StatusCode := -1;
-            Resp.Content := E.ClassName + ': ' + E.Message;
+            LastProviderErrText := Cfg.Fallbacks[fbi].GetName + ': '
+                                   + E.ClassName + ': ' + E.Message;
           end;
         end;
         if not IsRetryableStatus(Resp.StatusCode) then
@@ -594,13 +613,22 @@ begin
     if (Length(Cfg.Hooks) > 0) and
        ((Resp.StatusCode < 200) or (Resp.StatusCode >= 300)) then
     begin
-      { Include Resp.Content when populated — for raised exceptions
-        (the try/except blocks above stash "EClass: message" there)
-        this gives the hook the actual exception text instead of
-        just "status=-1". For non-2xx HTTP responses Resp.Content
-        is typically the provider's error JSON, which is also
-        useful telemetry. }
-      if Resp.Content <> '' then
+      { Diagnostic preference order:
+          1. LastProviderErrText  — exception text we caught above.
+                                    Highest priority because we know
+                                    it's our own structured failure
+                                    and won't leak into Loop.Content.
+          2. Resp.Content         — typically the provider's error
+                                    JSON body on a non-2xx HTTP
+                                    response. Useful telemetry; we
+                                    don't filter it because the
+                                    provider returned it deliberately.
+          3. Just status=%d       — nothing else available. }
+      if LastProviderErrText <> '' then
+        HooksOnError(Cfg.Hooks, hsProviderCall,
+                      Format('provider returned status=%d: %s',
+                             [Resp.StatusCode, LastProviderErrText]))
+      else if Resp.Content <> '' then
         HooksOnError(Cfg.Hooks, hsProviderCall,
                       Format('provider returned status=%d: %s',
                              [Resp.StatusCode, Resp.Content]))
@@ -762,22 +790,34 @@ begin
           they can reset SystemPrompt in BeforeTurn. }
       if BatchSteering <> '' then
       begin
-        { Drain any mrSystem messages from Hist into the SystemPrompt
-          slot before appending the steering text. Provider builders
-          drop in-history mrSystem when SystemPrompt is non-empty, so
-          a direct-RunToolLoop embedder who supplied policy via
-          mrSystem (leaving Cfg.Options.SystemPrompt empty) would
-          otherwise see their policy disappear the first time
-          steering fires. (Codex P2 on PR #113.) Idempotent — once
-          drained, subsequent passes find no mrSystem to fold. }
-        HistSystem := DrainHistorySystem(Hist);
-        if HistSystem <> '' then
+        { Copy any mrSystem messages from Hist into SystemPrompt
+          when (and only when) SystemPrompt is currently empty.
+          Reasoning:
+
+            * SystemPrompt empty + mrSystem in Hist: provider
+              builders ship the mrSystem entries as the system
+              prompt. We want our steering to ride along with the
+              policy, so we copy the policy text into SystemPrompt
+              first, then append steering. After this call,
+              SystemPrompt is non-empty and the provider builders
+              drop in-history mrSystem on the next round (using
+              SystemPrompt instead). The Hist mrSystem entries
+              stay PUT — non-destructive copy — so if a BeforeTurn
+              hook later resets SystemPrompt to '' for the
+              ephemeral-steering pattern, the policy is still
+              available in Hist and ships again via the in-history
+              channel. (Codex P2 on PR #114.)
+
+            * SystemPrompt non-empty: it already contains the
+              policy (folded on the first pass) plus prior steering.
+              Just append the new steering. Re-reading Hist here
+              would duplicate the policy text on every fold.
+
+          Either way the policy reaches the model. }
+        if (LiveOptions.SystemPrompt = '') then
         begin
-          if LiveOptions.SystemPrompt <> '' then
-            LiveOptions.SystemPrompt := LiveOptions.SystemPrompt
-                                        + sLineBreak + sLineBreak
-                                        + HistSystem
-          else
+          HistSystem := CopyHistorySystem(Hist);
+          if HistSystem <> '' then
             LiveOptions.SystemPrompt := HistSystem;
         end;
         if LiveOptions.SystemPrompt <> '' then


### PR DESCRIPTION
## Summary

Two Codex P2 findings on merged PR #114, both legitimate.

### P2 #1 — Exception text leaked into `Loop.Content`

PR #114 stashed caught provider-exception text (e.g. `"EIdSocketError: Connection refused 192.168.1.42:443"`) in `Resp.Content` so the post-walk `HooksOnError` could include it. But `Resp.Content` is **also** what the loop's exit-clean path copies into `Loop.Content` (when the provider returns no tool_calls), so `Agent.Run('hi')` after a TLS handshake failure surfaced internal infrastructure detail (IPs, TLS versions, parser internals) as the assistant's reply.

**Fix**: new local `LastProviderErrText`. Exception text goes there, not `Resp.Content`. Post-walk `HooksOnError` dispatch priority:

1. `LastProviderErrText` (our caught exception)
2. `Resp.Content` (server's deliberately-returned error JSON)
3. `status=N` only

A successful fallback clears `LastProviderErrText` so only the last failed attempt's diagnostic surfaces. `Resp.Content` stays empty when we caught an exception — `Loop.Content := Resp.Content` returns `''` cleanly.

### P2 #2 — Destructive `Hist` drain made embedder policy unrecoverable

PR #113 introduced `DrainHistorySystem` to lift in-history `mrSystem` into `SystemPrompt` on first steering fold. But the drain **removed** the entries from `Hist` permanently — so when a `BeforeTurn` hook later cleared `SystemPrompt` for the documented ephemeral-steering semantics, the policy was gone from both the option slot AND from `Hist`. The model would silently start operating without policy.

**Fix**: replaced `DrainHistorySystem` with `CopyHistorySystem` (read-only). The fold copies `mrSystem` content **only when** `SystemPrompt` is currently empty (first fold). After that, `SystemPrompt` has the policy embedded and subsequent folds just append more steering — they don't re-read `Hist` (which would duplicate the policy).

| State | `SystemPrompt` | `Hist mrSystem` | Provider sees |
|---|---|---|---|
| Initial | empty | policy | policy via Hist (option empty → builder includes mrSystem) |
| After 1st fold | policy + steering | policy (unchanged) | policy + steering via option (builder drops Hist mrSystem) |
| After 2nd fold | policy + steering + steering | policy (unchanged) | the consolidated option |
| `BeforeTurn` clears option | empty | policy (unchanged) | policy via Hist again — recovers automatically |

## Verification

```
=== Test 1: provider exception text does NOT leak into Loop.Content ===
  PASS — Loop.Content="", OnError got the diagnostic
=== Test 2: in-history mrSystem policy preserved (non-destructive) ===
  PASS — policy in Hist + in SystemPrompt, steering folded

all PR #114 review-fix tests passed.
```

Test 1 raises an exception with `"simulated socket reset 192.168.1.42:443"`. Asserts that string does **not** appear in `Loop.Content`, and that the audit hook recorded it via `OnError`. Test 2 asserts the policy is **still** in `Loop.FinalMessages` as an `mrSystem` entry (proof of non-destructive copy) after the steering fold ran.

`make smoke` 11/11 green.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_