### PR TITLE
Vault tool — agent + CLI surface for the pasclaw.dev Code Vault (PR B of 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The main program lives at `src/pasclaw/PasClaw.dpr`. It initializes terminal col
 | `web_search` | DuckDuckGo / Brave / Tavily / SearXNG / Perplexity / Gemini-grounding — 6 providers |
 | `web_fetch` | HTTP GET → readable plain text (HTML stripped, entities decoded), SSRF-guarded |
 | `memory_search` | SQLite FTS5 BM25 over `workspace/memory/*.md` and `MEMORY.md` |
+| `vault_search` / `vault_get` | search + read pasclaw.dev Code Vault entries (Object Pascal samples + components); opt-in via `vault_tools_enabled` |
 | `skill_<name>` | Pascal-side tools registered from `kind: shell` / `kind: prompt` skills |
 | MCP-bridged | every tool a configured MCP server exports — see below |
 
@@ -27,6 +28,8 @@ The main program lives at `src/pasclaw/PasClaw.dpr`. It initializes terminal col
 **MCP** — both transports. Stdio MCP via spawned subprocess + JSON-RPC over pipes, and Streamable HTTP MCP (handles SSE-framed responses, Bearer-token auth). Catalog of public servers — `pasclaw mcp install replicate` / `digitalocean-apps` / `digitalocean-databases` / `runpod-docs` / `huggingface` — reads the right env var, writes the right Authorization header, never preloaded.
 
 **Skills** — markdown manifests under `$PASCLAW_HOME/workspace/skills/` advertised in the system prompt; the model loads the body via `fs_read` on demand. Install from GitHub (`pasclaw skills install owner/repo[/path][@ref]` — codeload zip, FPC's `Zipper.TUnZipper` or Delphi's `System.Zip.TZipFile`); from the pasclaw.dev hub (`pasclaw skills install hub:<slug>[@<version>]`, or just `pasclaw skills install <slug>` which tries pasclaw.dev first then falls back to ClawHub); or from ClawHub directly (`pasclaw skills install clawhub:<slug>[@<version>]`). `pasclaw skills search <q>` queries both hubs and aggregates the results (pasclaw.dev first, ClawHub deduped). Malware-flagged skills refused; suspicious-flagged install with a warning.
+
+**Code Vault** — the pasclaw.dev Code Vault hosts Object Pascal source code (sample programs, reusable components, libraries) as GitHub-backed entries. `pasclaw vault search <q>` and `pasclaw vault show <slug>` discover; `pasclaw vault install <slug> [<dest>]` `git clone`s the entry's `repoUrl` into `$PASCLAW_HOME/workspace/vault/<slug>` (or a path you pass). The agent gets two **opt-in** tools — `vault_search` and `vault_get` — registered only when `vault_tools_enabled: true` in config.json; `pasclaw onboard` asks during setup with a default-yes prompt. Both tools are read-only HTTP GETs against the vault registry; obtaining the code itself is a separate `shell_exec git clone` call the model makes after `vault_get` returns the `repoUrl`.
 
 **HTTP gateway** — `pasclaw gateway` and `pasclaw serve`. OpenAI-compatible `/v1/chat/completions` (streaming + non-streaming) and `/v1/responses` (tool-passthrough so Codex CLI can drive its own tools). Embedded web UI (vanilla ES2020, single HTML file, no JS toolchain) with 8 tabs: **Chat** (SSE-streamed, tool activity surfaced inline), **Memory**, **Files**, **MCP**, **Cron**, **Skills**, **Logs** (live tail via SSE from the in-process ring buffer), **Settings**. Read-only inspection endpoints (`/v1/mcp`, `/v1/cron`, `/v1/skills`, `/v1/memory`, `/v1/fs`, `/v1/config`, `/v1/logs`) backed by the gateway's sandbox + secret-masking.
 

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -30,6 +30,7 @@ uses
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
   PasClaw.Tools.WebFetch,
+  PasClaw.Tools.Vault,
   PasClaw.Tools.ToolLoop,
   PasClaw.Agent.Compact,
   PasClaw.MCP.Bridge,
@@ -144,7 +145,8 @@ begin
   Result := NewProviderFromConfig(Cfg, Name, Provider, Err);
 end;
 
-function NewBuiltinRegistry(UseHashline: Boolean = True): TToolRegistry;
+function NewBuiltinRegistry(UseHashline: Boolean = True;
+                            EnableVault: Boolean = False): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
@@ -154,6 +156,11 @@ begin
   RegisterMemoryTools(Result);
   RegisterWebSearchTool(Result);
   RegisterWebFetchTool(Result);
+  { Vault tools register only when explicitly enabled — callers pass
+    Cfg.VaultToolsEnabled. Off-by-default per the onboarding opt-in
+    flow; flipping the config flag (or re-running `pasclaw onboard`)
+    is the way to turn it on. }
+  if EnableVault then RegisterVaultTools(Result);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(Result, Skills);
 end;
@@ -293,7 +300,7 @@ begin
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
 
   Reg := nil;
-  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
+  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;
@@ -368,7 +375,7 @@ begin
 
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
   Reg := nil;
-  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline);
+  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -146,6 +146,38 @@ begin
   end;
 end;
 
