### PR TITLE
CliUI: UTF-8 BOM + FPC $CODEPAGE for banner mojibake

### DIFF
--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   PasClaw.CliUI - terminal colour handling, banner, help/error rendering.
   Mirrors cmd/picoclaw/internal/cliui in picoclaw.
 }
@@ -6,6 +6,19 @@ unit PasClaw.CliUI;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  { File has a UTF-8 BOM (Delphi auto-detects it). FPC also honours the
+    BOM, but additionally needs $CODEPAGE UTF8 so string literals are
+    stored as AnsiString CP_UTF8 — without it FPC stores them as
+    UnicodeString and the implicit conversions on PrintLn(Ansi.X + L +
+    Ansi.Reset) become 6 warnings per banner line. dcc64 has no
+    equivalent directive (E1030 "Invalid compiler directive: 'CODEPAGE'");
+    Delphi reads the source as UTF-8 from the BOM and the literals
+    become UnicodeString naturally. }
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 


### PR DESCRIPTION
## Why this is different from the reverted #149

PR #149 used `{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}` alone. That's a no-op for Delphi — `dcc64` has no `$CODEPAGE` directive (it errors with E1030 if it sees one). Delphi still read `CliUI.pas` as the current ANSI codepage (CP1252 on English Windows) when there was no BOM, turning each UTF-8 byte of `█` (`E2 96 88`) into 3 separate CP1252-mapped UnicodeChars (`â–ˆ`). Hence the banner kept mojibaking with `build-delphi.bat`.

## Why `banner_in_demo_app.dpr` worked under Delphi but PasClaw didn't

Best guess: the user's editor / IDE added a UTF-8 BOM to the standalone on save (the file I sent had no BOM — verified). On their disk, the standalone became BOM-ful, PasClaw stayed BOM-less, and modern Delphi reads the BOM-ful one as UTF-8 and the BOM-less one as CP1252.

## Fix

**UTF-8 BOM on `CliUI.pas`.** Modern Delphi (XE+) auto-detects the BOM and reads the source as UTF-8 regardless of project setting. msbuild + .dproj honours it the same as direct dcc64.

Kept `{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}` so FPC stores literals as `AnsiString` CP_UTF8 — without the directive, BOM alone makes FPC store them as `UnicodeString`, which produces 6 "AnsiString → UnicodeString" warnings per banner line on the `PrintLn(Ansi.X + L + Ansi.Reset)` concatenation. `$WARN IMPLICIT_STRING_CAST OFF` / `IMPLICIT_STRING_CAST_LOSS OFF` silence the remaining noise from `Ansi.*` fields (which carry the unit's default codepage tag) concatenating with the now-CP_UTF8 literals.

## Verified

- [x] FPC Linux build clean (501 lines, 0 new CliUI warnings)
- [x] Banner bytes round-trip: `e2 96 88 e2 96 88 ...` (U+2588 FULL BLOCK)
- [ ] Delphi Windows build via `build-delphi.bat` — you (only you can do this)

## Scope

Just `CliUI.pas`. Other source files have non-ASCII literals (`✓` markers, `╔` / `╗` panel chars, `é` in comments), and if those mojibake on Windows we can sweep them with the same 4-line preamble. I'm doing one-file-at-a-time so we can verify the approach before going broad.

## If the banner still mojibakes after this

The byte-level cause was something else, and we need to dig further:
- check `pasclaw.exe`'s embedded resources for source-encoding hints
- check whether `WriteConsoleW` is actually being called (vs. the `WriteFile` fallback path)
- run `pasclaw version 2>&1 | certutil -encodehex -` and share the hex dump so I can read the actual bytes coming out of your build

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_