### PR TITLE
web_fetch: opt-in default + save_to arg; allow curl in shell denylist

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -148,7 +148,8 @@ end;
 
 function NewBuiltinRegistry(UseHashline: Boolean = True;
                             EnableVault: Boolean = False;
-                            EnableWebSearch: Boolean = False): TToolRegistry;
+                            EnableWebSearch: Boolean = False;
+                            EnableWebFetch: Boolean = False): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
@@ -164,7 +165,12 @@ begin
     bot-detection wall refuses non-browser TLS fingerprints in 2026. }
   if EnableWebSearch then RegisterWebSearchTool(Result)
   else                    LogWebSearchSkipOnce;
-  RegisterWebFetchTool(Result);
+  { web_fetch is opt-in (Cfg.WebFetchEnabled). Off by default
+    because picoclaw's model fetches URLs via shell+curl and we
+    don't want to silently divert that traffic. Operators on
+    container/sandboxed deploys without curl can flip this in
+    config.json. }
+  if EnableWebFetch then RegisterWebFetchTool(Result);
   { Vault tools register only when explicitly enabled — callers pass
     Cfg.VaultToolsEnabled. Off-by-default per the onboarding opt-in
     flow; flipping the config flag (or re-running `pasclaw onboard`)
@@ -311,7 +317,8 @@ begin
   Reg := nil;
   if not A.NoTools then
     Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled,
-                              HasConfiguredWebSearchProvider(Cfg));
+                              HasConfiguredWebSearchProvider(Cfg),
+                              Cfg.WebFetchEnabled);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;
@@ -388,7 +395,8 @@ begin
   Reg := nil;
   if not A.NoTools then
     Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled,
-                              HasConfiguredWebSearchProvider(Cfg));
+                              HasConfiguredWebSearchProvider(Cfg),
+                              Cfg.WebFetchEnabled);
   MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -172,7 +172,7 @@ begin
         RegisterWebSearchTool(Reg)
       else
         LogWebSearchSkipOnce;
-      RegisterWebFetchTool(Reg);
+      if Cfg.WebFetchEnabled then RegisterWebFetchTool(Reg);
       { Off by default — onboarding opt-in flips Cfg.VaultToolsEnabled.
         Without this branch, `pasclaw onboard` could report
         "vault_search / vault_get enabled" but the gateway / web UI

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -126,7 +126,7 @@ begin
         RegisterWebSearchTool(Reg)
       else
         LogWebSearchSkipOnce;
-      RegisterWebFetchTool(Reg);
+      if Cfg.WebFetchEnabled then RegisterWebFetchTool(Reg);
       { Off by default — onboarding opt-in flips Cfg.VaultToolsEnabled.
         Without this branch, `pasclaw onboard` could report
         "vault_search / vault_get enabled" but the gateway / serve

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -98,7 +98,7 @@ begin
         RegisterWebSearchTool(Reg)
       else
         LogWebSearchSkipOnce;
-      RegisterWebFetchTool(Reg);
+      if Cfg.WebFetchEnabled then RegisterWebFetchTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
     end;

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -482,7 +482,7 @@ begin
     RegisterWebSearchTool(FRegistry)
   else
     LogWebSearchSkipOnce;
-  RegisterWebFetchTool(FRegistry);
+  if FConfig.WebFetchEnabled then RegisterWebFetchTool(FRegistry);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(FRegistry, Skills);
   if FUseMCP then
@@ -878,7 +878,7 @@ begin
       RegisterWebSearchTool(FRegistry)
     else
       LogWebSearchSkipOnce;
-    RegisterWebFetchTool(FRegistry);
+    if FConfig.WebFetchEnabled then RegisterWebFetchTool(FRegistry);
     Skills := LoadSkillManifests(GetHome);
     RegisterSkills(FRegistry, Skills);
   end;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -235,6 +235,14 @@ type
        Operators who skip onboarding can flip this directly in
        config.json or re-run `pasclaw onboard`. *)
     VaultToolsEnabled: Boolean;
+    (* Off-by-default: when True, Cmd.Agent / Cmd.Gateway / Cmd.Serve
+       register the web_fetch tool. Picoclaw doesn't ship a web_fetch
+       — its model fetches arbitrary URLs through shell + curl — so
+       PasClaw's default posture mirrors that. Flip this on for
+       deployments where curl isn't available (sandboxed containers,
+       constrained shells), or where the operator wants the tracked
+       web_fetch path with its size cap / save_to convenience. *)
+    WebFetchEnabled:   Boolean;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -297,6 +305,7 @@ begin
   PromptCache.Enabled  := True;  { default-on; see TPromptCacheConfig comment }
   PromptCache.TTL      := '';    { default 5m via empty }
   VaultToolsEnabled    := False; { off by default; onboarding asks to opt in }
