### PR TITLE
Gemini: strip JSON-Schema fields the API rejects + bump default to 3.5-flash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,4 +238,10 @@ test-utf8-codepage-tag: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/utf8_codepage_tag_tests.pas -o$(BUILDDIR)/utf8_codepage_tag_tests
 	@$(BUILDDIR)/utf8_codepage_tag_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag
+# Gemini provider — JSON Schema scrub for additionalProperties etc.
+test-gemini-schema-strip: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/gemini_schema_strip_tests.pas -o$(BUILDDIR)/gemini_schema_strip_tests
+	@$(BUILDDIR)/gemini_schema_strip_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -59,6 +59,7 @@ type
     procedure PutObject(const Key: string; var Obj: TJsonObject);  { takes ownership; sets Obj := nil }
     procedure PutArray (const Key: string; var Arr: TJsonArray);   { takes ownership; sets Arr := nil }
     procedure PutRaw  (const Key, RawJSON: string);
+    procedure Remove  (const Key: string);
     function ToJSON: string;
     function Backing: TObject;  { for cross-unit interop when absolutely needed }
   end;
@@ -300,6 +301,11 @@ begin
   except
     fpjson.TJSONObject(FBacking).Add(Key, fpjson.TJSONObject.Create);
   end;
+end;
+
+procedure TJsonObject.Remove(const Key: string);
+begin
+  RemoveKey(fpjson.TJSONObject(FBacking), Key);
 end;
 
 function TJsonObject.ToJSON: string;
@@ -666,6 +672,11 @@ begin
   end;
   RemoveKey(System.JSON.TJSONObject(FBacking), Key);
   System.JSON.TJSONObject(FBacking).AddPair(Key, V);
+end;
+
+procedure TJsonObject.Remove(const Key: string);
+begin
+  RemoveKey(System.JSON.TJSONObject(FBacking), Key);
 end;
 
 function TJsonObject.ToJSON: string;

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -199,7 +199,7 @@ begin
                        'Proxy for 100+ providers (set api_base)');
   Result[18] := MkSpec('gemini',     'Google Gemini',
                        pfGemini,     'https://generativelanguage.googleapis.com',
-                       'gemini-1.5-flash',
+                       'gemini-3.5-flash',
                        MkAuth(asHeader, 'x-goog-api-key'),
                        'Gemini 1.5 / 2.0 (generateContent REST)');
 end;

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -74,6 +74,17 @@ function BuildRequest(const Messages: array of TMessage;
                       const Model:    string;
                       const Options:  TChatOptions): string;
 
+(* Strip JSON-Schema fields Gemini's function-calling API doesn't
+   accept (additionalProperties, $schema, $id, $ref, definitions,
+   $defs, patternProperties, unevaluatedProperties, propertyNames)
+   from a tool parameter schema. Walker is schema-aware — only
+   strips on schema nodes, never on the user-property name map
+   under `properties`, so a tool parameter literally named
+   "additionalProperties" survives. Returns the input verbatim on
+   parse failure so a genuinely-malformed schema still surfaces
+   Gemini's own 400 with a useful pointer. Exposed for tests. *)
+function SanitizeSchemaForGemini(const RawSchema: string): string;
+
 implementation
 
 uses
@@ -111,8 +122,8 @@ begin
 end;
 
 procedure StripUnsupportedSchemaFields(Obj: TJsonObject); forward;
-
 procedure StripUnsupportedFromArray(Arr: TJsonArray); forward;
+procedure WalkPropertyMap(Map: TJsonObject); forward;
 
 procedure StripUnsupportedSchemaFields(Obj: TJsonObject);
 { Recursively remove JSON-Schema fields that Gemini's
@@ -135,15 +146,23 @@ procedure StripUnsupportedSchemaFields(Obj: TJsonObject);
   Tools[i].Schema via PutRaw. Anthropic and OpenAI tolerate the
   extra fields silently; Gemini 400s. Strip them at the wire boundary
   so all three back-ends see the same schema with no behavioural
-  change on the others. }
+  change on the others.
+
+  Walker is schema-aware: it only strips keywords on schema nodes,
+  and only recurses through schema-keyword fields that hold
+  subschemas (`items`, `anyOf`, `oneOf`, `allOf`, `not`) or maps of
+  subschemas (`properties`). Codex P2 on PR #153: the original
+  blind recursion treated the `properties` map as a schema node and
+  would drop a tool parameter literally named "additionalProperties"
+  (or any other stripped keyword). Rare but legitimately broken —
+  user property names share a namespace with schema keywords. }
 var
