### PR TITLE
Anthropic: opt-in server-side web_search / web_fetch tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview print-version get-indy webui-res
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools print-version get-indy webui-res
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -214,4 +214,10 @@ test-toolview: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/toolview_tests.pas -o$(BUILDDIR)/toolview_tests
 	@$(BUILDDIR)/toolview_tests
 
-test: smoke test-hashline test-toolview
+# Anthropic provider — server-side web_search / web_fetch wire shape.
+test-anthropic-server-tools: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/anthropic_server_tools_tests.pas -o$(BUILDDIR)/anthropic_server_tools_tests
+	@$(BUILDDIR)/anthropic_server_tools_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -202,6 +202,29 @@ type
     TTL:     string;
   end;
 
+  (* Anthropic-only: register Anthropic's server-side web tools
+     (web_search_20260209 / web_fetch_20260209) in the request's
+     tools array. Claude runs the queries / fetches on Anthropic's
+     side and stitches the results into the final response — no
+     round-trip through PasClaw's tool loop, no SearXNG / curl on
+     the operator's box.
+
+     Off by default. Only the Anthropic provider honours these;
+     OpenAI / Gemini / others ignore them. When one of these is on,
+     the Anthropic builder also drops any user-registered tool whose
+     name collides (e.g. the local web_search tool) to avoid a
+     duplicate-name 400 from the Messages API.
+
+     MaxUses bounds how many times Claude may call the tool per turn;
+     0 means "let Anthropic apply its default". See:
+     https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview *)
+  TAnthropicServerToolsConfig = record
+    WebSearch:        Boolean;
+    WebSearchMaxUses: Integer;
+    WebFetch:         Boolean;
+    WebFetchMaxUses:  Integer;
+  end;
+
   TConfig = class
   public
     DefaultProvider: string;
@@ -243,6 +266,7 @@ type
        constrained shells), or where the operator wants the tracked
        web_fetch path with its size cap / save_to convenience. *)
     WebFetchEnabled:   Boolean;
+    AnthropicServerTools: TAnthropicServerToolsConfig;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -306,6 +330,10 @@ begin
   PromptCache.TTL      := '';    { default 5m via empty }
   VaultToolsEnabled    := False; { off by default; onboarding asks to opt in }
   WebFetchEnabled      := False; { off by default; the model uses shell+curl }
+  AnthropicServerTools.WebSearch        := False;
+  AnthropicServerTools.WebSearchMaxUses := 0;
+  AnthropicServerTools.WebFetch         := False;
+  AnthropicServerTools.WebFetchMaxUses  := 0;
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -442,6 +470,20 @@ begin
       Root.PutBool('vault_tools_enabled', True);
     if WebFetchEnabled then
       Root.PutBool('web_fetch_enabled', True);
+    if AnthropicServerTools.WebSearch
+       or AnthropicServerTools.WebFetch
+       or (AnthropicServerTools.WebSearchMaxUses > 0)
+       or (AnthropicServerTools.WebFetchMaxUses > 0) then
+    begin
+      Tmp := TJsonObject.Create;
+      if AnthropicServerTools.WebSearch then Tmp.PutBool('web_search', True);
+      if AnthropicServerTools.WebSearchMaxUses > 0 then
+        Tmp.PutInt('web_search_max_uses', AnthropicServerTools.WebSearchMaxUses);
+      if AnthropicServerTools.WebFetch then Tmp.PutBool('web_fetch', True);
+      if AnthropicServerTools.WebFetchMaxUses > 0 then
+        Tmp.PutInt('web_fetch_max_uses', AnthropicServerTools.WebFetchMaxUses);
+      Root.PutObject('anthropic_server_tools', Tmp);
+    end;
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -594,6 +636,21 @@ begin
 
     VaultToolsEnabled := Root.GetBool('vault_tools_enabled', VaultToolsEnabled);
     WebFetchEnabled   := Root.GetBool('web_fetch_enabled',   WebFetchEnabled);