+  WebFetchEnabled      := False; { off by default; the model uses shell+curl }
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -431,6 +440,8 @@ begin
     { Off-by-default — only serialise when True so stock configs stay tidy. }
     if VaultToolsEnabled then
       Root.PutBool('vault_tools_enabled', True);
+    if WebFetchEnabled then
+      Root.PutBool('web_fetch_enabled', True);
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -582,6 +593,7 @@ begin
     end;
 
     VaultToolsEnabled := Root.GetBool('vault_tools_enabled', VaultToolsEnabled);
+    WebFetchEnabled   := Root.GetBool('web_fetch_enabled',   WebFetchEnabled);
 
     Arr := Root.ChildArray('providers');
     if Arr <> nil then

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -125,6 +125,20 @@ function GetURLToStream(const URL: string; Stream: TStream;
                         const Headers: array of THeaderPair;
                         TimeoutSeconds: Integer): THTTPResult;
 
+{ GetURL's redirect-guard + UA/Accept overrides combined with
+  GetURLToStream's raw-bytes output. For web_fetch's save_to path:
+  callers want SSRF-checked downloads of arbitrary content (PDFs,
+  images, tarballs) where the UTF-8 round-trip through THTTPResult.Body
+  would mangle non-text bytes. ContentType/StatusCode/RespHeaders are
+  populated as usual; Body stays empty. }
+function GetURLToStreamGuarded(const URL: string;
+                                RespStream: TStream;
+                                const Headers: array of THeaderPair;
+                                TimeoutSeconds: Integer;
+                                const UserAgent: string;
+                                const Accept: string;
+                                OnRedirect: THTTPRedirectGuard): THTTPResult;
+
 function MakeHeader(const Name, Value: string): THeaderPair;
 
 { Returns True if Indy can load OpenSSL; otherwise False and ErrMsg
@@ -507,6 +521,47 @@ begin
                Result.StatusCode, Result.ContentType,
                Result.RespHeaders, Result.ErrorMsg);
   finally
+    C.Free;
+  end;
+end;
+
+function GetURLToStreamGuarded(const URL: string;
+                                RespStream: TStream;
+                                const Headers: array of THeaderPair;
+                                TimeoutSeconds: Integer;
+                                const UserAgent: string;
+                                const Accept: string;
+                                OnRedirect: THTTPRedirectGuard): THTTPResult;
+var
+  C: THTTPClient;
+  Hdrs: TNetHeaders;
+  EffAccept: string;
+  Adapter: TNetRedirectAdapter;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  if Accept <> '' then EffAccept := Accept else EffAccept := '*/*';
+  C       := NewNetClient(TimeoutSeconds, UserAgent, EffAccept);
+  Adapter := nil;
+  try
+    if Assigned(OnRedirect) then
+    begin
+      Adapter := TNetRedirectAdapter.Create(OnRedirect);
+      C.OnRedirect := Adapter.OnRedirect;
+    end;
+    Hdrs := MakeNetHeaders(Headers);
+    NetExecute(C, 'GET', URL, nil, RespStream, Hdrs,
+               Result.StatusCode, Result.ContentType,
+               Result.RespHeaders, Result.ErrorMsg);
+    if (Adapter <> nil) and Adapter.Rejected then
+    begin
+      Result.ErrorMsg    := Adapter.RejectReason;
+      Result.StatusCode  := -1;
+    end;
+  finally
+    Adapter.Free;
     C.Free;
   end;
 end;
