### PR TITLE
Mid-loop steering — push follow-ups into a running agent's tool loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ Form-designable with published properties for the VCL/FMX path; code-driven OOP 
 
 Patterns are exact ids or `<platform>:*` wildcards; `*` allows anyone (escape hatch). Empty array (default) = no gate. Each channel calls `IsAllowedSender` before invoking the agent — non-matching senders are dropped at the boundary with a log line, the model never sees them. Ports picoclaw's `pkg/identity` pattern.
 
+**Mid-loop steering** — push a follow-up into a running agent without waiting for the current tool loop to finish. From another terminal:
+
+```sh
+pasclaw steer 20260601T093015-1a2b3c4d "actually skip X, focus on Y"
+pasclaw steer <session-id> --list        # show pending count
+pasclaw steer <session-id> --clear       # drop the queue
+```
+
+The running `pasclaw agent --session <id>` drains the queue at the top of its NEXT tool-loop iteration and folds each pending message into history as a `[user steering] ...` system note before the next LLM round-trip. Up to 4 messages per iteration are applied (`MaxSteeringPerTurn`, matching nanobot's `_MAX_INJECTIONS_PER_TURN`); extras are dropped with a warning so a runaway pusher can't grow history unbounded. `/steer <msg>` inside an interactive session is the same mechanism (handy for testing). `/reset`, `/new`, and `pasclaw session delete` clear the queue. Storage is one append-only JSONL file per session under `$PASCLAW_HOME/workspace/steering/<id>.jsonl` — atomic per-line POSIX appends + rename-to-tmp-on-drain so concurrent push/drain doesn't lose messages. Currently only CLI sessions wire `SteeringKey`; channels can opt in by passing their own per-conversation key on `TToolLoopConfig.SteeringKey` once they restructure to non-blocking poll loops.
+
 **Hooks + steering** — `TPasClawHook` (in `PasClaw.Agent.Hooks`) is the typed callback surface for embedders to observe, transform, or veto agent events. Four virtuals: `BeforeTurn(var ContinueTurn, var Messages)` — set ContinueTurn := False to abort cleanly; `BeforeToolCall(call, var Cancel, var SyntheticResult)` — Cancel := True bypasses the real tool handler and uses SyntheticResult as the tool_result (the approval-gate pattern); `AfterToolResult(call, var ResultText, var ErrMsg, var SteeringMessage)` — rewrite results inline AND inject a system note before the next LLM round (picoclaw's steering); `OnError(Stage, Msg)` — observe failures. Register via `Agent.RegisterHook(THook.Create)`; multiple hooks form an ordered chain in registration order.
 
 **Subagents** — fan-out to focused specialists via a `spawn(agent, prompt)` tool. Declare them in `config.json`'s `subagents:` array (name + description + system prompt + tool allowlist + optional model / max-iterations override). Each spawn runs a short `RunToolLoop` against the parent's provider + fallback chain with a registry filtered to the named tools and a specialist system prompt; result lands back as the parent's `tool_result`. Implementation in `src/pkg/agent/PasClaw.Agent.Subagent.pas` — picoclaw's `SubTurn` pattern, nanobot's `subagent` module, openclaw's multi-agent routing, ~300 LOC.

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -38,7 +38,8 @@ uses
   PasClaw.Agent.Subagent,
   PasClaw.Session.Store,
   PasClaw.Tools.Sandbox,
-  PasClaw.Identity;
+  PasClaw.Identity,
+  PasClaw.Agent.Steering;
 
 type
   TAgentArgs = record
@@ -411,15 +412,31 @@ begin
           openclaw and nanobot semantics. }
         if Line = '/new' then
         begin
+          { Old session's queue might have leftover pending steering
+            messages — drop them before re-keying so the fresh session
+            doesn't pick up the previous conversation's interrupts. }
+          ClearSteering(Session.Meta.Id);
           Session.Free;
           Session := TSession.Create('');   { fresh id }
           WriteLn(Ansi.Dim, '(new session ', Session.Meta.Id, ')', Ansi.Reset);
         end
         else
         begin
+          ClearSteering(Session.Meta.Id);
           PersistSession;   { writes empty Msgs + cleared override }
           WriteLn(Ansi.Dim, '(history cleared)', Ansi.Reset);
         end;
+        Continue;
+      end;
+      if Copy(Line, 1, 7) = '/steer ' then
+      begin
+        { Same-process steering — handy for testing, but the real
+          win is `pasclaw steer <id> "..."` from another terminal
+          while a long loop is mid-execution. }
+        if PushSteering(Session.Meta.Id, Copy(Line, 8, MaxInt)) then
+          WriteLn(Ansi.Dim, '(queued; injects at top of next iteration)', Ansi.Reset)
+        else
+          WriteLn(Ansi.Red, '(steer push failed)', Ansi.Reset);
         Continue;
       end;
       if Line = '/tools' then
@@ -435,14 +452,15 @@ begin
       end;
       if (Line = '/help') or (Line = '/?') then
       begin
-        WriteLn('  /help     show this list');
-        WriteLn('  /status   model + provider + message count + thinking state');
-        WriteLn('  /new      clear conversation history (alias: /reset)');
-        WriteLn('  /reset    clear conversation history');
-        WriteLn('  /compact  force a one-shot summariser pass on the history now');
-        WriteLn('  /think    toggle extended thinking on the next turn (if the provider supports it)');
-        WriteLn('  /tools    list registered tools');
-        WriteLn('  /quit     exit (alias: /exit)');
+        WriteLn('  /help        show this list');
+        WriteLn('  /status      model + provider + message count + thinking state');
+        WriteLn('  /new         clear conversation history (alias: /reset)');
+        WriteLn('  /reset       clear conversation history');
+        WriteLn('  /compact     force a one-shot summariser pass on the history now');
+        WriteLn('  /think       toggle extended thinking on the next turn (if the provider supports it)');
+        WriteLn('  /tools       list registered tools');
+        WriteLn('  /steer <msg> queue a mid-loop steering message for the NEXT iteration');
+        WriteLn('  /quit        exit (alias: /exit)');
         Continue;
       end;
       if Line = '/status' then
@@ -476,6 +494,14 @@ begin
         end
         else
           WriteLn('  cache:     off (prompt_cache.enabled=false in config)');
+        if Session <> nil then
+        begin
+          i := PendingSteeringCount(Session.Meta.Id);
+          if i > 0 then
+            WriteLn('  steering:  ', i, ' pending (folded at next iteration)')
+          else
+            WriteLn('  steering:  none queued');
+        end;
         Continue;
       end;
       if Line = '/think' then
@@ -550,7 +576,15 @@ begin
         prefix). Anthropic ignores the field; OpenAI uses it to pin
         prefix routing on the back-end. }
       if Session <> nil then
