### PR TITLE
Fix FPC mojibake at byte-stream boundaries (TagUTF8 codepage retag)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper print-version get-indy webui-res
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag print-version get-indy webui-res
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -232,4 +232,10 @@ test-println-helper: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/println_helper_tests.pas -o$(BUILDDIR)/println_helper_tests
 	@$(BUILDDIR)/println_helper_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper
+# PasClaw.Utils.TagUTF8 — codepage retag at byte-stream boundaries.
+test-utf8-codepage-tag: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/utf8_codepage_tag_tests.pas -o$(BUILDDIR)/utf8_codepage_tag_tests
+	@$(BUILDDIR)/utf8_codepage_tag_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -239,11 +239,20 @@ procedure WriteBodyStream(AResp: TIdHTTPResponseInfo; const Body: string);
 var
   Strm: TMemoryStream;
   Bytes: TBytes;
+  Tagged: string;
 begin
   { Indy's ContentText writer on FPC + UTF-8 doesn't always flush a body
     correctly. ContentStream is the reliable path: encode the string to bytes
-    ourselves, hand Indy a TMemoryStream sized in bytes, and let it stream. }
-  Bytes := TEncoding.UTF8.GetBytes(Body);
+    ourselves, hand Indy a TMemoryStream sized in bytes, and let it stream.
+
+    The TagUTF8 call is defence-in-depth: PasClaw.Providers.HTTP already
+    tags response bodies at the boundary, but anywhere a CP_0 string slips
+    through (an unimported source literal, a third-party path we add later)
+    TEncoding.UTF8.GetBytes would double-encode it via the system codepage.
+    Tagging here keeps the wire bytes honest regardless of upstream tag. }
+  Tagged := Body;
+  TagUTF8(Tagged);
+  Bytes := TEncoding.UTF8.GetBytes(Tagged);
   Strm := TMemoryStream.Create;
   if Length(Bytes) > 0 then
     Strm.WriteBuffer(Bytes[0], Length(Bytes));
@@ -1190,10 +1199,18 @@ const
   CRLF: array[0..1] of Byte = (13, 10);
 var
   Payload, Header, Frame: TBytes;
-  HeaderStr: string;
+  HeaderStr, Tagged: string;
   i, Offset: Integer;
 begin
-  Payload := TEncoding.UTF8.GetBytes(Data);
+  { Same FPC retag the body writer does — without it, a CP_0-tagged
+    Data string (e.g. literal SSE control text like 'data: [DONE]'
+    or fragments built across mixed-codepage concatenations) goes
+    through TEncoding.UTF8.GetBytes assuming system codepage and
+    double-encodes any non-ASCII byte. The chunked SSE path bypasses
+    WriteBodyStream entirely, so it needs its own retag. }
+  Tagged := Data;
+  TagUTF8(Tagged);
+  Payload := TEncoding.UTF8.GetBytes(Tagged);
   if Length(Payload) = 0 then Exit;
   (* HTTP/1.1 chunked-transfer chunk: `<hex-length>\r\n<bytes>\r\n`.
      The response header (set by HandleChatCompletions) carries

--- a/src/pkg/memory/PasClaw.Memory.pas
+++ b/src/pkg/memory/PasClaw.Memory.pas
@@ -89,12 +89,17 @@ end;
 procedure TMemoryLog.WriteLine(const S: string);
 var
   Bytes: TBytes;
+  Tagged: string;
 begin
   if FStream = nil then Exit;
   { Encode UTF-8 bytes explicitly. Writing `Line[1]` directly worked under
     FPC (1-byte AnsiString) but wrote half the bytes under Delphi
-    (2-byte UnicodeString). }
-  Bytes := TEncoding.UTF8.GetBytes(S + #10);
+    (2-byte UnicodeString). TagUTF8 the input under FPC so GetBytes
+    doesn't reinterpret CP_0 bytes through the system codepage and
+    double-encode (see PasClaw.Utils.TagUTF8 doc). }
+  Tagged := S + #10;
+  TagUTF8(Tagged);
+  Bytes := TEncoding.UTF8.GetBytes(Tagged);
   if Length(Bytes) > 0 then
     FStream.WriteBuffer(Bytes[0], Length(Bytes));
 end;

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -149,6 +149,7 @@ function EnsureOpenSSL(out ErrMsg: string): Boolean;
 implementation
 
 uses
+  PasClaw.Utils,
 {$IF Defined(PASCLAW_NETHTTP) and not Defined(FPC)}
   System.Net.URLClient, System.Net.HttpClient;
 {$ELSE}
@@ -333,6 +334,7 @@ begin
                Result.StatusCode, Result.ContentType,
                Result.RespHeaders, Result.ErrorMsg);
     Result.Body := Resp.DataString;
