### PR TITLE
Onboarding: optional MCP-catalog install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Environment variables:
 Useful config commands:
 
 ```sh
-pasclaw onboard       # create/update home, workspace directories, and provider config
+pasclaw onboard       # create/update home + workspace dirs, pick a provider + model + API key,
+                      # then optionally enable any of the 5 built-in MCP servers inline
+                      # (replicate, digitalocean-apps, digitalocean-databases, runpod-docs, huggingface)
 pasclaw config        # print current JSON config
 pasclaw config path   # print resolved config path
 pasclaw config reset  # write a default config
@@ -265,7 +267,7 @@ MCP entries are stored in the config as `mcp_servers`. A command starting with `
 
 | name | env var | provider |
 |---|---|---|
-| `replicate` | `REPLICATE_API_TOKEN` | Run AI models on Replicate. |
+| `replicate` | `REPLICATE_API_TOKEN` | Run AI models (text/image/video/audio) on Replicate — 5000+ models. |
 | `digitalocean-apps` | `DIGITALOCEAN_TOKEN` | Manage DigitalOcean App Platform. |
 | `digitalocean-databases` | `DIGITALOCEAN_TOKEN` | Manage DigitalOcean Managed Databases. |
 | `runpod-docs` | _(none)_ | Search RunPod documentation. |

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -23,7 +23,8 @@ uses
   PasClaw.Utils,
   PasClaw.CliUI,
   PasClaw.Logger,
-  PasClaw.Providers.Catalog;
+  PasClaw.Providers.Catalog,
+  PasClaw.MCP.Catalog;
 
 function ReadLineEcho(const Prompt: string): string;
 begin
@@ -107,6 +108,124 @@ begin
   end;
 end;
 
