### PR TITLE
UTF-8 BOM + $CODEPAGE sweep for user-facing text surfaces (37 files)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   Agent — chat with the assistant.
 
   Two modes:
@@ -11,6 +11,11 @@
 unit PasClaw.Cmd.Agent;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Auth.pas
+++ b/src/cmd/PasClaw.Cmd.Auth.pas
@@ -1,7 +1,12 @@
-{ Auth — login/logout/status for configured providers. }
+﻿{ Auth — login/logout/status for configured providers. }
 unit PasClaw.Cmd.Auth;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Cron.pas
+++ b/src/cmd/PasClaw.Cmd.Cron.pas
@@ -1,7 +1,12 @@
-{ Cron — list/add/disable/enable/remove scheduled tasks. Real scheduler in Phase 5. }
+﻿{ Cron — list/add/disable/enable/remove scheduled tasks. Real scheduler in Phase 5. }
 unit PasClaw.Cmd.Cron;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   Gateway - starts the HTTP gateway, and optionally the Telegram channel
   alongside it. Blocks until SIGINT / Ctrl-C, then shuts down cleanly.
 
@@ -11,6 +11,11 @@
 unit PasClaw.Cmd.Gateway;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -1,7 +1,12 @@
-{ MCP — list/add/remove/edit/test/show MCP server entries in config. }
+﻿{ MCP — list/add/remove/edit/test/show MCP server entries in config. }
 unit PasClaw.Cmd.MCP;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Model.pas
+++ b/src/cmd/PasClaw.Cmd.Model.pas
@@ -1,7 +1,12 @@
-{ Model — view or switch the default model. }
+﻿{ Model — view or switch the default model. }
 unit PasClaw.Cmd.Model;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   Onboard — initialise config and workspace. Creates ~/.pasclaw, a
   starter config.json, and walks the user through picking a provider
   from the catalog (PasClaw.Providers.Catalog). Selection by number
@@ -10,6 +10,11 @@
 unit PasClaw.Cmd.Onboard;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Post.pas
+++ b/src/cmd/PasClaw.Cmd.Post.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   Post - send a message to a configured channel from the command line.
   Useful for cron jobs and skills.
 
@@ -20,6 +20,11 @@ unit PasClaw.Cmd.Post;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   PasClaw.Cmd.Root - root command dispatcher, equivalent to NewPicoclawCommand()
   in cmd/picoclaw/main.go. Each subcommand exposes a CmdSpec record and a
   Run() function; we route argv[1] to the matching command.
@@ -7,6 +7,11 @@ unit PasClaw.Cmd.Root;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   serve - Start the OpenAI-compatible API server.
 
     pasclaw serve                         # default bind/port from config
@@ -24,6 +24,11 @@
 unit PasClaw.Cmd.Serve;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Session.pas
+++ b/src/cmd/PasClaw.Cmd.Session.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Cmd.Session — list / show / delete / export persistent
   conversation sessions stored under
   $PASCLAW_HOME/workspace/sessions/.
