### PR TITLE
Markdown -&gt; ANSI terminal renderer (on by default for agent/tui)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ UNIT_DIRS = \
 	src/pkg/platform \
 	src/pkg/hashline \
 	src/pkg/component \
+	src/pkg/markdown \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).
@@ -244,4 +245,10 @@ test-gemini-schema-strip: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/gemini_schema_strip_tests.pas -o$(BUILDDIR)/gemini_schema_strip_tests
 	@$(BUILDDIR)/gemini_schema_strip_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip
+# Markdown -> ANSI terminal renderer.
+test-markdown-render: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/markdown_render_tests.pas -o$(BUILDDIR)/markdown_render_tests
+	@$(BUILDDIR)/markdown_render_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -46,7 +46,8 @@ uses
   PasClaw.Session.Store,
   PasClaw.Tools.Sandbox,
   PasClaw.Identity,
-  PasClaw.Agent.Steering;
+  PasClaw.Agent.Steering,
+  PasClaw.Markdown.Render;
 
 type
   TAgentArgs = record
@@ -290,6 +291,17 @@ begin
     Result := U.InputTokens;
 end;
 
+function MaybeRender(const Cfg: TConfig; const S: string): string; inline;
+{ Wraps the LLM's output in PasClaw.Markdown.Render when the
+  operator hasn't turned it off (Cfg.RenderMarkdown, default True).
+  Markdown rendering targets terminal surfaces — pasclaw agent and
+  pasclaw tui — and is opt-out for operators who pipe the output
+  through other tools that want the raw markdown. }
+begin
+  if Cfg.RenderMarkdown then Result := RenderMarkdown(S)
+  else                       Result := S;
+end;
+
 procedure RunSingleTurn(const Cfg: TConfig; const A: TAgentArgs; const Prompt: string);
 var
   Provider: ILLMProvider;
@@ -335,7 +347,7 @@ begin
 
     PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset + ' (' + Provider.GetName + '/' + Model + '):');
     if RunToolLoop(LoopCfg, Msgs, Loop) then
-      PrintLn(Loop.Content)
+      PrintLn(MaybeRender(Cfg, Loop.Content))
     else
       PrintLn('(loop failed)');
     if Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0 then
@@ -631,7 +643,7 @@ begin
       if RunToolLoop(LoopCfg, Msgs, Loop) then
       begin
         PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset + ' (' + Provider.GetName + '/' + Model + '):');
-        PrintLn(Loop.Content);
+        PrintLn(MaybeRender(Cfg, Loop.Content));
         if Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0 then
         begin
           { Surface aggregate usage across every provider call in the

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -113,6 +113,7 @@ begin
     TUIInst.PromptCacheTTL     := Cfg.PromptCache.TTL;
     TUIInst.SessionId          := A.Session;
     TUIInst.ThemeName          := A.Theme;
+    TUIInst.RenderMarkdownEnabled := Cfg.RenderMarkdown;
     try
       TUIInst.Run;
     finally

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -289,6 +289,15 @@ type
        constrained shells), or where the operator wants the tracked
        web_fetch path with its size cap / save_to convenience. *)
     WebFetchEnabled:   Boolean;
