### PR TITLE
Gemini 3: round-trip thoughtSignature on functionCall parts

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1779,7 +1779,8 @@ begin
     Result := Result + Alphabet[1 + Random(Length(Alphabet))];
 end;
 
-function FunctionCallItemJSON(const ItemId, CallId, Name, ArgsJSON, Status: string): string;
+function FunctionCallItemJSON(const ItemId, CallId, Name, ArgsJSON, Status,
+                              Signature: string): string;
 { One ResponseOutputItem of type function_call, serialized to a JSON
   string so the SSE event helpers can paste it verbatim into their
   payloads. The Responses API schema uses two ids:
@@ -1796,7 +1797,15 @@ function FunctionCallItemJSON(const ItemId, CallId, Name, ArgsJSON, Status: stri
 
   The arguments field is a *string* (raw JSON), not a JSON object.
   That matches OpenAI's schema and means a model that emits args
-  with escaped quotes round-trips correctly. }
+  with escaped quotes round-trips correctly.
+
+  Signature: provider-specific opaque blob the gateway must echo
+  back on the next turn (Gemini 3+'s thoughtSignature). Emitted as a
+  custom "provider_signature" extension; the OpenAI Responses spec
+  permits unknown fields, and PasClaw's own Codex client knows to
+  echo this back on the function_call_output input item. Empty
+  string -> field omitted so stock /v1/responses traffic stays clean.
+  Codex P1 on PR #154. }
 var
   Obj: TJsonObject;
 begin
@@ -1808,6 +1817,8 @@ begin
     Obj.PutStr('call_id',   CallId);
     Obj.PutStr('name',      Name);
     Obj.PutStr('arguments', ArgsJSON);
+    if Signature <> '' then
+      Obj.PutStr('provider_signature', Signature);
     Result := Obj.ToJSON;
   finally
     Obj.Free;
@@ -1913,7 +1924,8 @@ begin
     OutputArr.AddRaw(FunctionCallItemJSON(ItemId, CallId,
                                            ToolCalls[i].Func.Name,
                                            ToolCalls[i].Func.Arguments,
-                                           'completed'));
+                                           'completed',
+                                           ToolCalls[i].ProviderSignature));
   end;
   Result.PutArray('output', OutputArr);
 
@@ -2270,10 +2282,12 @@ begin
 
       FcEmptyJSON     := FunctionCallItemJSON(FcItemId, FcCallId,
                                               ToolCalls[TcIdx].Func.Name,
-                                              '', 'in_progress');
+                                              '', 'in_progress',
+                                              ToolCalls[TcIdx].ProviderSignature);
       FcCompletedJSON := FunctionCallItemJSON(FcItemId, FcCallId,
                                               ToolCalls[TcIdx].Func.Name,
-                                              FcArgs, 'completed');
+                                              FcArgs, 'completed',
+                                              ToolCalls[TcIdx].ProviderSignature);
 
       EmitResponsesEvent(Streamer, 'response.output_item.added',
         ResItemAddedEvt(Seq, NextOutputIdx, FcEmptyJSON)); Inc(Seq);
@@ -2540,10 +2554,12 @@ begin
 
         FcEmptyJSON     := FunctionCallItemJSON(FcItemId, FcCallId,
                                                 Resp.ToolCalls[i].Func.Name,
-                                                '', 'in_progress');
+                                                '', 'in_progress',
+                                                Resp.ToolCalls[i].ProviderSignature);
         FcCompletedJSON := FunctionCallItemJSON(FcItemId, FcCallId,
                                                 Resp.ToolCalls[i].Func.Name,
-                                                FcArgs, 'completed');
+                                                FcArgs, 'completed',
+                                                Resp.ToolCalls[i].ProviderSignature);
 
         EmitResponsesEvent(State.Streamer, 'response.output_item.added',
           ResItemAddedEvt(State.Seq, State.NextOutputIdx, FcEmptyJSON)); Inc(State.Seq);
@@ -2639,7 +2655,8 @@ var
     Inc(MsgCount);
   end;
 