+procedure PromptVaultTools(Cfg: TConfig);
+{ Opt-in toggle for the agent-callable vault_search / vault_get
+  tools. Default YES because pressing Enter through onboarding
+  should land a useful agent, and the vault tools are read-only
+  HTTP GETs against a curated registry — no execution path. User
+  can flip back later by editing config.json or re-running
+  onboard. }
+var
+  Choice: string;
+begin
+  WriteLn;
+  WriteLn(Ansi.Bold, 'Code Vault tools', Ansi.Reset);
+  WriteLn(Ansi.Dim,
+    'vault_search / vault_get let the agent discover Object Pascal source code',
+    Ansi.Reset);
+  WriteLn(Ansi.Dim,
+    '(samples, components, libraries) on pasclaw.dev — read-only HTTP GETs.',
+    Ansi.Reset);
+  WriteLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable vault tools for the agent [Y/n]: ')));
+  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.VaultToolsEnabled := True;
+    WriteLn('  ', Ansi.Green, '✓', Ansi.Reset, ' vault_search / vault_get enabled');
+  end
+  else
+  begin
+    Cfg.VaultToolsEnabled := False;
+    WriteLn('  ', Ansi.Dim, '(skipped — flip vault_tools_enabled in config.json to enable later)', Ansi.Reset);
+  end;
+end;
+
 procedure PromptMCPInstalls(Cfg: TConfig);
 var
   Entries: TMCPCatalogEntryArray;
@@ -303,6 +335,7 @@ begin
       header value (same shape pasclaw mcp install writes when an
       env var is set). }
     PromptMCPInstalls(Cfg);
+    PromptVaultTools(Cfg);
 
     SaveConfig(Cfg);
     WriteLn;

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -39,6 +39,7 @@ uses
   PasClaw.Cmd.MCP,
   PasClaw.Cmd.Migrate,
   PasClaw.Cmd.Skills,
+  PasClaw.Cmd.Vault,
   PasClaw.Cmd.Session,
   PasClaw.Cmd.Steer,
   PasClaw.Cmd.Model,
@@ -100,7 +101,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 20);
+  SetLength(Sub, 21);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
@@ -113,14 +114,15 @@ begin
   Sub[9]  := 'mcp          Manage MCP servers';
   Sub[10] := 'migrate      Migrate data from older versions';
   Sub[11] := 'skills       Manage skill extensions';
-  Sub[12] := 'model        View or switch the default model';
-  Sub[13] := 'post         Send a one-shot message to a channel';
-  Sub[14] := 'membench     Benchmark the memory log subsystem';
-  Sub[15] := 'session      List/show/delete/export saved sessions';
-  Sub[16] := 'resume       Resume a saved session (alias for agent --session)';
-  Sub[17] := 'steer        Push a mid-loop follow-up into a running agent';
-  Sub[18] := 'update       Self-update PasClaw';
-  Sub[19] := 'version      Show version info';
+  Sub[12] := 'vault        Search / fetch pasclaw.dev Code Vault entries';
+  Sub[13] := 'model        View or switch the default model';
+  Sub[14] := 'post         Send a one-shot message to a channel';
+  Sub[15] := 'membench     Benchmark the memory log subsystem';
+  Sub[16] := 'session      List/show/delete/export saved sessions';
+  Sub[17] := 'resume       Resume a saved session (alias for agent --session)';
+  Sub[18] := 'steer        Push a mid-loop follow-up into a running agent';
+  Sub[19] := 'update       Self-update PasClaw';
+  Sub[20] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -144,6 +146,7 @@ begin
   else if Cmd = 'mcp'      then Result := Cmd_MCP_Run(Argv)
   else if Cmd = 'migrate'  then Result := Cmd_Migrate_Run(Argv)
   else if Cmd = 'skills'   then Result := Cmd_Skills_Run(Argv)
+  else if Cmd = 'vault'    then Result := Cmd_Vault_Run(Argv)
   else if Cmd = 'session'  then Result := Cmd_Session_Run(Argv)
   { resume <id> is shorthand for `agent --session <id>` — wire it
     here so `pasclaw resume foo` works as a top-level shortcut. }