+
+    Obj := Root.ChildObject('anthropic_server_tools');
+    if Obj <> nil then
+    try
+      AnthropicServerTools.WebSearch :=
+        Obj.GetBool('web_search', AnthropicServerTools.WebSearch);
+      AnthropicServerTools.WebSearchMaxUses :=
+        Obj.GetInt('web_search_max_uses', AnthropicServerTools.WebSearchMaxUses);
+      AnthropicServerTools.WebFetch :=
+        Obj.GetBool('web_fetch', AnthropicServerTools.WebFetch);
+      AnthropicServerTools.WebFetchMaxUses :=
+        Obj.GetInt('web_fetch_max_uses', AnthropicServerTools.WebFetchMaxUses);
+    finally
+      Obj.Free;
+    end;
 
     Arr := Root.ChildArray('providers');
     if Arr <> nil then

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -76,6 +76,18 @@ function BuildRequest(const Messages: array of TMessage;
                       const Options:  TChatOptions;
                       const ServerTools: TAnthropicServerTools): string;
 
+(* Build the follow-up request body for a stop_reason: "pause_turn"
+   continuation. Takes the prior request body and the response body
+   that returned pause_turn, appends a new assistant turn to the
+   request's messages[] carrying the response's content array
+   verbatim, and serialises the result. Anthropic detects the
+   trailing server_tool_use block and resumes the server-side
+   sampling loop where it paused. Returns '' on parse failure.
+
+   Exposed for tests; production callers reach it via Chat() which
+   runs the bounded continuation loop. *)
+function ContinuePausedTurn(const ReqBody, RespBody: string): string;
+
 implementation
 
 uses
@@ -477,14 +489,91 @@ begin
   end;
 end;
 
