### PR TITLE
Gate web_search registration on a real provider being configured

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -29,6 +29,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
+  PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.Vault,
   PasClaw.Tools.ToolLoop,
@@ -146,7 +147,8 @@ begin
 end;
 
 function NewBuiltinRegistry(UseHashline: Boolean = True;
-                            EnableVault: Boolean = False): TToolRegistry;
+                            EnableVault: Boolean = False;
+                            EnableWebSearch: Boolean = False): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
@@ -154,7 +156,14 @@ begin
   RegisterFSTools(Result, UseHashline);
   RegisterShellTool(Result);
   RegisterMemoryTools(Result);
-  RegisterWebSearchTool(Result);
+  { web_search registers only when a real provider is configured
+    (Brave / Tavily / Perplexity / Gemini key, or SearXNG base URL).
+    Callers compute the flag via PasClaw.Search.Factory's
+    HasConfiguredWebSearchProvider and pass it here. The DDG scrape
+    fallback is intentionally hidden from the model because DDG's
+    bot-detection wall refuses non-browser TLS fingerprints in 2026. }
+  if EnableWebSearch then RegisterWebSearchTool(Result)
+  else                    LogWebSearchSkipOnce;
   RegisterWebFetchTool(Result);
   { Vault tools register only when explicitly enabled — callers pass
     Cfg.VaultToolsEnabled. Off-by-default per the onboarding opt-in
@@ -300,7 +309,9 @@ begin
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
 
   Reg := nil;
-  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled);
+  if not A.NoTools then
+    Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled,
+                              HasConfiguredWebSearchProvider(Cfg));
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;
@@ -375,7 +386,9 @@ begin
 
   if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
   Reg := nil;
-  if not A.NoTools then Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled);
+  if not A.NoTools then
+    Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled,
+                              HasConfiguredWebSearchProvider(Cfg));
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -28,6 +28,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
+  PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.Vault,
   PasClaw.Tools.Sandbox,
@@ -167,7 +168,10 @@ begin
       RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
       RegisterMemoryTools(Reg);