-  procedure AppendAssistantToolCall(const CallId, Name, ArgumentsJSON: string);
+  procedure AppendAssistantToolCall(const CallId, Name, ArgumentsJSON,
+                                    Signature: string);
   { Codex (and any Responses-API client doing multi-turn tool use)
     sends previous-turn function_call items as separate input items
     with no parent message. The Chat-Completions-style providers we
@@ -2651,7 +2668,14 @@ var
     rejects request shapes where a tool_use block appears in a turn
     whose preceding turn already produced tool_use blocks without
     intervening tool_result blocks. Matching with the corresponding
-    function_call_output is still by call_id regardless of grouping. }
+    function_call_output is still by call_id regardless of grouping.
+
+    Signature: the provider_signature extension we emit when shipping
+    function_call items downstream. Codex (or any PasClaw-aware
+    client) echoes it back on the input function_call item so this
+    side can stuff it back onto the TToolCall — required for Gemini
+    3+ thoughtSignature round-trips through /v1/responses. Codex P1
+    on PR #154. }
   var
     Tc: TToolCall;
     Last: Integer;
@@ -2660,6 +2684,7 @@ var
     Tc.Kind := 'function';
     Tc.Func.Name      := Name;
     Tc.Func.Arguments := ArgumentsJSON;
+    Tc.ProviderSignature := Signature;
 
     if (MsgCount > 0)
        and (Msgs[MsgCount - 1].Role = mrAssistant)
@@ -2838,7 +2863,8 @@ begin
             AppendAssistantToolCall(
               InputObj.GetStr('call_id', InputObj.GetStr('id', '')),
               InputObj.GetStr('name',      ''),
-              InputObj.GetStr('arguments', '{}'));
+              InputObj.GetStr('arguments', '{}'),
+              InputObj.GetStr('provider_signature', ''));
           end
           else if ItemType = 'function_call_output' then
           begin

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -421,6 +421,15 @@ begin
           else
             FuncCall.PutRaw('args', ArgsJSON);
           Part.PutObject('functionCall', FuncCall);
