### PR TITLE
Register vault tools in serve + gateway when enabled in config

### DIFF
--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -29,6 +29,7 @@ uses
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
   PasClaw.Tools.WebFetch,
+  PasClaw.Tools.Vault,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -168,6 +169,11 @@ begin
       RegisterMemoryTools(Reg);
       RegisterWebSearchTool(Reg);
       RegisterWebFetchTool(Reg);
+      { Off by default — onboarding opt-in flips Cfg.VaultToolsEnabled.
+        Without this branch, `pasclaw onboard` could report
+        "vault_search / vault_get enabled" but the gateway / web UI
+        chat surface would still tell the user "no Code Vault tool". }
+      if Cfg.VaultToolsEnabled then RegisterVaultTools(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -42,6 +42,7 @@ uses
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
   PasClaw.Tools.WebFetch,
+  PasClaw.Tools.Vault,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
@@ -122,6 +123,11 @@ begin
       RegisterMemoryTools(Reg);
       RegisterWebSearchTool(Reg);
       RegisterWebFetchTool(Reg);
+      { Off by default — onboarding opt-in flips Cfg.VaultToolsEnabled.
+        Without this branch, `pasclaw onboard` could report
+        "vault_search / vault_get enabled" but the gateway / serve
+        chat surface would still tell the user "no Code Vault tool". }
+      if Cfg.VaultToolsEnabled then RegisterVaultTools(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       if Length(Skills) > 0 then


### PR DESCRIPTION
## Summary

Fixes the bug: `pasclaw onboard` reports "✓ vault_search / vault_get enabled" and flips `Cfg.VaultToolsEnabled := True`, but when the user chats with the agent via the web UI the model truthfully says "I don't have any Code Vault tool available".

Root cause: `pasclaw serve` and `pasclaw gateway` (which the web UI talks to) build their tool registries by hand and skipped vault registration entirely. The `agent` / `resume` paths already route through `NewBuiltinRegistry(... , Cfg.VaultToolsEnabled)` and get it right.

Add the missing `if Cfg.VaultToolsEnabled then RegisterVaultTools(Reg);` branch to both `serve` and `gateway` so all three chat surfaces behave consistently. `PasClaw.Tools.Vault` added to each uses clause.

## Test plan

- [x] `make` clean, `make smoke` green.
- [ ] `pasclaw onboard` → enable vault → `pasclaw gateway` → chat: model now lists `vault_search` / `vault_get`.
- [ ] Same path through `pasclaw serve` (OpenAI-compatible endpoint).
- [ ] With vault disabled, the tools are absent (no regression).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_