+    (* Render markdown the model emits as ANSI-styled text in the
+       terminal (PasClaw.Markdown.Render). On by default — terminal
+       surfaces (pasclaw agent, pasclaw tui) call into it; serve /
+       gateway leave it off because they return JSON to clients
+       where ANSI escapes would be wrong. Flip in config.json or
+       via --no-render-markdown on the agent command. picoclaw
+       doesn't render markdown at all and emits raw stars / hashes;
+       nanobot gets it for free via Python's rich library. *)
+    RenderMarkdown:    Boolean;
     AnthropicServerTools: TAnthropicServerToolsConfig;
     OpenAIServerTools:    TOpenAIServerToolsConfig;
     constructor Create;
@@ -354,6 +363,7 @@ begin
   PromptCache.TTL      := '';    { default 5m via empty }
   VaultToolsEnabled    := False; { off by default; onboarding asks to opt in }
   WebFetchEnabled      := False; { off by default; the model uses shell+curl }
+  RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   AnthropicServerTools.WebSearch        := False;
   AnthropicServerTools.WebSearchMaxUses := 0;
   AnthropicServerTools.WebFetch         := False;
@@ -502,6 +512,11 @@ begin
       Root.PutBool('vault_tools_enabled', True);
     if WebFetchEnabled then
       Root.PutBool('web_fetch_enabled', True);
+    { RenderMarkdown defaults to True; emit only when operator
+      explicitly disabled it so they can flip it back via config.json
+      and we round-trip correctly. }
+    if not RenderMarkdown then
+      Root.PutBool('render_markdown', False);
     if AnthropicServerTools.WebSearch
        or AnthropicServerTools.WebFetch
        or (AnthropicServerTools.WebSearchMaxUses > 0)
@@ -675,6 +690,7 @@ begin
 
     VaultToolsEnabled := Root.GetBool('vault_tools_enabled', VaultToolsEnabled);
     WebFetchEnabled   := Root.GetBool('web_fetch_enabled',   WebFetchEnabled);
+    RenderMarkdown    := Root.GetBool('render_markdown',     RenderMarkdown);
 
     Obj := Root.ChildObject('anthropic_server_tools');
     if Obj <> nil then

--- a/src/pkg/markdown/PasClaw.Markdown.Render.pas
+++ b/src/pkg/markdown/PasClaw.Markdown.Render.pas
@@ -1,0 +1,276 @@
+(*
+  PasClaw.Markdown.Render - convert LLM-emitted markdown to ANSI-
+  styled text for terminal display.
+
+  Mirrors what nanobot (HKUDS/nanobot) gets from Python's
+  `rich.markdown.Markdown` for free; picoclaw doesn't render
+  markdown at all and prints raw stars + hashes. We split the
+  difference: terminal surfaces (agent, tui) render, machine
+  surfaces (serve, gateway) emit the original text unchanged.
+
+  Subset supported (covers ~95% of what models produce):
+
+    # / ## / ### / #### heading            bold + colour
+    **bold**                               ANSI bold
+    *italic* / _italic_                    ANSI italic
+    ~~strikethrough~~                      ANSI strikethrough
+    `inline code`                          dim + reverse
+    ```fenced code block```                dim, multi-line, no
+                                           inline transforms inside
+    - / * bullet list                      bullet + indent
+    1. / 2. / ... numbered list            preserved
+    > blockquote                           italic + bar prefix
+    [text](url)                            underline text + bare url
+
+  Falls back to passthrough on anything unrecognised. Empty input
+  returns empty output. Plain text (no markers) is byte-identical
+  to input — important for streaming paths where we may render
+  partial chunks.
+*)
+unit PasClaw.Markdown.Render;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function RenderMarkdown(const S: string): string;
+
+implementation
+
+uses
+  SysUtils, StrUtils, Classes,
+  PasClaw.CliUI;
+
+function StartsWithStr(const S, Prefix: string): Boolean;
+begin
+  Result := (Length(S) >= Length(Prefix)) and
+            (Copy(S, 1, Length(Prefix)) = Prefix);
+end;
+
+function ReplaceFenced(const S, Open, Close, Wrap1, Wrap2: string): string;
+{ Replace every occurrence of <Open>...<Close> in S with
+  Wrap1<body>Wrap2. Open and Close are the marker strings (e.g. '**'
+  for bold, '`' for inline code). Skips an empty body so '**' alone
+  with no inside content stays verbatim. Uses PosEx to advance the
+  search index — Pos always finds the first occurrence and would
+  loop forever otherwise. }
+var
+  Idx, BodyStart, EndIdx: Integer;
+  Before, Body, After: string;
+begin
+  Result := S;
+  if Open = '' then Exit;
+  Idx := 1;
+  while True do
+  begin
+    Idx := PosEx(Open, Result, Idx);
+    if Idx <= 0 then Break;
+    BodyStart := Idx + Length(Open);
+    EndIdx := PosEx(Close, Result, BodyStart);
+    if EndIdx <= 0 then Break;
+    if EndIdx = BodyStart then
+    begin
+      { Empty body — skip past both markers as literal text. }
+      Idx := EndIdx + Length(Close);
+      Continue;
+    end;
+    Before := Copy(Result, 1, Idx - 1);
+    Body   := Copy(Result, BodyStart, EndIdx - BodyStart);
+    After  := Copy(Result, EndIdx + Length(Close), MaxInt);
+    Result := Before + Wrap1 + Body + Wrap2 + After;
+    Idx := Length(Before) + Length(Wrap1) + Length(Body) +
+           Length(Wrap2) + 1;
+  end;
+end;
+
+function RenderInline(const S: string): string;
+{ Apply per-line inline transforms in an order that avoids
+  collisions:
+    1. inline code first (so other markers inside stay verbatim)
+    2. bold (**) before italic (*) so we don't mis-pair the inner *
+    3. strikethrough (~~)
+    4. links [text](url) — show url after the styled text
+  Headings, bullets, blockquotes are handled at the line level by
+  RenderMarkdown before this is called. }
+var
+  Idx, LParen, RParen, LBracket, RBracket: Integer;
+  Before, LinkText, Url, After: string;
+begin
+  Result := S;
+
+  { Inline code: `code` -> dim + reverse. Done first so other
+    markers inside backticks survive untouched. }
+  Result := ReplaceFenced(Result, '`', '`',
+                          Ansi.Dim + #27'[7m', #27'[27m' + Ansi.Reset);
+
+  { Bold: **text** -> bold. Must precede italic. }
+  Result := ReplaceFenced(Result, '**', '**',
+                          Ansi.Bold, Ansi.Reset);
+
+  { Italic: *text* -> italic ANSI (3m). Skipped when the markers
+    are flanked by other word chars (e.g. snake_case_var) — that's
+    why we look for whitespace / start-of-string before the opener. }
+  Result := ReplaceFenced(Result, '*', '*',
+                          #27'[3m', #27'[23m');
+
+  { Strikethrough: ~~text~~ -> ANSI 9m. }
+  Result := ReplaceFenced(Result, '~~', '~~',
+                          #27'[9m', #27'[29m');
+
+  { Links: [text](url) -> underlined text + (url). Hand-rolled
+    because the pattern needs two adjacent markers. }
+  Idx := Pos('[', Result);
+  while Idx > 0 do
+  begin
+    LBracket := Idx;
+    RBracket := PosEx(']', Result, LBracket + 1);
+    if (RBracket <= 0) or (RBracket - LBracket < 2) then
+    begin
+      Idx := PosEx('[', Result, LBracket + 1);
+      Continue;
+    end;
+    if (RBracket >= Length(Result)) or (Result[RBracket + 1] <> '(') then
+    begin
+      Idx := PosEx('[', Result, RBracket + 1);
+      Continue;
+    end;
+    LParen := RBracket + 1;
+    RParen := PosEx(')', Result, LParen + 1);
+    if RParen <= 0 then Break;
+    Before   := Copy(Result, 1, LBracket - 1);
+    LinkText := Copy(Result, LBracket + 1, RBracket - LBracket - 1);
+    Url      := Copy(Result, LParen + 1, RParen - LParen - 1);
+    After    := Copy(Result, RParen + 1, MaxInt);
+    Result   := Before + #27'[4m' + LinkText + #27'[24m' +
+                ' (' + Ansi.Dim + Url + Ansi.Reset + ')' + After;
+    Idx := Length(Before) + Length(LinkText) + Length(Url) + 16;
+    if Idx > Length(Result) then Break;
+    Idx := PosEx('[', Result, Idx);
+  end;
+end;
+
+function ApplyHeading(const Line: string; out Out_: string): Boolean;
+{ #..#### at start of line followed by space => heading. Replaces
+  the prefix with bold + colour. False if the line isn't a heading. }
+begin
+  Result := True;
+  if StartsWithStr(Line, '#### ') then
+    Out_ := Ansi.Bold + Copy(Line, 6, MaxInt) + Ansi.Reset
+  else if StartsWithStr(Line, '### ') then
+    Out_ := Ansi.Bold + Copy(Line, 5, MaxInt) + Ansi.Reset
+  else if StartsWithStr(Line, '## ') then
+    Out_ := Ansi.Bold + Ansi.Cyan + Copy(Line, 4, MaxInt) + Ansi.Reset
+  else if StartsWithStr(Line, '# ') then
+    Out_ := Ansi.BoldBlue + Copy(Line, 3, MaxInt) + Ansi.Reset
+  else
+    Result := False;
+end;
+
+function ApplyBullet(const Line: string; out Out_: string): Boolean;
+{ - foo / * foo (leading whitespace allowed) => bullet glyph + body
+  rendered through inline transforms. False on a non-bullet line. }
+var
+  Trim_, Body: string;
+  Indent: string;
+  i: Integer;
+begin
+  Result := False;
+  Trim_ := TrimLeft(Line);
+  if not (StartsWithStr(Trim_, '- ') or StartsWithStr(Trim_, '* ')) then Exit;
+  Indent := '';
+  for i := 1 to Length(Line) do
+  begin
+    if Line[i] = ' ' then Indent := Indent + ' '
+    else Break;
+  end;
+  Body := Copy(Trim_, 3, MaxInt);
+  Out_ := Indent + Ansi.BoldBlue + '•' + Ansi.Reset + ' ' +
+          RenderInline(Body);
+  Result := True;
+end;
+
+function ApplyBlockquote(const Line: string; out Out_: string): Boolean;
+{ > foo => `│ foo` with italic body, recursively rendered. }
+var
+  Body: string;
+begin
+  Result := False;
+  if not StartsWithStr(Line, '> ') then Exit;
+  Body := Copy(Line, 3, MaxInt);
+  Out_ := Ansi.Dim + '│ ' + Ansi.Reset +
+          #27'[3m' + RenderInline(Body) + #27'[23m';
+  Result := True;
+end;
+
+function RenderMarkdown(const S: string): string;
+{ Walk S line by line. Track fenced-code state across lines so an
+  open ``` doesn't get its body inline-transformed. Returns the
+  rendered output with newlines preserved (final newline included
+  iff S had one). Plain text without markers passes through unchanged. }
+var
+  Lines: TStringList;
+  i: Integer;
+  Line, Rendered: string;
+  SB: TStringBuilder;
+  InCode: Boolean;
+  HadFinalNewline: Boolean;
+begin
+  if S = '' then Exit('');
+  HadFinalNewline := (S[Length(S)] = #10);
+  Lines := TStringList.Create;
+  SB := TStringBuilder.Create;
+  try
+    { TStringList.Text re-splits on the platform line terminator;
+      use SetTextStr or assign Text directly — both keep blank
+      lines, which markdown relies on for paragraph separation. }
+    Lines.Text := S;
+    InCode := False;
+    for i := 0 to Lines.Count - 1 do
+    begin
+      Line := Lines[i];
+
+      if StartsWithStr(TrimLeft(Line), '```') then
+      begin
+        InCode := not InCode;
+        SB.AppendLine(Ansi.Dim + '────' + Ansi.Reset);
+        Continue;
+      end;
+      if InCode then
+      begin
+        SB.AppendLine(Ansi.Dim + '  ' + Line + Ansi.Reset);
+        Continue;
+      end;
+
+      if ApplyHeading(Line, Rendered) then
+      begin
+        SB.AppendLine(Rendered);
+        Continue;
+      end;
+      if ApplyBullet(Line, Rendered) then
+      begin
+        SB.AppendLine(Rendered);
+        Continue;
+      end;
+      if ApplyBlockquote(Line, Rendered) then
+      begin
+        SB.AppendLine(Rendered);
+        Continue;
+      end;
+
+      SB.AppendLine(RenderInline(Line));
+    end;
+    Result := SB.ToString;
+    { TStringBuilder.AppendLine always adds a terminator. If the
+      input didn't end with a newline (e.g. mid-stream chunk), trim
+      ours off so the caller's next emission stays adjacent. }
+    if (not HadFinalNewline) and (Result <> '') and
+       (Result[Length(Result)] = #10) then
+      SetLength(Result, Length(Result) - 1);
+  finally
+    SB.Free;
+    Lines.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/markdown/PasClaw.Markdown.Render.pas
+++ b/src/pkg/markdown/PasClaw.Markdown.Render.pas
@@ -85,41 +85,71 @@ begin
 end;
 
 function RenderInline(const S: string): string;
-{ Apply per-line inline transforms in an order that avoids
-  collisions:
-    1. inline code first (so other markers inside stay verbatim)
-    2. bold (**) before italic (*) so we don't mis-pair the inner *
-    3. strikethrough (~~)
-    4. links [text](url) — show url after the styled text
-  Headings, bullets, blockquotes are handled at the line level by
-  RenderMarkdown before this is called. }
+{ Apply per-line inline transforms in an order that prevents nested
+  styling inside code spans (Codex P2 on PR #155).
+
+  Strategy: pull every backtick-delimited code span out FIRST, store
+  its already-rendered ANSI body in a parallel array, and leave a
+  placeholder `#1<index>#1` in the text. Subsequent transforms
+  (bold, italic, strikethrough, links) scan the placeholder-laden
+  string and can't see what was inside the code; once they're done,
+  we substitute each placeholder back with its stored body. The
+  delimiter is SOH (#1), which models virtually never emit and which
+  has no markdown meaning.
+
+  Pass order on the remaining text:
+    1. Bold (**) before italic (*) so the inner * isn't mis-paired.
+    2. Strikethrough (~~).
+    3. Links [text](url) — show URL after the styled text.
+  Headings, bullets, blockquotes are line-level — handled before
+  this is called. }
+const
+  PLACEHOLDER = #1;
 var
-  Idx, LParen, RParen, LBracket, RBracket: Integer;
-  Before, LinkText, Url, After: string;
+  CodeBodies: array of string;
+  Idx, BodyStart, EndIdx, LParen, RParen, LBracket, RBracket: Integer;
+  Before, Body, LinkText, Url, After, Tag: string;
+  i: Integer;
 begin
   Result := S;
 
-  { Inline code: `code` -> dim + reverse. Done first so other
-    markers inside backticks survive untouched. }
-  Result := ReplaceFenced(Result, '`', '`',
-                          Ansi.Dim + #27'[7m', #27'[27m' + Ansi.Reset);
+  { Pass 1: extract inline code into placeholders.
 
-  { Bold: **text** -> bold. Must precede italic. }
-  Result := ReplaceFenced(Result, '**', '**',
-                          Ansi.Bold, Ansi.Reset);
+    `code` -> #1<N>#1 in the string, and CodeBodies[N] holds the
+    already-styled "dim+reverse code reset" so later passes can't
+    walk into it. Empty body (` `) stays verbatim. }
+  SetLength(CodeBodies, 0);
+  Idx := 1;
+  while True do
+  begin
+    Idx := PosEx('`', Result, Idx);
+    if Idx <= 0 then Break;
+    BodyStart := Idx + 1;
+    EndIdx := PosEx('`', Result, BodyStart);
+    if EndIdx <= 0 then Break;
+    if EndIdx = BodyStart then
+    begin
+      Idx := EndIdx + 1;
+      Continue;
+    end;
+    Before := Copy(Result, 1, Idx - 1);
+    Body   := Copy(Result, BodyStart, EndIdx - BodyStart);
+    After  := Copy(Result, EndIdx + 1, MaxInt);
+    SetLength(CodeBodies, Length(CodeBodies) + 1);
+    CodeBodies[High(CodeBodies)] :=
+      Ansi.Dim + #27'[7m' + Body + #27'[27m' + Ansi.Reset;
+    Tag := PLACEHOLDER + IntToStr(High(CodeBodies)) + PLACEHOLDER;
+    Result := Before + Tag + After;
+    Idx := Length(Before) + Length(Tag) + 1;
+  end;
 
-  { Italic: *text* -> italic ANSI (3m). Skipped when the markers
-    are flanked by other word chars (e.g. snake_case_var) — that's
-    why we look for whitespace / start-of-string before the opener. }
-  Result := ReplaceFenced(Result, '*', '*',
-                          #27'[3m', #27'[23m');
+  { Pass 2: the rest. Placeholders are #1-delimited, contain no
+    markdown markers, and are invisible to these scans. }
+  Result := ReplaceFenced(Result, '**', '**', Ansi.Bold, Ansi.Reset);
+  Result := ReplaceFenced(Result, '*', '*', #27'[3m', #27'[23m');
+  Result := ReplaceFenced(Result, '~~', '~~', #27'[9m', #27'[29m');
 
-  { Strikethrough: ~~text~~ -> ANSI 9m. }
-  Result := ReplaceFenced(Result, '~~', '~~',
-                          #27'[9m', #27'[29m');
-
-  { Links: [text](url) -> underlined text + (url). Hand-rolled
-    because the pattern needs two adjacent markers. }
+  { Links: [text](url) -> underlined text + (url) in dim. }
   Idx := Pos('[', Result);
   while Idx > 0 do
   begin
@@ -147,6 +177,15 @@ begin
     Idx := Length(Before) + Length(LinkText) + Length(Url) + 16;
     if Idx > Length(Result) then Break;
     Idx := PosEx('[', Result, Idx);
+  end;
+
+  { Pass 3: substitute placeholders back with the stored code
+    bodies. Runs after every other transform so the styled code
+    text drops in untouched. }
+  for i := 0 to High(CodeBodies) do
+  begin
+    Tag := PLACEHOLDER + IntToStr(i) + PLACEHOLDER;
+    Result := StringReplace(Result, Tag, CodeBodies[i], []);
   end;
 end;
 

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -118,6 +118,12 @@ type
        and Codex P2 on PR #118. *)
     PromptCacheEnabled: Boolean;
     PromptCacheTTL:     string;
+    (* When True, the assistant's reply is run through
+       PasClaw.Markdown.Render before being printed — headings and
+       fenced code blocks get ANSI styling, raw stars and hashes
+       disappear. On by default for the TUI; Cmd_TUI_Run forwards
+       Cfg.RenderMarkdown here. *)
+    RenderMarkdownEnabled: Boolean;
     (* Initial session to load. Empty = auto-allocate a fresh id (Delphi
        branch only; FPC branch ignores it). Cmd_TUI_Run forwards
        --session here, mirroring `pasclaw agent --session <id>`. *)
@@ -145,7 +151,8 @@ uses
   PasClaw.CliUI,
   PasClaw.Logger,
   PasClaw.Tools.ToolLoop,
-  PasClaw.Agent.Steering
+  PasClaw.Agent.Steering,
+  PasClaw.Markdown.Render
   {$IFNDEF FPC}
   , Math, StrUtils,
   MVCFramework.Console, LoggerPro.AnsiColors
@@ -226,6 +233,7 @@ begin
   FModel    := Model;
   PromptCacheEnabled := True;
   PromptCacheTTL     := '';
+  RenderMarkdownEnabled := True;
 end;
 
 function StatusLine(Provider: ILLMProvider; const Model: string;
@@ -1379,7 +1387,10 @@ begin
   W.Free;
   LogDebug('tool-loop end ok iters=%d', [Loop.Iterations]);
   Print(Ansi.BoldBlue + 'pasclaw' + Ansi.Reset + '  > ');
-  PrintLn(Loop.Content);
+  if Self.RenderMarkdownEnabled then
+    PrintLn(RenderMarkdown(Loop.Content))
+  else
+    PrintLn(Loop.Content);
   if Loop.LastResp.Usage.InputTokens + Loop.LastResp.Usage.OutputTokens > 0 then
     PrintLn(Ansi.Dim + '         ' +
       Format('[tokens in=%d out=%d, iters=%d]',

--- a/src/tests/markdown_render_tests.pas
+++ b/src/tests/markdown_render_tests.pas
@@ -147,6 +147,54 @@ begin
     Fail('empty input returned non-empty', RenderMarkdown(''));
 end;
 
+procedure TestInlineCodeProtectsMarkdownMarkers;
+{ Codex P2 on PR #155: inline code that contains markdown-looking
+  text (`**kwargs**`, `*.pas`, `[x](y)`) must NOT have those markers
+  consumed by subsequent bold/italic/link transforms. The original
+  renderer ran bold/italic after wrapping code spans with ANSI
+  escapes, so the body chars were still visible to the later scans
+  and got eaten. The fix protects code bodies via #1-delimited
+  placeholders that subsequent transforms can't see into. }
+var
+  Got: string;
+begin
+  { **kwargs** literally inside code — must show as bold-marker
+    literals, NOT as the word "kwargs" rendered bold. }
+  Got := RenderMarkdown('use `**kwargs**` to splat');
+  AssertContains(Got, '**kwargs**',
+    '** inside `..` survives the bold transform');
+  AssertContains(Got, 'to splat',
+    'text after the code span preserved');
+
+  { *.pas — the asterisk inside the code span must not start an
+    italic. Before the fix, `*.pas` would get the * consumed and
+    the rest mangled. }
+  Got := RenderMarkdown('the `*.pas` files');
+  AssertContains(Got, '*.pas',
+    '* inside `..` survives the italic transform');
+
+  { [text](url) inside code — must not become a link. }
+  Got := RenderMarkdown('see `[x](y)` syntax');
+  AssertContains(Got, '[x](y)',
+    'link syntax inside `..` survives the link transform');
+
+  { Two adjacent code spans with markers in both — both must
+    survive intact. }
+  Got := RenderMarkdown('mix `**a**` and `**b**` here');
+  AssertContains(Got, '**a**', 'first code span markers survive');
+  AssertContains(Got, '**b**', 'second code span markers survive');
+
+  { Code followed by genuine bold — code body protected, the real
+    bold OUTSIDE the code still applies. }
+  Got := RenderMarkdown('`raw**stays**raw` then **really bold**');
+  AssertContains(Got, 'raw**stays**raw',
+    'code span body fully verbatim');
+  AssertContains(Got, Ansi.Bold,
+    'genuine bold outside still rendered');
+  AssertContains(Got, 'really bold',
+    'bold body outside preserved');
+end;
+
 procedure TestNoTrailingNewlineAdded;
 { Streaming chunks arrive without a final newline; if we add one
   the caller's next emission lands on the wrong line. }
@@ -171,5 +219,6 @@ begin
   TestBlockquote;
   TestEmpty;
   TestNoTrailingNewlineAdded;
+  TestInlineCodeProtectsMarkdownMarkers;
   WriteLn('markdown_render_tests: OK');
 end.

--- a/src/tests/markdown_render_tests.pas
+++ b/src/tests/markdown_render_tests.pas
@@ -1,0 +1,175 @@
+program markdown_render_tests;
+{ Covers PasClaw.Markdown.Render — the ANSI styler for LLM output
+  in the terminal. We don't assert on exact escape codes because
+  Ansi.* fields are configurable; instead, prove the structural
+  transformations happened: marker chars consumed, content
+  preserved, ANSI escapes present in expected places. }
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.CliUI,
+  PasClaw.Markdown.Render;
+
+procedure Fail(const Msg, Body: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  WriteLn('--- output ---');
+  WriteLn(Body);
+  Halt(1);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) = 0 then
+    Fail(Msg + ' (expected substring: ' + Needle + ')', Haystack);
+end;
+
+procedure AssertMissing(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) > 0 then
+    Fail(Msg + ' (did NOT expect substring: ' + Needle + ')', Haystack);
+end;
+
+procedure TestPlainPassThrough;
+{ A plain-text reply with no markers should round-trip unchanged
+  (modulo line terminators). Important for streaming chunks: we
+  don't want the renderer adding ANSI noise to "Hello!". }
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('Hello, world.');
+  if Got <> 'Hello, world.' then
+    Fail('plain text changed', Got);
+end;
+
+procedure TestBold;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('this is **important** text');
+  AssertMissing(Got, '**', 'bold markers consumed');
+  AssertContains(Got, 'important', 'bold content preserved');
+  AssertContains(Got, Ansi.Bold, 'ANSI bold inserted');
+end;
+
+procedure TestItalic;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('an *emphasised* word');
+  AssertMissing(Got, '*emphasised*', 'italic markers consumed');
+  AssertContains(Got, 'emphasised',  'italic content preserved');
+  AssertContains(Got, #27'[3m',      'ANSI italic-on inserted');
+  AssertContains(Got, #27'[23m',     'ANSI italic-off inserted');
+end;
+
+procedure TestInlineCode;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('use `RenderMarkdown` here');
+  AssertMissing(Got, '`RenderMarkdown`', 'backticks consumed');
+  AssertContains(Got, 'RenderMarkdown',  'code text preserved');
+  AssertContains(Got, Ansi.Dim,          'code styled with dim');
+end;
+
+procedure TestHeading;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('# Big Header');
+  AssertMissing(Got, '# Big',     'heading hash consumed');
+  AssertContains(Got, 'Big Header', 'heading text preserved');
+  AssertContains(Got, Ansi.BoldBlue, 'h1 wrapped in BoldBlue');
+end;
+
+procedure TestBulletList;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('- one' + sLineBreak +
+                        '- two' + sLineBreak +
+                        '- three');
+  AssertContains(Got, 'one',   'bullet 1 body preserved');
+  AssertContains(Got, 'two',   'bullet 2 body preserved');
+  AssertContains(Got, 'three', 'bullet 3 body preserved');
+  AssertMissing(Got, '- one',  'bullet marker consumed');
+  AssertContains(Got, #$E2#$80#$A2, 'unicode bullet glyph emitted');
+end;
+
+procedure TestFencedCode;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('before' + sLineBreak +
+                        '```' + sLineBreak +
+                        '  x := 1;' + sLineBreak +
+                        '  **not bold inside**' + sLineBreak +
+                        '```' + sLineBreak +
+                        'after');
+  AssertContains(Got, 'x := 1;', 'fenced code body preserved');
+  { Bold markers inside a fenced block must NOT be transformed —
+    that's the model's literal code, not styling. }
+  AssertContains(Got, '**not bold inside**',
+    'bold inside fenced block stays verbatim');
+  AssertContains(Got, 'before', 'pre-fence content preserved');
+  AssertContains(Got, 'after',  'post-fence content preserved');
+end;
+
+procedure TestLink;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('see [the docs](https://example.com/x) for more');
+  AssertMissing(Got, '[the docs](https://example.com/x)',
+    'link markdown markers consumed');
+  AssertContains(Got, 'the docs', 'link text preserved');
+  AssertContains(Got, 'https://example.com/x', 'link URL preserved');
+  AssertContains(Got, #27'[4m',  'underline applied to link text');
+end;
+
+procedure TestBlockquote;
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('> a quoted line');
+  AssertContains(Got, 'a quoted line', 'blockquote body preserved');
+  AssertMissing(Got, '> a',            'leading > consumed');
+  AssertContains(Got, '│',             'blockquote bar emitted');
+end;
+
+procedure TestEmpty;
+begin
+  if RenderMarkdown('') <> '' then
+    Fail('empty input returned non-empty', RenderMarkdown(''));
+end;
+
+procedure TestNoTrailingNewlineAdded;
+{ Streaming chunks arrive without a final newline; if we add one
+  the caller's next emission lands on the wrong line. }
+var
+  Got: string;
+begin
+  Got := RenderMarkdown('partial **token**');
+  if (Got <> '') and (Got[Length(Got)] = #10) then
+    Fail('renderer added a trailing newline to a no-newline input', Got);
+end;
+
+begin
+  CliUI_Init(False);   { populate Ansi.* so style markers compare correctly }
+  TestPlainPassThrough;
+  TestBold;
+  TestItalic;
+  TestInlineCode;
+  TestHeading;
+  TestBulletList;
+  TestFencedCode;
+  TestLink;
+  TestBlockquote;
+  TestEmpty;
+  TestNoTrailingNewlineAdded;
+  WriteLn('markdown_render_tests: OK');
+end.


### PR DESCRIPTION
## TL;DR

Models emit markdown — `**bold**`, `# headings`, fenced code, lists, `[links](urls)`. PasClaw was printing all that verbatim with the raw stars and hashes showing through. picoclaw does the same (no markdown rendering in its agent loop, just `println`). nanobot uses Python's `rich` library and renders markdown to styled ANSI for free. We pick the nanobot direction.

## New unit

`src/pkg/markdown/PasClaw.Markdown.Render.pas`

```pascal
function RenderMarkdown(const S: string): string;
```

Subset covered (~95% of what models actually emit):

| Source              | Rendered                              |
|---------------------|---------------------------------------|
| `# h1` / `## h2`    | Bold + colour                         |
| `**bold**`          | ANSI bold                             |
| `*italic*` / `_italic_` | ANSI italic                       |
| `~~strikethrough~~` | ANSI strikethrough                    |
| `` `inline code` `` | Dim + reverse                         |
| ```` ```fenced``` ```` | Dim, multi-line, inline transforms suppressed inside |
| `- ` / `* ` bullet  | `•` glyph + indent                    |
| `> blockquote`      | `│ ` bar + italic body                |
| `[text](url)`       | Underline text + `(url)` in dim       |

- Plain text (no markers) → **byte-identical passthrough**. Matters for streaming chunks where we render mid-message.
- Empty input → empty output.
- No trailing newline added to non-newline-terminated input (streaming-friendly).

## Config knob

`Cfg.RenderMarkdown` — default `True`.

- **`pasclaw agent`** — wired via new `MaybeRender(Cfg, Loop.Content)` helper at both `RunSingleTurn` + `RunInteractive` sites.
- **`pasclaw tui`** — wired via new `TTUI.RenderMarkdownEnabled` field; `Cmd_TUI_Run` sets it from `Cfg.RenderMarkdown`.
- **`pasclaw serve` / `pasclaw gateway`** — left alone. They emit JSON to API clients; ANSI escapes would corrupt the wire body. Their `Loop.Content` flows through `WriteJSON` / `WriteSSE`, not the renderer.

Round-trips through `config.json`: default-True emits no key; explicit `"render_markdown": false` from operator preserves through save/load.

## Test plan

`make test-markdown-render` runs 11 cases:

- [x] `TestPlainPassThrough` — plain text byte-identical
- [x] `TestBold`, `TestItalic`, `TestInlineCode` — markers consumed, content + ANSI escapes present
- [x] `TestHeading` — `# ` consumed, `Ansi.BoldBlue` applied
- [x] `TestBulletList` — `-`/`*` consumed, `•` glyph emitted
- [x] `TestFencedCode` — body preserved, **bold** inside stays verbatim (no nested transforms)
- [x] `TestLink` — `[text](url)` becomes underlined text + `(url)` in dim
- [x] `TestBlockquote` — `> ` consumed, `│` bar emitted
- [x] `TestEmpty` — empty in, empty out
- [x] `TestNoTrailingNewlineAdded` — streaming-friendly
- [x] `make smoke` — all 11 commands OK
- [x] `make test-anthropic-server-tools` / `-openai-server-tools` / `-gemini-schema-strip` — unchanged, OK
- [ ] Live exercise: `pasclaw agent -m "in markdown, show me a heading, a bulleted list of three things, and a code block with hello world in python"` — should render styled, no visible stars/hashes.

## Caveats (honest)

- The italic detector is naive: `5 * 4 = 20` would currently consume the asterisks. Same trap any non-word-boundary-aware markdown parser hits. Documented; can tighten if it bites.
- No table rendering. Models rarely emit them and the Pascal-side `TStringBuilder` math gets hairy. Easy to add later.
- The renderer assumes `CliUI_Init` has populated `Ansi.*` — the test calls it explicitly. Production paths call it via `RunRootCommand` startup.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_