+    TagUTF8(Result.Body);
   finally
     Resp.Free;
     Req.Free;
@@ -362,6 +364,7 @@ begin
                Result.StatusCode, Result.ContentType,
                Result.RespHeaders, Result.ErrorMsg);
     Result.Body := Resp.DataString;
+    TagUTF8(Result.Body);
   finally
     Resp.Free;
     Req.Free;
@@ -389,6 +392,7 @@ begin
                Result.StatusCode, Result.ContentType,
                Result.RespHeaders, Result.ErrorMsg);
     Result.Body := Resp.DataString;
+    TagUTF8(Result.Body);
   finally
     Resp.Free;
     C.Free;
@@ -427,6 +431,7 @@ begin
                Result.StatusCode, Result.ContentType,
                Result.RespHeaders, Result.ErrorMsg);
     Result.Body := Resp.DataString;
+    TagUTF8(Result.Body);
     if (Adapter <> nil) and Adapter.Rejected then
     begin
       Result.ErrorMsg    := Adapter.RejectReason;
@@ -465,6 +470,7 @@ begin
                Result.StatusCode, Result.ContentType,
                Result.RespHeaders, Result.ErrorMsg);
     Result.Body := Resp.DataString;
+    TagUTF8(Result.Body);
   finally
     Resp.Free;
     Req.Free;
@@ -627,6 +633,7 @@ begin
         Http.Get(URL, Resp);
       Result.StatusCode := Http.ResponseCode;
       Result.Body := Resp.DataString;
+      TagUTF8(Result.Body);
       Result.ContentType := LowerCase(Http.Response.ContentType);
       CaptureIndyHeaders(Http, Result.RespHeaders);
     except
@@ -634,6 +641,7 @@ begin
       begin
         Result.StatusCode := E.ErrorCode;
         Result.Body       := E.ErrorMessage;
+        TagUTF8(Result.Body);
         Result.ContentType := LowerCase(Http.Response.ContentType);
         Result.ErrorMsg   := E.Message;
         CaptureIndyHeaders(Http, Result.RespHeaders);
@@ -642,6 +650,7 @@ begin
       begin
         Result.StatusCode := Http.ResponseCode;
         Result.Body       := Resp.DataString;
+        TagUTF8(Result.Body);
         Result.ContentType := LowerCase(Http.Response.ContentType);
         Result.ErrorMsg   := E.Message;
         CaptureIndyHeaders(Http, Result.RespHeaders);
@@ -781,17 +790,20 @@ begin
       Http.Put(URL, Req, Resp);
       Result.StatusCode := Http.ResponseCode;
       Result.Body       := Resp.DataString;
+      TagUTF8(Result.Body);
     except
       on E: EIdHTTPProtocolException do
       begin
         Result.StatusCode := E.ErrorCode;
         Result.Body       := E.ErrorMessage;
+        TagUTF8(Result.Body);
         Result.ErrorMsg   := E.Message;
       end;
       on E: Exception do
       begin
         Result.StatusCode := Http.ResponseCode;
         Result.Body       := Resp.DataString;
+        TagUTF8(Result.Body);
         Result.ErrorMsg   := E.Message;
       end;
     end;

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -27,7 +27,45 @@ procedure WriteFileText(const Path, Content: string);
 function SplitToList(const S: string; Sep: Char): TStringList;
 function NowIsoUtc: string;
 
