### PR TITLE
HTTP wrapper consolidation + opt-in TNetHTTPClient backend for Delphi

### DIFF
--- a/build-delphi.bat
+++ b/build-delphi.bat
@@ -45,7 +45,11 @@ if not exist "build\delphi\%PLATFORM%\%CONFIG%\dcu" mkdir "build\delphi\%PLATFOR
 set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\cron;src\pkg\skills;src\pkg\agent;src\pkg\memory;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\vendor\dmvcframework"
 
 echo Building %DPR% with dcc64.exe...
-dcc64.exe -B -CC -E"build\delphi\%PLATFORM%\%CONFIG%" -N0"build\delphi\%PLATFORM%\%CONFIG%\dcu" -U"%UNIT_PATH%" -NSSystem;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi "%DPR%"
+rem -DPASCLAW_NETHTTP routes outbound HTTP through System.Net.HttpClient
+rem so the Delphi build uses SChannel for TLS instead of needing the
+rem OpenSSL DLLs shipped alongside pasclaw.exe. The .dproj path picks
+rem this up via DCC_Define; the direct-dcc64 path needs it explicitly.
+dcc64.exe -B -CC -E"build\delphi\%PLATFORM%\%CONFIG%" -N0"build\delphi\%PLATFORM%\%CONFIG%\dcu" -U"%UNIT_PATH%" -NSSystem;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi -DPASCLAW_NETHTTP "%DPR%"
 if errorlevel 1 (
   echo ERROR: Delphi dcc64 build failed.
   exit /b 1

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -81,6 +81,16 @@
         -->
         <DCC_Namespace>System;System.Net;System.Win;Xml;Data;Datasnap;Web;Soap;Winapi;Posix;$(DCC_Namespace)</DCC_Namespace>
         <DCC_UnitAlias>WinTypes=Winapi.Windows;WinProcs=Winapi.Windows;$(DCC_UnitAlias)</DCC_UnitAlias>
+        <!--
+          Route outbound HTTP through System.Net.HttpClient (THTTPClient)
+          instead of Indy under Delphi. SChannel handles TLS on Windows
+          so users don't need libeay32.dll / ssleay32.dll alongside the
+          exe. Defined in the Base group so every Platform × Config
+          inherits it. To switch back to Indy for cross-checking,
+          delete this DCC_Define line — FPC ignores PASCLAW_NETHTTP
+          regardless (TNetHTTPClient doesn't exist there).
+        -->
+        <DCC_Define>PASCLAW_NETHTTP;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>vcl;rtl;$(DCC_UsePackage)</DCC_UsePackage>

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -1,7 +1,7 @@
 (*
   PasClaw.Channels.Telegram - long-polling Telegram bot adapter.
 
-  Uses TIdHTTP to call the Bot API. No webhook needed - getUpdates with a
+  Uses PasClaw.Providers.HTTP to call the Bot API. No webhook needed - getUpdates with a
   long poll keeps things firewall-friendly. Each incoming text message is
   fed to the agent loop and the reply is sent back via sendMessage.
 

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -1,16 +1,29 @@
-{
-  PasClaw.Providers.HTTP - thin wrapper around TIdHTTP for JSON POSTs.
-  Builds in both Delphi and FPC (Indy works in both). Under FPC the project
-  vendors Indy via `make get-indy`; under Delphi it ships with RAD Studio.
+(*
+  PasClaw.Providers.HTTP - centralised outbound HTTP wrapper.
 
-  HTTPS support requires OpenSSL. On Linux: package "libssl-dev" / runtime
-  "libssl.so.3"; on Windows: copy libeay32.dll + ssleay32.dll next to the
-  binary. We probe two search locations before the first HTTPS request:
-    1. $PASCLAW_OPENSSL_DIR (if set)
-    2. the directory holding pasclaw.exe
-  If neither resolves a working OpenSSL pair we surface an actionable
-  error message instead of Indy's cryptic 'Could not load SSL library.'.
-}
+  Two interchangeable backends, picked by compile-time define:
+
+    Indy (default everywhere)
+      - TIdHTTP + TIdSSLIOHandlerSocketOpenSSL.
+      - HTTPS needs OpenSSL DLLs: libssl-dev / libssl.so.3 on Linux;
+        libeay32.dll + ssleay32.dll next to pasclaw.exe on Windows
+        (or under $PASCLAW_OPENSSL_DIR). EnsureOpenSSL probes both.
+      - Works on FPC and Delphi — the only path FPC supports.
+
+    TNetHTTPClient (Delphi-only, opt-in)
+      - THTTPClient via System.Net.HttpClient.
+      - Uses Windows SChannel / Apple TransportSecurity / NSURLSession,
+        so no OpenSSL DLLs are needed at all.
+      - Enable with -DPASCLAW_NETHTTP on the dcc32/dcc64 command line,
+        or by adding the symbol to the project's conditional defines.
+        Ignored under FPC since TNetHTTPClient doesn't exist there —
+        FPC stays on Indy regardless.
+
+  The public interface is library-neutral; callers see neither Indy
+  nor TNetHTTPClient types. EnsureOpenSSL stays in the interface for
+  both backends — it's a no-op success under TNetHTTPClient so an
+  onboarding precheck can call it uniformly.
+*)
 unit PasClaw.Providers.HTTP;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
@@ -19,9 +32,7 @@ unit PasClaw.Providers.HTTP;
 interface
 
 uses
-  SysUtils, Classes,
-  IdHTTP, IdSSLOpenSSL, IdSSLOpenSSLHeaders,
-  IdGlobal, IdExceptionCore, IdException;
+  SysUtils, Classes;
 
 type
   THTTPResult = record
@@ -117,6 +128,14 @@ function EnsureOpenSSL(out ErrMsg: string): Boolean;
 
 implementation
 
+uses
+{$IF Defined(PASCLAW_NETHTTP) and not Defined(FPC)}
+  System.Net.URLClient, System.Net.HttpClient;
+{$ELSE}
+  IdHTTP, IdSSLOpenSSL, IdSSLOpenSSLHeaders,
+  IdGlobal, IdExceptionCore, IdException;
+{$IFEND}
+
 function MakeHeader(const Name, Value: string): THeaderPair;
 begin
   Result.Name  := Name;
@@ -127,6 +146,333 @@ function MakeHTTPS(URL: string): Boolean;
 begin
   Result := (Length(URL) >= 8) and SameText(Copy(URL, 1, 8), 'https://');
 end;
+
+{$IF Defined(PASCLAW_NETHTTP) and not Defined(FPC)}
+(* ============================================================
+   TNetHTTPClient backend — Delphi only, opt-in via -DPASCLAW_NETHTTP.
+   TLS via the OS (SChannel on Windows, Secure Transport on macOS,
+   OpenSSL via NSURLSession-equivalent on Linux), so no OpenSSL DLL
+   shipping requirement. EnsureOpenSSL is a no-op success here for
+   onboarding-precheck parity.
+   ============================================================ *)
+
+function EnsureOpenSSL(out ErrMsg: string): Boolean;
+begin
+  ErrMsg := '';
+  Result := True;
+end;
+
+function MakeNetHeaders(const Headers: array of THeaderPair): TNetHeaders;
+var
+  i: Integer;
+begin
+  SetLength(Result, Length(Headers));
+  for i := 0 to High(Headers) do
+    Result[i] := TNetHeader.Create(Headers[i].Name, Headers[i].Value);
+end;
+
+function NewNetClient(TimeoutSeconds: Integer;
+                      const UserAgent, Accept: string): THTTPClient;
+begin
+  Result := THTTPClient.Create;
+  Result.ConnectionTimeout := TimeoutSeconds * 1000;
+  Result.ResponseTimeout   := TimeoutSeconds * 1000;
+  Result.HandleRedirects   := True;
+  if UserAgent <> '' then
+    Result.UserAgent := UserAgent
+  else
+    Result.UserAgent := 'PasClaw/0.1 (+https://github.com/FMXExpress/PasClaw)';
+  if Accept <> '' then
+    Result.Accept := Accept;
+end;
+
+type
+  { Bridges THTTPRedirectGuard to THTTPClient.OnRedirect. The TNetHTTPClient
+    redirect event can't raise — it cancels the follow by setting
+    AAllowRedirect := False — so we record the refusal here and the caller
+    promotes it to a THTTPResult.ErrorMsg after the request returns. }
+  TNetRedirectAdapter = class
+  private
+    FGuard: THTTPRedirectGuard;
+  public
+    Rejected:     Boolean;
+    RejectReason: string;
+    constructor Create(AGuard: THTTPRedirectGuard);
+    procedure OnRedirect(const Sender: TObject; var ARequest: IHTTPRequest;
+                          const AResponse: IHTTPResponse;
+                          var AAllowRedirect: Boolean);
+  end;
+
+constructor TNetRedirectAdapter.Create(AGuard: THTTPRedirectGuard);
+begin
+  inherited Create;
+  FGuard       := AGuard;
+  Rejected     := False;
+  RejectReason := '';
+end;
+
+procedure TNetRedirectAdapter.OnRedirect(const Sender: TObject;
+                                          var ARequest: IHTTPRequest;
+                                          const AResponse: IHTTPResponse;
+                                          var AAllowRedirect: Boolean);
+var
+  Dest, LocalReason: string;
+  Allow: Boolean;
+begin
+  if not Assigned(FGuard) then
+  begin
+    AAllowRedirect := True;
+    Exit;
+  end;
+  Dest        := ARequest.URL.ToString;
+  Allow       := True;
+  LocalReason := '';
+  FGuard(Dest, Allow, LocalReason);
+  ARequest.URL   := TURI.Create(Dest);
+  AAllowRedirect := Allow;
+  if not Allow then
+  begin
+    Rejected     := True;
+    RejectReason := LocalReason;
+  end;
+end;
+
+function NetExecute(C: THTTPClient; const Method, URL: string;
+                    Req: TStream;
+                    Resp: TStream;
+                    const Hdrs: TNetHeaders;
+                    out StatusCode: Integer;
+                    out ContentType: string;
+                    out ErrMsg: string): Boolean;
+var
+  R: IHTTPResponse;
+begin
+  Result := False;
+  StatusCode  := 0;
+  ContentType := '';
+  ErrMsg      := '';
+  try
+    R := C.Execute(Method, URL, Req, Resp, Hdrs);
+    StatusCode  := R.StatusCode;
+    ContentType := LowerCase(R.MimeType);
+    Result      := True;
+  except
+    on E: Exception do
+      ErrMsg := E.Message;
+  end;
+end;
+
+function PostJSON(const URL, JSON: string;
+                  const Headers: array of THeaderPair;
+                  TimeoutSeconds: Integer): THTTPResult;
+var
+  C: THTTPClient;
+  Req, Resp: TStringStream;
+  Hdrs: TNetHeaders;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  C    := NewNetClient(TimeoutSeconds, '', 'application/json');
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
+  Resp := TStringStream.Create('', TEncoding.UTF8);
+  try
+    Hdrs := MakeNetHeaders(Headers);
+    Hdrs := Hdrs + [TNetHeader.Create('Content-Type', 'application/json; charset=utf-8')];
+    NetExecute(C, 'POST', URL, Req, Resp, Hdrs,
+               Result.StatusCode, Result.ContentType, Result.ErrorMsg);
+    Result.Body := Resp.DataString;
+  finally
+    Resp.Free;
+    Req.Free;
+    C.Free;
+  end;
+end;
+
+function PutJSON(const URL, JSON: string;
+                 const Headers: array of THeaderPair;
+                 TimeoutSeconds: Integer): THTTPResult;
+var
+  C: THTTPClient;
+  Req, Resp: TStringStream;
+  Hdrs: TNetHeaders;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  C    := NewNetClient(TimeoutSeconds, '', 'application/json');
+  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
+  Resp := TStringStream.Create('', TEncoding.UTF8);
+  try
+    Hdrs := MakeNetHeaders(Headers);
+    Hdrs := Hdrs + [TNetHeader.Create('Content-Type', 'application/json; charset=utf-8')];
+    NetExecute(C, 'PUT', URL, Req, Resp, Hdrs,
+               Result.StatusCode, Result.ContentType, Result.ErrorMsg);
+    Result.Body := Resp.DataString;
+  finally
+    Resp.Free;
+    Req.Free;
+    C.Free;
+  end;
+end;
+
+function GetJSONURL(const URL: string;
+                    const Headers: array of THeaderPair;
+                    TimeoutSeconds: Integer): THTTPResult;
+var
+  C: THTTPClient;
+  Resp: TStringStream;
+  Hdrs: TNetHeaders;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  C    := NewNetClient(TimeoutSeconds, '', 'application/json');
+  Resp := TStringStream.Create('', TEncoding.UTF8);
+  try
+    Hdrs := MakeNetHeaders(Headers);
+    NetExecute(C, 'GET', URL, nil, Resp, Hdrs,
+               Result.StatusCode, Result.ContentType, Result.ErrorMsg);
+    Result.Body := Resp.DataString;
+  finally
+    Resp.Free;
+    C.Free;
+  end;
+end;
+
+function GetURL(const URL: string;
+                const Headers: array of THeaderPair;
+                TimeoutSeconds: Integer;
+                const UserAgent: string;
+                const Accept: string;
+                OnRedirect: THTTPRedirectGuard): THTTPResult;
+var
+  C: THTTPClient;
+  Resp: TStringStream;
+  Hdrs: TNetHeaders;
+  EffAccept: string;
+  Adapter: TNetRedirectAdapter;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  if Accept <> '' then EffAccept := Accept else EffAccept := '*/*';
+  C       := NewNetClient(TimeoutSeconds, UserAgent, EffAccept);
+  Resp    := TStringStream.Create('', TEncoding.UTF8);
+  Adapter := nil;
+  try
+    if Assigned(OnRedirect) then
+    begin
+      Adapter := TNetRedirectAdapter.Create(OnRedirect);
+      C.OnRedirect := Adapter.OnRedirect;
+    end;
+    Hdrs := MakeNetHeaders(Headers);
+    NetExecute(C, 'GET', URL, nil, Resp, Hdrs,
+               Result.StatusCode, Result.ContentType, Result.ErrorMsg);
+    Result.Body := Resp.DataString;
+    if (Adapter <> nil) and Adapter.Rejected then
+    begin
+      Result.ErrorMsg    := Adapter.RejectReason;
+      Result.StatusCode  := -1;
+    end;
+  finally
+    Adapter.Free;
+    Resp.Free;
+    C.Free;
+  end;
+end;
+
+function PostRaw(const URL, ContentType, Body: string;
+                 const Headers: array of THeaderPair;
+                 TimeoutSeconds: Integer;
+                 const UserAgent: string;
+                 const Accept: string): THTTPResult;
+var
+  C: THTTPClient;
+  Req, Resp: TStringStream;
+  Hdrs: TNetHeaders;
+  EffAccept: string;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  if Accept <> '' then EffAccept := Accept else EffAccept := '*/*';
+  C    := NewNetClient(TimeoutSeconds, UserAgent, EffAccept);
+  Req  := TStringStream.Create(Body, TEncoding.UTF8);
+  Resp := TStringStream.Create('', TEncoding.UTF8);
+  try
+    Hdrs := MakeNetHeaders(Headers);
+    Hdrs := Hdrs + [TNetHeader.Create('Content-Type', ContentType + '; charset=utf-8')];
+    NetExecute(C, 'POST', URL, Req, Resp, Hdrs,
+               Result.StatusCode, Result.ContentType, Result.ErrorMsg);
+    Result.Body := Resp.DataString;
+  finally
+    Resp.Free;
+    Req.Free;
+    C.Free;
+  end;
+end;
+
+function PostJSONToStream(const URL, JSON: string;
+                          RespStream: TStream;
+                          const Headers: array of THeaderPair;
+                          TimeoutSeconds: Integer;
+                          const UserAgent: string;
+                          const Accept: string;
+                          out StatusCode: Integer;
+                          out ErrMsg: string): Boolean;
+var
+  C: THTTPClient;
+  Req: TStringStream;
+  Hdrs: TNetHeaders;
+  EffAccept, RespContentType: string;
+begin
+  Result := False;
+  if Accept <> '' then EffAccept := Accept else EffAccept := 'application/json';
+  C   := NewNetClient(TimeoutSeconds, UserAgent, EffAccept);
+  Req := TStringStream.Create(JSON, TEncoding.UTF8);
+  try
+    Hdrs := MakeNetHeaders(Headers);
+    Hdrs := Hdrs + [TNetHeader.Create('Content-Type', 'application/json; charset=utf-8')];
+    NetExecute(C, 'POST', URL, Req, RespStream, Hdrs,
+               StatusCode, RespContentType, ErrMsg);
+    Result := (StatusCode >= 200) and (StatusCode < 300);
+  finally
+    Req.Free;
+    C.Free;
+  end;
+end;
+
+function GetURLToStream(const URL: string; Stream: TStream;
+                        const Headers: array of THeaderPair;
+                        TimeoutSeconds: Integer): THTTPResult;
+var
+  C: THTTPClient;
+  Hdrs: TNetHeaders;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  C := NewNetClient(TimeoutSeconds, '', '*/*');
+  try
+    Hdrs := MakeNetHeaders(Headers);
+    NetExecute(C, 'GET', URL, nil, Stream, Hdrs,
+               Result.StatusCode, Result.ContentType, Result.ErrorMsg);
+  finally
+    C.Free;
+  end;
+end;
+
+{$ELSE}
+(* ============================================================
+   Indy backend — default on both Delphi and FPC.
+   ============================================================ *)
 
 procedure ApplyHeaders(Http: TIdHTTP; const Headers: array of THeaderPair);
 var
@@ -562,5 +908,7 @@ begin
     Http.Free;
   end;
 end;
+
+{$IFEND}
 
 end.

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -25,14 +25,27 @@ uses
 
 type
   THTTPResult = record
-    StatusCode: Integer;
-    Body:       string;
-    ErrorMsg:   string;
+    StatusCode:  Integer;
+    Body:        string;
+    { Lower-cased Content-Type returned by the server, with charset
+      etc. preserved (e.g. "text/html; charset=utf-8"). Empty on error
+      or for endpoints that do not set one. }
+    ContentType: string;
+    ErrorMsg:    string;
   end;
 
   THeaderPair = record
     Name, Value: string;
   end;
+
+  { Redirect guard invoked before following each 3xx response. Set
+    Allow := False to abort the request; the wrapper raises with
+    Reason, which propagates back as ErrorMsg on the THTTPResult.
+    DestURL is mutable for callers that want to rewrite redirects;
+    leaving it untouched preserves the server's Location header. }
+  THTTPRedirectGuard = procedure(var DestURL: string;
+                                  var Allow: Boolean;
+                                  var Reason: string) of object;
 
 function PostJSON(const URL, JSON: string;
                   const Headers: array of THeaderPair;
@@ -43,6 +56,45 @@ function PutJSON(const URL, JSON: string;
 function GetJSONURL(const URL: string;
                     const Headers: array of THeaderPair;
                     TimeoutSeconds: Integer): THTTPResult;
+
+{ GET with optional User-Agent / Accept overrides and a redirect
+  guard. Pass '' for UserAgent/Accept to keep the wrapper's defaults
+  ('PasClaw/0.1 ...' and '*/*'); nil for OnRedirect to follow
+  redirects without inspection.
+
+  Used by web_fetch (SSRF guard on each hop, browser-ish UA, HTML
+  Accept) and by search providers that need a custom UA. }
+function GetURL(const URL: string;
+                const Headers: array of THeaderPair;
+                TimeoutSeconds: Integer;
+                const UserAgent: string;
+                const Accept: string;
+                OnRedirect: THTTPRedirectGuard): THTTPResult;
+
+{ POST with caller-supplied content type and a UTF-8 encoded body.
+  For form-encoded posts (application/x-www-form-urlencoded) and any
+  other non-JSON payload. UserAgent/Accept follow the same '' = default
+  convention as GetURL. }
+function PostRaw(const URL, ContentType, Body: string;
+                 const Headers: array of THeaderPair;
+                 TimeoutSeconds: Integer;
+                 const UserAgent: string;
+                 const Accept: string): THTTPResult;
+
+{ POST JSON and write the response body into RespStream instead of
+  returning it as a string. The SSE provider uses this — it asks for
+  text/event-stream and parses the buffered response after the call
+  completes. Returns False on transport error with ErrMsg populated;
+  StatusCode is always set to what Indy saw (0 if the request never
+  reached a status line). }
+function PostJSONToStream(const URL, JSON: string;
+                          RespStream: TStream;
+                          const Headers: array of THeaderPair;
+                          TimeoutSeconds: Integer;
+                          const UserAgent: string;
+                          const Accept: string;
+                          out StatusCode: Integer;
+                          out ErrMsg: string): Boolean;
 
 { Binary HTTP GET into a caller-owned stream. Use this for zip
   downloads, embedding fetches, etc. — anything where TStringStream's
@@ -91,6 +143,7 @@ var
 begin
   Result.StatusCode := 0;
   Result.Body := '';
+  Result.ContentType := '';
   Result.ErrorMsg := '';
   { Force UTF-8 on the response stream. Under Delphi modern, TStringStream
     defaults to TEncoding.Default (the system codepage), which mangles
@@ -105,17 +158,20 @@ begin
         Http.Get(URL, Resp);
       Result.StatusCode := Http.ResponseCode;
       Result.Body := Resp.DataString;
+      Result.ContentType := LowerCase(Http.Response.ContentType);
     except
       on E: EIdHTTPProtocolException do
       begin
         Result.StatusCode := E.ErrorCode;
         Result.Body       := E.ErrorMessage;
+        Result.ContentType := LowerCase(Http.Response.ContentType);
         Result.ErrorMsg   := E.Message;
       end;
       on E: Exception do
       begin
         Result.StatusCode := Http.ResponseCode;
         Result.Body       := Resp.DataString;
+        Result.ContentType := LowerCase(Http.Response.ContentType);
         Result.ErrorMsg   := E.Message;
       end;
     end;
@@ -299,6 +355,172 @@ begin
   end;
 end;
 
+type
+  { Bridges the public THTTPRedirectGuard signature to Indy's
+    TIdHTTP.OnRedirect. One-shot helper: created per request, freed
+    in the same try/finally. }
+  TRedirectAdapter = class
+  private
+    FGuard: THTTPRedirectGuard;
+  public
+    constructor Create(AGuard: THTTPRedirectGuard);
+    procedure OnRedirect(Sender: TObject; var Dest: string;
+                          var NumRedirect: Integer;
+                          var Handled: Boolean;
+                          var VMethod: TIdHTTPMethod);
+  end;
+
+constructor TRedirectAdapter.Create(AGuard: THTTPRedirectGuard);
+begin
+  inherited Create;
+  FGuard := AGuard;
+end;
+
+procedure TRedirectAdapter.OnRedirect(Sender: TObject; var Dest: string;
+                                       var NumRedirect: Integer;
+                                       var Handled: Boolean;
+                                       var VMethod: TIdHTTPMethod);
+var
+  Allow: Boolean;
+  Reason: string;
+begin
+  if not Assigned(FGuard) then Exit;
+  Allow := True;
+  Reason := '';
+  FGuard(Dest, Allow, Reason);
+  if not Allow then
+    raise Exception.Create(Reason);
+end;
+
+function GetURL(const URL: string;
+                const Headers: array of THeaderPair;
+                TimeoutSeconds: Integer;
+                const UserAgent: string;
+                const Accept: string;
+                OnRedirect: THTTPRedirectGuard): THTTPResult;
+var
+  Http: TIdHTTP;
+  SSLErr: string;
+  Adapter: TRedirectAdapter;
+begin
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  if SSLErr <> '' then
+  begin
+    Result.StatusCode  := -1;
+    Result.Body        := '';
+    Result.ContentType := '';
+    Result.ErrorMsg    := SSLErr;
+    Http.Free;
+    Exit;
+  end;
+  Adapter := nil;
+  try
+    if UserAgent <> '' then Http.Request.UserAgent := UserAgent;
+    if Accept    <> '' then Http.Request.Accept    := Accept
+    else                    Http.Request.Accept    := '*/*';
+    if Assigned(OnRedirect) then
+    begin
+      Adapter := TRedirectAdapter.Create(OnRedirect);
+      Http.OnRedirect := Adapter.OnRedirect;
+    end;
+    ApplyHeaders(Http, Headers);
+    Result := DoRequest(Http, URL, nil, False);
+  finally
+    Adapter.Free;
+    Http.Free;
+  end;
+end;
+
+function PostRaw(const URL, ContentType, Body: string;
+                 const Headers: array of THeaderPair;
+                 TimeoutSeconds: Integer;
+                 const UserAgent: string;
+                 const Accept: string): THTTPResult;
+var
+  Http: TIdHTTP;
+  Req: TStringStream;
+  SSLErr: string;
+begin
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  if SSLErr <> '' then
+  begin
+    Result.StatusCode  := -1;
+    Result.Body        := '';
+    Result.ContentType := '';
+    Result.ErrorMsg    := SSLErr;
+    Http.Free;
+    Exit;
+  end;
+  Req := TStringStream.Create(Body, TEncoding.UTF8);
+  try
+    if UserAgent <> '' then Http.Request.UserAgent := UserAgent;
+    Http.Request.ContentType     := ContentType;
+    Http.Request.ContentEncoding := 'utf-8';
+    if Accept <> '' then Http.Request.Accept := Accept
+    else                 Http.Request.Accept := '*/*';
+    ApplyHeaders(Http, Headers);
+    Result := DoRequest(Http, URL, Req, True);
+  finally
+    Req.Free;
+    Http.Free;
+  end;
+end;
+
+function PostJSONToStream(const URL, JSON: string;
+                          RespStream: TStream;
+                          const Headers: array of THeaderPair;
+                          TimeoutSeconds: Integer;
+                          const UserAgent: string;
+                          const Accept: string;
+                          out StatusCode: Integer;
+                          out ErrMsg: string): Boolean;
+var
+  Http: TIdHTTP;
+  Req: TStringStream;
+  SSLErr: string;
+begin
+  Result := False;
+  StatusCode := 0;
+  ErrMsg := '';
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  if SSLErr <> '' then
+  begin
+    StatusCode := -1;
+    ErrMsg := SSLErr;
+    Http.Free;
+    Exit;
+  end;
+  Req := TStringStream.Create(JSON, TEncoding.UTF8);
+  try
+    if UserAgent <> '' then Http.Request.UserAgent := UserAgent;
+    Http.Request.ContentType     := 'application/json';
+    Http.Request.ContentEncoding := 'utf-8';
+    if Accept <> '' then Http.Request.Accept := Accept
+    else                 Http.Request.Accept := 'application/json';
+    ApplyHeaders(Http, Headers);
+    try
+      Http.Post(URL, Req, RespStream);
+      StatusCode := Http.ResponseCode;
+    except
+      on E: EIdHTTPProtocolException do
+      begin
+        StatusCode := E.ErrorCode;
+        ErrMsg     := E.Message;
+        { fall through — caller may still want to parse what we got }
+      end;
+      on E: Exception do
+      begin
+        StatusCode := Http.ResponseCode;
+        ErrMsg     := E.Message;
+      end;
+    end;
+    Result := (StatusCode >= 200) and (StatusCode < 300);
+  finally
+    Req.Free;
+    Http.Free;
+  end;
+end;
+
 function GetURLToStream(const URL: string; Stream: TStream;
                         const Headers: array of THeaderPair;
                         TimeoutSeconds: Integer): THTTPResult;
@@ -306,9 +528,10 @@ var
   Http: TIdHTTP;
   SSLErr: string;
 begin
-  Result.StatusCode := 0;
-  Result.Body       := '';
-  Result.ErrorMsg   := '';
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
   Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
   if SSLErr <> '' then
   begin

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -187,10 +187,13 @@ begin
 end;
 
 type
-  { Bridges THTTPRedirectGuard to THTTPClient.OnRedirect. The TNetHTTPClient
-    redirect event can't raise — it cancels the follow by setting
-    AAllowRedirect := False — so we record the refusal here and the caller
-    promotes it to a THTTPResult.ErrorMsg after the request returns. }
+  { Bridges THTTPRedirectGuard to THTTPClient.OnRedirect (typed as
+    THTTPRedirectEvent). The event can't raise to abort — it cancels
+    the follow by setting AAllow := False — so we record the refusal
+    on this adapter and the caller promotes it to THTTPResult.ErrorMsg
+    after the request returns. ARequest.URL is mutable through the
+    interface even though ARequest itself is const, so the guard can
+    rewrite the redirect destination. }
   TNetRedirectAdapter = class
   private
     FGuard: THTTPRedirectGuard;
@@ -198,9 +201,11 @@ type
     Rejected:     Boolean;
     RejectReason: string;
     constructor Create(AGuard: THTTPRedirectGuard);
-    procedure OnRedirect(const Sender: TObject; var ARequest: IHTTPRequest;
+    procedure OnRedirect(const Sender: TObject;
+                          const ARequest: IHTTPRequest;
                           const AResponse: IHTTPResponse;
-                          var AAllowRedirect: Boolean);
+                          ARedirections: Integer;
+                          var AAllow: Boolean);
   end;
 
 constructor TNetRedirectAdapter.Create(AGuard: THTTPRedirectGuard);
@@ -212,24 +217,25 @@ begin
 end;
 
 procedure TNetRedirectAdapter.OnRedirect(const Sender: TObject;
-                                          var ARequest: IHTTPRequest;
+                                          const ARequest: IHTTPRequest;
                                           const AResponse: IHTTPResponse;
-                                          var AAllowRedirect: Boolean);
+                                          ARedirections: Integer;
+                                          var AAllow: Boolean);
 var
   Dest, LocalReason: string;
   Allow: Boolean;
 begin
   if not Assigned(FGuard) then
   begin
-    AAllowRedirect := True;
+    AAllow := True;
     Exit;
   end;
   Dest        := ARequest.URL.ToString;
   Allow       := True;
   LocalReason := '';
   FGuard(Dest, Allow, LocalReason);
-  ARequest.URL   := TURI.Create(Dest);
-  AAllowRedirect := Allow;
+  ARequest.URL := TURI.Create(Dest);
+  AAllow       := Allow;
   if not Allow then
   begin
     Rejected     := True;
@@ -244,6 +250,10 @@ function NetExecute(C: THTTPClient; const Method, URL: string;
                     out StatusCode: Integer;
                     out ContentType: string;
                     out ErrMsg: string): Boolean;
+{ Dispatch through THTTPClient's verb-specific helpers. The inherited
+  TURLClient.Execute(method, url, ...) overload returns IURLResponse,
+  not IHTTPResponse, so its result can't be assigned to an IHTTPResponse
+  local. Get/Post/Put each return IHTTPResponse natively. }
 var
   R: IHTTPResponse;
 begin
@@ -252,7 +262,17 @@ begin
   ContentType := '';
   ErrMsg      := '';
   try
-    R := C.Execute(Method, URL, Req, Resp, Hdrs);
+    if SameText(Method, 'GET') then
+      R := C.Get(URL, Resp, Hdrs)
+    else if SameText(Method, 'POST') then
+      R := C.Post(URL, Req, Resp, Hdrs)
+    else if SameText(Method, 'PUT') then
+      R := C.Put(URL, Req, Resp, Hdrs)
+    else
+    begin
+      ErrMsg := 'unsupported HTTP method: ' + Method;
+      Exit;
+    end;
     StatusCode  := R.StatusCode;
     ContentType := LowerCase(R.MimeType);
     Result      := True;

--- a/src/pkg/providers/PasClaw.Providers.Stream.pas
+++ b/src/pkg/providers/PasClaw.Providers.Stream.pas
@@ -9,10 +9,11 @@
     event: <name>\n  <- optional, present in Anthropic stream
     ...
 
-  We don't use TIdEventStream because we need fine-grained per-chunk callbacks
-  and the Indy version of EventStream is not present in older Indy builds.
-  Instead we POST with stream=true and read the response off TIdHTTP.IOHandler
-  line by line.
+  The HTTP POST is delegated to PasClaw.Providers.HTTP.PostJSONToStream
+  so this unit doesn't need its own Indy plumbing or SSL setup. We
+  parse the buffered response (Indy doesn't expose true real-time
+  streaming for the protocols we care about) and drive per-event
+  callbacks from that.
 *)
 unit PasClaw.Providers.Stream;
 
@@ -23,7 +24,6 @@ interface
 
 uses
   SysUtils, Classes,
-  IdHTTP, IdSSLOpenSSL, IdGlobal, IdExceptionCore,
   PasClaw.Providers.Types,
   PasClaw.Providers.HTTP;
 
@@ -47,9 +47,6 @@ function PostStreaming(const URL, JSON: string;
                        out StatusCode: Integer;
                        out ErrMsg: string): Boolean;
 var
-  Http: TIdHTTP;
-  SSL:  TIdSSLIOHandlerSocketOpenSSL;
-  Req:  TStringStream;
   Resp: TStringStream;
   Body: TStringList;
   i: Integer;
@@ -67,50 +64,14 @@ var
 
 begin
   Result := False;
-  ErrMsg := '';
-  StatusCode := 0;
-
-  Http := TIdHTTP.Create(nil);
-  { Explicit UTF-8 — Delphi's TStringStream defaults to ANSI which would
-    mangle the SSE response body and the JSON request body. }
-  Req  := TStringStream.Create(JSON, TEncoding.UTF8);
+  { Explicit UTF-8 — Delphi's TStringStream defaults to ANSI which
+    would mangle the SSE response body. }
   Resp := TStringStream.Create('', TEncoding.UTF8);
-  SSL  := nil;
   try
-    Http.ConnectTimeout := TimeoutSeconds * 1000;
-    Http.ReadTimeout    := TimeoutSeconds * 1000;
-    Http.Request.UserAgent   := 'PasClaw/0.1';
-    Http.Request.ContentType := 'application/json';
-    Http.Request.Accept      := 'text/event-stream';
-    for i := 0 to High(Headers) do
-      Http.Request.CustomHeaders.AddValue(Headers[i].Name, Headers[i].Value);
-    if (Length(URL) >= 8) and SameText(Copy(URL, 1, 8), 'https://') then
-    begin
-      if not EnsureOpenSSL(ErrMsg) then
-      begin
-        StatusCode := -1;
-        Exit;
-      end;
-      SSL := TIdSSLIOHandlerSocketOpenSSL.Create(Http);
-      SSL.SSLOptions.Method := sslvTLSv1_2;
-      SSL.SSLOptions.SSLVersions := [sslvTLSv1_2];
-      Http.IOHandler := SSL;
-    end;
-    try
-      Http.Post(URL, Req, Resp);
-      StatusCode := Http.ResponseCode;
-    except
-      on E: Exception do
-      begin
-        StatusCode := Http.ResponseCode;
-        ErrMsg     := E.Message;
-        { fall through and try to parse what we got }
-      end;
-    end;
+    PostJSONToStream(URL, JSON, Resp, Headers, TimeoutSeconds,
+                     'PasClaw/0.1', 'text/event-stream',
+                     StatusCode, ErrMsg);
 
-    { Indy's TIdHTTP buffers the full response into Resp. For true real-time
-      streaming the caller can switch to a custom IOHandler hook; here we
-      parse the buffered body, which still drives per-event callbacks. }
     Body := TStringList.Create;
     try
       Body.Text := Resp.DataString;
@@ -140,8 +101,6 @@ begin
     Result := (StatusCode >= 200) and (StatusCode < 300);
   finally
     Resp.Free;
-    Req.Free;
-    Http.Free;
   end;
 end;
 

--- a/src/pkg/search/PasClaw.Search.DuckDuckGo.pas
+++ b/src/pkg/search/PasClaw.Search.DuckDuckGo.pas
@@ -40,8 +40,6 @@ implementation
 
 uses
   StrUtils,
-  IdHTTP, IdSSLOpenSSL,
-  IdGlobal,
   PasClaw.Logger,
   PasClaw.Providers.HTTP;
 
@@ -186,45 +184,28 @@ const
   SnippetEnd  = '</a>';
 var
   HTML, Body, Block, RawTitle, RawSnippet, Href: string;
-  HTTP: TIdHTTP;
-  SSLHandler: TIdSSLIOHandlerSocketOpenSSL;
+  Resp: THTTPResult;
+  Headers: array of THeaderPair;
   Cursor, HrefStart, HrefEnd, BlockStart, TitleClose: Integer;
   N: Integer;
 begin
   SetLength(Hits, 0);
   ErrMsg := '';
   Result := False;
+  SetLength(Headers, 0);
 
-  HTTP := TIdHTTP.Create(nil);
-  SSLHandler := nil;
-  try
-    HTTP.HandleRedirects := True;
-    HTTP.Request.UserAgent := 'Mozilla/5.0 (PasClaw web_search)';
-    HTTP.Request.Accept := 'text/html';
-    HTTP.ConnectTimeout := 15000;
-    HTTP.ReadTimeout    := 15000;
-    { html.duckduckgo.com is HTTPS-only; Indy needs an SSL IOHandler
-      attached before the POST or it raises
-      "Could not load SSL library" / "no IOHandler for SSL".
-      web_fetch already does this for arbitrary URLs; the
-      zero-config search fallback obviously needs it too. }
-    SSLHandler := TIdSSLIOHandlerSocketOpenSSL.Create(nil);
-    SSLHandler.SSLOptions.SSLVersions := [sslvTLSv1_2];
-    HTTP.IOHandler := SSLHandler;
-    Body := 'q=' + UrlEncode(Query) + '&kl=us-en';
-    try
-      HTML := HTTP.Post('https://html.duckduckgo.com/html/', Body);
-    except
-      on E: Exception do
-      begin
-        ErrMsg := 'duckduckgo: HTTP error: ' + E.Message;
-        Exit;
-      end;
-    end;
-  finally
-    HTTP.Free;
-    if SSLHandler <> nil then SSLHandler.Free;
+  Body := 'q=' + UrlEncode(Query) + '&kl=us-en';
+  Resp := PostRaw('https://html.duckduckgo.com/html/',
+                  'application/x-www-form-urlencoded', Body,
+                  Headers, 15,
+                  'Mozilla/5.0 (PasClaw web_search)',
+                  'text/html');
+  if Resp.ErrorMsg <> '' then
+  begin
+    ErrMsg := 'duckduckgo: HTTP error: ' + Resp.ErrorMsg;
+    Exit;
   end;
+  HTML := Resp.Body;
 
   if Trim(HTML) = '' then
   begin

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -44,48 +44,46 @@ implementation
 
 uses
   Classes,
-  IdHTTP, IdSSLOpenSSL,
   PasClaw.JSON,
   PasClaw.Logger,
+  PasClaw.Providers.HTTP,
   PasClaw.Search.HTMLText,
   PasClaw.Net.SSRF,
   PasClaw.Tools.Sandbox;
 
 type
-  (* Indy's OnRedirect callback is `of object`; this tiny holder gives
-     us the method to assign without leaking helper state outside. The
-     redirect handler runs URLIsLocal on every 3xx target so a
-     public→private redirect can't smuggle a request past the
-     pre-check. Raising aborts the redirect chain — the outer
-     try/except in Tool_WebFetch turns it into the same "SSRF
-     blocked" surface as a direct hit. *)
+  (* Redirect guard hooked into PasClaw.Providers.HTTP. Runs URLIsLocal
+     on every 3xx target so a public→private redirect can't smuggle a
+     request past the pre-check. Setting Allow := False aborts the
+     redirect chain — the wrapper raises with Reason, and the outer
+     try/except in Tool_WebFetch surfaces it as the same "SSRF
+     blocked" string a direct hit would produce. *)
   TWebFetchRedirectGuard = class
-    procedure OnRedirect(Sender: TObject; var Dest: string;
-                          var NumRedirect: Integer;
-                          var Handled: Boolean;
-                          var VMethod: TIdHTTPMethod);
+    procedure OnRedirect(var Dest: string;
+                          var Allow: Boolean;
+                          var Reason: string);
   end;
 
 function IsAbsoluteHttpURL(const S: string): Boolean;
 { True iff S has an http:// or https:// scheme. Anything else is
   either path-relative ("/login", "next.html") or protocol-relative
-  ("//cdn.example.com/a"). Indy hands TIdHTTP.OnRedirect whatever
-  the server's Location header said — which is frequently a bare
-  path, NOT a full URL. Codex PR #85 P2 caught that we were
-  rejecting "/login" as malformed. }
+  ("//cdn.example.com/a"). The wrapper hands OnRedirect whatever the
+  server's Location header said — which is frequently a bare path,
+  NOT a full URL. Codex PR #85 P2 caught that we were rejecting
+  "/login" as malformed. }
 begin
   Result := (Length(S) >= 7) and
             (SameText(Copy(S, 1, 7),  'http://')  or
              (Length(S) >= 8) and SameText(Copy(S, 1, 8), 'https://'));
 end;
 
-procedure TWebFetchRedirectGuard.OnRedirect(Sender: TObject; var Dest: string;
-                                              var NumRedirect: Integer;
-                                              var Handled: Boolean;
-                                              var VMethod: TIdHTTPMethod);
+procedure TWebFetchRedirectGuard.OnRedirect(var Dest: string;
+                                              var Allow: Boolean;
+                                              var Reason: string);
 var
-  Reason: string;
+  Why: string;
 begin
+  Allow := True;
   if not NetworkBlockingActive then Exit;
 
   { Same-origin redirects retain the host that already passed the
@@ -101,24 +99,30 @@ begin
     if (Length(Dest) >= 2) and (Dest[1] = '/') and (Dest[2] = '/') then
     begin
       { Protocol-relative. Synthesise an http:// prefix purely for
-        the parse — Indy itself will re-prefix with the current
-        URL's scheme before connecting. }
-      if URLIsLocal('http:' + Dest, Reason) then
-        raise Exception.CreateFmt(
+        the parse — the underlying client will re-prefix with the
+        current URL's scheme before connecting. }
+      if URLIsLocal('http:' + Dest, Why) then
+      begin
+        Allow := False;
+        Reason := Format(
           'SSRF: protocol-relative redirect to %s refused (%s; ' +
           'flip sandbox.block_private_networks=false in config.json to allow)',
-          [Dest, Reason]);
+          [Dest, Why]);
+      end;
       Exit;
     end;
     { Path-relative — same host as the request that just passed
-      the check. Let Indy proceed. }
+      the check. Let the request proceed. }
     Exit;
   end;
 
-  if URLIsLocal(Dest, Reason) then
-    raise Exception.CreateFmt('SSRF: redirect to %s refused (%s; ' +
+  if URLIsLocal(Dest, Why) then
+  begin
+    Allow := False;
+    Reason := Format('SSRF: redirect to %s refused (%s; ' +
       'flip sandbox.block_private_networks=false in config.json to allow)',
-      [Dest, Reason]);
+      [Dest, Why]);
+  end;
 end;
 
 const
@@ -175,14 +179,13 @@ function Tool_WebFetch(const ArgsJSON: string; out ErrMsg: string): string;
 var
   URL: string;
   MaxChars: Integer;
-  HTTP: TIdHTTP;
-  SSLHandler: TIdSSLIOHandlerSocketOpenSSL;
   RedirectGuard: TWebFetchRedirectGuard;
-  Body: string;
-  ContentType: string;
+  Resp: THTTPResult;
+  Headers: array of THeaderPair;
 begin
   ErrMsg := '';
   Result := '';
+  SetLength(Headers, 0);
 
   if not ParseStringArg(ArgsJSON, 'url', URL) then
   begin
@@ -199,7 +202,7 @@ begin
   if MaxChars < 100           then MaxChars := 100;
   if MaxChars > HARD_MAX_CHARS then MaxChars := HARD_MAX_CHARS;
 
-  { SSRF pre-check on the initial URL. The redirect handler covers
+  { SSRF pre-check on the initial URL. The redirect guard covers
     subsequent hops; both layers must pass for the request to land. }
   if NetworkBlockingActive then
   begin
@@ -212,59 +215,40 @@ begin
     ErrMsg := '';
   end;
 
-  HTTP := TIdHTTP.Create(nil);
   RedirectGuard := TWebFetchRedirectGuard.Create;
-  SSLHandler := nil;
   try
-    HTTP.HandleRedirects   := True;
-    HTTP.RedirectMaximum   := 5;
-    HTTP.ConnectTimeout    := 20000;
-    HTTP.ReadTimeout       := 30000;
-    HTTP.Request.UserAgent := 'Mozilla/5.0 (PasClaw web_fetch)';
-    HTTP.Request.Accept    := 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5';
-    HTTP.OnRedirect        := RedirectGuard.OnRedirect;
-
-    if LowerStartsWith(URL, 'https://') then
-    begin
-      SSLHandler := TIdSSLIOHandlerSocketOpenSSL.Create(nil);
-      SSLHandler.SSLOptions.SSLVersions := [sslvTLSv1_2];
-      HTTP.IOHandler := SSLHandler;
-    end;
-
-    try
-      Body := HTTP.Get(URL);
-    except
-      on E: Exception do
-      begin
-        ErrMsg := 'web_fetch: HTTP error: ' + E.Message;
-        Exit;
-      end;
-    end;
-
-    ContentType := LowerCase(HTTP.Response.ContentType);
-    if (Pos('text/html',             ContentType) > 0) or
-       (Pos('application/xhtml+xml', ContentType) > 0) or
-       (ContentType = '') then
-      Result := HTMLToText(Body, MaxChars)
-    else if Pos('text/', ContentType) = 1 then
-    begin
-      Result := Body;
-      if Length(Result) > MaxChars then
-        Result := Copy(Result, 1, MaxChars) + #10 + '…(truncated)';
-    end
-    else
-    begin
-      ErrMsg := Format('web_fetch: unsupported content-type %s', [ContentType]);
-      Exit;
-    end;
+    Resp := GetURL(URL, Headers, 30,
+                   'Mozilla/5.0 (PasClaw web_fetch)',
+                   'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5',
+                   RedirectGuard.OnRedirect);
   finally
-    HTTP.Free;
     RedirectGuard.Free;
-    if SSLHandler <> nil then SSLHandler.Free;
+  end;
+
+  if Resp.ErrorMsg <> '' then
+  begin
+    ErrMsg := 'web_fetch: HTTP error: ' + Resp.ErrorMsg;
+    Exit;
+  end;
+
+  if (Pos('text/html',             Resp.ContentType) > 0) or
+     (Pos('application/xhtml+xml', Resp.ContentType) > 0) or
+     (Resp.ContentType = '') then
+    Result := HTMLToText(Resp.Body, MaxChars)
+  else if Pos('text/', Resp.ContentType) = 1 then
+  begin
+    Result := Resp.Body;
+    if Length(Result) > MaxChars then
+      Result := Copy(Result, 1, MaxChars) + #10 + '…(truncated)';
+  end
+  else
+  begin
+    ErrMsg := Format('web_fetch: unsupported content-type %s', [Resp.ContentType]);
+    Exit;
   end;
 
   LogDebug('web_fetch url=%s bytes_in=%d chars_out=%d',
-           [URL, Length(Body), Length(Result)]);
+           [URL, Length(Resp.Body), Length(Result)]);
 end;
 
 procedure RegisterWebFetchTool(R: TToolRegistry);


### PR DESCRIPTION
## Summary

Two-step HTTP backend consolidation so Delphi/Windows users no longer need to ship OpenSSL DLLs alongside `pasclaw.exe`.

**Step 1 — Centralise.** `Tools.WebFetch`, `Search.DuckDuckGo`, and `Providers.Stream` were each instantiating `TIdHTTP` + `TIdSSLIOHandlerSocketOpenSSL` directly. Now they all flow through `PasClaw.Providers.HTTP`, which grew three targeted entry points covering what the existing functions didn't:

| Function | Replaces |
|---|---|
| `GetURL` | Direct `TIdHTTP.Get` with custom UA/Accept + an SSRF redirect guard (used by `web_fetch`). |
| `PostRaw` | Direct `TIdHTTP.Post` with caller-supplied `Content-Type` (used by DuckDuckGo's form-encoded scrape). |
| `PostJSONToStream` | Direct `TIdHTTP.Post` writing the response into a `TStream` (used by the SSE provider). |

`THTTPResult` gained `ContentType` (lower-cased) so callers don't need to hold an Indy reference. The redirect-guard signature is library-neutral so it works the same under either backend.

**Step 2 — Add a second backend behind the wrapper.** Same public interface, gated by `{$IF Defined(PASCLAW_NETHTTP) and not Defined(FPC)}`:

| Build | Backend |
|---|---|
| FPC (any flags) | Indy — `TNetHTTPClient` doesn't exist on FPC. Define silently ignored. |
| Delphi, no define | Indy (no behavior change for older builds). |
| Delphi, `-DPASCLAW_NETHTTP` | `THTTPClient` (System.Net.HttpClient) + OS TLS — SChannel on Windows, Secure Transport on macOS. **No OpenSSL DLLs needed.** |

`EnsureOpenSSL` becomes a no-op success on the NetHTTP path so an onboarding precheck calls it uniformly across both backends.

The Delphi build entry points now default to NetHTTP:
- `PasClaw.dproj` adds `PASCLAW_NETHTTP` to the Base `DCC_Define` so every Platform × Config inherits it when opened in RAD Studio.
- `build-delphi.bat` adds `-DPASCLAW_NETHTTP` to the direct `dcc64.exe` fallback path (MSBuild picks it up from the dproj automatically).

To cross-check the Indy backend from Delphi, delete the `DCC_Define` line; FPC + Makefile already exercise it by default.

## Test plan

- [x] FPC default — `make clean && make` clean, `make smoke` green.
- [x] FPC with `-dPASCLAW_NETHTTP` — clean build (falls back to Indy as designed); smoke green.
- [x] `pasclaw mcp catalog` exercises the HTTP path; under sandboxed FPC the missing libssl produces the actionable `EnsureOpenSSL` error surface end-to-end.
- [ ] Delphi (RAD Studio open + Build) — verify the NetHTTP branch compiles and outbound HTTPS works without DLLs alongside the exe.
- [ ] `build-delphi.bat` MSBuild and dcc64 paths.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_