+      begin
         LoopCfg.Options.CacheKey := Session.Meta.Id;
+        { Steering queue key — RunToolLoop drains it at iteration
+          top and folds pending messages into history as
+          "[user steering] ..." system notes. The other terminal's
+          `pasclaw steer <session-id> "..."` writes to the same
+          file the loop is about to read. }
+        LoopCfg.SteeringKey := Session.Meta.Id;
+      end;
       { /think: apply ThinkingLevel for this turn, then clear so
         subsequent turns reset (matches the OpenClaw /think model —
         single-turn extended thinking). The user can /think again

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -40,6 +40,7 @@ uses
   PasClaw.Cmd.Migrate,
   PasClaw.Cmd.Skills,
   PasClaw.Cmd.Session,
+  PasClaw.Cmd.Steer,
   PasClaw.Cmd.Model,
   PasClaw.Cmd.Config_,
   PasClaw.Cmd.Update,
@@ -99,7 +100,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 19);
+  SetLength(Sub, 20);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
@@ -117,8 +118,9 @@ begin
   Sub[14] := 'membench     Benchmark the memory log subsystem';
   Sub[15] := 'session      List/show/delete/export saved sessions';
   Sub[16] := 'resume       Resume a saved session (alias for agent --session)';
-  Sub[17] := 'update       Self-update PasClaw';
-  Sub[18] := 'version      Show version info';
+  Sub[17] := 'steer        Push a mid-loop follow-up into a running agent';
+  Sub[18] := 'update       Self-update PasClaw';
+  Sub[19] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -160,6 +162,7 @@ begin
       Result := Cmd_Agent_Run(ResumeArgv);
     end;
   end
+  else if Cmd = 'steer'    then Result := Cmd_Steer_Run(Argv)
   else if Cmd = 'model'    then Result := Cmd_Model_Run(Argv)
   else if Cmd = 'post'     then Result := Cmd_Post_Run(Argv)
   else if Cmd = 'membench' then Result := Cmd_Membench_Run(Argv)

--- a/src/cmd/PasClaw.Cmd.Session.pas
+++ b/src/cmd/PasClaw.Cmd.Session.pas
@@ -23,7 +23,8 @@ uses
   SysUtils, Classes, DateUtils,
   PasClaw.CliUI,
   PasClaw.Providers.Types,   { TMsgRole = (mrSystem, mrUser, mrAssistant, mrTool) }
-  PasClaw.Session.Store;
+  PasClaw.Session.Store,
+  PasClaw.Agent.Steering;
 
 procedure PrintHelp;
 begin
@@ -123,6 +124,9 @@ function DoDelete(const Id: string): Integer;
 begin
   if DeleteSession(Id) then
   begin
+    { Stray steering messages for the just-deleted session would
+      otherwise sit on disk forever — clear them too. }
+    ClearSteering(Id);
     WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'deleted session ', Id);
     Result := 0;
   end