--- a/src/cmd/PasClaw.Cmd.Vault.pas
+++ b/src/cmd/PasClaw.Cmd.Vault.pas
@@ -1,0 +1,279 @@
+(*
+  PasClaw.Cmd.Vault — `pasclaw vault <search|show|install>`.
+
+    pasclaw vault search <query> [--limit N]
+        Search the pasclaw.dev Code Vault. Prints a table of
+        matching entries (slug + version + name + summary).
+
+    pasclaw vault show <slug>
+        Print full entry detail — description, repo URL, license,
+        Delphi versions, install snippet.
+
+    pasclaw vault install <slug> [<dest-path>]
+        git clone the entry's repoUrl into <dest-path> (or
+        $PASCLAW_HOME/workspace/vault/<slug> if not given).
+        Refuses if the destination already exists.
+
+  Vault entries are GitHub repos — there's no zip / download step
+  the way Skills + ClawHub have. The install path shells out to
+  `git clone` and inherits whatever git auth the user already has.
+*)
+unit PasClaw.Cmd.Vault;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function Cmd_Vault_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  Process,
+  PasClaw.Config,
+  PasClaw.Utils,
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Vault.Client;
+
+procedure Help;
+begin
+  WriteLn('Usage: pasclaw vault <search|show|install> [args]');
+  WriteLn;
+  WriteLn('  search <query> [--limit N]   Search pasclaw.dev Code Vault.');
+  WriteLn('  show <slug>                  Print full entry detail.');
+  WriteLn('  install <slug> [<dest>]      git clone the repo into <dest>');
+  WriteLn('                               (default $PASCLAW_HOME/workspace/vault/<slug>).');
+end;
+
+function DoSearch(const Argv: array of string): Integer;
+var
+  Query: string;
+  Limit, i: Integer;
+  Results: TVaultResultArray;
+  ErrMsg, Summary: string;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Query := Argv[1];
+  Limit := 25;
+  if Length(Argv) >= 4 then
+    if Argv[2] = '--limit' then
+      Limit := StrToIntDef(Argv[3], 25);
+
+  WriteLn('Searching pasclaw.dev Code Vault: ', Query, ' …');
+  if not SearchVault(Query, Limit, Results, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'search failed: ', ErrMsg);
+    Exit(1);
+  end;
+  if Length(Results) = 0 then
+  begin
+    WriteLn('(no matches)');
+    Exit(0);
+  end;
+  WriteLn(Ansi.Bold, 'slug', Ansi.Reset, '                       version    name');
+  for i := 0 to High(Results) do
+  begin
+    WriteLn(Results[i].Slug:26, '  ', Results[i].Version:9, '  ', Results[i].DisplayName);
+    Summary := Trim(Results[i].Summary);
+    if Summary <> '' then
+      WriteLn('                            ', Ansi.Dim, Summary, Ansi.Reset);
+  end;
+  WriteLn;
+  WriteLn(Ansi.Dim, 'Show with:    ', Ansi.Reset,
+          Ansi.Bold, 'pasclaw vault show <slug>', Ansi.Reset);
+  WriteLn(Ansi.Dim, 'Install with: ', Ansi.Reset,
+          Ansi.Bold, 'pasclaw vault install <slug>', Ansi.Reset,
+          Ansi.Dim, '  (git clone into workspace/vault/<slug>)', Ansi.Reset);
+  Result := 0;
+end;
+
+function DoShow(const Argv: array of string): Integer;
+var
+  Slug, ErrMsg: string;
+  Detail: TVaultDetail;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Slug := Argv[1];
+  if not GetVaultEntry(Slug, Detail, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'get failed: ', ErrMsg);
+    Exit(1);
+  end;
+  if Detail.Blocked then
+    WriteLn(Ansi.Red, '⚠ malware-flagged', Ansi.Reset)
+  else if Detail.Suspicious then
+    WriteLn(Ansi.Yellow, '⚠ flagged as suspicious', Ansi.Reset);
+  WriteLn(Ansi.Bold, 'slug:        ', Ansi.Reset, Detail.Slug);
+  WriteLn(Ansi.Bold, 'name:        ', Ansi.Reset, Detail.DisplayName);
+  if Detail.Summary <> '' then
+    WriteLn(Ansi.Bold, 'summary:     ', Ansi.Reset, Detail.Summary);
+  if Detail.RepoURL <> '' then
+    WriteLn(Ansi.Bold, 'repo:        ', Ansi.Reset, Detail.RepoURL);
+  if Detail.HomepageURL <> '' then
+    WriteLn(Ansi.Bold, 'homepage:    ', Ansi.Reset, Detail.HomepageURL);
+  if Detail.License <> '' then
+    WriteLn(Ansi.Bold, 'license:     ', Ansi.Reset, Detail.License);
+  if Detail.LatestVersion <> '' then
+    WriteLn(Ansi.Bold, 'version:     ', Ansi.Reset, Detail.LatestVersion);
+  if Detail.Category <> '' then
+    WriteLn(Ansi.Bold, 'category:    ', Ansi.Reset, Detail.Category);
+  if Detail.Tags <> '' then
+    WriteLn(Ansi.Bold, 'tags:        ', Ansi.Reset, Detail.Tags);
+  if Detail.DelphiVersions <> '' then
+    WriteLn(Ansi.Bold, 'delphi:      ', Ansi.Reset, Detail.DelphiVersions);
+  if Detail.PackageManager <> '' then
+    WriteLn(Ansi.Bold, 'package mgr: ', Ansi.Reset, Detail.PackageManager);
+  if Detail.ViewCount > 0 then
+    WriteLn(Ansi.Bold, 'views:       ', Ansi.Reset, IntToStr(Detail.ViewCount));
+  if Detail.InstallSnippet <> '' then
+  begin
+    WriteLn;
+    WriteLn(Ansi.Bold, 'install snippet:', Ansi.Reset);
+    WriteLn(Detail.InstallSnippet);
+  end;
+  if Detail.DescriptionMarkdown <> '' then
+  begin
+    WriteLn;
+    WriteLn(Ansi.Bold, 'description:', Ansi.Reset);
+    WriteLn(Detail.DescriptionMarkdown);
+  end;
+  Result := 0;
+end;
+
+function RunGitClone(const RepoURL, DestDir: string; out ErrMsg: string): Boolean;
+{ Shells out to `git clone <repoUrl> <destDir>`. Inherits whatever
+  git auth the user already has (SSH keys, credential helper, etc.)
+  — we don't try to handle private-repo auth ourselves. Output is
+  captured and surfaced on failure; success prints git's own
+  progress as it runs. }
+var
+  P: TProcess;
+  ExitCode: Integer;
+  OutLines: TStringList;
+begin
+  Result := False;
+  ErrMsg := '';
+  P := TProcess.Create(nil);
+  OutLines := TStringList.Create;
+  try
+    P.Executable := 'git';
+    P.Parameters.Add('clone');
+    P.Parameters.Add('--');
+    P.Parameters.Add(RepoURL);
+    P.Parameters.Add(DestDir);
+    P.Options := [poUsePipes, poStderrToOutPut];
+    try
+      P.Execute;
+    except
+      on E: Exception do
+      begin
+        ErrMsg := 'git clone failed to start: ' + E.Message +
+                  ' (is `git` installed and on PATH?)';
+        Exit;
+      end;
+    end;
+    { Drain stdout while the process runs so the user sees clone
+      progress in real time rather than waiting for a final blob. }
+    while P.Running do
+    begin
+      if P.Output.NumBytesAvailable > 0 then
+      begin
+        OutLines.LoadFromStream(P.Output);
+        Write(OutLines.Text);
+        OutLines.Clear;
+      end
+      else
+        Sleep(50);
+    end;
+    if P.Output.NumBytesAvailable > 0 then
+    begin
+      OutLines.LoadFromStream(P.Output);
+      Write(OutLines.Text);
+    end;
+    ExitCode := P.ExitStatus;
+    if ExitCode <> 0 then
+    begin
+      ErrMsg := Format('git clone exited %d', [ExitCode]);
+      Exit;
+    end;
+    Result := True;
+  finally
+    OutLines.Free;
+    P.Free;
+  end;
+end;
+
+function DoInstall(const Argv: array of string): Integer;
+var
+  Slug, DestDir, ErrMsg: string;
+  Detail: TVaultDetail;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  Slug := Argv[1];
+
+  if Length(Argv) >= 3 then
+    DestDir := Argv[2]
+  else
+    DestDir := JoinPath(GetHome, 'workspace/vault/' + Slug);
+
+  if DirectoryExists(DestDir) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset,
+            'destination already exists: ', DestDir);
+    WriteLn(Ansi.Dim, '  remove it first, or pass a different <dest> path.', Ansi.Reset);
+    Exit(1);
+  end;
+
+  if not GetVaultEntry(Slug, Detail, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, 'vault lookup failed: ', ErrMsg);
+    Exit(1);
+  end;
+  if Detail.Blocked then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset,
+            'pasclaw.dev flagged "', Slug, '" as malware — refusing install');
+    Exit(1);
+  end;
+  if Detail.Suspicious then
+    WriteLn(Ansi.Yellow, '! ', Ansi.Reset,
+            'pasclaw.dev flagged "', Slug, '" as suspicious — proceeding anyway');
+  if Detail.RepoURL = '' then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset,
+            'vault entry has no repoUrl');
+    Exit(1);
+  end;
+
+  ForceDirectories(ExtractFileDir(DestDir));
+  WriteLn('Cloning ', Detail.RepoURL, ' …');
+  if not RunGitClone(Detail.RepoURL, DestDir, ErrMsg) then
+  begin
+    WriteLn(Ansi.Red, '✗ ', Ansi.Reset, ErrMsg);
+    Exit(1);
+  end;
+  WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'cloned into ', DestDir);
+  if Detail.InstallSnippet <> '' then
+  begin
+    WriteLn(Ansi.Dim, 'Install snippet from vault:', Ansi.Reset);
+    WriteLn(Detail.InstallSnippet);
+  end;
+  Result := 0;
+end;
+
+function Cmd_Vault_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then begin Help; Exit(1); end;
+  Sub := Argv[0];
+  if      Sub = 'search'  then Result := DoSearch(Argv)
+  else if Sub = 'show'    then Result := DoShow(Argv)
+  else if Sub = 'install' then Result := DoInstall(Argv)
+  else                         begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Vault.pas
+++ b/src/cmd/PasClaw.Cmd.Vault.pas
@@ -208,7 +208,7 @@ end;
 
 function DoInstall(const Argv: array of string): Integer;
 var
