### PR TITLE
MCP bridge: CoInitialize loader threads on Windows (WinHTTP needs it)

### DIFF
--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -317,6 +317,23 @@ begin
   inherited Destroy;
 end;
 
+{$IFDEF MSWINDOWS}
+{ ole32 imports — declared locally instead of pulling in Windows /
+  Winapi.ActiveX so the bridge stays cross-compiler-friendly. WinHTTP
+  (which System.Net.HttpClient uses under PASCLAW_NETHTTP) needs COM
+  initialised on any thread that issues a request — without it the
+  WinHTTP proxy/cert/cred plumbing can't talk to the OS providers and
+  every request fails with WINHTTP_NAME_NOT_RESOLVED (12007) even
+  though main-thread requests against the same host succeed fine.
+  Indy on FPC doesn't care, but the call is cheap and consistent. }
+const
+  COINIT_MULTITHREADED = $0;
+function CoInitializeEx(pvReserved: Pointer; dwCoInit: LongWord): Integer; stdcall;
+  external 'ole32.dll' name 'CoInitializeEx';
+procedure CoUninitialize; stdcall;
+  external 'ole32.dll' name 'CoUninitialize';
+{$ENDIF}
+
 procedure TMCPLoader.Execute;
 var
   Tools: TMCPToolArray;
@@ -324,6 +341,10 @@ var
   Dispatch: TMCPToolDispatch;
   i: Integer;
 begin
+  {$IFDEF MSWINDOWS}
+  CoInitializeEx(nil, COINIT_MULTITHREADED);
+  try
+  {$ENDIF}
   try
     if IsHttpUrl(FCfg.Cmd) then
       FClient := TMCPHttpClient.Create(FCfg.Name, FCfg.Cmd, FCfg.Args)
@@ -375,6 +396,11 @@ begin
       FState.SetFailed(E.Message);
     end;
   end;
+  {$IFDEF MSWINDOWS}
+  finally
+    CoUninitialize;
+  end;
+  {$ENDIF}
 end;
 
 { ============================================================


### PR DESCRIPTION
## Summary

Followup to PR #141 — the user reported that after the async-cache change, `replicate`'s background load fails on Windows:

```
[warn] OAuth[replicate]: refresh failed (Error sending data: (12007) The server name or address could not be resolved)
[warn] mcp-http[replicate] status=0 body=
[warn] mcp[replicate] connect failed: initialize failed
```

Both HTTP calls (OAuth token refresh + the actual `initialize`) fail with `WINHTTP_NAME_NOT_RESOLVED` (12007), but only from the new `TMCPLoader` worker thread. The same calls against the same host succeed from the main thread (e.g. `pasclaw mcp test replicate` before PR #141, and the `mcp auth` flow today).

Classic COM-init trap for WinHTTP-backed `System.Net.HttpClient`: WinHTTP needs COM initialised on any thread issuing requests so it can reach the OS providers for proxy resolution, cert validation, and credential lookup. Without it the failure surfaces at the DNS step.

Wrap `TMCPLoader.Execute` in `CoInitializeEx(MULTITHREADED)` + `CoUninitialize`. `ole32` imports declared locally so the bridge stays cross-compiler-friendly (no pull of `Windows` / `Winapi.ActiveX` into the FPC build). Indy on FPC doesn't care about COM init, but the call is cheap and the `{$IFDEF MSWINDOWS}` keeps it Windows-only either way.

## Test plan

- [x] FPC `make` clean, `make smoke` green.
- [ ] Delphi/Windows build with `replicate` configured: background load succeeds, OAuth refresh + initialize complete in the worker thread.
- [ ] Subsequent boots still hit the cache for instant tools (no regression).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_