### PR TITLE
Fix Delphi build: route Vault git clone through PasClaw.Platform

### DIFF
--- a/src/cmd/PasClaw.Cmd.Vault.pas
+++ b/src/cmd/PasClaw.Cmd.Vault.pas
@@ -31,7 +31,7 @@ implementation
 
 uses
   SysUtils, Classes,
-  Process,
+  PasClaw.Platform,
   PasClaw.Config,
   PasClaw.Utils,
   PasClaw.CliUI,
@@ -144,64 +144,53 @@ begin
 end;
 
 function RunGitClone(const RepoURL, DestDir: string; out ErrMsg: string): Boolean;
-{ Shells out to `git clone <repoUrl> <destDir>`. Inherits whatever
-  git auth the user already has (SSH keys, credential helper, etc.)
-  — we don't try to handle private-repo auth ourselves. Output is
-  captured and surfaced on failure; success prints git's own
-  progress as it runs. }
+{ Shells out to `git clone <repoUrl> <destDir>` via PasClaw.Platform's
+  TStdioProcess (fcl-process on FPC; CreateProcess / fork+execvp on
+  Delphi) so both compilers can drain output the same way. Inherits
+  whatever git auth the user already has (SSH keys, credential
+  helper, etc.) — we don't handle private-repo auth ourselves.
+  Output is streamed to stdout so the user sees clone progress in
+  real time. }
 var
-  P: TProcess;
-  ExitCode: Integer;
-  OutLines: TStringList;
+  P: TStdioProcess;
+  Args: TStringList;
+  Buf: array[0..4095] of Byte;
+  Bytes: TBytes;
+  N: Integer;
 begin
   Result := False;
   ErrMsg := '';
-  P := TProcess.Create(nil);
-  OutLines := TStringList.Create;
+  P    := TStdioProcess.Create;
+  Args := TStringList.Create;
   try
-    P.Executable := 'git';
-    P.Parameters.Add('clone');
-    P.Parameters.Add('--');
-    P.Parameters.Add(RepoURL);
-    P.Parameters.Add(DestDir);
-    P.Options := [poUsePipes, poStderrToOutPut];
-    try
-      P.Execute;
-    except
-      on E: Exception do
+    Args.Add('clone');
+    Args.Add('--');
+    Args.Add(RepoURL);
+    Args.Add(DestDir);
+    if not P.Spawn('git', Args) then
+    begin
+      ErrMsg := 'git clone failed to start (is `git` installed and on PATH?)';
+      Exit;
+    end;
+    repeat
+      N := P.ReadAvailable(Buf, SizeOf(Buf));
+      if N > 0 then
       begin
-        ErrMsg := 'git clone failed to start: ' + E.Message +
-                  ' (is `git` installed and on PATH?)';
-        Exit;
+        SetLength(Bytes, N);
+        Move(Buf[0], Bytes[0], N);
+        Write(TEncoding.UTF8.GetString(Bytes));
       end;
-    end;
-    { Drain stdout while the process runs so the user sees clone
-      progress in real time rather than waiting for a final blob. }
-    while P.Running do
+    until (N = 0) and (not P.Running);
+    { latch ExitCode via the side-effect on Running }
+    P.Running;
+    if P.ExitCode <> 0 then
     begin
-      if P.Output.NumBytesAvailable > 0 then
-      begin
-        OutLines.LoadFromStream(P.Output);
-        Write(OutLines.Text);
-        OutLines.Clear;
-      end
-      else
-        Sleep(50);
-    end;
-    if P.Output.NumBytesAvailable > 0 then
-    begin
-      OutLines.LoadFromStream(P.Output);
-      Write(OutLines.Text);
-    end;
-    ExitCode := P.ExitStatus;
-    if ExitCode <> 0 then
-    begin
-      ErrMsg := Format('git clone exited %d', [ExitCode]);
+      ErrMsg := Format('git clone exited %d', [P.ExitCode]);
       Exit;
     end;
     Result := True;
   finally
-    OutLines.Free;
+    Args.Free;
     P.Free;
   end;
 end;

--- a/src/cmd/PasClaw.Cmd.Vault.pas
+++ b/src/cmd/PasClaw.Cmd.Vault.pas
@@ -167,7 +167,10 @@ begin
     Args.Add('--');
     Args.Add(RepoURL);
     Args.Add(DestDir);
-    if not P.Spawn('git', Args) then
+    { git writes progress and most fatal messages to stderr — merge it
+      into stdout so users see clone progress and so a chatty failure
+      can't block the child on a full stderr pipe. }
+    if not P.Spawn('git', Args, {MergeStderr=}True) then
     begin
       ErrMsg := 'git clone failed to start (is `git` installed and on PATH?)';
       Exit;

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -61,8 +61,18 @@ type
     destructor  Destroy; override;
 
     { Spawn Cmd with each entry of Args as a separate argv element. Returns
-      True on successful spawn, False on failure (errno-style; check log). }
-    function Spawn(const Cmd: string; Args: TStrings): Boolean;
+      True on successful spawn, False on failure (errno-style; check log).
+
+      When MergeStderr is True the child's stderr is redirected into the
+      same pipe as stdout, so ReadAvailable surfaces both streams. This
+      is what shell-style "capture combined output" callers want — git
+      clone (progress + fatals on stderr) and RunOneShot rely on it.
+      The default (False) leaves stderr inheriting from the parent
+      process so a long-lived child's log lines reach the user's
+      terminal instead of polluting the JSON-RPC stream on stdout —
+      the contract MCP stdio servers expect. }
+    function Spawn(const Cmd: string; Args: TStrings;
+                    MergeStderr: Boolean = False): Boolean;
 
     { Send Buf to child stdin. Returns the byte count written. }
     function WriteBytes(const Buf; Count: Integer): Integer;
