### PR TITLE
Delphi: link sqlite3 statically via FireDAC.Phys.SQLiteWrapper.Stat

### DIFF
--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -23,11 +23,22 @@ uses
   cmem,
   {$ENDIF}{$ENDIF}
   {$IFNDEF FPC}
+  {$IFNDEF LINUX}
   FireDAC.Phys.SQLiteWrapper.Stat,  { Link sqlite3 statically into the exe so
                                       Delphi builds don't need to ship a
                                       sqlite3.dll alongside pasclaw.exe.
                                       Used by PasClaw.Memory.Index (FTS5).
-                                      FPC links libsqlite3 dynamically. }
+                                      FPC links libsqlite3 dynamically.
+
+                                      Excluded on Delphi's Linux64 target —
+                                      RAD Studio ships the static SQLite
+                                      wrapper for Windows / macOS / mobile
+                                      only; FireDAC on Linux supports just
+                                      the dynamic libsqlite3.so link path
+                                      and including the static unit there
+                                      breaks the compile.
+                                      Codex P1 on PR #135. }
+  {$ENDIF}
   {$ENDIF}
   SysUtils,
   PasClaw.CliUI,

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -22,6 +22,13 @@ uses
   cthreads,            { FPC/Linux: pull in pthreads so Indy can use TThread }
   cmem,
   {$ENDIF}{$ENDIF}
+  {$IFNDEF FPC}
+  FireDAC.Phys.SQLiteWrapper.Stat,  { Link sqlite3 statically into the exe so
+                                      Delphi builds don't need to ship a
+                                      sqlite3.dll alongside pasclaw.exe.
+                                      Used by PasClaw.Memory.Index (FTS5).
+                                      FPC links libsqlite3 dynamically. }
+  {$ENDIF}
   SysUtils,
   PasClaw.CliUI,
   PasClaw.Logger,


### PR DESCRIPTION
## Summary

Pulls `FireDAC.Phys.SQLiteWrapper.Stat` into the dpr so the SQLite amalgamation is linked statically into `pasclaw.exe` — no `sqlite3.dll` needs to ship alongside the binary. `PasClaw.Memory.Index` (FTS5 for `memory_search`) is the only consumer today; the existing FireDAC connection just stops resolving the DLL at startup.

Guarded with `{$IFNDEF FPC}` since the unit is part of FireDAC and only exists on the Delphi side. FPC keeps its dynamic `libsqlite3` link path unchanged.

## Test plan

- [x] FPC `make clean && make` — clean (the guard skips the unit).
- [ ] Delphi build — confirm `pasclaw.exe` runs `memory_search` without a `sqlite3.dll` next to it.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_