-  Slug, DestDir, ErrMsg: string;
+  Slug, DestDir, ParentDir, ErrMsg: string;
   Detail: TVaultDetail;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
@@ -248,7 +248,9 @@ begin
     Exit(1);
   end;
 
-  ForceDirectories(ExtractFileDir(DestDir));
+  ParentDir := ExtractFileDir(DestDir);
+  if ParentDir <> '' then
+    ForceDirectories(ParentDir);
   WriteLn('Cloning ', Detail.RepoURL, ' …');
   if not RunGitClone(Detail.RepoURL, DestDir, ErrMsg) then
   begin

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -126,6 +126,7 @@
         <DCCReference Include="..\cmd\PasClaw.Cmd.MCP.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Migrate.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Skills.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Vault.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Session.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Steer.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Model.pas"/>
@@ -174,6 +175,7 @@
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Memory.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.WebSearch.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.WebFetch.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.Vault.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.ToolLoop.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Obj.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.pas"/>
@@ -233,6 +235,7 @@
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.GitHub.pas"/>
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.ClawHub.pas"/>
         <DCCReference Include="..\pkg\skills\PasClaw.Skills.PasClawHub.pas"/>
+        <DCCReference Include="..\pkg\skills\PasClaw.Vault.Client.pas"/>
 
         <!-- pkg/session -->
         <DCCReference Include="..\pkg\session\PasClaw.Session.Store.pas"/>

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -229,6 +229,12 @@ type
        picoclaw's pkg/channels/base.go IsAllowedSender semantics).
        Configure via "allow_senders": [...] in config.json. *)
     AllowSenders: array of string;
+    (* Off-by-default: when True, Cmd.Agent.NewBuiltinRegistry
+       registers vault_search and vault_get for the model. The
+       onboarding flow asks the user to opt in (default yes).
+       Operators who skip onboarding can flip this directly in
+       config.json or re-run `pasclaw onboard`. *)
+    VaultToolsEnabled: Boolean;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -290,6 +296,7 @@ begin
   WebSearch.MaxResults := 5;
   PromptCache.Enabled  := True;  { default-on; see TPromptCacheConfig comment }
   PromptCache.TTL      := '';    { default 5m via empty }