+const
+  { Cap on continuation rounds for stop_reason: "pause_turn". Server-side
+    web tools (web_search_20260209 / web_fetch_20260209) run inside an
+    Anthropic-side sampling loop with a default 10-iteration ceiling;
+    when that ceiling hits, the API returns pause_turn with the partial
+    assistant content and expects the client to re-POST with the prior
+    assistant turn appended verbatim. Five rounds is enough headroom for
+    multi-search agentic queries while still bounding spend if Anthropic
+    ever pause_turn'd unboundedly. }
+  PAUSE_TURN_MAX_CONTINUATIONS = 5;
+
+function SafeParseObject(const S: string): TJsonObject;
+{ TJsonObject.Parse raises EPasClawJSON on malformed input rather than
+  returning nil; ContinuePausedTurn needs nil-on-failure semantics so
+  a bad body short-circuits to "return original" instead of crashing. }
+begin
+  Result := nil;
+  try
+    Result := TJsonObject.Parse(S);
+  except
+    Result := nil;
+  end;
+end;
+
+function ContinuePausedTurn(const ReqBody, RespBody: string): string;
+{ Build the follow-up request body for a pause_turn continuation:
+  take the prior response's content array verbatim and append it to
+  the request's messages[] as a new assistant turn. Anthropic detects
+  the trailing server_tool_use block and resumes the server-side
+  loop from where it paused. Adding any user message in between (or
+  re-rendering the assistant content as text-only) would break the
+  resume detection.
+  Returns the new wire body, or '' on parse failure (caller surfaces
+  the prior response unchanged). }
+var
+  Req, Resp, AssistantMsg: TJsonObject;
+  MsgArr, ContentArr: TJsonArray;
+  ContentRaw: string;
+begin
+  Result := '';
+  Req := SafeParseObject(ReqBody);
+  if Req = nil then Exit;
+  try
+    Resp := SafeParseObject(RespBody);
+    if Resp = nil then Exit;
+    try
+      ContentArr := Resp.ChildArray('content');
+      if ContentArr = nil then Exit;
+      try
+        ContentRaw := ContentArr.ToJSON;
+      finally
+        ContentArr.Free;
+      end;
+      if ContentRaw = '' then Exit;
+
+      MsgArr := Req.ChildArray('messages');
+      if MsgArr = nil then Exit;
+      try
+        AssistantMsg := TJsonObject.Create;
+        AssistantMsg.PutStr('role', 'assistant');
+        AssistantMsg.PutRaw('content', ContentRaw);
+        MsgArr.AddObject(AssistantMsg);
+      finally
+        MsgArr.Free;
+      end;
+
+      Result := Req.ToJSON;
+    finally
+      Resp.Free;
+    end;
+  finally
+    Req.Free;
+  end;
+end;
+
 function TAnthropicProvider.Chat(const Messages: array of TMessage;
                                  const Tools:    array of TToolDefinition;
                                  const Model:    string;
                                  const Options:  TChatOptions): TLLMResponse;
 var
-  Body, URL, UseModel: string;
+  Body, NextBody, URL, UseModel: string;
   Resp: THTTPResult;
   Headers: array of THeaderPair;
+  RoundResp: TLLMResponse;
+  Continuations, i: Integer;
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1/messages';
@@ -494,23 +583,69 @@ begin
   Headers[0] := MakeHeader('x-api-key',          FAPIKey);
   Headers[1] := MakeHeader('anthropic-version', '2023-06-01');
 
-  LogDebug('anthropic POST %s (model=%s, body=%d bytes)', [URL, UseModel, Length(Body)]);
-  Resp := PostJSON(URL, Body, Headers, 120);
-
   Result.Content := '';
-  Result.StatusCode := Resp.StatusCode;
+  Result.StatusCode := 0;
   SetLength(Result.ToolCalls, 0);
-  if (Resp.StatusCode >= 200) and (Resp.StatusCode < 300) then
-  begin
-    ParseResponse(Resp.Body, Result);
-    Exit;
-  end;
 
-  if Resp.Body <> '' then
-    Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, Resp.Body])
-  else
-    Result.Content := Format('anthropic error: status=%d msg=%s', [Resp.StatusCode, Resp.ErrorMsg]);
-  Result.FinishReason := 'error';
+  Continuations := 0;
+  while True do
+  begin
+    LogDebug('anthropic POST %s (model=%s, body=%d bytes, continuation=%d)',
+             [URL, UseModel, Length(Body), Continuations]);
+    Resp := PostJSON(URL, Body, Headers, 120);
+    Result.StatusCode := Resp.StatusCode;
+
+    if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+    begin
+      if Resp.Body <> '' then
+        Result.Content := Format('anthropic error %d: %s', [Resp.StatusCode, Resp.Body])
+      else
+        Result.Content := Format('anthropic error: status=%d msg=%s', [Resp.StatusCode, Resp.ErrorMsg]);
+      Result.FinishReason := 'error';
+      Exit;
+    end;
+
+    Finalize(RoundResp);
+    FillChar(RoundResp, SizeOf(RoundResp), 0);
+    ParseResponse(Resp.Body, RoundResp);
+
+    { Aggregate text across continuation rounds. Tool calls and usage
+      come from the FINAL round (the only round that returns control
+      to PasClaw); intermediate pause_turn rounds carry server-side
+      activity only and have no client ToolCalls to surface. }
+    if RoundResp.Content <> '' then
+    begin
+      if Result.Content <> '' then Result.Content := Result.Content + sLineBreak;
+      Result.Content := Result.Content + RoundResp.Content;
+    end;
+    Result.FinishReason := RoundResp.FinishReason;
+    Result.Model        := RoundResp.Model;
+    Result.Usage.InputTokens        := Result.Usage.InputTokens        + RoundResp.Usage.InputTokens;
+    Result.Usage.OutputTokens       := Result.Usage.OutputTokens       + RoundResp.Usage.OutputTokens;
+    Result.Usage.CacheReadTokens    := Result.Usage.CacheReadTokens    + RoundResp.Usage.CacheReadTokens;
+    Result.Usage.CacheCreatedTokens := Result.Usage.CacheCreatedTokens + RoundResp.Usage.CacheCreatedTokens;
+    SetLength(Result.ToolCalls, Length(RoundResp.ToolCalls));
+    for i := 0 to High(RoundResp.ToolCalls) do
+      Result.ToolCalls[i] := RoundResp.ToolCalls[i];
+
+    if RoundResp.FinishReason <> 'pause_turn' then Exit;
+
+    if Continuations >= PAUSE_TURN_MAX_CONTINUATIONS then
+    begin
+      LogWarn('anthropic pause_turn cap (%d) reached; returning partial answer',
+              [PAUSE_TURN_MAX_CONTINUATIONS]);
+      Exit;
+    end;
+
+    NextBody := ContinuePausedTurn(Body, Resp.Body);
+    if NextBody = '' then
+    begin
+      LogWarn('anthropic pause_turn: continuation body build failed; returning partial answer');
+      Exit;
+    end;
+    Body := NextBody;
+    Inc(Continuations);
+  end;
 end;
 
 var

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -18,13 +18,28 @@ uses
   PasClaw.Providers.Intf;
 
 type