--- a/src/cmd/PasClaw.Cmd.Steer.pas
+++ b/src/cmd/PasClaw.Cmd.Steer.pas
@@ -1,0 +1,101 @@
+(*
+  PasClaw.Cmd.Steer — push a follow-up message into a running
+  agent's mid-loop steering queue. Mirrors picoclaw's `steer`
+  subcommand and nanobot's _inject_pending side-channel.
+
+  Usage:
+    pasclaw steer <session-id> "your follow-up message"
+    pasclaw steer <session-id> --list           # show pending count
+    pasclaw steer <session-id> --clear          # drop pending queue
+    pasclaw steer --help
+
+  The other terminal running `pasclaw agent --session <id>` (or a
+  channel daemon wired to use this session key) will drain the
+  queue at the top of its NEXT tool-loop iteration and fold each
+  pending message into history as a "[user steering] ..." system
+  note. If no loop is currently running, the message sits queued
+  for the next time one is.
+*)
+unit PasClaw.Cmd.Steer;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function Cmd_Steer_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.CliUI,
+  PasClaw.Agent.Steering;
+
+procedure PrintHelp;
+begin
+  WriteLn('Usage: pasclaw steer <session-id> <message>');
+  WriteLn('       pasclaw steer <session-id> --list');
+  WriteLn('       pasclaw steer <session-id> --clear');
+  WriteLn;
+  WriteLn('Push a mid-loop steering message to a running agent. The');
+  WriteLn('next iteration of the agent''s tool loop folds it into');
+  WriteLn('history as a "[user steering] ..." system note before the');
+  WriteLn('next LLM call.');
+end;
+
+function Cmd_Steer_Run(const Argv: array of string): Integer;
+var
+  Id, Msg: string;
+  i, n: Integer;
+begin
+  if Length(Argv) = 0 then begin PrintHelp; Exit(1); end;
+  if (Argv[0] = '-h') or (Argv[0] = '--help') then
+  begin
+    PrintHelp; Exit(0);
+  end;
+
+  Id := Argv[0];
+  if Length(Argv) < 2 then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'missing message argument');
+    PrintHelp;
+    Exit(1);
+  end;
+
+  if Argv[1] = '--list' then
+  begin
+    n := PendingSteeringCount(Id);
+    if n = 0 then
+      WriteLn(Ansi.Dim, '(no pending steering for ', Id, ')', Ansi.Reset)
+    else
+      WriteLn('  pending steering messages for ', Id, ': ', n);
+    Exit(0);
+  end;
+
+  if Argv[1] = '--clear' then
+  begin
+    ClearSteering(Id);
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'cleared steering queue for ', Id);
+    Exit(0);
+  end;
+
+  { Concatenate remaining argv as the message (shell already split
+    on whitespace; we want the original sentence back). }
+  Msg := Argv[1];
+  for i := 2 to High(Argv) do Msg := Msg + ' ' + Argv[i];
+
+  if PushSteering(Id, Msg) then
+  begin
+    WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'queued: "', Copy(Msg, 1, 80), '"');
+    WriteLn(Ansi.Dim, '  the running agent will pick it up at the top of its next iteration', Ansi.Reset);
+    Exit(0);
+  end
+  else
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'push failed — invalid session id "', Id, '" or write error');
+    Exit(1);
+  end;
+end;
+
+end.

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -127,6 +127,7 @@
         <DCCReference Include="..\cmd\PasClaw.Cmd.Migrate.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Skills.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Session.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Steer.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Model.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Config_.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Update.pas"/>
@@ -243,6 +244,7 @@
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Compact.pas"/>
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Subagent.pas"/>
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.Hooks.pas"/>
+        <DCCReference Include="..\pkg\agent\PasClaw.Agent.Steering.pas"/>
 
         <!-- pkg/memory -->
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>

--- a/src/pkg/agent/PasClaw.Agent.Steering.pas
+++ b/src/pkg/agent/PasClaw.Agent.Steering.pas
@@ -18,12 +18,15 @@
   chat id, Slack channel, etc.) when they wire concurrent polling
   (currently CLI-only — see README for the per-channel follow-up).
 
-  Concurrency model: pushes are atomic per-line POSIX appends (a
-  PIPE_BUF-sized write to an O_APPEND fd is atomic). Drains rename
-  the queue file to <key>.jsonl.draining, then read and delete — so
-  a concurrent push during drain lands in a freshly-created
+  Concurrency model: every push AND drain acquires a directory-
+  based mutex first (mkdir of <key>.jsonl.lock — atomic on both
+  POSIX and Windows). A stale lock from a crashed process is auto-
+  recovered after STALE_LOCK_SECS. Inside the mutex a drain renames
+  the queue file to <key>.jsonl.draining, then reads and deletes,
+  so a push that beat the drain to the lock is in the renamed
+  inode and gets returned; one that arrives later opens a fresh
   <key>.jsonl that the NEXT drain picks up. No message lost, no
