### PR TITLE
Fix banner mojibake: tag CliUI source as UTF-8 ({$CODEPAGE UTF8})

### DIFF
--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -6,6 +6,33 @@ unit PasClaw.CliUI;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{ Source-codepage directive. Tells the compiler the bytes in this .pas
+  file are UTF-8 — so non-ASCII string literals (banner box-drawing
+  glyphs ██╔═, panel chars ┌─┐, the ✓ in onboarding output) are
+  stored as UTF-8 bytes tagged CP_UTF8 in AnsiString constants.
+
+  Without this directive, FPC interprets the source as the system
+  codepage (UTF-8 on Linux, CP1252 on Windows). On Windows, each UTF-8
+  byte of `█` (E2 96 88) becomes a separate AnsiChar tagged CP1252;
+  at runtime the output path transcodes those bytes through CP1252 →
+  UTF-8 and double-encodes the glyph — classic banner mojibake.
+
+  Other source files don't (yet) get this directive because they only
+  use ASCII in their string literals; if more non-ASCII glyphs migrate
+  into onboarding / status / vault / etc. output, add the directive
+  there too. }
+{$CODEPAGE UTF8}
+{$IFDEF FPC}
+  { Silence the AnsiString↔UnicodeString implicit-conversion warnings
+    the directive introduces on PrintLn(Ansi.BoldBlue + L1 + ...) —
+    Ansi.* fields are AnsiString CP_0, the L1 literal becomes
+    AnsiString CP_UTF8, FPC promotes to UnicodeString to concat, then
+    back to AnsiString for the parameter. The byte content is correct
+    throughout (verified by the banner-bytes round-trip test); the
+    warnings are noise. }
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 


### PR DESCRIPTION
## Summary

You were right — PRs #147 and #148 fixed adjacent symptoms, not the banner. The PASCLAW box-drawing banner lives in a **single file** (`src/pkg/cliui/PasClaw.CliUI.pas`) and doesn't touch HTTP, JSON, or LLM responses. The mojibake there points at **compile-time source-file encoding**, not runtime output.

## Diagnosis

Without `{$CODEPAGE UTF8}`, FPC reads source bytes in the system default codepage.

- **Linux**: system codepage = UTF-8. Works *by accident* — the literal stores the raw UTF-8 bytes as `CP_0`-tagged `AnsiString` and the terminal interprets them as UTF-8.
- **Windows**: system codepage = CP1252. Each byte of `█` (`E2 96 88`) becomes a separate `AnsiChar` tagged CP1252. At output time the runtime transcodes CP1252 → UTF-8 and **double-encodes every glyph**. Classic banner mojibake.

`{$CODEPAGE UTF8}` tells FPC: the bytes in this file *are* UTF-8. Literals are stored verbatim and tagged CP_UTF8. Output transcodes CP_UTF8 → CP_UTF8 (no-op), so what arrives at the terminal is exactly what's in the source. Delphi modern (XE+) accepts the same directive identically.

## Why only one file

Only `CliUI.pas` has non-ASCII string literals that flow through `PrintLn` (banner `██╔═`, panel chars `┌─┐`). If more non-ASCII glyphs ever migrate into other surfaces (Onboard `✓`, Vault search panels), the directive lands there too — same one-line change.

## Test plan

- [x] `make` — 1 note, 0 new warnings on CliUI (the directive's implicit-cast warnings are silenced locally — see commit body for why)
- [x] Banner byte dump on Linux+FPC — `e2 96 88` (correct UTF-8 for `█`), unchanged from before, confirms Linux didn't regress
- [x] `make smoke` — all 11 commands OK
- [ ] **Live verify on Windows**: run `pasclaw version` (or anything that triggers `PrintBanner`) on `cmd.exe` / Windows Terminal under FPC build. Bytes coming out should be the same UTF-8 you'd see on Linux. The console renderer takes it from there.

## Note on PRs #147 / #148

Those PRs addressed real issues elsewhere in the stack (Windows + Delphi `WriteLn` codepage trap in #147, FPC `StringCodePage=0` after `TStringStream.DataString` in #148) but the **banner** wasn't going through either of those paths. This is the missing piece for that specific symptom.

If LLM-response mojibake is still happening after merging this, that's a separate path — likely still in the byte-stream boundary territory of #148, but possibly somewhere else (channel writers, fpjson serialise-back-out). Happy to dig further once you confirm the banner is fixed.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_