+  VaultToolsEnabled    := False; { off by default; onboarding asks to opt in }
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -420,6 +427,10 @@ begin
       for i := 0 to High(AllowSenders) do Arr.AddStr(AllowSenders[i]);
       Root.PutArray('allow_senders', Arr);
     end;
+
+    { Off-by-default — only serialise when True so stock configs stay tidy. }
+    if VaultToolsEnabled then
+      Root.PutBool('vault_tools_enabled', True);
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -569,6 +580,8 @@ begin
     finally
       Arr.Free;
     end;
+
+    VaultToolsEnabled := Root.GetBool('vault_tools_enabled', VaultToolsEnabled);
 
     Arr := Root.ChildArray('providers');
     if Arr <> nil then

--- a/src/pkg/skills/PasClaw.Vault.Client.pas
+++ b/src/pkg/skills/PasClaw.Vault.Client.pas
@@ -1,0 +1,326 @@
+(*
+  PasClaw.Vault.Client — search + fetch entries in the pasclaw.dev
+  Code Vault. Vault entries are GitHub repos (Object Pascal samples,
+  reusable components, libraries); the registry is search-and-get
+  only — there's no zip/download step. Use the returned `repoUrl`
+  with `git clone` (the `pasclaw vault install` CLI does this) or
+  with the agent's `web_fetch` / `shell_exec` tools.
+
+  Endpoints (base: https://pasclaw.dev/api/public/v1):
+
+    GET /vault?q=<query>&limit=<n>
+       {"results":[{"slug":"…","displayName":"…","summary":"…",
+                    "category":"…","tags":[…],"repoUrl":"…",
+                    "latestVersion":"…"}]}
+
+    GET /vault/<slug>
+       {"slug":"…", "displayName":"…", "summary":"…",
+        "descriptionMarkdown":"…", "category":"…", "tags":[…],
+        "repoUrl":"…", "homepageUrl":"…", "license":"…",
+        "delphiVersions":[…], "packageManager":"…",
+        "installSnippet":"…", "latestVersion":"…",
+        "viewCount":42, "moderation":{…}}
+
+  Failure semantics match PasClaw.Skills.PasClawHub: 404 returns
+  ErrMsg = 'not found' so callers can distinguish miss from network
+  error.
+*)
+unit PasClaw.Vault.Client;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TVaultResult = record
+    Slug:        string;
+    DisplayName: string;
+    Summary:     string;
+    Category:    string;
+    Tags:        string;   { comma-joined for compactness — list rendering only }
+    RepoURL:     string;
+    Version:     string;
+  end;
+  TVaultResultArray = array of TVaultResult;
+
+  TVaultDetail = record
+    Slug:                string;
+    DisplayName:         string;
+    Summary:             string;
+    DescriptionMarkdown: string;
+    Category:            string;
+    Tags:                string;
+    RepoURL:             string;
+    HomepageURL:         string;
+    License:             string;
+    DelphiVersions:      string;
+    PackageManager:      string;
+    InstallSnippet:      string;
+    LatestVersion:       string;
+    ViewCount:           Integer;
+    Blocked:             Boolean;
+    Suspicious:          Boolean;
+  end;
+
+function SearchVault(const Query: string; Limit: Integer;
+                     out Results: TVaultResultArray;
+                     out ErrMsg: string): Boolean;
+
+function GetVaultEntry(const Slug: string;
+                       out Detail: TVaultDetail;
+                       out ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  PasClaw.Logger,
+  PasClaw.JSON,
+  PasClaw.Providers.HTTP;
+
+const
+  VaultBaseURL       = 'https://pasclaw.dev/api/public/v1';
+  ListEndpoint       = '/vault';
+  GetEndpoint        = '/vault/';
+  RequestTimeoutSec  = 30;
+
+function UrlEncode(const S: string): string;
+{ Duplicated from PasClaw.Skills.PasClawHub — minimal percent-encoder.
+  The codebase has accepted this duplication across hub clients; a
+  follow-up should extract to a shared util. }
+var
+  i: Integer;
+  C: Char;
+begin
+  Result := '';
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if ((C >= 'A') and (C <= 'Z')) or
+       ((C >= 'a') and (C <= 'z')) or
+       ((C >= '0') and (C <= '9')) or
+       (C = '-') or (C = '_') or (C = '.') or (C = '~') then
+      Result := Result + C
+    else
+      Result := Result + Format('%%%2.2X', [Ord(C)]);
+  end;
+end;
+
+function IsValidSlug(const S: string): Boolean;
+(* Mirrors the pattern the OpenAPI documents: ^[a-z0-9_-]\{1,128\}$ *)
+var
+  i: Integer;
+  C: Char;
+begin
+  Result := False;
+  if (S = '') or (Length(S) > 128) then Exit;
+  for i := 1 to Length(S) do
+  begin
+    C := S[i];
+    if not ( ((C >= 'a') and (C <= 'z')) or
+             ((C >= '0') and (C <= '9')) or
+             (C = '-') or (C = '_') ) then Exit;
+  end;
+  Result := True;
+end;
+
+function DoGetJSON(const URL: string; out Body, ErrMsg: string): Boolean;
+var
+  Headers: array of THeaderPair;
+  Resp: THTTPResult;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Headers, 0);
+  Resp := GetJSONURL(URL, Headers, RequestTimeoutSec);
+  if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+  begin
+    if Resp.StatusCode = 404 then ErrMsg := 'not found'
+    else if Resp.ErrorMsg <> '' then ErrMsg := Format('http %d: %s', [Resp.StatusCode, Resp.ErrorMsg])
+    else ErrMsg := Format('http %d', [Resp.StatusCode]);
+    Exit;
+  end;
+  Body := Resp.Body;
+  Result := True;
+end;
+
+function CommaJoinArray(Arr: TJsonArray): string;
+var
+  i: Integer;
+  S: string;
+begin
+  Result := '';
+  if Arr = nil then Exit;
+  for i := 0 to Arr.Count - 1 do
+  begin
+    S := Arr.ItemStr(i, '');
+    if S = '' then Continue;
+    if Result <> '' then Result := Result + ', ';
+    Result := Result + S;
+  end;
+end;
+
+function SearchVault(const Query: string; Limit: Integer;
+                     out Results: TVaultResultArray;
+                     out ErrMsg: string): Boolean;
+var
+  URL, Body, S: string;
+  Root: TJsonObject;
+  Arr, TagsArr: TJsonArray;
+  Item: TJsonObject;
+  i: Integer;
+  Res: TVaultResult;
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Results, 0);
+  if Limit <= 0 then Limit := 25;
+  if Limit > 100 then Limit := 100;
+
+  URL := VaultBaseURL + ListEndpoint + '?limit=' + IntToStr(Limit);
+  if Trim(Query) <> '' then
+    URL := URL + '&q=' + UrlEncode(Query);
+  LogDebug('vault: GET %s', [URL]);
+  if not DoGetJSON(URL, Body, ErrMsg) then Exit;
+
+  Root := nil;
+  try
+    try
+      Root := TJsonObject.Parse(Body);
+    except
+      on E: Exception do
+      begin
+        ErrMsg := 'malformed JSON response: ' + E.Message;
+        Exit;
+      end;
+    end;
+    if Root = nil then
+    begin
+      ErrMsg := 'malformed JSON response';
+      Exit;
+    end;
+    Arr := Root.ChildArray('results');
+    if Arr = nil then Exit(True);
+    try
+      for i := 0 to Arr.Count - 1 do
+      begin
+        Item := Arr.ItemObject(i);
+        if Item = nil then Continue;
+        try
+          S := Item.GetStr('slug', '');
+          if S = '' then Continue;
+          Res.Slug        := S;
+          Res.DisplayName := Item.GetStr('displayName', S);
+          Res.Summary     := Item.GetStr('summary', '');
+          Res.Category    := Item.GetStr('category', '');
+          Res.RepoURL     := Item.GetStr('repoUrl', '');
+          Res.Version     := Item.GetStr('latestVersion', '');
+          TagsArr := Item.ChildArray('tags');
+          if TagsArr <> nil then
+          try
+            Res.Tags := CommaJoinArray(TagsArr);
+          finally
+            TagsArr.Free;
+          end
+          else
+            Res.Tags := '';
+          SetLength(Results, Length(Results) + 1);
+          Results[High(Results)] := Res;
+        finally
+          Item.Free;
+        end;
+      end;
+    finally
+      Arr.Free;
+    end;
+    Result := True;
+  finally
+    Root.Free;
+  end;
+end;
+
+function GetVaultEntry(const Slug: string;
+                       out Detail: TVaultDetail;
+                       out ErrMsg: string): Boolean;
+var
+  URL, Body: string;
+  Root, ModObj: TJsonObject;
+  TagsArr, DelphiArr: TJsonArray;
+begin
+  Result := False;
+  ErrMsg := '';
+  FillChar(Detail, SizeOf(Detail), 0);
+  if not IsValidSlug(Slug) then
+  begin
+    ErrMsg := 'invalid slug: ' + Slug;
+    Exit;
+  end;
+
+  URL := VaultBaseURL + GetEndpoint + UrlEncode(Slug);
+  LogDebug('vault: GET %s', [URL]);
+  if not DoGetJSON(URL, Body, ErrMsg) then Exit;
+
+  Root := nil;
+  try
+    try
+      Root := TJsonObject.Parse(Body);
+    except
+      on E: Exception do
+      begin
+        ErrMsg := 'malformed JSON response: ' + E.Message;
+        Exit;
+      end;
+    end;
+    if Root = nil then
+    begin
+      ErrMsg := 'malformed JSON response';
+      Exit;
+    end;
+    Detail.Slug                := Root.GetStr('slug', Slug);
+    Detail.DisplayName         := Root.GetStr('displayName', '');
+    Detail.Summary             := Root.GetStr('summary', '');
+    Detail.DescriptionMarkdown := Root.GetStr('descriptionMarkdown', '');
+    Detail.Category            := Root.GetStr('category', '');
+    Detail.RepoURL             := Root.GetStr('repoUrl', '');
+    Detail.HomepageURL         := Root.GetStr('homepageUrl', '');
+    Detail.License             := Root.GetStr('license', '');
+    Detail.PackageManager      := Root.GetStr('packageManager', '');
+    Detail.InstallSnippet      := Root.GetStr('installSnippet', '');
+    Detail.LatestVersion       := Root.GetStr('latestVersion', '');
+    Detail.ViewCount           := Root.GetInt('viewCount', 0);
+
+    TagsArr := Root.ChildArray('tags');
+    if TagsArr <> nil then
+    try
+      Detail.Tags := CommaJoinArray(TagsArr);
+    finally
+      TagsArr.Free;
+    end;
+
+    DelphiArr := Root.ChildArray('delphiVersions');
+    if DelphiArr <> nil then
+    try
+      Detail.DelphiVersions := CommaJoinArray(DelphiArr);
+    finally
+      DelphiArr.Free;
+    end;
+
+    ModObj := Root.ChildObject('moderation');
+    if ModObj <> nil then
+    try
+      Detail.Blocked    := ModObj.GetBool('isMalwareBlocked', False);
+      Detail.Suspicious := ModObj.GetBool('isSuspicious',     False);
+    finally
+      ModObj.Free;
+    end;
+
+    Result := True;
+  finally
+    Root.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Vault.pas
+++ b/src/pkg/tools/PasClaw.Tools.Vault.pas
@@ -1,0 +1,238 @@
+(*
+  PasClaw.Tools.Vault — registers the vault_search and vault_get
+  tools, which let the agent discover Object Pascal source code
+  (samples, components, libraries) in the pasclaw.dev Code Vault.
+
+  Both tools are tcReadOnly (HTTP GETs against the vault registry,
+  no shared state). Off by default — Cmd.Agent.NewBuiltinRegistry
+  registers them only when the EnableVault flag is set, which
+  Cmd.Agent reads from Cfg.VaultToolsEnabled. The onboarding flow
+  asks the user to opt in (default yes); operators who skip the
+  prompt can still enable later by flipping the config field or
+  re-running `pasclaw onboard`.
+
+  Output shape: both tools return JSON strings (the model handles
+  JSON natively). vault_search returns
+    [{"slug":"…","displayName":"…","summary":"…",
+      "category":"…","tags":"…","repoUrl":"…","version":"…"}]
+  vault_get returns the full entry detail including
+  descriptionMarkdown so the model can read the description body
+  inline without a second hop.
+*)
+unit PasClaw.Tools.Vault;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterVaultTools(R: TToolRegistry);
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger,
+  PasClaw.Vault.Client;
+
+function ParseStrArg(const ArgsJSON, Key: string; out V: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj = nil then Exit;
+  try
+    V := Obj.GetStr(Key, '');
+    Result := V <> '';
+  finally
+    Obj.Free;
+  end;
+end;
+
+function ParseIntArg(const ArgsJSON, Key: string; Default_: Integer): Integer;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default_;
+  if Trim(ArgsJSON) = '' then Exit;
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj = nil then Exit;
+  try
+    Result := Obj.GetInt(Key, Default_);
+  finally
+    Obj.Free;
+  end;
+end;
+
+function ResultsToJSON(const Results: TVaultResultArray): string;
+var
+  Root, Item: TJsonObject;
+  Arr: TJsonArray;
+  i: Integer;
+begin
+  Arr := TJsonArray.Create;
+  try
+    for i := 0 to High(Results) do
+    begin
+      Item := TJsonObject.Create;
+      Item.PutStr('slug',        Results[i].Slug);
+      Item.PutStr('displayName', Results[i].DisplayName);
+      Item.PutStr('summary',     Results[i].Summary);
+      Item.PutStr('category',    Results[i].Category);
+      Item.PutStr('tags',        Results[i].Tags);
+      Item.PutStr('repoUrl',     Results[i].RepoURL);
+      Item.PutStr('version',     Results[i].Version);
+      Arr.AddObject(Item);
+    end;
+    Root := TJsonObject.Create;
+    try
+      Root.PutArray('results', Arr);
+      Result := Root.ToJSON;
+    finally
+      Root.Free;
+    end;
+  except
+    Arr.Free;
+    raise;
+  end;
+end;
+
+function DetailToJSON(const D: TVaultDetail): string;
+var
+  Root: TJsonObject;
+  ModObj: TJsonObject;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('slug',                D.Slug);
+    Root.PutStr('displayName',         D.DisplayName);
+    Root.PutStr('summary',             D.Summary);
+    Root.PutStr('descriptionMarkdown', D.DescriptionMarkdown);
+    Root.PutStr('category',            D.Category);
+    Root.PutStr('tags',                D.Tags);
+    Root.PutStr('repoUrl',             D.RepoURL);
+    Root.PutStr('homepageUrl',         D.HomepageURL);
+    Root.PutStr('license',             D.License);
+    Root.PutStr('delphiVersions',      D.DelphiVersions);
+    Root.PutStr('packageManager',      D.PackageManager);
+    Root.PutStr('installSnippet',      D.InstallSnippet);
+    Root.PutStr('latestVersion',       D.LatestVersion);
+    Root.PutInt('viewCount',           D.ViewCount);
+    ModObj := TJsonObject.Create;
+    ModObj.PutBool('isMalwareBlocked', D.Blocked);
+    ModObj.PutBool('isSuspicious',     D.Suspicious);
+    Root.PutObject('moderation', ModObj);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function Tool_VaultSearch(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Query: string;
+  Limit: Integer;
+  Results: TVaultResultArray;
+  Err: string;
+begin
+  Result := '';
+  ErrMsg := '';
+  if not ParseStrArg(ArgsJSON, 'query', Query) then
+  begin
+    ErrMsg := 'missing "query" string argument';
+    Exit;
+  end;
+  Limit := ParseIntArg(ArgsJSON, 'limit', 10);
+  if Limit < 1 then Limit := 1;
+  if Limit > 25 then Limit := 25;
+
+  if not SearchVault(Query, Limit, Results, Err) then
+  begin
+    ErrMsg := 'vault search failed: ' + Err;
+    LogWarn('vault_search failed: %s', [Err]);
+    Exit;
+  end;
+  if Length(Results) = 0 then
+  begin
+    Result := '{"results":[],"note":"no matches"}';
+    Exit;
+  end;
+  Result := ResultsToJSON(Results);
+  LogInfo('vault_search query=%s hits=%d', [Query, Length(Results)]);
+end;
+
+function Tool_VaultGet(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Slug: string;
+  Detail: TVaultDetail;
+  Err: string;
+begin
+  Result := '';
+  ErrMsg := '';
+  if not ParseStrArg(ArgsJSON, 'slug', Slug) then
+  begin
+    ErrMsg := 'missing "slug" string argument';
+    Exit;
+  end;
+  if not GetVaultEntry(Slug, Detail, Err) then
+  begin
+    ErrMsg := 'vault get failed: ' + Err;
+    LogWarn('vault_get failed: %s', [Err]);
+    Exit;
+  end;
+  Result := DetailToJSON(Detail);
+  LogInfo('vault_get slug=%s repo=%s', [Slug, Detail.RepoURL]);
+end;
+
+procedure RegisterVaultTools(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if R = nil then Exit;
+
+  T.Name        := 'vault_search';
+  T.Description :=
+    'Search the pasclaw.dev Code Vault for Object Pascal source — ' +
+    'sample programs, reusable components, libraries. Returns up to ' +
+    'k entries as a list of {slug, displayName, summary, category, ' +
+    'tags, repoUrl, version}. Use vault_get(slug) to read full ' +
+    'description + install snippet; use shell_exec("git clone " + ' +
+    'repoUrl) to obtain the code.';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"query":{"type":"string","description":"Free-text search query."},' +
+    '"limit":{"type":"integer","minimum":1,"maximum":25,"description":"Max results (default 10)."}' +
+    '},"required":["query"]}';
+  T.Handler     := Tool_VaultSearch;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;
+  R.Register(T);
+
+  T.Name        := 'vault_get';
+  T.Description :=
+    'Fetch full detail for a Code Vault entry by slug, including ' +
+    'descriptionMarkdown (the entry''s full README-style body), ' +
+    'repoUrl, license, delphiVersions, and installSnippet. Pair ' +
+    'with vault_search to first discover slugs; the repoUrl is what ' +
+    'you pass to git clone.';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"slug":{"type":"string","description":"Vault entry slug, e.g. ''indy-ssl-helper''."}' +
+    '},"required":["slug"]}';
+  T.Handler     := Tool_VaultGet;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;
+  R.Register(T);
+end;
+
+end.


### PR DESCRIPTION
## Summary

PR B of three. Adds search + get + install for the pasclaw.dev Code Vault registry, which hosts Object Pascal source code (samples, components, libraries) as GitHub-backed entries. Vault is search-and-get only on the wire — no zip/download envelope; entries link to GitHub repos and the install path shells out to `git clone`.

- **PR A** (#129, merged) — skills hub-first lookup with ClawHub fallback
- **PR B (this)** — Vault tool + CLI + onboarding opt-in
- **PR C** — MCP search registry with offline fallback (next)

## What's new

**Three new units:**

| File | Purpose |
|---|---|
| `src/pkg/skills/PasClaw.Vault.Client.pas` | HTTP client for `GET /vault?q=` and `GET /vault/<slug>`. Returns `TVaultResult[]` and `TVaultDetail` records. |
| `src/pkg/tools/PasClaw.Tools.Vault.pas` | Agent-callable `vault_search(query, limit?)` and `vault_get(slug)` tools. Both `tcReadOnly`. |
| `src/cmd/PasClaw.Cmd.Vault.pas` | `pasclaw vault <search\|show\|install>` CLI. Install shells out to `git clone <repoUrl> <dest>` and streams git's stdout. |

**Config:** new `TConfig.VaultToolsEnabled: Boolean` (default `False`). Only serialised when `True` so stock configs stay tidy (same pattern as `prompt_cache`).

**Cmd.Agent.NewBuiltinRegistry** gained an `EnableVault: Boolean = False` parameter; callers pass `Cfg.VaultToolsEnabled`. Vault tools register only when that's true.

**Onboarding:** new `PromptVaultTools` step after the MCP-install loop. `Enable vault tools for the agent [Y/n]:` — default yes (pressing Enter enables). Explicit `n` skips with a hint to flip the config later.

**Cmd.Root:** new top-level `vault` subcommand in dispatch + help list.

## Usage

```sh
# CLI surface (does not require vault_tools_enabled — only the agent tools do)
pasclaw vault search "indy ssl"
pasclaw vault show indy-ssl-helper
pasclaw vault install indy-ssl-helper                 # → workspace/vault/indy-ssl-helper
pasclaw vault install indy-ssl-helper /path/to/here   # custom dest
```

**Agent flow** (when `vault_tools_enabled: true`):

1. User: "find me Object Pascal SSL helper code"
2. Model calls `vault_search("ssl")` → gets slugs + repoUrls
3. Model calls `vault_get("indy-ssl-helper")` → reads description, license, install snippet
4. Model either tells the user the repo URL or calls `shell_exec("git clone <repoUrl>")` itself

The agent already has every primitive it needs once it knows the repo URL — vault's only job is the discovery hop.

## Test plan

- [x] FPC build clean
- [x] `make smoke` 11/11 OK
- [x] `pasclaw` top-level help shows `vault` row
- [x] `pasclaw vault` prints subcommand help
- [x] Scripted onboarding default-yes (Enter) → `vault_tools_enabled: true` in config
- [x] Scripted onboarding explicit `n` → field omitted (default-off, default-suppressed)
- [ ] **Manual** `pasclaw vault search <q>` against the real pasclaw.dev hub
- [ ] **Manual** `pasclaw vault install <slug>` — verify git clone runs with streaming stdout, lands at the expected workspace path
- [ ] **Manual** With `vault_tools_enabled: true`, run `pasclaw agent` and ask for code — verify `vault_search` + `vault_get` appear in the tool-call stream


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_