-  Keys: TStringList;
-  i: Integer;
-  Key: string;
-  ChildObj: TJsonObject;
-  ChildArr: TJsonArray;
+  Sub: TJsonObject;
+  SubArr: TJsonArray;
 begin
   if Obj = nil then Exit;
+
+  { Drop unsupported schema keywords on THIS schema node. }
   Obj.Remove('additionalProperties');
   Obj.Remove('$schema');
   Obj.Remove('$id');
@@ -154,28 +173,88 @@ begin
   Obj.Remove('unevaluatedProperties');
   Obj.Remove('propertyNames');
 
-  Keys := Obj.Keys;
+  { Recurse into name->subschema maps. The map's KEYS are arbitrary
+    user-supplied names — never strip keywords on the map itself. }
+  Sub := Obj.ChildObject('properties');
+  if Sub <> nil then
+  try
+    WalkPropertyMap(Sub);
+  finally
+    Sub.Free;
+  end;
+
+  { Recurse into schema-keyword fields that hold a single subschema. }
+  Sub := Obj.ChildObject('items');
+  if Sub <> nil then
+  try
+    StripUnsupportedSchemaFields(Sub);
+  finally
+    Sub.Free;
+  end;
+  Sub := Obj.ChildObject('not');
+  if Sub <> nil then
+  try
+    StripUnsupportedSchemaFields(Sub);
+  finally
+    Sub.Free;
+  end;
+
+  { Recurse into schema-keyword fields that hold arrays of
+    subschemas. `items` can be array-shaped in tuple-validation
+    schemas; we already handle the object case above and fall
+    through to the array case here. }
+  SubArr := Obj.ChildArray('items');
+  if SubArr <> nil then
+  try
+    StripUnsupportedFromArray(SubArr);
+  finally
+    SubArr.Free;
+  end;
+  SubArr := Obj.ChildArray('anyOf');
+  if SubArr <> nil then
+  try
+    StripUnsupportedFromArray(SubArr);
+  finally
+    SubArr.Free;
+  end;
+  SubArr := Obj.ChildArray('oneOf');
+  if SubArr <> nil then
+  try
+    StripUnsupportedFromArray(SubArr);
+  finally
+    SubArr.Free;
+  end;
+  SubArr := Obj.ChildArray('allOf');
+  if SubArr <> nil then
+  try
+    StripUnsupportedFromArray(SubArr);
+  finally
+    SubArr.Free;
+  end;
+end;
+
+procedure WalkPropertyMap(Map: TJsonObject);
+{ The `properties` field is a map from arbitrary user property name
+  to subschema. Iterate the values (each IS a schema, recurse with
+  the full strip pass) but never strip on Map itself — Map's keys
+  are user data, not schema keywords. }
+var
+  Keys: TStringList;
+  i: Integer;
+  ChildObj: TJsonObject;
+begin
+  if Map = nil then Exit;
+  Keys := Map.Keys;
   if Keys = nil then Exit;
   try
     for i := 0 to Keys.Count - 1 do
     begin
-      Key := Keys[i];
-      ChildObj := Obj.ChildObject(Key);
+      ChildObj := Map.ChildObject(Keys[i]);
       if ChildObj <> nil then
       try
         StripUnsupportedSchemaFields(ChildObj);
       finally
         ChildObj.Free;
-      end
-      else
-      begin
-        ChildArr := Obj.ChildArray(Key);
-        if ChildArr <> nil then
-        try
-          StripUnsupportedFromArray(ChildArr);
-        finally
-          ChildArr.Free;
-        end;
       end;
     end;
   finally
@@ -184,12 +263,11 @@ begin
 end;
 
 procedure StripUnsupportedFromArray(Arr: TJsonArray);
-{ Walk array entries so nested schemas inside anyOf/oneOf/items get
-  their unsupported fields scrubbed too. }
+{ Recurse into each element of an anyOf/oneOf/allOf/items array.
+  Every element is itself a schema, so the full strip pass applies. }
 var
   i: Integer;
   ChildObj: TJsonObject;
-  ChildArr: TJsonArray;
 begin
   if Arr = nil then Exit;
   for i := 0 to Arr.Count - 1 do
@@ -200,16 +278,6 @@ begin
       StripUnsupportedSchemaFields(ChildObj);
     finally
       ChildObj.Free;
-    end
-    else
-    begin
-      ChildArr := Arr.ItemArray(i);
-      if ChildArr <> nil then
-      try
-        StripUnsupportedFromArray(ChildArr);
-      finally
-        ChildArr.Free;
-      end;
     end;
   end;
 end;

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -110,6 +110,133 @@ begin
   end;
 end;
 