+  (* Opt-in toggles for Anthropic-side server tools. Mirrors
+     PasClaw.Config.TAnthropicServerToolsConfig — kept in this unit so
+     PasClaw.Providers.Anthropic doesn't have to USE the config unit
+     (the providers/config dependency direction is currently
+     config → providers, and inverting that would pull TConfig into
+     every provider unit test). *)
+  TAnthropicServerTools = record
+    WebSearch:        Boolean;
+    WebSearchMaxUses: Integer;
+    WebFetch:         Boolean;
+    WebFetchMaxUses:  Integer;
+  end;
+
   TAnthropicProvider = class(TInterfacedObject, ILLMProvider)
   private
     FAPIKey:  string;
     FAPIBase: string;
     FDefaultModel: string;
+    FServerTools: TAnthropicServerTools;
   public
-    constructor Create(const APIKey, APIBase, DefaultModel: string);
+    constructor Create(const APIKey, APIBase, DefaultModel: string;
+                       const ServerTools: TAnthropicServerTools);
     function Chat(const Messages: array of TMessage;
                   const Tools:    array of TToolDefinition;
                   const Model:    string;
@@ -41,13 +56,25 @@ type
     function SupportsStreaming: Boolean;
   end;
 
+{ Default-initialised TAnthropicServerTools (everything off). Use in
+  tests / embedders that don't care about the server-tool surface. }
+function NoAnthropicServerTools: TAnthropicServerTools;
+
 { Exposed so tests + embedders can render the wire body without
   hitting the network. Pure function; doesn't depend on the provider
-  instance. Same code path Chat / ChatStream execute. }
+  instance. Same code path Chat / ChatStream execute.
+
+  ServerTools.WebSearch / WebFetch append the corresponding
+  Anthropic server-side tool entries (web_search_20260209 /
+  web_fetch_20260209) to the tools array. When a server tool is
+  active, any caller-supplied tool with a colliding name (web_search,
+  web_fetch) is silently dropped so the request doesn't 400 with
+  "tools[*].name: duplicate". }
 function BuildRequest(const Messages: array of TMessage;
                       const Tools:    array of TToolDefinition;
                       const Model:    string;
-                      const Options:  TChatOptions): string;
+                      const Options:  TChatOptions;
+                      const ServerTools: TAnthropicServerTools): string;
 
 implementation
 
@@ -57,12 +84,22 @@ uses
   PasClaw.Providers.Stream,
   PasClaw.Logger;
 
-constructor TAnthropicProvider.Create(const APIKey, APIBase, DefaultModel: string);
+function NoAnthropicServerTools: TAnthropicServerTools;
+begin
+  Result.WebSearch        := False;
+  Result.WebSearchMaxUses := 0;
+  Result.WebFetch         := False;
+  Result.WebFetchMaxUses  := 0;
+end;
+
+constructor TAnthropicProvider.Create(const APIKey, APIBase, DefaultModel: string;
+                                      const ServerTools: TAnthropicServerTools);
 begin
   inherited Create;
   FAPIKey := APIKey;
   if APIBase <> '' then FAPIBase := APIBase else FAPIBase := 'https://api.anthropic.com';
   if DefaultModel <> '' then FDefaultModel := DefaultModel else FDefaultModel := 'claude-opus-4-7';
+  FServerTools := ServerTools;
 end;
 
 function TAnthropicProvider.GetDefaultModel: string;
@@ -112,14 +149,43 @@ begin
   if TTL = '1h' then Result.PutStr('ttl', '1h');
 end;
 