@@ -976,6 +1031,68 @@ begin
       end;
     end;
   finally
+    Http.Free;
+  end;
+end;
+
+function GetURLToStreamGuarded(const URL: string;
+                                RespStream: TStream;
+                                const Headers: array of THeaderPair;
+                                TimeoutSeconds: Integer;
+                                const UserAgent: string;
+                                const Accept: string;
+                                OnRedirect: THTTPRedirectGuard): THTTPResult;
+var
+  Http: TIdHTTP;
+  SSLErr: string;
+  Adapter: TRedirectAdapter;
+begin
+  Result.StatusCode  := 0;
+  Result.Body        := '';
+  Result.ContentType := '';
+  Result.ErrorMsg    := '';
+  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  if SSLErr <> '' then
+  begin
+    Result.StatusCode := -1;
+    Result.ErrorMsg   := SSLErr;
+    Http.Free;
+    Exit;
+  end;
+  Adapter := nil;
+  try
+    if UserAgent <> '' then Http.Request.UserAgent := UserAgent;
+    if Accept    <> '' then Http.Request.Accept    := Accept
+    else                    Http.Request.Accept    := '*/*';
+    if Assigned(OnRedirect) then
+    begin
+      Adapter := TRedirectAdapter.Create(OnRedirect);
+      Http.OnRedirect := Adapter.OnRedirect;
+    end;
+    ApplyHeaders(Http, Headers);
+    try
+      Http.Get(URL, RespStream);
+      Result.StatusCode  := Http.ResponseCode;
+      Result.ContentType := LowerCase(Http.Response.ContentType);
+      CaptureIndyHeaders(Http, Result.RespHeaders);
+    except
+      on E: EIdHTTPProtocolException do
+      begin
+        Result.StatusCode  := E.ErrorCode;
+        Result.ContentType := LowerCase(Http.Response.ContentType);
+        Result.ErrorMsg    := E.Message;
+        CaptureIndyHeaders(Http, Result.RespHeaders);
+      end;
+      on E: Exception do
+      begin
+        Result.StatusCode  := Http.ResponseCode;
+        Result.ContentType := LowerCase(Http.Response.ContentType);
+        Result.ErrorMsg    := E.Message;
+        CaptureIndyHeaders(Http, Result.RespHeaders);
+      end;
+    end;
+  finally
+    Adapter.Free;
     Http.Free;
   end;
 end;

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -309,7 +309,7 @@ const
     plain literals — adequate because the patterns themselves are
     just punctuation runs ($(...), `...`, etc.) or fixed token
     sequences (apt install, npm install -g, etc.). }
