### PR TITLE
Register PasClaw.Markdown.Render in PasClaw.dproj (dcc64 F2613 fix)

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -285,6 +285,9 @@
         <!-- pkg/agent (TPasClawAgent component lives here; PasClaw.Component is a back-compat shim) -->
         <DCCReference Include="..\pkg\agent\PasClaw.Agent.pas"/>
         <DCCReference Include="..\pkg\component\PasClaw.Component.pas"/>
+
+        <!-- pkg/markdown (markdown -> ANSI terminal renderer) -->
+        <DCCReference Include="..\pkg\markdown\PasClaw.Markdown.Render.pas"/>
 
         <!-- pkg/vendor/dmvcframework (Apache-2.0, Delphi-only) -->
         <DCCReference Include="..\pkg\vendor\dmvcframework\LoggerPro.AnsiColors.pas"/>


### PR DESCRIPTION
## TL;DR

dcc64 reports after PR #155 merge:

```
[dcc64 Fatal Error] PasClaw.Cmd.Agent.pas(50): F2613 Unit
'PasClaw.Markdown.Render' not found.
```

PR #155 added the new unit dir to the Makefile's `UNIT_DIRS` (for FPC) but didn't update `src/pasclaw/PasClaw.dproj` (for Delphi). The `.dproj` has its own list — `DCC_UnitSearchPath` plus an explicit `DCCReference` per `.pas` — and adds don't auto-sync from the Makefile side.

## Fix

Two edits in `src/pasclaw/PasClaw.dproj`:

1. **`DCC_UnitSearchPath`** gains `..\pkg\markdown` so dcc64 finds the directory on the unit search path (mirror of the Makefile's `UNIT_DIRS += src/pkg/markdown`).
2. **`DCCReference`** added for `..\pkg\markdown\PasClaw.Markdown.Render.pas` alongside the other `pkg/*` entries so the unit is part of the project (and gets a build slot in the IDE).

No source changes. FPC build still clean (`make smoke` passes).

## Process gap on my end

Every time I add a new unit directory I update `Makefile` but consistently forget the `.dproj`. Suggested follow-up: a `make check-dproj` target that diffs the `.pas` files under `src/cmd` + `src/pkg/**` against the `DCCReference` list, fails if any are missing. Would have caught this. Want me to add that in a separate PR?

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_