-  message returned twice.
+  message returned twice, no torn writes.
 
   Cap: caller decides via MaxPerTurn (RunToolLoop passes a small
   fixed cap so a runaway pusher can't grow Hist unbounded). Drained
@@ -101,6 +104,61 @@ begin
   Result := DateTimeToUnix(Now, False);
 end;
 
+const
+  { A process that crashed mid-push leaves the lock dir behind. After
+    this many seconds we treat it as orphaned and reclaim — small
+    enough that an interrupted user CLI doesn't permanently wedge
+    the queue, large enough that a normal push/drain (millisecond
+    scale) never trips it. }
+  STALE_LOCK_SECS  = 30;
+  LOCK_SPIN_MS     = 25;
+  LOCK_MAX_WAIT_MS = 2000;
+
+{ Directory-based mutex. mkdir is atomic on both POSIX and Windows
+  (POSIX: O_CREAT|O_EXCL semantics; Windows: CreateDirectory is
+  atomic against concurrent calls). One process creates, others see
+  EEXIST and spin. Returns True when acquired; False on timeout.
+  Stale locks older than STALE_LOCK_SECS are reclaimed. }
+function AcquireLock(const LockDir: string): Boolean;
+var
+  Waited: Integer;
+  Age: Int64;
+  Info: TSearchRec;
+begin
+  Waited := 0;
+  while Waited < LOCK_MAX_WAIT_MS do
+  begin
+    if CreateDir(LockDir) then Exit(True);
+    { Already exists — check whether it's stale. FindFirst on the
+      directory itself gives us its mtime via SR.Time. }
+    if FindFirst(LockDir, faDirectory, Info) = 0 then
+    try
+      Age := DateTimeToUnix(Now, False) - DateTimeToUnix(FileDateToDateTime(Info.Time), False);
+      if Age > STALE_LOCK_SECS then
+      begin
+        LogWarn('steering: reclaiming stale lock %s (age=%ds)', [LockDir, Age]);
+        RemoveDir(LockDir);
+        Continue;
+      end;
+    finally
+      FindClose(Info);
+    end;
+    Sleep(LOCK_SPIN_MS);
+    Inc(Waited, LOCK_SPIN_MS);
+  end;
+  Result := False;
+end;
+
+procedure ReleaseLock(const LockDir: string);
+begin
+  RemoveDir(LockDir);
+end;
+
+function LockPath(const SessionKey: string): string;
+begin
+  Result := JoinPath(SteeringDir, SessionKey + '.jsonl.lock');
+end;
+
 function EncodeLine(PostedAt: Int64; const Text: string): string;
 var
   Obj: TJsonObject;
@@ -134,7 +192,7 @@ end;
 
 function PushSteering(const SessionKey, Text: string): Boolean;
 var
-  Path: string;
+  Path, Lock: string;
   Stream: TFileStream;
   Line: UTF8String;
   TrimmedText: string;
@@ -144,79 +202,133 @@ begin
   if TrimmedText = '' then Exit;
   Path := SteeringPath(SessionKey);
   if Path = '' then Exit;
-  EnsureSteeringDir;
-  if FileExists(Path) then
-    Stream := TFileStream.Create(Path, fmOpenWrite or fmShareDenyNone)
-  else
-    Stream := TFileStream.Create(Path, fmCreate);
+
+  { Wrap directory creation, lock acquisition, and the write in
+    try/except so a read-only $PASCLAW_HOME, a permissions denial,
+    or a vanishing disk yields the documented False return instead
+    of an exception propagating out of the CLI. (Codex P2 on PR #120.) }
   try
-    Stream.Seek(0, soEnd);
-    Line := UTF8String(EncodeLine(NowUnix, TrimmedText) + #10);
-    Stream.WriteBuffer(Pointer(Line)^, Length(Line));
-    Result := True;
+    EnsureSteeringDir;
+  except
+    on E: Exception do
+    begin
+      LogWarn('steering: cannot create %s: %s', [SteeringDir, E.Message]);
+      Exit;
+    end;
+  end;
+
+  Lock := LockPath(SessionKey);
+  if not AcquireLock(Lock) then
+  begin
+    LogWarn('steering: lock acquisition timed out for %s', [SessionKey]);
+    Exit;
+  end;
+  try
+    try
+      if FileExists(Path) then
+        Stream := TFileStream.Create(Path, fmOpenWrite or fmShareDenyWrite)
+      else
+        Stream := TFileStream.Create(Path, fmCreate);
+    except
+      on E: Exception do
+      begin
+        LogWarn('steering: cannot open %s for append: %s', [Path, E.Message]);
+        Exit;
+      end;
+    end;
+    try
+      try
+        Stream.Seek(0, soEnd);
+        Line := UTF8String(EncodeLine(NowUnix, TrimmedText) + #10);
+        Stream.WriteBuffer(Pointer(Line)^, Length(Line));
+        Result := True;
+      except
+        on E: Exception do
+          LogWarn('steering: write to %s failed: %s', [Path, E.Message]);
+      end;
+    finally
+      Stream.Free;
+    end;
   finally
-    Stream.Free;
+    ReleaseLock(Lock);
   end;
 end;
 
 function DrainSteering(const SessionKey: string; MaxMessages: Integer): TSteeringMessageArray;
 var
-  Path, DrainPath: string;
+  Path, DrainPath, Lock: string;
   S: TStringList;
   i, Kept: Integer;
   Msg: TSteeringMessage;
 begin
   SetLength(Result, 0);
   Path := SteeringPath(SessionKey);
-  if (Path = '') or (not FileExists(Path)) then Exit;
-  DrainPath := Path + '.draining';
-  { Rename first so a concurrent push lands in a fresh file. Any
-    push between the rename and the read is preserved; any push
-    after the rename targets a new <key>.jsonl which the NEXT
-    drain handles. }
-  if FileExists(DrainPath) then SysUtils.DeleteFile(DrainPath);
-  if not RenameFile(Path, DrainPath) then Exit;
-  S := TStringList.Create;
+  if Path = '' then Exit;
+
+  Lock := LockPath(SessionKey);
+  if not AcquireLock(Lock) then
+  begin
+    LogWarn('steering: drain lock timeout for %s', [SessionKey]);
+    Exit;
+  end;
   try
+    if not FileExists(Path) then Exit;
+    DrainPath := Path + '.draining';
+    { Inside the lock the rename is uncontended — but keep the
+      rename anyway so a stale-lock reclaim mid-drain doesn't
+      surprise a concurrent reader with mid-read deletion. }
+    if FileExists(DrainPath) then SysUtils.DeleteFile(DrainPath);
+    if not RenameFile(Path, DrainPath) then Exit;
+    S := TStringList.Create;
     try
-      S.LoadFromFile(DrainPath);
-    except
-      on E: Exception do
-      begin
-        LogWarn('steering: drain read failed (%s); discarding queue', [E.Message]);
-        SysUtils.DeleteFile(DrainPath);
-        Exit;
+      try
+        S.LoadFromFile(DrainPath);
+      except
+        on E: Exception do
+        begin
+          LogWarn('steering: drain read failed (%s); discarding queue', [E.Message]);
+          SysUtils.DeleteFile(DrainPath);
+          Exit;
+        end;
       end;
-    end;
-    Kept := 0;
-    for i := 0 to S.Count - 1 do
-    begin
-      if Kept >= MaxMessages then
+      Kept := 0;
+      for i := 0 to S.Count - 1 do
       begin
-        LogWarn('steering[%s]: %d pending exceeded cap of %d — dropping rest',
-                [SessionKey, S.Count - Kept, MaxMessages]);
-        Break;
+        if Kept >= MaxMessages then
+        begin
+          LogWarn('steering[%s]: %d pending exceeded cap of %d — dropping rest',
+                  [SessionKey, S.Count - Kept, MaxMessages]);
+          Break;
+        end;
+        if DecodeLine(S[i], Msg) then
+        begin
+          SetLength(Result, Length(Result) + 1);
+          Result[High(Result)] := Msg;
+          Inc(Kept);
+        end;
       end;
-      if DecodeLine(S[i], Msg) then
-      begin
-        SetLength(Result, Length(Result) + 1);
-        Result[High(Result)] := Msg;
-        Inc(Kept);
-      end;
+    finally
+      S.Free;
+      SysUtils.DeleteFile(DrainPath);
     end;
   finally
-    S.Free;
-    SysUtils.DeleteFile(DrainPath);
+    ReleaseLock(Lock);
   end;
 end;
 
 procedure ClearSteering(const SessionKey: string);
 var
-  Path: string;
+  Path, Lock: string;
 begin
   Path := SteeringPath(SessionKey);
-  if (Path = '') or (not FileExists(Path)) then Exit;
-  SysUtils.DeleteFile(Path);
+  if Path = '' then Exit;
+  Lock := LockPath(SessionKey);
+  if not AcquireLock(Lock) then Exit;   { best-effort — no log spam }
+  try
+    if FileExists(Path) then SysUtils.DeleteFile(Path);
+  finally
+    ReleaseLock(Lock);
+  end;
 end;
 
 function PendingSteeringCount(const SessionKey: string): Integer;

--- a/src/pkg/agent/PasClaw.Agent.Steering.pas
+++ b/src/pkg/agent/PasClaw.Agent.Steering.pas
@@ -1,0 +1,243 @@
+(*
+  PasClaw.Agent.Steering — mid-loop interrupt queue.
+
+  Today a user mid-conversation can't course-correct while a tool loop
+  is running — their next message is processed AFTER the loop returns.
+  picoclaw's pkg/agent/steering.go and nanobot's _inject_pending path
+  both let the user push a follow-up into a queue that the loop drains
+  between iterations and folds into the next LLM round-trip as a
+  system note. This unit ports that mechanism.
+
+  Storage: append-only JSONL files at
+    $PASCLAW_HOME/workspace/steering/<key>.jsonl
+  one line per pending message: {"at":<unix>,"text":"..."}
+
+  Key choice: callers pass the SessionKey on TToolLoopConfig.SteeringKey.
+  Cmd.Agent uses Session.Meta.Id (always present since PR #117);
+  channels can pass their own stable per-conversation key (Telegram
+  chat id, Slack channel, etc.) when they wire concurrent polling
+  (currently CLI-only — see README for the per-channel follow-up).
+
+  Concurrency model: pushes are atomic per-line POSIX appends (a
+  PIPE_BUF-sized write to an O_APPEND fd is atomic). Drains rename
+  the queue file to <key>.jsonl.draining, then read and delete — so
+  a concurrent push during drain lands in a freshly-created
+  <key>.jsonl that the NEXT drain picks up. No message lost, no
+  message returned twice.
+
+  Cap: caller decides via MaxPerTurn (RunToolLoop passes a small
+  fixed cap so a runaway pusher can't grow Hist unbounded). Drained
+  messages beyond the cap are logged + dropped — picoclaw's
+  MaxInjections behaves the same.
+*)
+unit PasClaw.Agent.Steering;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TSteeringMessage = record
+    PostedAt: Int64;     { unix seconds, UTC }
+    Text:     string;
+  end;
+  TSteeringMessageArray = array of TSteeringMessage;
+
+{ Push a steering message to the queue keyed by SessionKey. Returns
+  True on success, False when the key is unsafe (rejected for the
+  same reasons PasClaw.Session.Store.IsSafeSessionId rejects: path
+  traversal, NULs, leading dot, length cap) or write fails. }
+function PushSteering(const SessionKey, Text: string): Boolean;
+
+{ Drain up to MaxMessages from the queue (rest are LOST — caller
+  picked the cap). Empty array when no messages or unsafe key.
+  Atomic across concurrent drains via rename. }
+function DrainSteering(const SessionKey: string; MaxMessages: Integer): TSteeringMessageArray;
+
+{ Erase the queue entirely. Called by /reset, /new, session delete. }
+procedure ClearSteering(const SessionKey: string);
+
+{ Inspect without consuming — list / show / debug. }
+function PendingSteeringCount(const SessionKey: string): Integer;
+
+{ Absolute path of the on-disk queue file (or '' for an unsafe key).
+  Exposed so the CLI `pasclaw steer` can print where the message
+  landed and so cmd/session show can include it. }
+function SteeringPath(const SessionKey: string): string;
+
+implementation
+
+uses
+  Classes, DateUtils,
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Session.Store,
+  PasClaw.JSON,
+  PasClaw.Logger;
+
+function SteeringDir: string;
+begin
+  Result := JoinPath(GetHome, 'workspace/steering');
+end;
+
+function SteeringPath(const SessionKey: string): string;
+begin
+  if not IsSafeSessionId(SessionKey) then Exit('');
+  Result := JoinPath(SteeringDir, SessionKey + '.jsonl');
+end;
+
+procedure EnsureSteeringDir;
+begin
+  if not DirectoryExists(SteeringDir) then
+    ForceDirectories(SteeringDir);
+end;
+
+function NowUnix: Int64;
+begin
+  Result := DateTimeToUnix(Now, False);
+end;
+
+function EncodeLine(PostedAt: Int64; const Text: string): string;
+var
+  Obj: TJsonObject;
+begin
+  Obj := TJsonObject.Create;
+  try
+    Obj.PutInt('at',   PostedAt);
+    Obj.PutStr('text', Text);
+    Result := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
+end;
+
+function DecodeLine(const Line: string; out Msg: TSteeringMessage): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  if Trim(Line) = '' then Exit;
+  Obj := TJsonObject.Parse(Line);
+  if Obj = nil then Exit;
+  try
+    Msg.PostedAt := Obj.GetInt('at',   0);
+    Msg.Text     := Obj.GetStr('text', '');
+  finally
+    Obj.Free;
+  end;
+  Result := Msg.Text <> '';
+end;
+
+function PushSteering(const SessionKey, Text: string): Boolean;
+var
+  Path: string;
+  Stream: TFileStream;
+  Line: UTF8String;
+  TrimmedText: string;
+begin
+  Result := False;
+  TrimmedText := Trim(Text);
+  if TrimmedText = '' then Exit;
+  Path := SteeringPath(SessionKey);
+  if Path = '' then Exit;
+  EnsureSteeringDir;
+  if FileExists(Path) then
+    Stream := TFileStream.Create(Path, fmOpenWrite or fmShareDenyNone)
+  else
+    Stream := TFileStream.Create(Path, fmCreate);
+  try
+    Stream.Seek(0, soEnd);
+    Line := UTF8String(EncodeLine(NowUnix, TrimmedText) + #10);
+    Stream.WriteBuffer(Pointer(Line)^, Length(Line));
+    Result := True;
+  finally
+    Stream.Free;
+  end;
+end;
+
+function DrainSteering(const SessionKey: string; MaxMessages: Integer): TSteeringMessageArray;
+var
+  Path, DrainPath: string;
+  S: TStringList;
+  i, Kept: Integer;
+  Msg: TSteeringMessage;
+begin
+  SetLength(Result, 0);
+  Path := SteeringPath(SessionKey);
+  if (Path = '') or (not FileExists(Path)) then Exit;
+  DrainPath := Path + '.draining';
+  { Rename first so a concurrent push lands in a fresh file. Any
+    push between the rename and the read is preserved; any push
+    after the rename targets a new <key>.jsonl which the NEXT
+    drain handles. }
+  if FileExists(DrainPath) then SysUtils.DeleteFile(DrainPath);
+  if not RenameFile(Path, DrainPath) then Exit;
+  S := TStringList.Create;
+  try
+    try
+      S.LoadFromFile(DrainPath);
+    except
+      on E: Exception do
+      begin
+        LogWarn('steering: drain read failed (%s); discarding queue', [E.Message]);
+        SysUtils.DeleteFile(DrainPath);
+        Exit;
+      end;
+    end;
+    Kept := 0;
+    for i := 0 to S.Count - 1 do
+    begin
+      if Kept >= MaxMessages then
+      begin
+        LogWarn('steering[%s]: %d pending exceeded cap of %d — dropping rest',
+                [SessionKey, S.Count - Kept, MaxMessages]);
+        Break;
+      end;
+      if DecodeLine(S[i], Msg) then
+      begin
+        SetLength(Result, Length(Result) + 1);
+        Result[High(Result)] := Msg;
+        Inc(Kept);
+      end;
+    end;
+  finally
+    S.Free;
+    SysUtils.DeleteFile(DrainPath);
+  end;
+end;
+
+procedure ClearSteering(const SessionKey: string);
+var
+  Path: string;
+begin
+  Path := SteeringPath(SessionKey);
+  if (Path = '') or (not FileExists(Path)) then Exit;
+  SysUtils.DeleteFile(Path);
+end;
+
+function PendingSteeringCount(const SessionKey: string): Integer;
+var
+  Path: string;
+  S: TStringList;
+begin
+  Result := 0;
+  Path := SteeringPath(SessionKey);
+  if (Path = '') or (not FileExists(Path)) then Exit;
+  S := TStringList.Create;
+  try
+    try
+      S.LoadFromFile(Path);
+    except
+      Exit;
+    end;
+    Result := S.Count;
+  finally
+    S.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -554,22 +554,40 @@ begin
 
     { Mid-loop steering: drain any user follow-ups that arrived
       while we were busy (CLI `pasclaw steer <id> "..."`, channels
-      with concurrent polling) and fold each into history as a
-      bracketed mrSystem note. The next provider call sees them as
-      part of the conversation context — pivot or abort behaviour
-      is up to the model. Cap at MaxSteeringPerTurn so a runaway
-      pusher can't grow Hist unbounded; the cap matches nanobot's
-      _MAX_INJECTIONS_PER_TURN sanity bound. }
+      with concurrent polling) and fold each into LiveOptions.
+      SystemPrompt as a "[user steering received mid-turn]" addendum
+      so the next provider call's `system` field carries them.
+
+      We CANNOT append mrSystem to Hist here — the OpenAI builder
+      (PasClaw.Providers.OpenAI.pas:148-151) and Anthropic
+      (PasClaw.Providers.Anthropic.pas:170-172) and Gemini all skip
+      in-history mrSystem entries when Options.SystemPrompt is
+      already populated (which it is on the CLI path,
+      BuildLoopConfig always sets it). The drain would then
+      permanently consume the queue without the model ever seeing
+      the correction. Folding into SystemPrompt is the same channel
+      compaction uses for the same reason. (Codex P1 on PR #120.)
+
+      Cap at MaxSteeringPerTurn so a runaway pusher can't grow the
+      system prompt unbounded; the cap matches nanobot's
+      _MAX_INJECTIONS_PER_TURN sanity bound. Cache breakpoint
+      invalidates for the steering turn — acceptable cost. }
     if Cfg.SteeringKey <> '' then
     begin
       Steers := DrainSteering(Cfg.SteeringKey, MaxSteeringPerTurn);
-      for sti := 0 to High(Steers) do
+      if Length(Steers) > 0 then
       begin
-        LogDebug('steering[%s] injecting: %s',
-                 [Cfg.SteeringKey, Copy(Steers[sti].Text, 1, 80)]);
-        SetLength(Hist, Length(Hist) + 1);
-        Hist[High(Hist)] := MakeMessage(mrSystem,
-          '[user steering] ' + Steers[sti].Text);
+        if LiveOptions.SystemPrompt <> '' then
+          LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + sLineBreak + sLineBreak;
+        LiveOptions.SystemPrompt := LiveOptions.SystemPrompt +
+          '[user steering received mid-turn]';
+        for sti := 0 to High(Steers) do
+        begin
+          LogDebug('steering[%s] injecting: %s',
+                   [Cfg.SteeringKey, Copy(Steers[sti].Text, 1, 80)]);
+          LiveOptions.SystemPrompt := LiveOptions.SystemPrompt +
+            sLineBreak + '- ' + Steers[sti].Text;
+        end;
       end;
     end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -18,6 +18,7 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Agent.Compact,
   PasClaw.Agent.Hooks,
+  PasClaw.Agent.Steering,
   PasClaw.Identity;
 
 type
@@ -81,6 +82,17 @@ type
        dispatching so hook subclasses can read `Self.Identity` to
        gate per-tool / per-turn behaviour. *)
     Identity:       TIdentity;
+    (* Mid-loop steering: the queue key for PasClaw.Agent.Steering.
+       When non-empty, RunToolLoop drains the queue at iteration top
+       and folds pending messages into history as mrSystem turns
+       ("[user steering]: ..."), so the LLM's next round-trip sees
+       the user's course-correction without aborting the loop or
+       discarding tool results so far. Empty key = steering disabled
+       (CLI / cron one-shot paths don't bother).
+       Cmd.Agent sets this to Session.Meta.Id (always present since
+       PR #117); channels can set their own per-conversation key
+       when wiring concurrent polling. *)
+    SteeringKey:    string;
   end;
 
   TToolLoopResult = record
@@ -476,8 +488,13 @@ end;
 function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
+const
+  { Per-iteration steering cap. Picoclaw and nanobot both bound this
+    around 4-5 to keep a runaway pusher from growing Hist unbounded.
+    Drained messages beyond the cap are logged + dropped. }
+  MaxSteeringPerTurn = 4;
 var
-  Iter, i, bi, j, fbi: Integer;
+  Iter, i, bi, j, fbi, sti: Integer;
   Tools: TToolDefinitionArray;
   FallbackModel: string;
   Resp: TLLMResponse;
@@ -488,6 +505,7 @@ var
   Batch: TToolBatch;
   Workers: array of TToolCallWorker;
   Steering, BatchSteering, HistSystem, LastProviderErrText: string;
+  Steers: TSteeringMessageArray;
 begin
   Loop.Content    := '';
   Loop.Iterations := 0;
@@ -533,6 +551,27 @@ begin
   begin
     Inc(Iter);
     LogDebug('toolloop iteration %d / %d', [Iter, Cfg.MaxIterations]);
+
+    { Mid-loop steering: drain any user follow-ups that arrived
+      while we were busy (CLI `pasclaw steer <id> "..."`, channels
+      with concurrent polling) and fold each into history as a
+      bracketed mrSystem note. The next provider call sees them as
+      part of the conversation context — pivot or abort behaviour
+      is up to the model. Cap at MaxSteeringPerTurn so a runaway
+      pusher can't grow Hist unbounded; the cap matches nanobot's
+      _MAX_INJECTIONS_PER_TURN sanity bound. }
+    if Cfg.SteeringKey <> '' then
+    begin
+      Steers := DrainSteering(Cfg.SteeringKey, MaxSteeringPerTurn);
+      for sti := 0 to High(Steers) do
+      begin
+        LogDebug('steering[%s] injecting: %s',
+                 [Cfg.SteeringKey, Copy(Steers[sti].Text, 1, 80)]);
+        SetLength(Hist, Length(Hist) + 1);
+        Hist[High(Hist)] := MakeMessage(mrSystem,
+          '[user steering] ' + Steers[sti].Text);
+      end;
+    end;
 
     { Pre-call compaction. NeedsCompact is a cheap token estimate;
       only when it trips do we pay for a summariser round.


### PR DESCRIPTION
## Summary

Ports picoclaw's `pkg/agent/steering.go` and nanobot's `_inject_pending` pattern: while an agent is mid-tool-loop, a follow-up message can be queued and folded into history as a `[user steering] ...` system note at the top of the NEXT iteration. The next LLM round-trip sees the course-correction without aborting the loop or discarding tool results so far. ~280 LOC.

The audit's #1 Tier 1 gap from yesterday's survey.

## What's new

- **`src/pkg/agent/PasClaw.Agent.Steering.pas`** — file-backed FIFO queue at `$PASCLAW_HOME/workspace/steering/<key>.jsonl`. Pushes are atomic per-line POSIX appends; drains rename to `.draining` then read+delete, so concurrent push during drain lands in a fresh file the next drain picks up — no message lost, none returned twice. Key validation reuses `IsSafeSessionId` from PR #117 (no path traversal). Empty / whitespace text refused.
- **`TToolLoopConfig.SteeringKey`** field. `RunToolLoop` drains it at iteration top with `MaxSteeringPerTurn=4` (matches nanobot's `_MAX_INJECTIONS_PER_TURN`); extras are dropped with a warn log so a runaway pusher can't grow `Hist` unbounded.
- **`src/cmd/PasClaw.Cmd.Steer.pas`** — `pasclaw steer <id> "..."` pushes from another terminal, `--list` shows pending count, `--clear` drops the queue. Wired into `Cmd.Root` + `PrintRootHelp`.
- **`Cmd.Agent`** sets `LoopCfg.SteeringKey := Session.Meta.Id` (PR #117 auto-allocates session ids, so this is always populated for interactive runs). New `/steer <msg>` slash command for same-terminal testing. `/help` lists it. `/status` shows pending count. `/reset`, `/new`, and `pasclaw session delete` clear the queue alongside their existing cleanup.
- dproj + `uses` chain entries for the new units.

## Usage

```sh
# Terminal A
pasclaw agent --session daily-2026-06-01
> Research the latest FPC release notes and tell me about everything that changed since 3.2.4.

# Terminal B, while the tool loop is running
pasclaw steer daily-2026-06-01 "actually skip ARM-specific changes, focus on the language features"
# ✓ queued: "actually skip ARM-specific changes, focus on the language features"
#   the running agent will pick it up at the top of its next iteration

# Terminal A's next loop iteration sees:
# [user steering] actually skip ARM-specific changes, focus on the language features
```

## Out of scope

Channels (Telegram, Discord, etc.) don't yet wire `SteeringKey` — their inbound message handlers run `RunToolLoop` synchronously, so there's no "while a loop is running" window for steering to interrupt. That restructure (non-blocking polling per chat) is a per-channel follow-up; the queue + drain mechanism is in place for when each channel opts in.

## Test plan

- [x] `make clean && make` clean (442688 lines)
- [x] `make smoke` 11/11 OK
- [x] Focused steering queue test (built, ran, removed): 8 assertion groups — unsafe-key rejection at every entry point, push+drain roundtrip with PostedAt, FIFO ordering, MaxMessages cap drops rest (not requeues), drain consumes, PendingSteeringCount inspects without consuming, ClearSteering, empty/whitespace text refused, multiline + quotes + backslashes survive JSON encoding
- [x] CLI ergonomics spot-checked: push, `--list`, `--clear`, unsafe-id rejection
- [ ] Manual: live `pasclaw agent --session X` + parallel `pasclaw steer X "..."` against Anthropic — confirm the steering note appears in the next iteration and the model adjusts behaviour


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_