### PR TITLE
mcp auth: clear stale Args header so OAuth tokens actually win

### DIFF
--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -422,6 +422,30 @@ begin
   begin
     WriteLn(Ansi.Green, '✓ ', Ansi.Reset, 'authorized ', Argv[1],
             ' — tokens written to ', OAuthTokenPath(Argv[1]));
+    { Clear any pre-existing Args header on the server entry. Pre-OAuth
+      installs of the same catalog name (e.g. an old `mcp install
+      replicate` that wrote "Bearer r8_…" from REPLICATE_API_TOKEN)
+      would otherwise short-circuit the HTTP client's auth resolver and
+      send the stale token instead of the fresh OAuth one — the exact
+      symptom the user reported after a successful `mcp auth`. A
+      successful auth run is the canonical "use OAuth for this server"
+      signal, so the Args slot belongs to the OAuth token store now. }
+    Cfg := LoadConfig;
+    try
+      for i := 0 to High(Cfg.MCPServers) do
+        if SameText(Cfg.MCPServers[i].Name, Argv[1]) and
+           (Cfg.MCPServers[i].Args <> '') then
+        begin
+          Cfg.MCPServers[i].Args := '';
+          SaveConfig(Cfg);
+          WriteLn(Ansi.Dim,
+                  '  cleared stale Authorization header on the server entry',
+                  Ansi.Reset);
+          Break;
+        end;
+    finally
+      Cfg.Free;
+    end;
     WriteLn('  Try it: ', Ansi.Bold, 'pasclaw mcp test ', Argv[1], Ansi.Reset);
     Result := 0;
   end


### PR DESCRIPTION
## Summary

Follows up PR #138 — that fix added the RFC 8707 `resource` parameter to OAuth requests so the issued access tokens are audience-bound to the MCP resource. But users with a pre-OAuth `mcp install replicate` still saw "Invalid token format" after running `mcp auth replicate`, because:

`TMCPHttpClient`'s auth resolver checks `FAuth` (= `Cfg.MCPServers[i].Args`) **before** falling through to the OAuth token store. A pre-OAuth install of the same catalog name (e.g. before #134 shipped) had written `Args: "Bearer r8_…"` from `REPLICATE_API_TOKEN`. That stale value short-circuited the OAuth path, the raw API token kept being sent on every request, and Replicate kept rejecting it.

A successful `mcp auth` is the canonical "this server speaks OAuth from now on" signal — so `DoAuth` now also zeroes the `Args` slot on the matching `MCPServers` entry and saves the config. Subsequent `mcp test` takes the OAuth-token-store path cleanly. Confirmation line printed when stale Args were actually cleared, so the user can see it happened.

## Test plan

- [x] FPC `make` clean, `make smoke` green.
- [ ] On a Delphi/Windows install with a stale `Args: "Bearer r8_…"` for replicate:
  - `pasclaw mcp auth replicate` — confirms "cleared stale Authorization header on the server entry".
  - `pasclaw mcp test replicate` — now reaches initialize/tools/list.
- [ ] Fresh install (no stale Args) — `mcp auth` still succeeds, no spurious "cleared" message.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_