-  ForbiddenSubstrings: array[0..45] of string = (
+  ForbiddenSubstrings: array[0..43] of string = (
     'dd if=',
     ':(){:|',         { fork bomb }
     '<<eof',
@@ -323,8 +323,12 @@ const
     '|bash',
     '|/bin/sh',
     '|/bin/bash',
-    'curl ',          { paired with denylist context below }
-    'wget ',
+    { curl and wget are intentionally NOT denied — they're the
+      conventional way the model fetches arbitrary URLs from the
+      shell, and we already provide web_fetch as the tracked-tool
+      alternative. Denying them put PasClaw strictly behind picoclaw
+      on URL access, and operators can still flip the whole
+      denylist off via sandbox.shell_deny_enabled = false. }
     'apt install',
     'apt remove',
     'apt purge',

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -175,40 +175,52 @@ begin
             SameText(Copy(S, 1, Length(Prefix)), Prefix);
 end;
 
-function WriteBodyToFile(const Path, Body: string; out ErrMsg: string): Boolean;
-{ Write the UTF-8 bytes of Body to Path, creating parent dirs as needed.
-  Returns False with ErrMsg on any failure. Direct TFileStream avoids
-  TStringList.SaveToFile's TEncoding.Default codepage trap on Delphi/
-  Windows — content with non-ASCII bytes would otherwise be mangled
-  on the way to disk. }
+function EnsureParentDir(const Path: string; out ErrMsg: string): Boolean;
 var
   Dir: string;
-  Bytes: TBytes;
-  FS: TFileStream;
 begin
-  Result := False;
+  Result := True;
   ErrMsg := '';
   Dir := ExtractFilePath(Path);
   if (Dir <> '') and not DirectoryExists(Dir) then
     if not ForceDirectories(Dir) then
     begin
       ErrMsg := 'web_fetch: cannot create parent directory: ' + Dir;
-      Exit;
+      Result := False;
     end;
+end;
+
+function ReadPreviewBytes(const Path: string; MaxBytes: Integer): TBytes;
+{ Read up to MaxBytes from Path for the receipt preview. Used after a
+  binary-safe stream download where Resp.Body is empty. }
+var
+  FS: TFileStream;
+  N: Int64;
+begin
+  SetLength(Result, 0);
+  if not FileExists(Path) then Exit;
   try
-    FS := TFileStream.Create(Path, fmCreate);
+    FS := TFileStream.Create(Path, fmOpenRead or fmShareDenyWrite);
     try
-      Bytes := TEncoding.UTF8.GetBytes(Body);
-      if Length(Bytes) > 0 then
-        FS.WriteBuffer(Bytes[0], Length(Bytes));
+      N := FS.Size;
+      if N > MaxBytes then N := MaxBytes;
+      SetLength(Result, N);
+      if N > 0 then FS.ReadBuffer(Result[0], N);
     finally
       FS.Free;
     end;
-    Result := True;
   except
-    on E: Exception do
-      ErrMsg := 'web_fetch: write failed: ' + E.Message;
+    SetLength(Result, 0);
   end;
+end;
+
+function LooksTextual(const ContentType: string): Boolean;
+begin
+  Result := (Pos('text/', ContentType) = 1) or
+            (Pos('application/json',       ContentType) > 0) or
+            (Pos('application/xml',        ContentType) > 0) or
+            (Pos('application/javascript', ContentType) > 0) or
+            (Pos('application/xhtml',      ContentType) > 0);
 end;
 
 function Tool_WebFetch(const ArgsJSON: string; out ErrMsg: string): string;
@@ -218,6 +230,9 @@ var
   RedirectGuard: TWebFetchRedirectGuard;
   Resp: THTTPResult;
   Headers: array of THeaderPair;
+  FS: TFileStream;
+  Bytes: TBytes;
+  WrittenBytes: Int64;
 begin
   ErrMsg := '';
   Result := '';
@@ -267,6 +282,64 @@ begin
     ErrMsg := '';
   end;
 
+  { save_to: stream bytes straight to disk via the binary-safe wrapper.
+    GetURL returns a UTF-8-decoded string, which mangles non-text
+    payloads (PDFs, images, archives) on the round trip back through
+    TEncoding.UTF8.GetBytes — losing precisely the use case save_to
+    advertises. The receipt + preview are reconstructed from the file
+    so the model still gets a sniffable hint. }
+  if SaveTo <> '' then
+  begin
+    if not EnsureParentDir(SaveTo, ErrMsg) then Exit;
+    RedirectGuard := TWebFetchRedirectGuard.Create;
+    FS := nil;
+    WrittenBytes := 0;
+    try
+      try
+        FS := TFileStream.Create(SaveTo, fmCreate);
+      except
+        on E: Exception do
+        begin
+          ErrMsg := 'web_fetch: write failed: ' + E.Message;
+          Exit;
+        end;
+      end;
+      try
+        Resp := GetURLToStreamGuarded(URL, FS, Headers, 30,
+                                       'Mozilla/5.0 (PasClaw web_fetch)',
+                                       '*/*',
+                                       RedirectGuard.OnRedirect);
+        WrittenBytes := FS.Size;
+      finally
+        FS.Free;
+      end;
+    finally
+      RedirectGuard.Free;
+    end;
+
+    if Resp.ErrorMsg <> '' then
+    begin
+      ErrMsg := 'web_fetch: HTTP error: ' + Resp.ErrorMsg;
+      Exit;
+    end;
+
+    Bytes := ReadPreviewBytes(SaveTo, 200);
+    if (Length(Bytes) > 0) and LooksTextual(Resp.ContentType) then
+      Preview := TEncoding.UTF8.GetString(Bytes)
+    else
+      Preview := '';
+
+    Result := Format('web_fetch: saved %d bytes to %s (status %d, content-type %s)',
+                     [WrittenBytes, SaveTo, Resp.StatusCode, Resp.ContentType]);
+    if Trim(Preview) <> '' then
+      Result := Result + sLineBreak + 'preview: ' + Preview
+    else if not LooksTextual(Resp.ContentType) then
+      Result := Result + sLineBreak + 'preview: (binary content)';
+    LogDebug('web_fetch url=%s bytes_in=%d saved_to=%s',
+             [URL, WrittenBytes, SaveTo]);
+    Exit;
+  end;
+
   RedirectGuard := TWebFetchRedirectGuard.Create;
   try
     Resp := GetURL(URL, Headers, 30,
@@ -280,22 +353,6 @@ begin
   if Resp.ErrorMsg <> '' then
   begin
     ErrMsg := 'web_fetch: HTTP error: ' + Resp.ErrorMsg;
-    Exit;
-  end;
-
-  { save_to path: write full body to disk regardless of content-type
-    (operator already allowed the path via the sandbox), return only
-    a short receipt with a preview. }
-  if SaveTo <> '' then
-  begin
-    if not WriteBodyToFile(SaveTo, Resp.Body, ErrMsg) then Exit;
-    Preview := Copy(Resp.Body, 1, 200);
-    Result := Format('web_fetch: saved %d bytes to %s (status %d, content-type %s)',
-                     [Length(Resp.Body), SaveTo, Resp.StatusCode, Resp.ContentType]);
-    if Trim(Preview) <> '' then
-      Result := Result + sLineBreak + 'preview: ' + Preview;
-    LogDebug('web_fetch url=%s bytes_in=%d saved_to=%s',
-             [URL, Length(Resp.Body), SaveTo]);
     Exit;
   end;
 
@@ -343,7 +400,12 @@ begin
     '},"required":["url"]}';
   T.Handler     := Tool_WebFetch;
   T.IsCore      := True;
-  T.Category    := tcReadOnly;  { HTTP GET only, no shared state }
+  { Mutating because save_to writes to the workspace. Without this the
+    agent scheduler can run a follow-up fs_read in parallel with the
+    in-flight download and observe a half-written file. The plain
+    inlined-text path doesn't touch shared state, but tagging at the
+    tool level (not per-call) is the only signal the registry exposes. }
+  T.Category    := tcMutating;
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -175,9 +175,45 @@ begin
             SameText(Copy(S, 1, Length(Prefix)), Prefix);
 end;
 
+function WriteBodyToFile(const Path, Body: string; out ErrMsg: string): Boolean;
+{ Write the UTF-8 bytes of Body to Path, creating parent dirs as needed.
+  Returns False with ErrMsg on any failure. Direct TFileStream avoids
+  TStringList.SaveToFile's TEncoding.Default codepage trap on Delphi/
+  Windows — content with non-ASCII bytes would otherwise be mangled
+  on the way to disk. }
+var
+  Dir: string;
+  Bytes: TBytes;
+  FS: TFileStream;
+begin
+  Result := False;
+  ErrMsg := '';
+  Dir := ExtractFilePath(Path);
+  if (Dir <> '') and not DirectoryExists(Dir) then
+    if not ForceDirectories(Dir) then
+    begin
+      ErrMsg := 'web_fetch: cannot create parent directory: ' + Dir;
+      Exit;
+    end;
+  try
+    FS := TFileStream.Create(Path, fmCreate);
+    try
+      Bytes := TEncoding.UTF8.GetBytes(Body);
+      if Length(Bytes) > 0 then
+        FS.WriteBuffer(Bytes[0], Length(Bytes));
+    finally
+      FS.Free;
+    end;
+    Result := True;
+  except
+    on E: Exception do
+      ErrMsg := 'web_fetch: write failed: ' + E.Message;
+  end;
+end;
+
 function Tool_WebFetch(const ArgsJSON: string; out ErrMsg: string): string;
 var
-  URL: string;
+  URL, SaveTo, SandboxReason, Preview: string;
   MaxChars: Integer;
   RedirectGuard: TWebFetchRedirectGuard;
   Resp: THTTPResult;
@@ -201,6 +237,22 @@ begin
   MaxChars := ParseIntArg(ArgsJSON, 'max_chars', DEFAULT_MAX_CHARS);
   if MaxChars < 100           then MaxChars := 100;
   if MaxChars > HARD_MAX_CHARS then MaxChars := HARD_MAX_CHARS;
+
+  { Optional curl -o: when save_to is set, the full response body is
+    written to disk and the tool result becomes a small receipt
+    instead of the inlined content. The model then uses fs_read /
+    fs_grep on the saved file. This skips the max_chars cap entirely
+    so the model can pull down arbitrarily large pages / API dumps
+    without blowing the context window. }
+  ParseStringArg(ArgsJSON, 'save_to', SaveTo);
+  if SaveTo <> '' then
+  begin
+    if not CanWritePath(SaveTo, SandboxReason) then
+    begin
+      ErrMsg := 'web_fetch: save_to refused: ' + SandboxReason;
+      Exit;
+    end;
+  end;
 
   { SSRF pre-check on the initial URL. The redirect guard covers
     subsequent hops; both layers must pass for the request to land. }
@@ -231,6 +283,22 @@ begin
     Exit;
   end;
 
+  { save_to path: write full body to disk regardless of content-type
+    (operator already allowed the path via the sandbox), return only
+    a short receipt with a preview. }
+  if SaveTo <> '' then
+  begin
+    if not WriteBodyToFile(SaveTo, Resp.Body, ErrMsg) then Exit;
+    Preview := Copy(Resp.Body, 1, 200);
+    Result := Format('web_fetch: saved %d bytes to %s (status %d, content-type %s)',
+                     [Length(Resp.Body), SaveTo, Resp.StatusCode, Resp.ContentType]);
+    if Trim(Preview) <> '' then
+      Result := Result + sLineBreak + 'preview: ' + Preview;
+    LogDebug('web_fetch url=%s bytes_in=%d saved_to=%s',
+             [URL, Length(Resp.Body), SaveTo]);
+    Exit;
+  end;
+
   if (Pos('text/html',             Resp.ContentType) > 0) or
      (Pos('application/xhtml+xml', Resp.ContentType) > 0) or
      (Resp.ContentType = '') then
@@ -243,7 +311,8 @@ begin
   end
   else
   begin
-    ErrMsg := Format('web_fetch: unsupported content-type %s', [Resp.ContentType]);
+    ErrMsg := Format('web_fetch: unsupported content-type %s (try save_to to download as-is)',
+                     [Resp.ContentType]);
     Exit;
   end;
 
@@ -258,15 +327,19 @@ begin
   if R = nil then Exit;
   T.Name        := 'web_fetch';
   T.Description :=
-    'Fetch the contents of an HTTP/HTTPS URL and return readable plain text. ' +
-    'Strips HTML tags, decodes entities, collapses whitespace. Useful after ' +
-    'web_search to read a specific result page. Caps the output at 50 KB ' +
-    'by default; pass max_chars to override (range 100–200000).';
+    'Fetch the contents of an HTTP/HTTPS URL. By default returns ' +
+    'readable plain text (strips HTML tags, decodes entities) capped at ' +
+    'max_chars (default 50000). Pass save_to to write the full body to a ' +
+    'file under the workspace instead — useful for large pages, binary ' +
+    'downloads, or anything that would blow the model''s context. When ' +
+    'save_to is set, the tool result is a short receipt + preview, and ' +
+    'the model uses fs_read / fs_grep on the saved file.';
   T.Schema      :=
     '{"type":"object",' +
     '"properties":{' +
     '"url":{"type":"string","description":"http:// or https:// URL."},' +
-    '"max_chars":{"type":"integer","minimum":100,"maximum":200000,"description":"Output char cap (default 50000)."}' +
+    '"max_chars":{"type":"integer","minimum":100,"maximum":200000,"description":"Inline output char cap (default 50000). Ignored when save_to is set."},' +
+    '"save_to":{"type":"string","description":"Optional workspace-relative path. When set, the full response body is written there and the tool returns a receipt only."}' +
     '},"required":["url"]}';
   T.Handler     := Tool_WebFetch;
   T.IsCore      := True;


### PR DESCRIPTION
## Summary

Three related changes that restore parity with picoclaw's shell+curl posture while keeping `web_fetch` as a managed alternative for operators who want it.

### 1. Allow `curl`/`wget` in the shell denylist

Picoclaw's model fetches arbitrary URLs by shelling out to `curl`. Our denylist blocked both `curl ` and `wget `, which put PasClaw strictly behind picoclaw on URL access. Removed both entries from `Tools.Sandbox.ForbiddenSubstrings` (array size updated `0..45` → `0..43`). The rest of the denylist (`sudo`, `rm -rf`, `dd`, command-substitution, `curl | sh`-style pipes, package-manager installs, `git push`, etc.) is untouched. Operators who want the old posture can still flip the whole list off via `sandbox.shell_deny_enabled = false`.

### 2. `web_fetch` off by default

New `Cfg.WebFetchEnabled: Boolean` (default False, JSON-serialised only when True). Gates registration in all six callsites:
- `Cmd.Agent` (via `NewBuiltinRegistry`'s new `EnableWebFetch` parameter, same shape as `EnableVault` / `EnableWebSearch`)
- `Cmd.TUI`, `Cmd.Gateway`, `Cmd.Serve` (inline `if Cfg.WebFetchEnabled then …`)
- The two `PasClaw.Agent.pas` `InstallTools` paths (also inline)

Picoclaw doesn't ship a `web_fetch` — the model uses shell+curl — and the default posture now mirrors that. Operators on containerised / sandboxed deploys without curl can flip `"web_fetch_enabled": true` in `config.json`.

### 3. `web_fetch` grows `save_to`

Optional argument; when set, the full response body is written to that workspace-relative path (gated by `Sandbox.CanWritePath`) and the tool returns a short receipt + 200-char preview instead of the inlined content:

```
web_fetch: saved 1247892 bytes to workspace/scratch/page.html (status 200, content-type text/html; charset=utf-8)
preview: <!DOCTYPE html><html lang="en"><head>…
```

Skips the `max_chars` cap entirely so the model can pull arbitrary page sizes / JSON dumps / API dumps without blowing the context window, and skips the `text/*` content-type check so binary downloads work (image, PDF, etc.). The schema + description on the registered tool both call out the new convention so the model knows when to use it.

## Test plan

- [x] FPC `make clean && make` clean, `make smoke` green.
- [ ] `pasclaw agent` with default config (no `web_fetch_enabled`): tool absent from the registry, model uses shell+curl.
- [ ] `pasclaw agent` with `"web_fetch_enabled": true`: tool registered.
  - [ ] `web_fetch {url: "..."}` returns inline text (existing behaviour).
  - [ ] `web_fetch {url: "...", save_to: "workspace/test.html"}` writes the file, returns the receipt + preview, file readable via `fs_read`.
  - [ ] `web_fetch {url: ".../bigfile.json", save_to: "workspace/dump.json"}` works for content types that used to error.
- [ ] `shell_exec` with `curl https://example.com` no longer hits the denylist (returns curl's output).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_