+function ServerToolCollides(const Name: string;
+                            const ServerTools: TAnthropicServerTools): Boolean;
+{ True iff Name is one of the user-tool names that would duplicate a
+  server-side tool we're about to emit. Anthropic rejects a tools
+  array with two entries sharing a name; we drop the user entry in
+  favour of the server-side one (Claude runs the latter on its own
+  infrastructure, no round-trip needed). }
+begin
+  Result := (ServerTools.WebSearch and SameText(Name, 'web_search'))
+         or (ServerTools.WebFetch  and SameText(Name, 'web_fetch'));
+end;
+
+function CountEffectiveTools(const Tools: array of TToolDefinition;
+                              const ServerTools: TAnthropicServerTools): Integer;
+{ How many user tools survive the collision filter, plus the server
+  tools that will be appended. Used to pick the last-tool index for
+  the cache_control breakpoint. }
+var
+  i: Integer;
+begin
+  Result := 0;
+  for i := 0 to High(Tools) do
+    if not ServerToolCollides(Tools[i].Name, ServerTools) then
+      Inc(Result);
+  if ServerTools.WebSearch then Inc(Result);
+  if ServerTools.WebFetch  then Inc(Result);
+end;
+
 function BuildRequest(const Messages: array of TMessage;
                       const Tools:    array of TToolDefinition;
                       const Model:    string;
-                      const Options:  TChatOptions): string;
+                      const Options:  TChatOptions;
+                      const ServerTools: TAnthropicServerTools): string;
 var
   Root, Block, ToolObj, Thinking, Msg, EmptyInput, SysBlock, CC: TJsonObject;
   MsgArr, ToolArr, ContentArr, SysArr: TJsonArray;
-  i, j: Integer;
+  i, j, Emitted, LastIdx: Integer;
   Sys: string;
 begin
   Root := TJsonObject.Create;
@@ -218,11 +284,20 @@ begin
     end;
     Root.PutArray('messages', MsgArr);
 
-    if Length(Tools) > 0 then
+    if (Length(Tools) > 0) or ServerTools.WebSearch or ServerTools.WebFetch then
     begin
       ToolArr := TJsonArray.Create;
+      LastIdx := CountEffectiveTools(Tools, ServerTools) - 1;
+      Emitted := 0;
       for i := 0 to High(Tools) do
       begin