+procedure StripUnsupportedSchemaFields(Obj: TJsonObject); forward;
+
+procedure StripUnsupportedFromArray(Arr: TJsonArray); forward;
+
+procedure StripUnsupportedSchemaFields(Obj: TJsonObject);
+{ Recursively remove JSON-Schema fields that Gemini's
+  function-calling API rejects. Currently:
+
+    additionalProperties   — error: "Unknown name 'additionalProperties'
+                              at tools[0].function_declarations[N].
+                              parameters.properties[M].value: Cannot
+                              find field"
+    $schema, $id, $ref     — meta fields Gemini doesn't model
+    definitions, $defs     — JSON Schema 2019-09+ — Gemini takes
+                              OpenAPI 3.0 schema subset only
+    patternProperties      — not in OpenAPI 3.0
+    unevaluatedProperties  — JSON Schema 2019-09+
+    propertyNames          — JSON Schema 2019-09+
+
+  MCP servers and external skill manifests frequently emit
+  additionalProperties: false on their tool schemas (it's the JSON
+  Schema "strict" convention); these end up verbatim in PasClaw's
+  Tools[i].Schema via PutRaw. Anthropic and OpenAI tolerate the
+  extra fields silently; Gemini 400s. Strip them at the wire boundary
+  so all three back-ends see the same schema with no behavioural
+  change on the others. }
+var
+  Keys: TStringList;
+  i: Integer;
+  Key: string;
+  ChildObj: TJsonObject;
+  ChildArr: TJsonArray;
+begin
+  if Obj = nil then Exit;
+  Obj.Remove('additionalProperties');
+  Obj.Remove('$schema');
+  Obj.Remove('$id');
+  Obj.Remove('$ref');
+  Obj.Remove('definitions');
+  Obj.Remove('$defs');
+  Obj.Remove('patternProperties');
+  Obj.Remove('unevaluatedProperties');
+  Obj.Remove('propertyNames');
+
+  Keys := Obj.Keys;
+  if Keys = nil then Exit;
+  try
+    for i := 0 to Keys.Count - 1 do
+    begin
+      Key := Keys[i];
+      ChildObj := Obj.ChildObject(Key);
+      if ChildObj <> nil then
+      try
+        StripUnsupportedSchemaFields(ChildObj);
+      finally
+        ChildObj.Free;
+      end
+      else
+      begin
+        ChildArr := Obj.ChildArray(Key);
+        if ChildArr <> nil then
+        try
+          StripUnsupportedFromArray(ChildArr);
+        finally
+          ChildArr.Free;
+        end;
+      end;
+    end;
+  finally
+    Keys.Free;
+  end;
+end;
+
+procedure StripUnsupportedFromArray(Arr: TJsonArray);
+{ Walk array entries so nested schemas inside anyOf/oneOf/items get
+  their unsupported fields scrubbed too. }
+var
+  i: Integer;
+  ChildObj: TJsonObject;
+  ChildArr: TJsonArray;
+begin
+  if Arr = nil then Exit;
+  for i := 0 to Arr.Count - 1 do
+  begin
+    ChildObj := Arr.ItemObject(i);
+    if ChildObj <> nil then
+    try
+      StripUnsupportedSchemaFields(ChildObj);
+    finally
+      ChildObj.Free;
+    end
+    else
+    begin
+      ChildArr := Arr.ItemArray(i);
+      if ChildArr <> nil then
+      try
+        StripUnsupportedFromArray(ChildArr);
+      finally
+        ChildArr.Free;
+      end;
+    end;
+  end;
+end;
+
+function SanitizeSchemaForGemini(const RawSchema: string): string;
+{ Parse, scrub, re-serialise. Returns the original string verbatim on
+  parse failure so a malformed schema doesn't silently disappear —
+  the API will surface its own 400 with a clearer pointer. }
+var
+  Root: TJsonObject;
+begin
+  Result := RawSchema;
+  if Trim(RawSchema) = '' then Exit;
+  try
+    Root := TJsonObject.Parse(RawSchema);
+  except
+    Exit;
+  end;
+  if Root = nil then Exit;
+  try
+    StripUnsupportedSchemaFields(Root);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
 { Builds the request body. Mirrors picoclaw's pkg/providers/httpapi
   gemini_provider.go buildRequestBody, trimmed to text + tool support. }
 function BuildRequest(const Messages: array of TMessage;
@@ -277,7 +404,11 @@ begin
         if Tools[i].Description <> '' then
           FuncDecl.PutStr('description', Tools[i].Description);
         if Tools[i].Schema <> '' then
-          FuncDecl.PutRaw('parameters', Tools[i].Schema)
+          { Strip JSON-Schema fields Gemini's function-calling API
+            doesn't accept (additionalProperties, $schema, etc.) —
+            see SanitizeSchemaForGemini for the full list and why
+            MCP / skill schemas trip into them. }
+          FuncDecl.PutRaw('parameters', SanitizeSchemaForGemini(Tools[i].Schema))
         else
         begin
           EmptyObj := TJsonObject.Create;

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -1,0 +1,137 @@
+program gemini_schema_strip_tests;
+(*
+  Covers SanitizeSchemaForGemini — the wire-boundary scrub that lets
+  Gemini accept tool schemas containing additionalProperties (and
+  other JSON-Schema-but-not-OpenAPI-3.0 fields) that MCP servers and
+  external skill manifests emit.
+
+  Test 1 reproduces the exact 400 shape the user hit and asserts
+  the unsupported fields are gone while the legitimate ones survive.
+
+  Test 2 covers Codex P2 on PR #153 — a tool parameter literally
+  named "additionalProperties" must NOT be dropped by the walker.
+  The original blind-recursion walker treated the `properties` map
+  as a schema node and would strip user-defined keys colliding with
+  schema keywords. The schema-aware walker only strips on schema
+  nodes, never on the properties name->schema map itself.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Providers.Gemini;
+
+procedure Fail(const Msg, Body: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  WriteLn('--- body ---');
+  WriteLn(Body);
+  Halt(1);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) = 0 then
+    Fail(Msg + ' (expected substring: ' + Needle + ')', Haystack);
+end;
+
+procedure AssertMissing(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) > 0 then
+    Fail(Msg + ' (did NOT expect substring: ' + Needle + ')', Haystack);
+end;
+
+procedure TestRejectedFieldsScrubbed;
+const
+  { Same shape as the user's reported 400 — additionalProperties at
+    two nesting levels plus $schema meta. }
+  Bad =
+    '{' +
+      '"type":"object",' +
+      '"properties":{' +
+        '"url":{"type":"string"},' +
+        '"options":{' +
+          '"type":"object",' +
+          '"properties":{"timeout":{"type":"integer"}},' +
+          '"additionalProperties":false' +
+        '}' +
+      '},' +
+      '"required":["url"],' +
+      '"additionalProperties":false,' +
+      '"$schema":"http://json-schema.org/draft-07/schema#"' +
+    '}';
+var
+  Out_: string;
+begin
+  Out_ := SanitizeSchemaForGemini(Bad);
+  AssertMissing(Out_, 'additionalProperties', 'additionalProperties stripped');
+  AssertMissing(Out_, '$schema',              '$schema stripped');
+  AssertContains(Out_, '"url"',               'url property survives');
+  AssertContains(Out_, '"timeout"',           'nested timeout survives');
+  AssertContains(Out_, '"required"',          'required[] survives');
+end;
+
+procedure TestUserPropertyNamedAdditionalPropertiesSurvives;
+const
+  { Two layers of trickery:
+      - A schema KEYWORD additionalProperties at the top level
+        (should be stripped).
+      - A user PROPERTY literally named additionalProperties inside
+        the `properties` map (must NOT be stripped — it's a tool
+        parameter name).
+      - Same trap for $schema and $ref as user property names. }
+  Bad =
+    '{' +
+      '"type":"object",' +
+      '"properties":{' +
+        '"additionalProperties":{"type":"boolean","description":"user property"},' +
+        '"$schema":{"type":"string"},' +
+        '"$ref":{"type":"string"},' +
+        '"normal":{"type":"integer"}' +
+      '},' +
+      '"additionalProperties":false,' +
+      '"$schema":"http://json-schema.org/draft-07/schema#"' +
+    '}';
+var
+  Out_: string;
+begin
+  Out_ := SanitizeSchemaForGemini(Bad);
+
+  { The user PROPERTIES survive even though they share names with
+    schema keywords. Match on the description / type tag we put
+    inside their schemas — the bare key text "additionalProperties"
+    can match either the property name OR the schema keyword, so we
+    pin the assertion on a sibling that only exists if the property
+    schema was preserved. }
+  AssertContains(Out_, '"description" : "user property"',
+    'user property named "additionalProperties" survives');
+  AssertContains(Out_, '"normal"', 'normal property survives');
+
+  { Top-level schema keywords ARE stripped — we proved that in test 1.
+    Here, prove there are no instances of additionalProperties:false
+    or $schema as a URL (the keyword forms) left, while accepting
+    that "additionalProperties" as a key name in the properties map
+    is allowed. }
+  AssertMissing(Out_, ':false', 'top-level additionalProperties:false stripped');
+  AssertMissing(Out_, 'json-schema.org', '$schema URL keyword stripped');
+end;
+
+procedure TestEmptyAndMalformed;
+begin
+  if SanitizeSchemaForGemini('') <> '' then
+    Fail('empty input should round-trip as empty', SanitizeSchemaForGemini(''));
+  { Malformed JSON: walker returns input verbatim so Gemini's own
+    400 with field pointer surfaces, instead of a silent drop. }
+  if SanitizeSchemaForGemini('not json') <> 'not json' then
+    Fail('malformed input should round-trip verbatim',
+         SanitizeSchemaForGemini('not json'));
+end;
+
+begin
+  TestRejectedFieldsScrubbed;
+  TestUserPropertyNamedAdditionalPropertiesSurvives;
+  TestEmptyAndMalformed;
+  WriteLn('gemini_schema_strip_tests: OK');
+end.


### PR DESCRIPTION
## TL;DR

Two fixes — both visible the second you point an LLM loop at Gemini.

## 1. Schema sanitisation (the 400 you hit)

Gemini's function-calling API accepts only an **OpenAPI 3.0 subset** of JSON Schema. MCP servers and external skill manifests frequently emit `additionalProperties: false` on their tool parameter schemas (it's the JSON Schema "strict mode" convention). Anthropic and OpenAI ignore the extra field silently; Gemini 400s with:

```
Unknown name "additionalProperties" at
'tools[0].function_declarations[16].parameters.properties[2].value':
Cannot find field
```

— exactly what you saw. The Gemini docs say "only a subset of OpenAPI schema is supported" but don't enumerate which fields are rejected; turns out it's a fair number.

New `PasClaw.Providers.Gemini.SanitizeSchemaForGemini` parses each tool's schema, recursively strips the offending fields, and re-emits. Walks `properties` / `items` / `anyOf` / `oneOf` children so nested schemas get the same treatment.

**Fields stripped** (only when sending to Gemini — Anthropic and OpenAI still see the original schemas unchanged):

```
additionalProperties   # the actual blocker
$schema, $id, $ref     # meta — Gemini doesn't model
definitions, $defs     # JSON Schema 2019-09+ — Gemini takes OpenAPI 3.0
patternProperties      # not in OpenAPI 3.0
unevaluatedProperties  # JSON Schema 2019-09+
propertyNames          # JSON Schema 2019-09+
```

On parse failure, the helper returns the input verbatim so a genuinely-malformed schema still surfaces Gemini's own 400 with the actual pointer, instead of getting silently dropped.

## 2. Default Gemini model: `gemini-1.5-flash` → `gemini-3.5-flash`

`1.5-flash` is the 18-months-stale free-tier default the catalog scaffold ships with. `3.5-flash` is the current GA model — function calling, structured outputs, code execution, search grounding. Operators who'd already picked a model in `config.json` are unaffected; the catalog default only applies when `Cfg.Providers[i].Model` is empty.

## Supporting change

`PasClaw.JSON.TJsonObject.Remove(Key)` — needed for the recursive walker; existed as an internal `RemoveKey` helper, now exposed. FPC + Delphi backends both implemented.

## Verified

- [x] `make` and `make smoke` clean on Linux + FPC
- [x] `SanitizeSchemaForGemini` round-trip on a schema matching the shape in your 400 — `additionalProperties` removed, rest preserved
- [ ] Live exercise: configure `gemini` provider, run `pasclaw agent -m "list files in pwd"` with MCP tools enabled. The 400 should be gone.

## What's NOT in this PR

Your other question — "how can it list the models available when I got to select a model in the onboarding?" — Gemini does have `GET /v1beta/models` that returns the full available list with just an API key, and the same pattern works for OpenAI (`GET /v1/models`) and Anthropic (`GET /v1/models`). Wiring that into onboarding's "choose a model" prompt is the right answer but a separate concern from this 400 fix. Want me to open a follow-up PR for that?

## On the docs

> "what is the big deal: https://ai.google.dev/gemini-api/docs#rest"

Honest answer: the docs **don't tell you `additionalProperties` is rejected**. They say "only a subset of the OpenAPI schema is supported" with no exhaustive list and no concrete invalid example. You only find out which fields are unsupported by hitting the 400. So the discoverability is genuinely bad; the fix on the client side is mechanical once you know what the API rejects.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_