+          { Gemini 3+: echo back the thoughtSignature on the part
+            (sibling of functionCall) verbatim. Mandatory on Gemini
+            3 function calling; absent / empty on Gemini 2.x and
+            earlier. Without this, Gemini 3 rejects the next request
+            with 400 "Function call is missing a thought_signature
+            in functionCall parts". }
+          if Messages[i].ToolCalls[j].ProviderSignature <> '' then
+            Part.PutStr('thoughtSignature',
+                        Messages[i].ToolCalls[j].ProviderSignature);
           Parts.AddObject(Part);
         end;
 
@@ -560,6 +569,14 @@ begin
                   try
                     TC.Kind      := 'function';
                     TC.Func.Name := FuncCall.GetStr('name', '');
+                    { Gemini 3+: thoughtSignature is a sibling of
+                      functionCall on the part. Must be echoed back
+                      verbatim when we send the matching
+                      functionResponse, or the next request 400s
+                      with "Function call is missing a
+                      thought_signature". Empty for Gemini 2.x where
+                      it's not required. }
+                    TC.ProviderSignature := Part.GetStr('thoughtSignature', '');
                     { Gemini's functionCall has name + args but no
                       OpenAI-style id. The tool loop later records this
                       id on the mrTool result, and BuildRequest above

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -26,6 +26,13 @@ type
     Id:       string;
     Kind:     string;    { "function" for now }
     Func:     TFunctionCall;
+    { Opaque provider-specific blob the assistant must echo back
+      when sending the matching function/tool result. Currently used
+      only by Gemini 3+ (the `thoughtSignature` on functionCall
+      parts) — Gemini 3 rejects the follow-up request with a 400
+      "Function call is missing a thought_signature" if it's
+      dropped. Empty for other providers and for Gemini 2.x. }
+    ProviderSignature: string;
   end;
 
   { A chat message. The Content field holds plain text; ToolCalls and

--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -45,7 +45,8 @@ interface
 
 uses
   SysUtils, Classes,
-  PasClaw.Providers.Types;
+  PasClaw.Providers.Types,
+  PasClaw.JSON;
 
 type
   TSessionMeta = record
@@ -99,13 +100,18 @@ function SessionPath(const Id: string): string;
 function ListSessions: TSessionMetaArray;
 function DeleteSession(const Id: string): Boolean;
 
+(* Exposed for tests: TToolCall <-> JSON conversion used by TSession.
+   Round-trip preserves Id, Kind, Func.Name, Func.Arguments, and
+   (when non-empty) Gemini 3+'s ProviderSignature. *)
+function ToolCallToJSON(const TC: TToolCall): TJsonObject;
+procedure ToolCallFromJSON(const Obj: TJsonObject; out TC: TToolCall);
+
 implementation
 
 uses
   DateUtils,
   PasClaw.Config,
   PasClaw.Utils,
-  PasClaw.JSON,
   PasClaw.Logger;
 
 function NowUnix: Int64;
@@ -183,6 +189,14 @@ begin
   Func.PutStr('name',      TC.Func.Name);
   Func.PutStr('arguments', TC.Func.Arguments);
   Result.PutObject('function', Func);
+  { Persist Gemini 3+'s thoughtSignature so a session saved mid-loop
+    survives /quit + resume. Without this the resumed assistant turn
+    drops the signature and Gemini's next request 400s with
+    "Function call is missing a thought_signature". Omitted from
+    JSON when empty — that's the common case (other providers / older
+    Gemini) and keeps stock session files tidy. Codex P2 on PR #154. }
+  if TC.ProviderSignature <> '' then
+    Result.PutStr('provider_signature', TC.ProviderSignature);
 end;
 
 procedure ToolCallFromJSON(const Obj: TJsonObject; out TC: TToolCall);
@@ -191,6 +205,7 @@ var
 begin
   TC.Id   := Obj.GetStr('id',   '');
   TC.Kind := Obj.GetStr('type', 'function');
+  TC.ProviderSignature := Obj.GetStr('provider_signature', '');
   TC.Func.Name      := '';
   TC.Func.Arguments := '';
   Func := Obj.ChildObject('function');

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -21,6 +21,7 @@ program gemini_schema_strip_tests;
 
 uses
   SysUtils,
+  PasClaw.Providers.Types,
   PasClaw.Providers.Gemini;
 
 procedure Fail(const Msg, Body: string);
@@ -129,9 +130,89 @@ begin
          SanitizeSchemaForGemini('not json'));
 end;
 
+procedure TestThoughtSignatureRoundTrip;
+{ Gemini 3+ requires the assistant turn to carry the thoughtSignature
+  back on the part. Verify that when a TToolCall has ProviderSignature
+  set, BuildRequest emits "thoughtSignature": "<value>" as a sibling
+  of "functionCall" inside the part. Without this, Gemini 3 rejects
+  the follow-up with 400 "Function call is missing a thought_signature
+  in functionCall parts". }
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  Body:  string;
+begin
+  SetLength(Msgs, 3);
+  { user turn }
+  Msgs[0] := MakeMessage(mrUser, 'list pwd');
+  { assistant turn with a tool call carrying the signature }
+  Msgs[1].Role := mrAssistant;
+  Msgs[1].Content := '';
+  SetLength(Msgs[1].ToolCalls, 1);
+  Msgs[1].ToolCalls[0].Id   := 'gemini_call_fs_list_0';
+  Msgs[1].ToolCalls[0].Kind := 'function';
+  Msgs[1].ToolCalls[0].Func.Name      := 'fs_list';
+  Msgs[1].ToolCalls[0].Func.Arguments := '{"path":"."}';
+  Msgs[1].ToolCalls[0].ProviderSignature := 'SIG_AAA_BBB_OPAQUE_BLOB';
+  { tool result echoed back as a user/tool turn — Gemini path }
+  Msgs[2].Role       := mrTool;
+  Msgs[2].ToolCallId := 'gemini_call_fs_list_0';
+  Msgs[2].Content    := '[".", "..", "README.md"]';
+  Msgs[2].Name       := 'fs_list';
+
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts);
+
+  { The signature must be on the wire body, verbatim. }
+  AssertContains(Body, '"thoughtSignature"',
+    'thoughtSignature key emitted on assistant turn');
+  AssertContains(Body, 'SIG_AAA_BBB_OPAQUE_BLOB',
+    'thoughtSignature value preserved verbatim');
+  AssertContains(Body, '"functionCall"',
+    'functionCall still emitted alongside thoughtSignature');
+  AssertContains(Body, '"fs_list"',
+    'function name preserved');
+end;
+
+procedure TestNoSignatureWhenEmpty;
+{ Gemini 2.x doesn't require thoughtSignature. When ProviderSignature
+  is empty (the common case for non-Gemini-3 paths), BuildRequest must
+  NOT emit an empty "thoughtSignature":"" field — that's invalid wire
+  shape. }
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  Body:  string;
+begin
+  SetLength(Msgs, 2);
+  Msgs[0] := MakeMessage(mrUser, 'hi');
+  Msgs[1].Role := mrAssistant;
+  Msgs[1].Content := '';
+  SetLength(Msgs[1].ToolCalls, 1);
+  Msgs[1].ToolCalls[0].Id   := 'gemini_call_x_0';
+  Msgs[1].ToolCalls[0].Kind := 'function';
+  Msgs[1].ToolCalls[0].Func.Name := 'x';
+  Msgs[1].ToolCalls[0].Func.Arguments := '{}';
+  Msgs[1].ToolCalls[0].ProviderSignature := '';   { Gemini 2 path }
+
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+  Body := BuildRequest(Msgs, Tools, 'gemini-1.5-flash', Opts);
+
+  AssertMissing(Body, '"thoughtSignature"',
+    'no thoughtSignature key when ProviderSignature is empty');
+  AssertContains(Body, '"functionCall"',
+    'functionCall still emitted normally');
+end;
+
 begin
   TestRejectedFieldsScrubbed;
   TestUserPropertyNamedAdditionalPropertiesSurvives;
   TestEmptyAndMalformed;
+  TestThoughtSignatureRoundTrip;
+  TestNoSignatureWhenEmpty;
   WriteLn('gemini_schema_strip_tests: OK');
 end.

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -22,7 +22,9 @@ program gemini_schema_strip_tests;
 uses
   SysUtils,
   PasClaw.Providers.Types,
-  PasClaw.Providers.Gemini;
+  PasClaw.Providers.Gemini,
+  PasClaw.Session.Store,
+  PasClaw.JSON;
 
 procedure Fail(const Msg, Body: string);
 begin
@@ -208,11 +210,95 @@ begin
     'functionCall still emitted normally');
 end;
 
+procedure TestSessionPersistenceRoundTrip;
+{ Codex P2 on PR #154: a session saved mid-Gemini-3-tool-loop must
+  keep the thoughtSignature on disk, otherwise resume drops it and
+  the next provider request 400s. Round-trip a TToolCall through
+  ToolCallToJSON / ToolCallFromJSON and assert ProviderSignature
+  survives. }
+var
+  TC, Restored: TToolCall;
+  Obj, Reparsed: TJsonObject;
+  Body: string;
+begin
+  TC.Id   := 'gemini_call_fs_list_0';
+  TC.Kind := 'function';
+  TC.Func.Name      := 'fs_list';
+  TC.Func.Arguments := '{"path":"."}';
+  TC.ProviderSignature := 'SIG_PERSIST_THIS_BLOB';
+
+  Obj := ToolCallToJSON(TC);
+  try
+    Body := Obj.ToJSON;
+    AssertContains(Body, '"provider_signature"',
+      'session writer emits provider_signature key');
+    AssertContains(Body, 'SIG_PERSIST_THIS_BLOB',
+      'session writer preserves the blob verbatim');
+  finally
+    Obj.Free;
+  end;
+
+  Reparsed := TJsonObject.Parse(Body);
+  if Reparsed = nil then
+    Fail('reparse of session JSON failed', Body);
+  try
+    ToolCallFromJSON(Reparsed, Restored);
+  finally
+    Reparsed.Free;
+  end;
+
+  if Restored.ProviderSignature <> TC.ProviderSignature then
+    Fail('session reader did NOT restore ProviderSignature',
+         'got "' + Restored.ProviderSignature +
+         '", want "' + TC.ProviderSignature + '"');
+  if Restored.Id <> TC.Id then
+    Fail('Id did not round-trip', Restored.Id);
+  if Restored.Func.Name <> TC.Func.Name then
+    Fail('Func.Name did not round-trip', Restored.Func.Name);
+end;
+
+procedure TestSessionPersistenceEmpty;
+{ Empty ProviderSignature must NOT add an empty key to the session
+  file — keeps stock session JSON tidy for non-Gemini-3 sessions
+  (the common case) and round-trips back to empty. }
+var
+  TC, Restored: TToolCall;
+  Obj, Reparsed: TJsonObject;
+  Body: string;
+begin
+  TC.Id   := 'call_x';
+  TC.Kind := 'function';
+  TC.Func.Name      := 'x';
+  TC.Func.Arguments := '{}';
+  TC.ProviderSignature := '';
+
+  Obj := ToolCallToJSON(TC);
+  try
+    Body := Obj.ToJSON;
+    AssertMissing(Body, 'provider_signature',
+      'empty ProviderSignature omitted from session JSON');
+  finally
+    Obj.Free;
+  end;
+
+  Reparsed := TJsonObject.Parse(Body);
+  if Reparsed = nil then Fail('reparse failed', Body);
+  try
+    ToolCallFromJSON(Reparsed, Restored);
+  finally
+    Reparsed.Free;
+  end;
+  if Restored.ProviderSignature <> '' then
+    Fail('empty signature did not round-trip empty', Restored.ProviderSignature);
+end;
+
 begin
   TestRejectedFieldsScrubbed;
   TestUserPropertyNamedAdditionalPropertiesSurvives;
   TestEmptyAndMalformed;
   TestThoughtSignatureRoundTrip;
   TestNoSignatureWhenEmpty;
+  TestSessionPersistenceRoundTrip;
+  TestSessionPersistenceEmpty;
   WriteLn('gemini_schema_strip_tests: OK');
 end.


### PR DESCRIPTION
## The 400 this fixes

After PR #153's schema scrub landed, gemini-3.5-flash returns a new 400 on the second turn of any tool-using session:

```
Function call is missing a thought_signature in functionCall parts.
This is required for tools to work correctly, and missing
thought_signature may lead to degraded model performance.
Additional data, function call `default_api:fs_list`, position 2.
```

Ref: <https://ai.google.dev/gemini-api/docs/thought-signatures>

Gemini 3+ requires the client to echo back an opaque `thoughtSignature` blob the model returns on each `functionCall` part. The signature encodes the model's internal reasoning state; if we drop it, Gemini 3 rejects the next request. **Gemini 2.x doesn't require it.**

## Wire shape

```jsonc
// Assistant turn the model returned:
{
  "role": "model",
  "parts": [{
    "functionCall": {"name": "fs_list", "args": {"path":"."}},
    "thoughtSignature": "<opaque blob A>"
  }]
}

// Follow-up request MUST echo the signature verbatim:
{
  "role": "model",
  "parts": [{
    "functionCall": {"name": "fs_list", "args": {"path":"."}},
    "thoughtSignature": "<opaque blob A>"   // mandatory on Gemini 3
  }]
}
```

## Implementation

- **`TToolCall.ProviderSignature`** — new opaque string field on the shared `TToolCall` record (`PasClaw.Providers.Types`). Provider-specific blob; empty for everything except Gemini 3+. Survives session save/load because it lives on the `TToolCall` the gateway already serialises.
- **`PasClaw.Providers.Gemini.ParseResponse`** — reads the part-level `thoughtSignature` (sibling of `functionCall`, not inside it) and stashes it on the parsed `TToolCall`.
- **`PasClaw.Providers.Gemini.BuildRequest`** — when emitting the assistant turn's part, writes `thoughtSignature` as a sibling of `functionCall` when `ProviderSignature` is non-empty. Empty signature stays silent — no empty `"":""` field on the wire (would be invalid).

## Test plan

Two cases added to `make test-gemini-schema-strip`:

- [x] `TestThoughtSignatureRoundTrip` — `ProviderSignature = 'SIG_AAA_BBB_OPAQUE_BLOB'` survives unmodified onto the wire; `functionCall` + name + args also preserved.
- [x] `TestNoSignatureWhenEmpty` — empty signature ⇒ no `thoughtSignature` key at all (so Gemini 2.x stays happy).
- [x] `make smoke` — all 11 commands OK
- [x] `make` — clean Linux+FPC build
- [ ] Live exercise on `gemini-3.5-flash` with `pasclaw agent -m "list pwd"` — the 400 from PR #153's follow-up should be gone.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_