+function IsMCPInstalled(Cfg: TConfig; const Name: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  for i := 0 to High(Cfg.MCPServers) do
+    if SameText(Cfg.MCPServers[i].Name, Name) then Exit(True);
+end;
+
+procedure UpsertCatalogMCP(Cfg: TConfig; const Entry: TMCPCatalogEntry;
+                           const HeaderVal: string);
+var
+  i: Integer;
+begin
+  { Mirrors Cmd.MCP.DoInstall's upsert — if an entry for this catalog
+    name already exists, refresh URL/auth/enabled in place rather than
+    duplicating. The MCP Cmd field stores the URL (HTTP MCP transport
+    uses it directly); Args stores the literal Authorization header
+    value the client puts on every request. }
+  for i := 0 to High(Cfg.MCPServers) do
+    if SameText(Cfg.MCPServers[i].Name, Entry.Name) then
+    begin
+      Cfg.MCPServers[i].Cmd     := Entry.URL;
+      Cfg.MCPServers[i].Args    := HeaderVal;
+      Cfg.MCPServers[i].Enabled := True;
+      Exit;
+    end;
+  SetLength(Cfg.MCPServers, Length(Cfg.MCPServers) + 1);
+  with Cfg.MCPServers[High(Cfg.MCPServers)] do
+  begin
+    Name    := Entry.Name;
+    Cmd     := Entry.URL;
+    Args    := HeaderVal;
+    Env     := '';
+    Enabled := True;
+  end;
+end;
+
+procedure PromptMCPInstalls(Cfg: TConfig);
+var
+  Entries: TMCPCatalogEntryArray;
+  Entry: TMCPCatalogEntry;
+  i: Integer;
+  Choice, Token, HeaderVal, EnvTok: string;
+  AlreadyInstalled: Boolean;
+begin
+  Entries := KnownMCPServers;
+  if Length(Entries) = 0 then Exit;
+
+  WriteLn;
+  WriteLn(Ansi.Bold, 'Optional: enable built-in MCP servers', Ansi.Reset);
+  WriteLn(Ansi.Dim,
+    'These give the agent extra capabilities via the MCP protocol.',
+    Ansi.Reset);
+  WriteLn(Ansi.Dim,
+    'Skip what you don''t want — you can install later with ',
+    Ansi.Reset, '`pasclaw mcp install <name>`', Ansi.Dim, '.', Ansi.Reset);
+  WriteLn;
+
+  for i := 0 to High(Entries) do
+  begin
+    Entry := Entries[i];
+    AlreadyInstalled := IsMCPInstalled(Cfg, Entry.Name);
+
+    WriteLn(Ansi.Bold, '  ', Entry.Name, Ansi.Reset);
+    WriteLn('  ', Ansi.Dim, Entry.Desc, Ansi.Reset);
+    if Entry.Docs <> '' then
+      WriteLn('  ', Ansi.Dim, Entry.Docs, Ansi.Reset);
+    if AlreadyInstalled then
+    begin
+      WriteLn('  ', Ansi.Green, '(already installed — skipping)', Ansi.Reset);
+      WriteLn;
+      Continue;
+    end;
+
+    Choice := Trim(LowerCase(ReadLineEcho('  Enable [y/N]: ')));
+    if (Choice <> 'y') and (Choice <> 'yes') then
+    begin
+      WriteLn;
+      Continue;
+    end;
+
+    { Auth-less entries (runpod-docs today) install with no token. }
+    if Entry.EnvVar = '' then
+    begin
+      UpsertCatalogMCP(Cfg, Entry, '');
+      WriteLn('  ', Ansi.Green, '✓', Ansi.Reset, ' installed ',
+              Entry.Name, ' ', Ansi.Dim, '(no auth)', Ansi.Reset);
+      WriteLn;
+      Continue;
+    end;
+
+    { Prefer the env var when it's already set — same path
+      pasclaw mcp install takes today. }
+    EnvTok := GetEnvironmentVariable(Entry.EnvVar);
+    if EnvTok <> '' then
+    begin
+      WriteLn('  ', Ansi.Dim, 'using ', Entry.EnvVar,
+              ' from environment', Ansi.Reset);
+      HeaderVal := FormatAuthHeaderFromToken(Entry, EnvTok);
+    end
+    else
+    begin
+      Token := Trim(ReadLineEcho('  ' + Entry.EnvVar + ' (paste, or blank to skip auth): '));
+      HeaderVal := FormatAuthHeaderFromToken(Entry, Token);
+      if HeaderVal = '' then
+        WriteLn('  ', Ansi.Yellow, '!', Ansi.Reset,
+                ' installing with no auth header — set ', Entry.EnvVar,
+                ' and re-run `pasclaw mcp install ', Entry.Name,
+                '` later to refresh.');
+    end;
+
+    UpsertCatalogMCP(Cfg, Entry, HeaderVal);
+    WriteLn('  ', Ansi.Green, '✓', Ansi.Reset, ' installed ', Entry.Name);
+    WriteLn;
+  end;
+end;
+
 function Cmd_Onboard_Run(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
@@ -168,6 +287,15 @@ begin
     if Model <> '' then Cfg.DefaultModel := Model;
 
     UpsertProvider(Cfg, Spec, Model, Key);
+
+    { Built-in MCP catalog — opt-in per entry. Picoclaw's rule is
+      "never preloaded"; we keep the same default-off prompt so a
+      user pressing Enter through onboarding doesn't install
+      anything they didn't explicitly say yes to. Auth tokens
+      captured here land in config.json as a literal Authorization
+      header value (same shape pasclaw mcp install writes when an
+      env var is set). }
+    PromptMCPInstalls(Cfg);
 
     SaveConfig(Cfg);
     WriteLn;

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -211,7 +211,10 @@ begin
     end
     else
     begin
-      Token := Trim(ReadLineEcho('  ' + Entry.EnvVar + ' (paste, or blank to skip auth): '));
+      { No-echo input — pasted tokens stay out of terminal scrollback
+        and any screen recordings / shared sessions. Codex P2 on
+        PR #126. }
+      Token := Trim(ReadSecretLine('  ' + Entry.EnvVar + ' (paste, or blank to skip auth): '));
       HeaderVal := FormatAuthHeaderFromToken(Entry, Token);
       if HeaderVal = '' then
         WriteLn('  ', Ansi.Yellow, '!', Ansi.Reset,
@@ -280,7 +283,11 @@ begin
       asNone:
         Key := '';
     else
-      Key := ReadLineEcho(Spec.DisplayName + ' API key (leave blank to skip): ');
+      { No-echo for the same reason as the MCP token path below —
+        Codex P2 on PR #126 was scoped to MCP but the provider-key
+        prompt has the identical exposure (pasted credential lands
+        in terminal scrollback / screen recordings). }
+      Key := ReadSecretLine(Spec.DisplayName + ' API key (leave blank to skip): ');
     end;
 
     Cfg.DefaultProvider := Spec.Kind;

--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -33,12 +33,24 @@ function  FormatCLIError(const Msg, CommandPath: string): string;
 function  RenderCommandHelp(const Use, Short, Long, Example: string;
                             const Subcommands, Flags: array of string): string;
 
+(* Prompt for a line of input WITHOUT echoing keystrokes to the
+   terminal — for API keys, MCP auth tokens, and any other secret
+   credential the user pastes during onboarding. Echo is restored
+   before return regardless of exception. Falls back to a plain
+   ReadLn (with echo) when the terminal mode can't be queried
+   (e.g. stdin is a pipe, as in scripted tests) so non-interactive
+   automation still works. Codex P2 on PR #126. *)
+function ReadSecretLine(const Prompt: string): string;
+
 implementation
 
 uses
   PasClaw.Utils
   {$IFDEF MSWINDOWS}
   , {$IFDEF FPC}Windows{$ELSE}Winapi.Windows{$ENDIF}
+  {$ENDIF}
+  {$IFDEF UNIX}
+  , BaseUnix, TermIO
   {$ENDIF}
   ;
 
@@ -273,6 +285,66 @@ begin
     Lines.Free;
   end;
 end;
+
+function ReadSecretLine(const Prompt: string): string;
+{$IFDEF UNIX}
+var
+  Old, New_: TermIOS;
+  HaveTerm: Boolean;
+begin
+  Write(Prompt);
+  Flush(Output);
+  HaveTerm := tcgetattr(0, Old) = 0;
+  if HaveTerm then
+  begin
+    New_ := Old;
+    { Clear ECHO so the typed/pasted token doesn't appear on screen or
+      land in the terminal scrollback. Leave ICANON on so the user can
+      still backspace and the line is delivered on Enter. }
+    New_.c_lflag := New_.c_lflag and not ECHO;
+    tcsetattr(0, TCSANOW, New_);
+  end;
+  try
+    ReadLn(Result);
+  finally
+    if HaveTerm then tcsetattr(0, TCSANOW, Old);
+  end;
+  { ReadLn consumed the newline silently when echo was off — emit one
+    so the next prompt starts on a fresh line. }
+  if HaveTerm then WriteLn;
+end;
+{$ENDIF}
+{$IFDEF MSWINDOWS}
+var
+  H: THandle;
+  OldMode, NewMode: DWORD;
+  HaveMode: Boolean;
+begin
+  Write(Prompt);
+  Flush(Output);
+  H := GetStdHandle(STD_INPUT_HANDLE);
+  HaveMode := (H <> INVALID_HANDLE_VALUE) and GetConsoleMode(H, OldMode);
+  if HaveMode then
+  begin
+    NewMode := OldMode and not DWORD(ENABLE_ECHO_INPUT);
+    SetConsoleMode(H, NewMode);
+  end;
+  try
+    ReadLn(Result);
+  finally
+    if HaveMode then SetConsoleMode(H, OldMode);
+  end;
+  if HaveMode then WriteLn;
+end;
+{$ENDIF}
+{$IF NOT DEFINED(UNIX) AND NOT DEFINED(MSWINDOWS)}
+begin
+  { Unknown platform — fall through to plain echoing read so the
+    program still runs. }
+  Write(Prompt);
+  ReadLn(Result);
+end;
+{$IFEND}
 
 initialization
   SetAnsi(False);

--- a/src/pkg/mcp/PasClaw.MCP.Catalog.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Catalog.pas
@@ -67,6 +67,17 @@ function ResolveAuthHeader(const Entry: TMCPCatalogEntry;
                             out HeaderValue: string;
                             out EnvWasSet: Boolean): Boolean;
 
+(* Format the literal Authorization header for an entry given a
+   token the caller has already obtained (e.g. interactively from
+   `pasclaw onboard`). Sibling to ResolveAuthHeader, which sources
+   the token from the env var — this one takes it as an argument
+   so the onboarding flow can prompt the user and persist the
+   resulting header into config.json without requiring the env var
+   to be set. Empty Token returns '' (caller installs with no
+   auth, same as pasclaw mcp install when the env var is missing). *)
+function FormatAuthHeaderFromToken(const Entry: TMCPCatalogEntry;
+                                    const Token: string): string;
+
 implementation
 
 uses
@@ -80,7 +91,7 @@ begin
   Result[0].URL     := 'https://mcp.replicate.com/mcp';
   Result[0].EnvVar  := 'REPLICATE_API_TOKEN';
   Result[0].AuthFmt := 'Bearer %s';
-  Result[0].Desc    := 'Run AI models (text, image, video, audio) on Replicate.';
+  Result[0].Desc    := 'Run AI models (text/image/video/audio) on Replicate — 5000+ models.';
   Result[0].Docs    := 'https://replicate.com/docs/reference/mcp';
 
   Result[1].Name    := 'digitalocean-apps';
@@ -154,6 +165,15 @@ begin
 
   HeaderValue := Format(Entry.AuthFmt, [Tok]);
   Result := True;
+end;
+
+function FormatAuthHeaderFromToken(const Entry: TMCPCatalogEntry;
+                                    const Token: string): string;
+begin
+  if (Entry.AuthFmt = '') or (Token = '') then
+    Result := ''
+  else
+    Result := Format(Entry.AuthFmt, [Token]);
 end;
 
 end.


### PR DESCRIPTION
## Summary

After provider + model + API-key prompts, `pasclaw onboard` now walks through the 5 built-in MCP catalogue entries (`replicate`, `digitalocean-apps`, `digitalocean-databases`, `runpod-docs`, `huggingface`), prompting `Enable [y/N]:` (default off, picoclaw-style — never preloaded without explicit opt-in) and capturing the API token inline.

## What you see

```
Optional: enable built-in MCP servers
─────────────────────────────────────
These give the agent extra capabilities via the MCP protocol.
Skip what you don't want — you can install later with `pasclaw mcp install <name>`.

  replicate
  Run AI models (text/image/video/audio) on Replicate — 5000+ models.
  https://replicate.com/docs/reference/mcp
  Enable [y/N]: y
  REPLICATE_API_TOKEN (paste, or blank to skip auth): r8_xxxxxxxxxxxxx
  ✓ installed replicate

  digitalocean-apps
  Manage DigitalOcean App Platform deployments.
  …
  Enable [y/N]: n
  …

  runpod-docs
  Search RunPod documentation. No auth required.
  Enable [y/N]: y
  ✓ installed runpod-docs (no auth)
```

Resulting `config.json`:

```json
"mcp_servers": [
  { "name": "replicate",   "cmd": "https://mcp.replicate.com/mcp",  "args": "Bearer r8_xxx", "env": "", "enabled": true },
  { "name": "runpod-docs", "cmd": "https://docs.runpod.io/mcp",     "args": "",              "env": "", "enabled": true }
]
```

Same shape `pasclaw mcp install <name>` writes today, so `list / show / test / remove` all work unchanged.

## Behaviour notes

- **Already-installed entries** print `(already installed — skipping)` so re-running `onboard` preserves whatever the user set up via `pasclaw mcp install` earlier.
- **When the env var is already set** (e.g. `REPLICATE_API_TOKEN` exported in the shell), the prompt is skipped and the env value is used — matches `pasclaw mcp install` for symmetry.
- **When the env var isn't set**, prompt for the token. Blank input installs with no auth and warns to re-run with env set.
- **Auth-less entries** (`runpod-docs` today) skip the token prompt and install with an empty `Args`.

## Wiring

- New helper **`FormatAuthHeaderFromToken`** in `PasClaw.MCP.Catalog` — sibling to `ResolveAuthHeader`. The existing function sources the token from the env var; the new one takes it as an argument so onboarding can prompt the user and persist the resulting header directly.
- **`UpsertCatalogMCP`** private helper in `Cmd.Onboard.pas` mirrors the upsert logic in `Cmd.MCP.DoInstall` (refresh existing entry by name, otherwise append).
- **`PromptMCPInstalls`** iterates `KnownMCPServers` and drives the prompts; called between `UpsertProvider` and `SaveConfig`.
- Replicate catalogue **`Desc`** updated to mention the 5000+ model count so both `pasclaw mcp catalog` and the onboarding prompt surface it. README MCP-catalog row follows.

## Test plan

- [x] FPC build clean (443879 lines)
- [x] `make smoke` 11/11 OK
- [x] Live scripted onboarding via stdin: picks Anthropic (default), enables Replicate with a test token + runpod-docs (no auth), declines the others — resulting `config.json` matches the example above
- [ ] Manual: run `pasclaw onboard` in a real terminal, walk through interactively, then `pasclaw mcp list` to confirm both new servers show up enabled


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_