-      RegisterWebSearchTool(Reg);
+      if HasConfiguredWebSearchProvider(Cfg) then
+        RegisterWebSearchTool(Reg)
+      else
+        LogWebSearchSkipOnce;
       RegisterWebFetchTool(Reg);
       { Off by default — onboarding opt-in flips Cfg.VaultToolsEnabled.
         Without this branch, `pasclaw onboard` could report

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -41,6 +41,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
+  PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.Vault,
   PasClaw.Tools.Sandbox,
@@ -121,7 +122,10 @@ begin
       RegisterFSTools(Reg, not Args.NoHashline);
       RegisterShellTool(Reg);
       RegisterMemoryTools(Reg);
-      RegisterWebSearchTool(Reg);
+      if HasConfiguredWebSearchProvider(Cfg) then
+        RegisterWebSearchTool(Reg)
+      else
+        LogWebSearchSkipOnce;
       RegisterWebFetchTool(Reg);
       { Off by default — onboarding opt-in flips Cfg.VaultToolsEnabled.
         Without this branch, `pasclaw onboard` could report

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -26,6 +26,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
+  PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
@@ -93,7 +94,10 @@ begin
       RegisterFSTools(Reg, not A.NoHashline);
       RegisterShellTool(Reg);
       RegisterMemoryTools(Reg);
-      RegisterWebSearchTool(Reg);
+      if HasConfiguredWebSearchProvider(Cfg) then
+        RegisterWebSearchTool(Reg)
+      else
+        LogWebSearchSkipOnce;
       RegisterWebFetchTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -312,6 +312,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
   PasClaw.Tools.WebSearch,
+  PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
@@ -477,7 +478,10 @@ begin
   RegisterFSTools(FRegistry, FUseHashline);
   RegisterShellTool(FRegistry);
   RegisterMemoryTools(FRegistry);
-  RegisterWebSearchTool(FRegistry);
+  if HasConfiguredWebSearchProvider(FConfig) then
+    RegisterWebSearchTool(FRegistry)
+  else
+    LogWebSearchSkipOnce;
   RegisterWebFetchTool(FRegistry);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(FRegistry, Skills);
@@ -870,7 +874,10 @@ begin
     RegisterFSTools(FRegistry, FEnableHashline);
     RegisterShellTool(FRegistry);
     RegisterMemoryTools(FRegistry);
-    RegisterWebSearchTool(FRegistry);
+    if HasConfiguredWebSearchProvider(FConfig) then
+      RegisterWebSearchTool(FRegistry)
+    else
+      LogWebSearchSkipOnce;
     RegisterWebFetchTool(FRegistry);
     Skills := LoadSkillManifests(GetHome);
     RegisterSkills(FRegistry, Skills);

--- a/src/pkg/search/PasClaw.Search.Factory.pas
+++ b/src/pkg/search/PasClaw.Search.Factory.pas
@@ -32,6 +32,21 @@ uses
 
 function NewSearchProvider(const Cfg: TConfig; out ErrMsg: string): ISearchProvider;
 
+{ True when the operator has a real (non-DDG) provider configured —
+  either via Cfg.WebSearch.Provider + the required credential, or via
+  a known env-var API key alone (auto-detected). The web_search tool
+  gates registration on this so the model doesn't see a tool that
+  will silently come back empty when our zero-config fallback hits
+  DDG's anomaly wall. }
+function HasConfiguredWebSearchProvider(const Cfg: TConfig): Boolean;
+
+{ Log a one-time-per-process explanation that web_search was skipped
+  because no real provider is configured. Callers gating the tool's
+  registration should invoke this in their `else` branch so the
+  operator sees an actionable nudge in the boot log without us
+  spamming on every multi-registry pass. }
+procedure LogWebSearchSkipOnce;
+
 implementation
 
 uses
@@ -52,6 +67,23 @@ begin
   else              Result := FromCfg;
 end;
 
+function AutoDetectFromEnv: string;
+{ When the user set an API key but never set web_search.provider in
+  config.json, pick a sensible default. Priority is "key-only
+  providers first" — operators tend to set the Brave / Tavily /
+  Perplexity / Gemini keys when they want web search, and it'd be a
+  bad surprise to ignore that just because they didn't also touch
+  the Provider field. SearXNG isn't auto-detected because its
+  base_url is non-secret and lives in config.json proper. }
+begin
+  if GetEnvironmentVariable('PASCLAW_BRAVE_API_KEY')      <> '' then Exit('brave');
+  if GetEnvironmentVariable('PASCLAW_TAVILY_API_KEY')     <> '' then Exit('tavily');
+  if GetEnvironmentVariable('PASCLAW_PERPLEXITY_API_KEY') <> '' then Exit('perplexity');
+  if GetEnvironmentVariable('PASCLAW_GEMINI_API_KEY')     <> '' then Exit('gemini');
+  if GetEnvironmentVariable('PASCLAW_GOOGLE_API_KEY')     <> '' then Exit('gemini');
+  Result := '';
+end;
+
 function NewSearchProvider(const Cfg: TConfig; out ErrMsg: string): ISearchProvider;
 var
   Kind, Key: string;
@@ -61,8 +93,15 @@ begin
 
   if (Kind = '') or (Kind = 'duckduckgo') or (Kind = 'ddg') then
   begin
-    Result := NewDuckDuckGoProvider;
-    Exit;
+    { Auto-detect a real provider from env keys before falling all
+      the way back to DDG. The DDG-scrape fallback is only useful
+      when nothing else is configured. }
+    Kind := AutoDetectFromEnv;
+    if Kind = '' then
+    begin
+      Result := NewDuckDuckGoProvider;
+      Exit;
+    end;
   end;
 
   if Kind = 'brave' then
@@ -140,6 +179,64 @@ begin
 
   LogWarn('search.factory: unknown provider %s — falling back to duckduckgo', [Kind]);
   Result := NewDuckDuckGoProvider;
+end;
+
+var
+  GLogged: Boolean = False;
+
+procedure LogSkipOnceImpl;
+{ One-line info per process the first time web_search registration is
+  skipped, so the operator understands why the model doesn't see the
+  tool and how to flip it on. Subsequent skips during the same
+  process are silenced — multi-registry boots (cmd then component-
+  embedded refresh, etc.) shouldn't spam. }
+begin
+  if GLogged then Exit;
+  GLogged := True;
+  LogInfo('web_search disabled: no real provider configured. ' +
+          'Set $PASCLAW_BRAVE_API_KEY / $PASCLAW_TAVILY_API_KEY / ' +
+          '$PASCLAW_PERPLEXITY_API_KEY / $PASCLAW_GEMINI_API_KEY, ' +
+          'or set web_search.provider = "searxng" + base_url in config.json. ' +
+          '(DDG scrape fallback is disabled — its bot detection refuses non-browser ' +
+          'requests at the TLS-fingerprint level.)', []);
+end;
+
+function HasConfiguredWebSearchProvider(const Cfg: TConfig): Boolean;
+var
+  Kind: string;
+begin
+  Kind := LowerCase(Trim(Cfg.WebSearch.Provider));
+
+  { Explicit non-DDG provider: counts as "configured" iff its required
+    credential is reachable (env or cfg). The factory enforces the
+    same rule at NewSearchProvider time; mirror it here so the gate
+    decision lines up. }
+  if Kind = 'brave' then
+    Exit(PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_BRAVE_API_KEY') <> '');
+  if Kind = 'tavily' then
+    Exit(PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_TAVILY_API_KEY') <> '');
+  if Kind = 'perplexity' then
+    Exit(PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_PERPLEXITY_API_KEY') <> '');
+  if (Kind = 'gemini') or (Kind = 'google_search') then
+    Exit((PickKey(Cfg.WebSearch.APIKey, 'PASCLAW_GEMINI_API_KEY') <> '') or
+         (GetEnvironmentVariable('PASCLAW_GOOGLE_API_KEY') <> ''));
+  if Kind = 'searxng' then
+    Exit(Cfg.WebSearch.BaseURL <> '');
+
+  { Empty/DDG provider: fall back to "does the operator have any
+    auto-detectable env key set?". Without that, the only real
+    option is the DDG scrape, which we've decided not to expose. }
+  if (Kind = '') or (Kind = 'duckduckgo') or (Kind = 'ddg') then
+    Exit(AutoDetectFromEnv <> '');
+
+  { Unknown Kind — the factory logs a warning and falls back to DDG,
+    so for the gate decision treat it as "not configured". }
+  Result := False;
+end;
+
+procedure LogWebSearchSkipOnce;
+begin
+  LogSkipOnceImpl;
 end;
 
 end.

--- a/src/pkg/search/PasClaw.Search.Factory.pas
+++ b/src/pkg/search/PasClaw.Search.Factory.pas
@@ -91,17 +91,25 @@ begin
   ErrMsg := '';
   Kind := LowerCase(Trim(Cfg.WebSearch.Provider));
 
-  if (Kind = '') or (Kind = 'duckduckgo') or (Kind = 'ddg') then
+  if Kind = '' then
   begin
     { Auto-detect a real provider from env keys before falling all
-      the way back to DDG. The DDG-scrape fallback is only useful
-      when nothing else is configured. }
+      the way back to DDG. Only fires when the operator hasn't named
+      a provider — explicit "duckduckgo"/"ddg" below is respected
+      verbatim so a paid env key (left over from another tool's
+      config) can't silently hijack searches the operator meant to
+      send to DDG. Codex P2 on PR #143. }
     Kind := AutoDetectFromEnv;
     if Kind = '' then
     begin
       Result := NewDuckDuckGoProvider;
       Exit;
     end;
+  end
+  else if (Kind = 'duckduckgo') or (Kind = 'ddg') then
+  begin
+    Result := NewDuckDuckGoProvider;
+    Exit;
   end;
 
   if Kind = 'brave' then
@@ -223,11 +231,19 @@ begin
   if Kind = 'searxng' then
     Exit(Cfg.WebSearch.BaseURL <> '');
 
-  { Empty/DDG provider: fall back to "does the operator have any
+  { Empty provider: fall back to "does the operator have any
     auto-detectable env key set?". Without that, the only real
     option is the DDG scrape, which we've decided not to expose. }
-  if (Kind = '') or (Kind = 'duckduckgo') or (Kind = 'ddg') then
+  if Kind = '' then
     Exit(AutoDetectFromEnv <> '');
+
+  { Explicit 'duckduckgo'/'ddg': the operator chose the broken-
+    by-bot-wall scrape backend deliberately. Don't second-guess
+    them by sending requests to whatever paid key happens to be in
+    the env — and don't register the tool either, since DDG won't
+    deliver results. Codex P2 on PR #143. }
+  if (Kind = 'duckduckgo') or (Kind = 'ddg') then
+    Exit(False);
 
   { Unknown Kind — the factory logs a warning and falls back to DDG,
     so for the gate decision treat it as "not configured". }


### PR DESCRIPTION
## Summary

DuckDuckGo's `html.duckduckgo.com` endpoint now serves an anomaly-modal CAPTCHA page (literally `"Unfortunately, bots use DuckDuckGo too."`) for any request that fails its TLS-fingerprint check — even with a perfect Chrome UA + browser-shaped headers + a GET-from-form-flow Referer. The DDG-scrape fallback we ported from picoclaw doesn't return real results from our process anymore.

Rather than ship a tool that silently comes back empty (and lies to the model about the breadth of its world), gate `RegisterWebSearchTool` on whether the operator actually has a real provider configured.

### New: `PasClaw.Search.Factory.HasConfiguredWebSearchProvider(Cfg)`

Returns True when any of:
- `web_search.provider` = `brave` / `tavily` / `perplexity` AND the matching API key reaches us via env or cfg
- `web_search.provider` = `gemini` / `google_search` AND `$PASCLAW_GEMINI_API_KEY` or `$PASCLAW_GOOGLE_API_KEY` is set
- `web_search.provider` = `searxng` AND `web_search.base_url` is set
- `web_search.provider` is unset BUT one of the known API keys is set in the env (auto-detected, priority `brave` > `tavily` > `perplexity` > `gemini`)

The factory also auto-detects from env when `Provider` is unset, so just exporting `$PASCLAW_BRAVE_API_KEY` works without also editing `config.json`.

### Wiring

Six callsites updated to skip the tool when the gate returns False:
- `Cmd.Agent` (via `NewBuiltinRegistry`'s new `EnableWebSearch` parameter, same shape as `EnableVault`)
- `Cmd.TUI`, `Cmd.Gateway`, `Cmd.Serve` (inline `if/else` next to the rest of the boot-time tool registration)
- The two `PasClaw.Agent.pas` `InstallTools` paths (also inline)

When the gate skips registration, `LogWebSearchSkipOnce` drops a single dedup'd info line:

```
web_search disabled: no real provider configured. Set $PASCLAW_BRAVE_API_KEY /
$PASCLAW_TAVILY_API_KEY / $PASCLAW_PERPLEXITY_API_KEY / $PASCLAW_GEMINI_API_KEY,
or set web_search.provider = "searxng" + base_url in config.json. (DDG scrape
fallback is disabled — its bot detection refuses non-browser requests at the
TLS-fingerprint level.)
```

`TWebSearchTool.Install` (component-style embedders that pass the class to `Agent.RegisterTool`) keeps the unconditional path — those callers are opting in explicitly.

## Test plan

- [x] `make clean && make` clean, `make smoke` green.
- [ ] With no provider configured: `pasclaw agent` boot logs the skip line, the model's tool list omits `web_search`.
- [ ] With `$PASCLAW_BRAVE_API_KEY` set and `web_search.provider` unset: factory auto-picks Brave, tool registered, `web_search "picoclaw"` returns real results.
- [ ] With `web_search.provider = "searxng"` + `base_url`: tool registered, hits the configured instance.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_