@@ -122,7 +132,8 @@ begin
   inherited Destroy;
 end;
 
-function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
+function TStdioProcess.Spawn(const Cmd: string; Args: TStrings;
+                              MergeStderr: Boolean): Boolean;
 var
   P: TInternalProcess;
   i: Integer;
@@ -131,7 +142,10 @@ begin
   P := TInternalProcess.Create(nil);
   P.Executable := Cmd;
   for i := 0 to Args.Count - 1 do P.Parameters.Add(Args[i]);
-  P.Options := [poUsePipes];
+  if MergeStderr then
+    P.Options := [poUsePipes, poStderrToOutPut]
+  else
+    P.Options := [poUsePipes];
   try
     P.Execute;
   except
@@ -277,7 +291,8 @@ begin
     Result := S;
 end;
 
-function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
+function TStdioProcess.Spawn(const Cmd: string; Args: TStrings;
+                              MergeStderr: Boolean): Boolean;
 var
   SA: TSecurityAttributes;
   SI: TStartupInfoW;
@@ -308,7 +323,14 @@ begin
   SI.wShowWindow := SW_HIDE;
   SI.hStdInput  := ChildStdinRead;
   SI.hStdOutput := ChildStdoutWrite;
-  SI.hStdError  := ChildStdoutWrite;
+  { stderr: merge into stdout pipe iff caller asked. Otherwise let it
+    inherit from the parent process so the child's diagnostics reach
+    the user's terminal instead of mixing with stdout (the contract
+    MCP stdio servers expect for their JSON-RPC frames). }
+  if MergeStderr then
+    SI.hStdError := ChildStdoutWrite
+  else
+    SI.hStdError := GetStdHandle(STD_ERROR_HANDLE);
 
   CmdLine := QuoteArg(Cmd);
   for i := 0 to Args.Count - 1 do CmdLine := CmdLine + ' ' + QuoteArg(Args[i]);
@@ -428,7 +450,7 @@ begin
       try ChDir(WorkingDir); Restored := True; except end;
     end;
     Args.Add('/C'); Args.Add(Cmd);
-    if not P.Spawn('cmd.exe', Args) then Exit;
+    if not P.Spawn('cmd.exe', Args, {MergeStderr=}True) then Exit;
     Total := 0;
     while P.Running or True do
     begin
@@ -494,7 +516,8 @@ begin
   inherited Destroy;
 end;
 
-function TStdioProcess.Spawn(const Cmd: string; Args: TStrings): Boolean;
+function TStdioProcess.Spawn(const Cmd: string; Args: TStrings;
+                              MergeStderr: Boolean): Boolean;
 var
   StdinPipe, StdoutPipe: TPipeFDs;
   Pid: pid_t;
@@ -515,7 +538,12 @@ begin
     { child }
     dup2(StdinPipe[0],  STDIN_FILENO);
     dup2(StdoutPipe[1], STDOUT_FILENO);
-    dup2(StdoutPipe[1], STDERR_FILENO);
+    { stderr: merge into stdout pipe iff caller asked. Otherwise leave
+      it pointing at whatever the parent's stderr is (terminal, log
+      file, etc.) so child diagnostics don't pollute the stdout
+      JSON-RPC stream MCP stdio servers write. }
+    if MergeStderr then
+      dup2(StdoutPipe[1], STDERR_FILENO);
     __close(StdinPipe[0]);  __close(StdinPipe[1]);
     __close(StdoutPipe[0]); __close(StdoutPipe[1]);
 
@@ -632,7 +660,7 @@ begin
       try ChDir(WorkingDir); Restored := True; except end;
     end;
     Args.Add('-c'); Args.Add(Cmd);
-    if not P.Spawn('/bin/sh', Args) then Exit;
+    if not P.Spawn('/bin/sh', Args, {MergeStderr=}True) then Exit;
     Total := 0;
     while P.Running or True do
     begin


### PR DESCRIPTION
## Summary

- `dcc64` was failing on `PasClaw.Cmd.Vault.pas(34): F2613 Unit 'Process' not found.` — the Vault install path imported FPC's `Process` unit directly, which RAD Studio doesn't ship.
- Drop the bare `TProcess` shell-out, route the `git clone` through `PasClaw.Platform.TStdioProcess` instead. That class already has FPC (fcl-process), Delphi/Windows (`CreateProcess`), and Delphi/POSIX (fork+execvp) backends behind one interface, so both compilers compile and behave identically.
- Streaming-progress UX preserved via `ReadAvailable` per iteration so the user still sees git's progress in real time rather than a final blob.

## Test plan

- [x] `make clean && make` (FPC) — clean build
- [x] `make smoke` — all subcommands OK
- [ ] `dcc64` / `dcc32` build — verify the `F2613` is gone
- [ ] `pasclaw vault install <slug>` end-to-end clone under both compilers

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_