+(* Tag S as carrying CP_UTF8 bytes without rewriting them. No-op on
+   Delphi (string = UnicodeString, codepages don't apply) and on any
+   platform where the string is empty.
+
+   Why this exists. Under FPC {$MODE DELPHI}, `string` is still
+   `AnsiString` (1-byte elements) — it carries a codepage tag.
+   Strings produced by `TStringStream(... TEncoding.UTF8).DataString`,
+   by `Indy` response reads, and by `fpjson`'s `.Get('field', '')`
+   path come out tagged **CP_NONE / 0 (system default)**, even though
+   their bytes are valid UTF-8. Downstream code that does
+   codepage-aware conversion — `TEncoding.UTF8.GetBytes(s)`,
+   string-concat across mismatched codepages, AnsiString-aware
+   I/O — sees the system tag, interprets the UTF-8 bytes as the
+   system codepage (CP1252 on Windows), and re-encodes to UTF-8.
+   Result: classic mojibake on the wire and in the terminal —
+   `é` (UTF-8 `C3 A9`) becomes `Ã©` (`C3 83 C2 A9`).
+
+   Calling TagUTF8 at every boundary where bytes enter the program
+   (HTTP response read, file read, env var, JSON parse output) keeps
+   the tag honest. The bytes themselves are untouched — only the
+   `StringCodePage(s)` metadata flips from 0 → 65001. *)
+procedure TagUTF8(var S: string); inline;
+
 implementation
+
+procedure TagUTF8(var S: string);
+begin
+  if S = '' then Exit;
+  {$IFDEF FPC}
+  { SetCodePage with Convert=False retags the AnsiString in place
+    without touching the underlying bytes — exactly the boundary
+    behaviour we want. Convert=True would re-encode through the
+    current tag's codepage and corrupt anything already-UTF-8 that
+    was mis-tagged as CP_0; we do NOT want that. }
+  SetCodePage(RawByteString(S), CP_UTF8, False);
+  {$ENDIF}
+  { Delphi modern: string = UnicodeString, no codepage tag —
+    nothing to do, the inline compiler will collapse the call. }
+end;
 
 function DupStr(const S: string; Count: Integer): string;
 var
@@ -141,10 +179,12 @@ begin
   try
     SetLength(Bytes, Strm.Size);
     if Strm.Size > 0 then Strm.ReadBuffer(Bytes[0], Strm.Size);
-    { TEncoding.UTF8.GetString round-trips correctly in both FPC and Delphi:
-      under FPC the result is AnsiString-UTF8; under Delphi it's UnicodeString
-      decoded from the UTF-8 bytes. }
     Result := TEncoding.UTF8.GetString(Bytes);
+    { Under FPC, TEncoding.UTF8.GetString returns AnsiString carrying
+      CP_0 (system default) — the bytes are UTF-8 but the tag isn't.
+      Retag at the boundary so downstream code that calls
+      TEncoding.UTF8.GetBytes on this string doesn't double-encode. }
+    TagUTF8(Result);
   finally
     Strm.Free;
   end;
@@ -154,13 +194,19 @@ procedure WriteFileText(const Path, Content: string);
 var
   Strm: TFileStream;
   Bytes: TBytes;
+  Tagged: string;
 begin
   EnsureDir(ExtractFilePath(Path));
   Strm := TFileStream.Create(Path, fmCreate);
   try
     if Content <> '' then
     begin
-      Bytes := TEncoding.UTF8.GetBytes(Content);
+      { Retag before GetBytes — see PasClaw.Utils.TagUTF8 doc.
+        Without this, FPC interprets a CP_0 Content as the system
+        codepage and double-encodes any non-ASCII to UTF-8 on disk. }
+      Tagged := Content;
+      TagUTF8(Tagged);
+      Bytes := TEncoding.UTF8.GetBytes(Tagged);
       Strm.WriteBuffer(Bytes[0], Length(Bytes));
     end;
   finally

--- a/src/tests/utf8_codepage_tag_tests.pas
+++ b/src/tests/utf8_codepage_tag_tests.pas
@@ -1,0 +1,116 @@
+program utf8_codepage_tag_tests;
+(*
+  Proves the FPC UTF-8 codepage-tag fix that lives in
+  PasClaw.Utils.TagUTF8.
+
+  Under FPC mode delphi, `string` is AnsiString with a codepage tag.
+  Strings produced by TStringStream(... TEncoding.UTF8).DataString
+  carry CP_0 (system default) but their bytes are valid UTF-8. The
+  bug: any downstream TEncoding.UTF8.GetBytes() on that CP_0 string
+  reinterprets the bytes as the system codepage (CP1252 on Windows)
+  and re-encodes to UTF-8 — classic double-encoding mojibake
+  (`é` 2 bytes -> `Ã©` 4 bytes).
+
+  TagUTF8 retags in place without rewriting bytes, so the round-trip
+  through TEncoding.UTF8 is now lossless.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils, Classes,
+  PasClaw.Utils;
+
+procedure Fail(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertEqual(Got, Want: Integer; const Msg: string);
+begin
+  if Got <> Want then
+    Fail(Msg + ' (got ' + IntToStr(Got) + ', want ' + IntToStr(Want) + ')');
+end;
+
+procedure AssertBytesEqual(const Got, Want: TBytes; const Msg: string);
+var
+  i: Integer;
+begin
+  if Length(Got) <> Length(Want) then
+    Fail(Msg + Format(' (len got=%d want=%d)', [Length(Got), Length(Want)]));
+  for i := 0 to High(Got) do
+    if Got[i] <> Want[i] then
+      Fail(Msg + Format(' (byte[%d] got=%.2x want=%.2x)', [i, Got[i], Want[i]]));
+end;
+
+procedure TestTagOnDataString;
+{ The exact path PasClaw.Providers.HTTP.DoRequest used to take —
+  TStringStream(UTF8) -> DataString -> assign to result body. The
+  bytes ARE correct UTF-8 here (we wrote them), but on FPC the
+  resulting string is CP_0 until TagUTF8 runs. }
+var
+  S: TStringStream;
+  Body: string;
+  Cafe: TBytes;
+begin
+  Cafe := TBytes.Create($63, $61, $66, $C3, $A9);  { c a f UTF-8(é) }
+  S := TStringStream.Create('', TEncoding.UTF8);
+  try
+    S.WriteBuffer(Cafe[0], Length(Cafe));
+    Body := S.DataString;
+  finally
+    S.Free;
+  end;
+
+  {$IFDEF FPC}
+  { On FPC the smoking-gun symptom: codepage tag is 0, not 65001. }
+  AssertEqual(StringCodePage(Body), 0,
+              'pre-tag: AnsiString from DataString carries CP_0');
+  TagUTF8(Body);
+  AssertEqual(StringCodePage(Body), CP_UTF8,
+              'post-tag: TagUTF8 retags AnsiString to CP_UTF8');
+  {$ENDIF}
+
+  { Bytes are unchanged either way — the fix is metadata-only. }
+  AssertEqual(Length(Body), Length(Cafe), 'byte length preserved');
+  AssertBytesEqual(BytesOf(Body), Cafe,    'byte content preserved');
+end;
+
+procedure TestRoundTripThroughEncoding;
+{ The actual bug: PasClaw.Gateway.Server.WriteBodyStream calls
+  TEncoding.UTF8.GetBytes(Body) to put the bytes on the wire. With
+  Body tagged CP_0 under FPC, GetBytes interprets the UTF-8 bytes as
+  CP_1252 and re-encodes — that's the double-encode that produces
+  Ã© on the wire. With TagUTF8 applied first, GetBytes sees the
+  correct tag and returns the bytes unchanged. }
+var
+  Body: string;
+  Cafe, Wire: TBytes;
+begin
+  Cafe := TBytes.Create($63, $61, $66, $C3, $A9);
+  SetLength(Body, Length(Cafe));
+  Move(Cafe[0], Body[1], Length(Cafe));
+
+  TagUTF8(Body);
+  Wire := TEncoding.UTF8.GetBytes(Body);
+  AssertBytesEqual(Wire, Cafe,
+                   'TEncoding.UTF8.GetBytes(tagged) is lossless — no double-encoding');
+end;
+
+procedure TestEmptyStringNoOp;
+var
+  Empty: string;
+begin
+  Empty := '';
+  TagUTF8(Empty);
+  AssertEqual(Length(Empty), 0, 'empty string stays empty');
+end;
+
+begin
+  TestTagOnDataString;
+  TestRoundTripThroughEncoding;
+  TestEmptyStringNoOp;
+  WriteLn('utf8_codepage_tag_tests: OK');
+end.


### PR DESCRIPTION
## TL;DR

PR #147 fixed the wrong layer. The console-output sweep was patching a symptom. The actual mojibake (`é → Ã©` in TUI and web UI) is upstream: under FPC `{$MODE DELPHI}`, strings returned by `TStringStream(... TEncoding.UTF8).DataString`, Indy response reads, and file reads come back with `StringCodePage = 0` (system default) even though their bytes are valid UTF-8. Anything that downstream calls `TEncoding.UTF8.GetBytes` on those strings — gateway response writer, SSE streamer, file writes, memory log — interprets the bytes as the system codepage (CP1252 on Windows) and re-encodes to UTF-8. Double-encode → mojibake.

That's why the same corruption showed up in **both** the TUI and the web UI: the output layer wasn't the source. Both paths were consuming already-corrupted bytes.

## Direct probe

```pascal
Bytes := TBytes.Create($63, $61, $66, $C3, $A9);   { "café" UTF-8 }
S := TStringStream.Create('', TEncoding.UTF8);
S.WriteBuffer(Bytes[0], 5);
Body := S.DataString;
StringCodePage(Body)  =>  0   { not 65001 }
```

The bytes are correct, the **tag** is wrong. Subsequent `TEncoding.UTF8.GetBytes(Body)` treats `C3 A9` as CP1252 (`Ã©`) and re-encodes as 4 UTF-8 bytes. That's the bug.

## Fix

One-line in-place retag at every boundary where external bytes enter:

```pascal
procedure TagUTF8(var S: string); inline;
begin
  if S = '' then Exit;
  {$IFDEF FPC}
  SetCodePage(RawByteString(S), CP_UTF8, False);  { no convert — bytes unchanged }
  {$ENDIF}
end;
```

No-op on Delphi proper (`string = UnicodeString`, codepages don't apply). On FPC mode delphi, retags the `AnsiString` in place without touching the underlying bytes.

## Boundaries retagged

- **`PasClaw.Providers.HTTP`** — every `Result.Body := Resp.DataString` site in `PostJSON` / `PutJSON` / `GetJSONURL` / `GetURL` / `PostRaw` / `DoRequest`, including exception-handler bodies that surface server error text.
- **`PasClaw.Utils.ReadFileText`** — bytes read from disk via `TEncoding.UTF8.GetString` come back CP_0; retag at the boundary.
- **`PasClaw.Utils.WriteFileText`** — retag input before `TEncoding.UTF8.GetBytes` to disk.
- **`PasClaw.Memory.WriteLine`** — session log writes.
- **`PasClaw.Gateway.Server.WriteBodyStream`** — defence-in-depth on the HTTP-response writer.
- **`PasClaw.Gateway.Server.TSSEStreamer.WriteRaw`** — same, for the SSE chunked-transfer path that bypasses `WriteBodyStream`.

## What's NOT touched

Source-literal path — non-ASCII string literals in `.pas` files (e.g. `✓` in `Cmd.Model`) get the correct tag from the file's UTF-8 BOM / lack-of-codepage-directive interaction, which appears to be working in practice. If a regression surfaces, the targeted fix is `{$CODEPAGE UTF8}` at the top of the affected unit, not a global sweep.

## Test plan

New file: `src/tests/utf8_codepage_tag_tests.pas`

- [x] `TestTagOnDataString` — reproduces the exact failing path (TStringStream + TEncoding.UTF8 → DataString → assign); asserts `StringCodePage = 0` before, `CP_UTF8` after.
- [x] `TestRoundTripThroughEncoding` — the smoking gun: tagged string round-trips through `TEncoding.UTF8.GetBytes` losslessly. Before this fix, this assertion would fail with double-encoded bytes.
- [x] `TestEmptyStringNoOp` — `TagUTF8('')` is safe.
- [x] `make test-anthropic-server-tools` / `make test-openai-server-tools` / `make test-println-helper` — all unchanged, OK.
- [x] `make smoke` — all 11 commands pass.
- [ ] Live exercise on Windows: hit a Claude model with a French/Cyrillic/CJK prompt and confirm the response renders correctly in both `pasclaw tui` and the gateway web UI (this is the one we can't automate; needs a Windows box with cmd.exe + a browser).

## Note on PR #147

The output-layer helpers from #147 (`Print` / `PrintLn` / `WriteConsoleW` fallback) are independently correct on Windows + Delphi — that path's RTL codepage trap is real. But the mojibake the user was seeing wasn't coming from that layer; it was coming from this one. Keeping #147 as a defence-in-depth measure for output is fine; this PR fixes the actual upstream source.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_