@@ -12,6 +12,11 @@ unit PasClaw.Cmd.Session;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -1,4 +1,4 @@
-{ Skills — list / install / remove / search skill extensions.
+﻿{ Skills — list / install / remove / search skill extensions.
 
   install accepts three target shapes (in this dispatch order):
 
@@ -28,6 +28,11 @@
 unit PasClaw.Cmd.Skills;
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Steer.pas
+++ b/src/cmd/PasClaw.Cmd.Steer.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Cmd.Steer — push a follow-up message into a running
   agent's mid-loop steering queue. Mirrors picoclaw's `steer`
   subcommand and nanobot's _inject_pending side-channel.
@@ -20,6 +20,11 @@ unit PasClaw.Cmd.Steer;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Update.pas
+++ b/src/cmd/PasClaw.Cmd.Update.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   Update - self-update over GitHub releases.
 
     pasclaw update              # check + download + install
@@ -9,6 +9,11 @@ unit PasClaw.Cmd.Update;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/cmd/PasClaw.Cmd.Vault.pas
+++ b/src/cmd/PasClaw.Cmd.Vault.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Cmd.Vault — `pasclaw vault <search|show|install>`.
 
     pasclaw vault search <query> [--limit N]
@@ -22,6 +22,11 @@ unit PasClaw.Cmd.Vault;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/channels/PasClaw.Channels.Email.pas
+++ b/src/pkg/channels/PasClaw.Channels.Email.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Channels.Email - bidirectional email channel.
 
   Outbound: TIdSMTP — sends a text/plain message to a recipient with
@@ -35,6 +35,11 @@ unit PasClaw.Channels.Email;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/channels/PasClaw.Channels.IRC.pas
+++ b/src/pkg/channels/PasClaw.Channels.IRC.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Channels.IRC - IRC bot client wrapping Indy's TIdIRC.
 
   Connects to a single server, joins a single channel (extending to
@@ -46,6 +46,11 @@ unit PasClaw.Channels.IRC;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Channels.LINE - LINE Messaging API client.
 
   Two surfaces:
@@ -32,6 +32,11 @@ unit PasClaw.Channels.LINE;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/channels/PasClaw.Channels.Matrix.pas
+++ b/src/pkg/channels/PasClaw.Channels.Matrix.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Channels.Matrix - Matrix client/server bot.
 
   Federated, self-hostable, no token-vendor lock-in. The bot is a
@@ -41,6 +41,11 @@ unit PasClaw.Channels.Matrix;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Channels.Telegram - long-polling Telegram bot adapter.
 
   Uses PasClaw.Providers.HTTP to call the Bot API. No webhook needed - getUpdates with a
@@ -12,6 +12,11 @@ unit PasClaw.Channels.Telegram;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Channels.WhatsApp - WhatsApp Cloud API (Meta).
 
   Two surfaces, matching the LINE shape:
@@ -45,6 +45,11 @@ unit PasClaw.Channels.WhatsApp;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -24,6 +24,11 @@ unit PasClaw.Gateway.Server;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Gateway.ToolView - human-readable summaries of tool activity for
   the streaming /v1/chat/completions endpoint.
 
@@ -19,6 +19,11 @@ unit PasClaw.Gateway.ToolView;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   PasClaw.MCP.Bridge - register MCP tools into the PasClaw tool registry
   so the agent loop can invoke them transparently. Tools are namespaced
   "<server>__<tool>" to avoid clashes with built-ins or between servers.
@@ -40,6 +40,11 @@ unit PasClaw.MCP.Bridge;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/mcp/PasClaw.MCP.Catalog.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Catalog.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.MCP.Catalog - hand-curated catalogue of public remote MCP
   servers, so `pasclaw mcp install <name>` can wire one up without
   the user having to look up the URL + auth-header shape themselves.
@@ -34,6 +34,11 @@ unit PasClaw.MCP.Catalog;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/mcp/PasClaw.MCP.Hub.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Hub.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.MCP.Hub — pasclaw.dev MCP registry client + the resolver
   that prefers hub entries over the built-in 5-entry catalog with a
   fast offline fallback.
@@ -33,6 +33,11 @@ unit PasClaw.MCP.Hub;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/mcp/PasClaw.MCP.OAuth.pas
+++ b/src/pkg/mcp/PasClaw.MCP.OAuth.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.MCP.OAuth - OAuth 2.1 + PKCE flow for remote MCP servers
   that follow the MCP Authorization spec
   (https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization).
@@ -42,6 +42,11 @@ unit PasClaw.MCP.OAuth;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/skills/PasClaw.Skills.ClawHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.ClawHub.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Skills.ClawHub - install / search skills from the public
   ClawHub registry (https://clawhub.ai), the slug-based hub that
   picoclaw and nanobot standardised on.
@@ -44,6 +44,11 @@ unit PasClaw.Skills.ClawHub;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/skills/PasClaw.Skills.GitHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.GitHub.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Skills.GitHub - install a skill from a GitHub repository.
 
   Surface:
@@ -57,6 +57,11 @@ unit PasClaw.Skills.GitHub;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/skills/PasClaw.Skills.PasClawHub.pas
+++ b/src/pkg/skills/PasClaw.Skills.PasClawHub.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Skills.PasClawHub — install / search skills from the
   pasclaw.dev hub, the first-party registry that PasClaw checks
   before falling through to clawhub.ai.
@@ -41,6 +41,11 @@ unit PasClaw.Skills.PasClawHub;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Tools.FS - built-in filesystem tools: fs_read, fs_write, fs_list,
   fs_edit_hashline, fs_grep. Every path argument is fed through
   PasClaw.Tools.Sandbox before the underlying file operation runs;
@@ -17,6 +17,11 @@ unit PasClaw.Tools.FS;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Tools.Memory - registers the memory_search tool.
 
   Workflow (openclaw-style):
@@ -21,6 +21,11 @@ unit PasClaw.Tools.Memory;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Tools.Sandbox - tool-side enforcement for the workspace
   boundary and shell denylist documented in TSandboxPolicy
   (PasClaw.Config).
@@ -67,6 +67,11 @@ unit PasClaw.Tools.Sandbox;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   PasClaw.Tools.ToolLoop - the core agent loop. Repeatedly calls the LLM
   with the running message history; if the response contains tool_calls,
   dispatches each through the registry, appends the tool result as a tool
@@ -8,6 +8,11 @@ unit PasClaw.Tools.ToolLoop;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tools/PasClaw.Tools.Vault.pas
+++ b/src/pkg/tools/PasClaw.Tools.Vault.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Tools.Vault — registers the vault_search and vault_get
   tools, which let the agent discover Object Pascal source code
   (samples, components, libraries) in the pasclaw.dev Code Vault.
@@ -23,6 +23,11 @@ unit PasClaw.Tools.Vault;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.Tools.WebFetch - registers the web_fetch tool.
 
   Fetches an arbitrary HTTP/HTTPS URL with TIdHTTP, follows redirects
@@ -30,6 +30,11 @@ unit PasClaw.Tools.WebFetch;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   PasClaw.TUI - terminal UI for `pasclaw tui`.
 
   Two implementations behind the same TTUI class shape:
@@ -28,6 +28,11 @@ unit PasClaw.TUI;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 


### PR DESCRIPTION
## Summary

Apply the same UTF-8 BOM + `{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}` preamble that fixed the PASCLAW banner (#151) to every other user-facing source file with non-ASCII bytes inside string literals.

**Scope: 37 files** across `cmd/`, `channels/`, `gateway/`, `mcp/`, `skills/`, `tools/`, `tui/`. Identified by grep'ing for `'[^']*[^\x00-\x7F][^']*'` (non-ASCII byte inside single-quoted text) and filtering to directories that emit text to the user.

**Excluded**: pure-comment-only non-ASCII (em-dash in doc blocks, e.g. some lib units like `PasClaw.JSON.pas`, `PasClaw.Identity.pas`). Those bytes never reach a user-visible surface.

## Preamble (identical per file, same as PR #151)

```pascal
{$IFDEF FPC}
  {$CODEPAGE UTF8}
  {$WARN IMPLICIT_STRING_CAST OFF}
  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
{$ENDIF}
```

Plus a UTF-8 BOM (`EF BB BF`) at byte 0 of each file. Delphi auto-detects the BOM and reads the source as UTF-8 regardless of project setting — fixing the CP1252 misinterpretation that was turning each UTF-8 byte of `✓` (`E2 9C 93`) or `╗` (`E2 95 97`) into three separate CP1252 codepoints under `build-delphi.bat`.

## Verified Linux+FPC

- [x] Full rebuild clean (18705 lines, 0 new warnings on swept files — the silences work as intended)
- [x] `make smoke` — all 11 commands OK
- [x] Banner bytes still `e2 96 88 ...` for U+2588 (no regression)
- [ ] Delphi Windows build via `build-delphi.bat` — only you can do this. Run any of `pasclaw onboard`, `pasclaw model show` (has `✓`), `pasclaw vault search foo` and check that the status markers + box-drawing chars render correctly.

## Files swept (37)

- `src/cmd/PasClaw.Cmd.{Agent,Auth,Cron,Gateway,MCP,Model,Onboard,Post,Root,Serve,Session,Skills,Steer,Update,Vault}.pas`
- `src/pkg/channels/PasClaw.Channels.{Email,IRC,LINE,Matrix,Telegram,WhatsApp}.pas`
- `src/pkg/gateway/PasClaw.Gateway.{Server,ToolView}.pas`
- `src/pkg/mcp/PasClaw.MCP.{Bridge,Catalog,Hub,OAuth}.pas`
- `src/pkg/skills/PasClaw.Skills.{ClawHub,GitHub,PasClawHub}.pas`
- `src/pkg/tools/PasClaw.Tools.{FS,Memory,Sandbox,ToolLoop,Vault,WebFetch}.pas`
- `src/pkg/tui/PasClaw.TUI.pas`

Diff is large but mechanical — same six-line change per file. Reviewing one canonical change pattern (any file) covers all 37.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_