+        { When Cfg flips on a server-side equivalent, suppress the
+          user-registered tool with the same name. Two entries called
+          "web_search" in the tools array would 400 with "duplicate
+          tool name"; we keep the server-side one (Claude executes it
+          on Anthropic's infrastructure, no round-trip via PasClaw). }
+        if ServerToolCollides(Tools[i].Name, ServerTools) then Continue;
+
         ToolObj := TJsonObject.Create;
         ToolObj.PutStr('name', Tools[i].Name);
         if Tools[i].Description <> '' then ToolObj.PutStr('description', Tools[i].Description);
@@ -233,20 +308,59 @@ begin
           EmptyInput := TJsonObject.Create;
           ToolObj.PutObject('input_schema', EmptyInput);
         end;
-        { Tag the LAST tool entry with cache_control — Anthropic
-          caches up to and including the tagged block, so a single
-          breakpoint on the trailing tool covers the entire tools
-          array as a stable prefix. Combined with the system-prompt
-          breakpoint above we use 2 of Anthropic's 4-breakpoint
-          budget; the remaining two are reserved for compaction
-          summaries or higher-layer hints later. }
-        if Options.CacheEnabled and (i = High(Tools)) then
+        { Tag the LAST effective tool entry with cache_control —
+          Anthropic caches up to and including the tagged block, so
+          a single breakpoint on the trailing tool covers the entire
+          tools array as a stable prefix. Combined with the
+          system-prompt breakpoint above we use 2 of Anthropic's
+          4-breakpoint budget; the remaining two are reserved for
+          compaction summaries or higher-layer hints later. }
+        if Options.CacheEnabled and (Emitted = LastIdx) then
         begin
           CC := MakeCacheControl(Options.CacheTTL);
           ToolObj.PutObject('cache_control', CC);
         end;
         ToolArr.AddObject(ToolObj);
+        Inc(Emitted);
       end;
+
+      { Server-side tools — Claude executes web_search / web_fetch on
+        Anthropic's infrastructure. The tool entries are versioned
+        type strings, not the user-tool name+input_schema shape; no
+        beta header is required for the _20260209 versions. Dynamic
+        filtering of search results activates automatically.
+        See: https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview }
+      if ServerTools.WebSearch then
+      begin
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('type', 'web_search_20260209');
+        ToolObj.PutStr('name', 'web_search');
+        if ServerTools.WebSearchMaxUses > 0 then
+          ToolObj.PutInt('max_uses', ServerTools.WebSearchMaxUses);
+        if Options.CacheEnabled and (Emitted = LastIdx) then
+        begin
+          CC := MakeCacheControl(Options.CacheTTL);
+          ToolObj.PutObject('cache_control', CC);
+        end;
+        ToolArr.AddObject(ToolObj);
+        Inc(Emitted);
+      end;
+      if ServerTools.WebFetch then
+      begin
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('type', 'web_fetch_20260209');
+        ToolObj.PutStr('name', 'web_fetch');
+        if ServerTools.WebFetchMaxUses > 0 then
+          ToolObj.PutInt('max_uses', ServerTools.WebFetchMaxUses);
+        if Options.CacheEnabled and (Emitted = LastIdx) then
+        begin
+          CC := MakeCacheControl(Options.CacheTTL);
+          ToolObj.PutObject('cache_control', CC);
+        end;
+        ToolArr.AddObject(ToolObj);
+        Inc(Emitted);
+      end;
+
       Root.PutArray('tools', ToolArr);
 
       (* tool_choice mapping (Anthropic Messages API):
@@ -374,7 +488,7 @@ var
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1/messages';
-  Body := BuildRequest(Messages, Tools, UseModel, Options);
+  Body := BuildRequest(Messages, Tools, UseModel, Options, FServerTools);
 
   SetLength(Headers, 2);
   Headers[0] := MakeHeader('x-api-key',          FAPIKey);
@@ -556,7 +670,7 @@ begin
   { Force stream:true in the request body. }
   Opts := Options;
   Opts.Stream := True;
-  Body := BuildRequest(Messages, Tools, UseModel, Opts);
+  Body := BuildRequest(Messages, Tools, UseModel, Opts, FServerTools);
   Root := TJsonObject.Parse(Body);
   if Root = nil then
   begin

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -75,6 +75,7 @@ var
   Spec: TProviderSpec;
   Base, Model, APIKey: string;
   RequiresKey: Boolean;
+  ServerTools: TAnthropicServerTools;
 begin
   Provider := nil;
   ErrMsg := '';
@@ -109,7 +110,15 @@ begin
 
   case Spec.Family of
     pfAnthropic:
-      Provider := TAnthropicProvider.Create(APIKey, Base, Model);
+      begin
+        { Translate the operator's Anthropic server-tool toggles into
+          the provider's local record. Picked up in BuildRequest. }
+        ServerTools.WebSearch        := Cfg.AnthropicServerTools.WebSearch;
+        ServerTools.WebSearchMaxUses := Cfg.AnthropicServerTools.WebSearchMaxUses;
+        ServerTools.WebFetch         := Cfg.AnthropicServerTools.WebFetch;
+        ServerTools.WebFetchMaxUses  := Cfg.AnthropicServerTools.WebFetchMaxUses;
+        Provider := TAnthropicProvider.Create(APIKey, Base, Model, ServerTools);
+      end;
     pfOpenAI:
       Provider := TOpenAIProvider.Create(APIKey, Base, Model, Kind, Spec.Auth);
     pfGemini:

--- a/src/tests/anthropic_server_tools_tests.pas
+++ b/src/tests/anthropic_server_tools_tests.pas
@@ -1,0 +1,140 @@
+program anthropic_server_tools_tests;
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Anthropic;
+
+procedure Fail(const Msg, Body: string);
+begin
+  Writeln('FAIL: ' + Msg);
+  Writeln('--- body ---');
+  Writeln(Body);
+  Halt(1);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) = 0 then
+    Fail(Msg + ' (expected to find: ' + Needle + ')', Haystack);
+end;
+
+procedure AssertMissing(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) > 0 then
+    Fail(Msg + ' (did NOT expect: ' + Needle + ')', Haystack);
+end;
+
+function OneUserMessage(const Text: string): TMessageArray;
+begin
+  SetLength(Result, 1);
+  Result[0] := MakeMessage(mrUser, Text);
+end;
+
+function NoUserTools: TToolDefinitionArray;
+begin
+  SetLength(Result, 0);
+end;
+
+function UserTool(const Name, Desc, Schema: string): TToolDefinition;
+begin
+  Result.Name        := Name;
+  Result.Description := Desc;
+  Result.Schema      := Schema;
+end;
+
+procedure TestNoServerTools;
+var
+  Opts: TChatOptions;
+  Body: string;
+begin
+  Opts := DefaultChatOptions;
+  Opts.CacheEnabled := False;
+  Body := BuildRequest(OneUserMessage('hi'), NoUserTools, 'claude-opus-4-7',
+                       Opts, NoAnthropicServerTools);
+  AssertMissing(Body, '"web_search_20260209"', 'no server tools by default');
+  AssertMissing(Body, '"web_fetch_20260209"',  'no server tools by default');
+  AssertMissing(Body, '"tools"',               'no tools key when nothing registered');
+end;
+
+procedure TestServerWebSearchOnly;
+var
+  Opts: TChatOptions;
+  Body: string;
+  ST: TAnthropicServerTools;
+begin
+  Opts := DefaultChatOptions;
+  Opts.CacheEnabled := False;
+  ST := NoAnthropicServerTools;
+  ST.WebSearch := True;
+
+  Body := BuildRequest(OneUserMessage('hi'), NoUserTools, 'claude-opus-4-7',
+                       Opts, ST);
+  AssertContains(Body, '"tools"',                'tools array emitted');
+  AssertContains(Body, '"type" : "web_search_20260209"', 'web_search type id');
+  AssertContains(Body, '"name" : "web_search"',    'web_search name');
+  AssertMissing(Body, '"web_fetch_20260209"',    'web_fetch off when not enabled');
+  AssertMissing(Body, '"max_uses"',              'no max_uses when unset');
+end;
+
+procedure TestServerToolsBoth;
+var
+  Opts: TChatOptions;
+  Body: string;
+  ST: TAnthropicServerTools;
+begin
+  Opts := DefaultChatOptions;
+  Opts.CacheEnabled := False;
+  ST := NoAnthropicServerTools;
+  ST.WebSearch        := True;
+  ST.WebSearchMaxUses := 3;
+  ST.WebFetch         := True;
+  ST.WebFetchMaxUses  := 5;
+
+  Body := BuildRequest(OneUserMessage('hi'), NoUserTools, 'claude-opus-4-7',
+                       Opts, ST);
+  AssertContains(Body, '"type" : "web_search_20260209"', 'web_search type id');
+  AssertContains(Body, '"type" : "web_fetch_20260209"',  'web_fetch type id');
+  AssertContains(Body, '"max_uses" : 3',                  'web_search max_uses');
+  AssertContains(Body, '"max_uses" : 5',                  'web_fetch max_uses');
+end;
+
+procedure TestUserToolNameCollisionDropped;
+var
+  Opts: TChatOptions;
+  Body: string;
+  ST: TAnthropicServerTools;
+  Tools: TToolDefinitionArray;
+begin
+  Opts := DefaultChatOptions;
+  Opts.CacheEnabled := False;
+  ST := NoAnthropicServerTools;
+  ST.WebSearch := True;
+  ST.WebFetch  := True;
+
+  SetLength(Tools, 3);
+  Tools[0] := UserTool('fs_read',    'read a file', '{"type":"object"}');
+  Tools[1] := UserTool('web_search', 'should be dropped', '{"type":"object"}');
+  Tools[2] := UserTool('web_fetch',  'should be dropped', '{"type":"object"}');
+
+  Body := BuildRequest(OneUserMessage('hi'), Tools, 'claude-opus-4-7',
+                       Opts, ST);
+  { fs_read survives, the colliders are dropped, the server entries
+    take their place. The "should be dropped" description proves the
+    user entry was removed — Anthropic would otherwise see two tools
+    named "web_search" and 400. }
+  AssertContains(Body, '"name" : "fs_read"',           'non-colliding user tool kept');
+  AssertContains(Body, '"type" : "web_search_20260209"', 'server web_search emitted');
+  AssertContains(Body, '"type" : "web_fetch_20260209"',  'server web_fetch emitted');
+  AssertMissing(Body, 'should be dropped',           'colliding user tools dropped');
+end;
+
+begin
+  TestNoServerTools;
+  TestServerWebSearchOnly;
+  TestServerToolsBoth;
+  TestUserToolNameCollisionDropped;
+  Writeln('anthropic_server_tools_tests: OK');
+end.

--- a/src/tests/anthropic_server_tools_tests.pas
+++ b/src/tests/anthropic_server_tools_tests.pas
@@ -131,10 +131,58 @@ begin
   AssertMissing(Body, 'should be dropped',           'colliding user tools dropped');
 end;
 
+procedure TestContinuePausedTurnAppendsAssistantBlock;
+const
+  ReqBody  =
+    '{"model":"claude-opus-4-7","max_tokens":8192,' +
+    '"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}';
+  RespBody =
+    '{"id":"msg_1","model":"claude-opus-4-7","stop_reason":"pause_turn",' +
+    '"content":[' +
+      '{"type":"text","text":"searching..."},' +
+      '{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{"query":"CVE.org"}}' +
+    ']}';
+var
+  Next: string;
+begin
+  Next := ContinuePausedTurn(ReqBody, RespBody);
+  if Next = '' then
+    Fail('ContinuePausedTurn returned empty for valid input', RespBody);
+
+  { Original user turn survives. }
+  AssertContains(Next, '"role" : "user"', 'user turn preserved');
+  AssertContains(Next, '"text" : "hi"',   'user text preserved');
+
+  { New assistant turn carries the response content verbatim — both the
+    text block and the server_tool_use block — so Anthropic's server-
+    side loop sees the trailing server_tool_use and resumes. }
+  AssertContains(Next, '"role" : "assistant"', 'assistant turn appended');
+  AssertContains(Next, '"server_tool_use"',    'server_tool_use preserved verbatim');
+  AssertContains(Next, '"srvtoolu_1"',         'server tool id preserved');
+  AssertContains(Next, 'searching',            'in-flight text preserved');
+
+  { Top-level model + max_tokens still present so the body is a valid
+    /v1/messages POST, not just a fragment. }
+  AssertContains(Next, '"max_tokens" : 8192', 'request scaffolding preserved');
+end;
+
+procedure TestContinuePausedTurnHandlesMalformedInput;
+var
+  Next: string;
+begin
+  Next := ContinuePausedTurn('not json',   '{"content":[]}');
+  if Next <> '' then Fail('expected empty result on malformed request body', Next);
+
+  Next := ContinuePausedTurn('{"messages":[]}', 'not json');
+  if Next <> '' then Fail('expected empty result on malformed response body', Next);
+end;
+
 begin
   TestNoServerTools;
   TestServerWebSearchOnly;
   TestServerToolsBoth;
   TestUserToolNameCollisionDropped;
+  TestContinuePausedTurnAppendsAssistantBlock;
+  TestContinuePausedTurnHandlesMalformedInput;
   Writeln('anthropic_server_tools_tests: OK');
 end.


### PR DESCRIPTION
## Summary

When the agent is talking to Claude (Anthropic provider), the request can declare Anthropic's server-side `web_search_20260209` / `web_fetch_20260209` tools. Claude runs the queries / fetches on its own infrastructure and stitches results into the response — no round-trip through PasClaw's tool loop, no SearXNG or curl on the operator's box, no User-Agent bot blocks.

Opt-in via `config.json`:

```json
"anthropic_server_tools": {
  "web_search": true,
  "web_fetch": true,
  "web_search_max_uses": 5
}
```

Off by default — operators with a working local `web_search` provider (SearXNG, Brave, Tavily) keep that path. Other providers (OpenAI, Gemini) ignore the flag entirely; the toggles sit on the Anthropic provider record only.

## Implementation notes

- **GA `_20260209` versions** — no `anthropic-beta` header required; dynamic filtering of search results is built in. Optional `max_uses` bounds how many times Claude may call the tool per turn (0 = Anthropic default).
- **Collision handling.** When a server tool is on, `BuildRequest` drops any user-registered tool whose name collides (`web_search`, `web_fetch`) so the request doesn't 400 with `tools[*].name: duplicate`. This lets an operator flip the flag without separately unregistering the local tool.
- **Cache breakpoint** tracks effective last-tool index so the existing `cache_control` marker stays on the trailing entry whether that's a user tool or a server tool.

## Test plan

- [x] `make test-anthropic-server-tools` — four wire-shape cases (off, search-only, both + max_uses, collision-drop)
- [x] `make smoke` — every top-level CLI command still launches
- [x] Full FPC build clean — no new warnings on touched units
- [ ] Live exercise: set `ANTHROPIC_API_KEY`, flip both flags on in `config.json`, hit `pasclaw agent "what's the latest CVE on CVE.org?"` and confirm Claude runs the search server-side (no local `web_search` log entry, response text references current results)

## Not in this PR (follow-ups)

- `pasclaw onboard` doesn't yet prompt for the toggles — edit `config.json` directly.
- `stop_reason: "pause_turn"` (Anthropic's server-side 10-iteration cap) falls through to `end_turn` semantics. Rare in practice; can wire proper round-trip later if the cap actually bites.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_