### PR TITLE
Gemini: opt-in server-side google_search, default-on

### DIFF
--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -249,17 +249,31 @@ type
   end;
 
   (* Gemini: opt-in server-side Google search grounding.
-     Emits a `{ "google_search": {} }` entry inside the top-level
-     `tools` array when GoogleSearch is True. Claude executes the
-     search server-side and returns grounded text; no local
-     web_search tool is invoked.
+     Emits a `google_search` entry inside the top-level `tools`
+     array with an empty config object as its value, when
+     GoogleSearch is True. Gemini executes the search server-side
+     and returns grounded text; no local web_search tool runs.
 
-     Wire shape requires Gemini 2.x or newer. Gemini 1.5 used a
-     different field (`google_search_retrieval`) we don't emit;
-     pointing the toggle at a 1.5 model yields a 400 from the
-     generateContent endpoint — flip to False in config.json or
-     pick a 2.x+ model. The catalog default is gemini-3.5-flash
-     so the common path "just works".
+     Model gating happens at the Gemini provider's BuildRequest
+     boundary (IsGemini3OrLater), so default-on is safe across
+     the model matrix:
+       Gemini 3.x+        always emitted; combines with
+                          functionDeclarations on the same request.
+       Gemini 2.x         emitted only when no local tools are
+                          registered. Mixing google_search with
+                          functionDeclarations 400s on 2.x; the
+                          provider silently suppresses the search
+                          this turn to preserve the user's tools.
+                          With no local tools, the bare
+                          google_search request works.
+       Gemini 1.5 / 1.0   `google_search` is the wrong wire shape
+                          (1.x used `google_search_retrieval`,
+                          which we don't emit). Bare google_search
+                          requests 400. Operators on 1.x should
+                          set google_search: false in config.json
+                          or move to a 2.x+ model. The catalog
+                          default is gemini-3.5-flash so the
+                          common path "just works".
 
      On-by-default. Most operators picking Gemini want grounding;
      leaving it off would hide a free capability. Operators who

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -248,6 +248,28 @@ type
     WebSearch: Boolean;
   end;
 
+  (* Gemini: opt-in server-side Google search grounding.
+     Emits a `{ "google_search": {} }` entry inside the top-level
+     `tools` array when GoogleSearch is True. Claude executes the
+     search server-side and returns grounded text; no local
+     web_search tool is invoked.
+
+     Wire shape requires Gemini 2.x or newer. Gemini 1.5 used a
+     different field (`google_search_retrieval`) we don't emit;
+     pointing the toggle at a 1.5 model yields a 400 from the
+     generateContent endpoint — flip to False in config.json or
+     pick a 2.x+ model. The catalog default is gemini-3.5-flash
+     so the common path "just works".
+
+     On-by-default. Most operators picking Gemini want grounding;
+     leaving it off would hide a free capability. Operators who
+     embed a custom function tool named "google_search" (rare —
+     the name collides with the Anthropic/OpenAI patterns) will
+     hit a duplicate-name 400 on Gemini and should disable this. *)
+  TGeminiServerToolsConfig = record
+    GoogleSearch: Boolean;
+  end;
+
   TConfig = class
   public
     DefaultProvider: string;
@@ -300,6 +322,7 @@ type
     RenderMarkdown:    Boolean;
     AnthropicServerTools: TAnthropicServerToolsConfig;
     OpenAIServerTools:    TOpenAIServerToolsConfig;
+    GeminiServerTools:    TGeminiServerToolsConfig;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -376,6 +399,11 @@ begin
     "for free" with no extra config step. Flip to False in
     config.json to suppress emitting the field entirely. }
   OpenAIServerTools.WebSearch           := True;
+  { Default-on for the same reason as OpenAI's web_search: most
+    Gemini operators want grounding and the catalog default model
+    (gemini-3.5-flash) accepts the field. See the type comment for
+    the model-compat caveat. }
+  GeminiServerTools.GoogleSearch        := True;
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -538,6 +566,13 @@ begin
     Tmp := TJsonObject.Create;
     Tmp.PutBool('web_search', OpenAIServerTools.WebSearch);
     Root.PutObject('openai_server_tools', Tmp);
+
+    { Same round-trip rule as the OpenAI block: the default is True,
+      so we must emit unconditionally — otherwise `google_search:
+      false` in config.json silently reverts on the next load. }
+    Tmp := TJsonObject.Create;
+    Tmp.PutBool('google_search', GeminiServerTools.GoogleSearch);
+    Root.PutObject('gemini_server_tools', Tmp);
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -712,6 +747,15 @@ begin
     try
       OpenAIServerTools.WebSearch :=
         Obj.GetBool('web_search', OpenAIServerTools.WebSearch);
+    finally
+      Obj.Free;
+    end;
+
+    Obj := Root.ChildObject('gemini_server_tools');
+    if Obj <> nil then
+    try
+      GeminiServerTools.GoogleSearch :=
+        Obj.GetBool('google_search', GeminiServerTools.GoogleSearch);
     finally
       Obj.Free;
     end;

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -105,6 +105,7 @@ var
   RequiresKey: Boolean;
   ServerTools: TAnthropicServerTools;
   OAIServerTools: TOpenAIServerTools;
+  GeminiSrvTools: TGeminiServerTools;
 begin
   Provider := nil;
   ErrMsg := '';
@@ -164,7 +165,15 @@ begin
                                             OAIServerTools);
       end;
     pfGemini:
-      Provider := TGeminiProvider.Create(APIKey, Base, Model);
+      begin
+        { google_search is Gemini-native server-side grounding —
+          emitted as a `tools[]` entry. Default-on (see
+          TGeminiServerToolsConfig). Operators on a Gemini 1.5 model
+          should flip this off in config.json since the 1.5 line uses
+          the older google_search_retrieval shape. }
+        GeminiSrvTools.GoogleSearch := Cfg.GeminiServerTools.GoogleSearch;
+        Provider := TGeminiProvider.Create(APIKey, Base, Model, GeminiSrvTools);
+      end;
     pfPlaceholder:
       begin
         ErrMsg := 'provider "' + Spec.DisplayName + '" is in the catalog but ' +

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -40,13 +40,24 @@ uses
   PasClaw.Providers.Intf;
 
 type
+  (* Opt-in toggles for Gemini-side server tools. Mirrors
+     PasClaw.Config.TGeminiServerToolsConfig — kept local to this
+     unit so the provider's tests can build the wire body without
+     importing the config unit (same shape Anthropic uses, see
+     TAnthropicServerTools). *)
+  TGeminiServerTools = record
+    GoogleSearch: Boolean;
+  end;
+
   TGeminiProvider = class(TInterfacedObject, ILLMProvider)
   private
     FAPIKey:       string;
     FAPIBase:      string;
     FDefaultModel: string;
+    FServerTools:  TGeminiServerTools;
   public
-    constructor Create(const APIKey, APIBase, DefaultModel: string);
+    constructor Create(const APIKey, APIBase, DefaultModel: string;
+                       const ServerTools: TGeminiServerTools);
     function Chat(const Messages: array of TMessage;
                   const Tools:    array of TToolDefinition;
                   const Model:    string;
@@ -63,16 +74,29 @@ type
     function SupportsStreaming: Boolean;
   end;
 
+{ Default-initialised TGeminiServerTools (everything off). Use in
+  tests / embedders that don't want server tools in the wire body. }
+function NoGeminiServerTools: TGeminiServerTools;
+
 { Exported for test fixtures — given a TLLMResponse-shaped input,
   returns the JSON body that would be POSTed to generateContent.
   Used by the Codex PR #116 review-fix test to assert SystemPrompt
   / in-history mrSystem dedup without spinning up a real HTTPS
   round-trip. Tools / ToolIds / ToolNames are normally constructed
-  inside the request flow; tests pass empty arrays. }
+  inside the request flow; tests pass empty arrays.
+
+  The 4-arg overload delegates to the 5-arg form with
+  NoGeminiServerTools — server tools off — so existing call sites
+  and tests that don't care about Google search stay untouched. }
 function BuildRequest(const Messages: array of TMessage;
                       const Tools:    array of TToolDefinition;
                       const Model:    string;
-                      const Options:  TChatOptions): string;
+                      const Options:  TChatOptions): string; overload;
+function BuildRequest(const Messages: array of TMessage;
+                      const Tools:    array of TToolDefinition;
+                      const Model:    string;
+                      const Options:  TChatOptions;
+                      const ServerTools: TGeminiServerTools): string; overload;
 
 (* Strip JSON-Schema fields Gemini's function-calling API doesn't
    accept (additionalProperties, $schema, $id, $ref, definitions,
@@ -92,7 +116,13 @@ uses
   PasClaw.Providers.HTTP,
   PasClaw.Logger;
 
-constructor TGeminiProvider.Create(const APIKey, APIBase, DefaultModel: string);
+function NoGeminiServerTools: TGeminiServerTools;
+begin
+  Result.GoogleSearch := False;
+end;
+
+constructor TGeminiProvider.Create(const APIKey, APIBase, DefaultModel: string;
+                                   const ServerTools: TGeminiServerTools);
 begin
   inherited Create;
   FAPIKey := APIKey;
@@ -100,12 +130,13 @@ begin
                    else FAPIBase := 'https://generativelanguage.googleapis.com';
   if DefaultModel <> '' then FDefaultModel := DefaultModel
                        else FDefaultModel := 'gemini-1.5-flash';
+  FServerTools := ServerTools;
 end;
 
 function TGeminiProvider.GetDefaultModel: string;     begin Result := FDefaultModel; end;
 function TGeminiProvider.GetName: string;             begin Result := 'gemini';      end;
 function TGeminiProvider.SupportsThinking: Boolean;   begin Result := False;         end;
-function TGeminiProvider.SupportsNativeSearch: Boolean; begin Result := False;       end;
+function TGeminiProvider.SupportsNativeSearch: Boolean; begin Result := FServerTools.GoogleSearch; end;
 function TGeminiProvider.SupportsStreaming: Boolean;  begin Result := False;         end;
 
 { Map TMsgRole to Gemini's content.role. Note tool/system are special
@@ -305,15 +336,28 @@ begin
   end;
 end;
 
+{ 4-arg overload — no server tools. Preserved so existing tests
+  (gemini_schema_strip_tests.pas + friends) and embedders that
+  predate the server-tool field keep compiling unchanged. }
+function BuildRequest(const Messages: array of TMessage;
+                      const Tools:    array of TToolDefinition;
+                      const Model:    string;
+                      const Options:  TChatOptions): string;
+begin
+  Result := BuildRequest(Messages, Tools, Model, Options, NoGeminiServerTools);
+end;
+
 { Builds the request body. Mirrors picoclaw's pkg/providers/httpapi
   gemini_provider.go buildRequestBody, trimmed to text + tool support. }
 function BuildRequest(const Messages: array of TMessage;
                       const Tools:    array of TToolDefinition;
                       const Model:    string;
-                      const Options:  TChatOptions): string;
+                      const Options:  TChatOptions;
+                      const ServerTools: TGeminiServerTools): string;
 var
   Root, Content, Part, ToolObj, FuncDecl, FuncCall, FuncResp,
-    FuncRespBody, EmptyObj, GenCfg, SysContent, SysPart, ToolsTop: TJsonObject;
+    FuncRespBody, EmptyObj, GenCfg, SysContent, SysPart,
+    GoogleSearchObj, GoogleSearchEntry: TJsonObject;
   Contents, Parts, ToolsArr, FuncDecls, SysParts: TJsonArray;
   i, j: Integer;
   Sys, ToolName, ArgsJSON: string;
@@ -471,32 +515,56 @@ begin
       Root.PutObject('systemInstruction', SysContent);
     end;
 
-    if Length(Tools) > 0 then
+    (* Build the tools[] array when EITHER caller tools or a server
+       tool is active. Each tool category is its own object inside
+       the array — `functionDeclarations: [...]` for our local
+       tools, `google_search: ` empty-object for Gemini's grounded
+       search. Both can coexist on Gemini 2.5+ / 3.x. On Gemini 1.5
+       the API returns 400 for `google_search`; operator's choice
+       via the config toggle. *)
+    if (Length(Tools) > 0) or ServerTools.GoogleSearch then
     begin
-      FuncDecls := TJsonArray.Create;
-      for i := 0 to High(Tools) do
-      begin
-        FuncDecl := TJsonObject.Create;
-        FuncDecl.PutStr('name', Tools[i].Name);
-        if Tools[i].Description <> '' then
-          FuncDecl.PutStr('description', Tools[i].Description);
-        if Tools[i].Schema <> '' then
-          { Strip JSON-Schema fields Gemini's function-calling API
-            doesn't accept (additionalProperties, $schema, etc.) —
-            see SanitizeSchemaForGemini for the full list and why
-            MCP / skill schemas trip into them. }
-          FuncDecl.PutRaw('parameters', SanitizeSchemaForGemini(Tools[i].Schema))
-        else
-        begin
-          EmptyObj := TJsonObject.Create;
-          FuncDecl.PutObject('parameters', EmptyObj);
-        end;
-        FuncDecls.AddObject(FuncDecl);
-      end;
-      ToolObj := TJsonObject.Create;
-      ToolObj.PutArray('functionDeclarations', FuncDecls);
       ToolsArr := TJsonArray.Create;
-      ToolsArr.AddObject(ToolObj);
+
+      if Length(Tools) > 0 then
+      begin
+        FuncDecls := TJsonArray.Create;
+        for i := 0 to High(Tools) do
+        begin
+          FuncDecl := TJsonObject.Create;
+          FuncDecl.PutStr('name', Tools[i].Name);
+          if Tools[i].Description <> '' then
+            FuncDecl.PutStr('description', Tools[i].Description);
+          if Tools[i].Schema <> '' then
+            { Strip JSON-Schema fields Gemini's function-calling API
+              doesn't accept (additionalProperties, $schema, etc.) —
+              see SanitizeSchemaForGemini for the full list and why
+              MCP / skill schemas trip into them. }
+            FuncDecl.PutRaw('parameters', SanitizeSchemaForGemini(Tools[i].Schema))
+          else
+          begin
+            EmptyObj := TJsonObject.Create;
+            FuncDecl.PutObject('parameters', EmptyObj);
+          end;
+          FuncDecls.AddObject(FuncDecl);
+        end;
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutArray('functionDeclarations', FuncDecls);
+        ToolsArr.AddObject(ToolObj);
+      end;
+
+      if ServerTools.GoogleSearch then
+      begin
+        (* Wire shape: a tools-array entry whose only key is
+           "google_search" with an empty config object as its value.
+           The empty value opts into Gemini's default grounding
+           behaviour; extra keys here are rejected by the API. *)
+        GoogleSearchEntry := TJsonObject.Create;
+        GoogleSearchObj   := TJsonObject.Create;
+        GoogleSearchEntry.PutObject('google_search', GoogleSearchObj);
+        ToolsArr.AddObject(GoogleSearchEntry);
+      end;
+
       Root.PutArray('tools', ToolsArr);
     end;
 
@@ -660,7 +728,7 @@ var
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1beta/models/' + UseModel + ':generateContent';
-  Body := BuildRequest(Messages, Tools, UseModel, Options);
+  Body := BuildRequest(Messages, Tools, UseModel, Options, FServerTools);
 
   SetLength(Headers, 1);
   Headers[0] := MakeHeader('x-goog-api-key', FAPIKey);

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -121,6 +121,36 @@ begin
   Result.GoogleSearch := False;
 end;
 
+function IsGemini3OrLater(const Model: string): Boolean;
+(* True when Model names a Gemini family at major version 3 or higher.
+   Gates the google_search + functionDeclarations combo: pre-Gemini-3
+   models (2.0, 2.5, 1.5 etc.) reject the request with 400 when both
+   are present in the same `tools[]` array — Google's current docs
+   route mixed-tool flows on those models through the Live API
+   instead. Gemini 3.x lifted the restriction and accepts both shapes
+   in a single REST call.
+
+   Detection is a deliberate cheap prefix check on the digit
+   immediately after `gemini-` — covers `gemini-3-flash`,
+   `gemini-3.5-flash`, `gemini-3.0-pro`, hypothetical `gemini-4-*`,
+   etc. Vendor-prefixed deployments (e.g. `vertex/gemini-3-...`) hit
+   the substring match. Anything that doesn't fit the pattern —
+   `gemini-pro`, `gemini-1.5-flash`, `gemini-2.5-flash`, an unknown
+   name — is conservatively treated as "cannot combine", so the
+   default-on toggle never lights a 400 on a user's tool-using
+   chat. *)
+var
+  M: string;
+  i: Integer;
+begin
+  M := LowerCase(Model);
+  i := Pos('gemini-', M);
+  if i = 0 then Exit(False);
+  i := i + Length('gemini-');
+  if i > Length(M) then Exit(False);
+  Result := (M[i] >= '3') and (M[i] <= '9');
+end;
+
 constructor TGeminiProvider.Create(const APIKey, APIBase, DefaultModel: string;
                                    const ServerTools: TGeminiServerTools);
 begin
@@ -363,6 +393,7 @@ var
   Sys, ToolName, ArgsJSON: string;
   ToolIds, ToolNames: TStringList;   { id -> name map, parallel arrays }
   Idx: Integer;
+  EmitGoogleSearch: Boolean;
 begin
   ToolIds   := TStringList.Create;
   ToolNames := TStringList.Create;
@@ -515,14 +546,36 @@ begin
       Root.PutObject('systemInstruction', SysContent);
     end;
 
-    (* Build the tools[] array when EITHER caller tools or a server
-       tool is active. Each tool category is its own object inside
-       the array — `functionDeclarations: [...]` for our local
-       tools, `google_search: ` empty-object for Gemini's grounded
-       search. Both can coexist on Gemini 2.5+ / 3.x. On Gemini 1.5
-       the API returns 400 for `google_search`; operator's choice
-       via the config toggle. *)
-    if (Length(Tools) > 0) or ServerTools.GoogleSearch then
+    (* Decide whether google_search will actually go on the wire.
+       The toggle says "the operator wants grounding when possible",
+       but Gemini's wire constraints narrow that:
+
+         - On Gemini 3.x+ we may combine google_search with
+           functionDeclarations in the same request — emit both.
+         - On Gemini 2.x and earlier, mixing the two in a single
+           REST call returns 400 ("Live API only" per Google's
+           function-calling docs). If the caller has registered
+           local tools, preserve those (they're the user's
+           explicit configuration) and suppress google_search this
+           turn — silently better than a 400 on every tool-using
+           chat. With no local tools the combo doesn't arise and
+           google_search ships.
+
+       Codex P2 on PR #158. *)
+    EmitGoogleSearch := ServerTools.GoogleSearch and
+                       ((Length(Tools) = 0) or IsGemini3OrLater(Model));
+    if ServerTools.GoogleSearch and (Length(Tools) > 0) and
+       (not IsGemini3OrLater(Model)) then
+      LogDebug('gemini: suppressing google_search for this turn — model %s ' +
+               'rejects google_search alongside functionDeclarations ' +
+               '(combo requires gemini-3.x or later)', [Model]);
+
+    (* Build the tools[] array when EITHER caller tools or the
+       effective google_search emission is active. Each tool
+       category is its own object inside the array —
+       `functionDeclarations: [...]` for our local tools,
+       `google_search: ` empty-object for Gemini's grounded search. *)
+    if (Length(Tools) > 0) or EmitGoogleSearch then
     begin
       ToolsArr := TJsonArray.Create;
 
@@ -553,7 +606,7 @@ begin
         ToolsArr.AddObject(ToolObj);
       end;
 
-      if ServerTools.GoogleSearch then
+      if EmitGoogleSearch then
       begin
         (* Wire shape: a tools-array entry whose only key is
            "google_search" with an empty config object as its value.

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -343,8 +343,8 @@ begin
 end;
 
 procedure TestGoogleSearchCoexistsWithFunctionDeclarations;
-{ Gemini 2.5+ / 3.x accept both entries in the same tools array.
-  Verify the wire body emits BOTH on the same request. }
+{ Gemini 3.x accepts both entries in the same tools array. Verify
+  the wire body emits BOTH on a 3.x model. }
 var
   Msgs:  TMessageArray;
   Tools: TToolDefinitionArray;
@@ -368,7 +368,64 @@ begin
   AssertContains(Body, '"fs_list"',
     'local tool name preserved');
   AssertContains(Body, '"google_search"',
-    'google_search emitted alongside functionDeclarations');
+    'google_search emitted alongside functionDeclarations on 3.x');
+end;
+
+procedure TestGoogleSearchSuppressedOnPreGemini3WithLocalTools;
+(* Codex P2 on PR #158. Gemini 2.x rejects the
+   google_search + functionDeclarations combo with a 400. Default-on
+   would silently break every tool-using chat on a 2.x model.
+   BuildRequest must suppress google_search this turn and keep the
+   functionDeclarations the user explicitly registered. *)
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  ST:    TGeminiServerTools;
+  Body:  string;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'list pwd');
+  SetLength(Tools, 1);
+  Tools[0].Name        := 'fs_list';
+  Tools[0].Description := 'list a directory';
+  Tools[0].Schema      := '{"type":"object","properties":{"path":{"type":"string"}}}';
+  Opts := DefaultChatOptions;
+  ST.GoogleSearch := True;
+
+  Body := BuildRequest(Msgs, Tools, 'gemini-2.5-flash', Opts, ST);
+
+  AssertContains(Body, '"functionDeclarations"',
+    'local tools kept on 2.x — they were the user''s explicit config');
+  AssertContains(Body, '"fs_list"',
+    'local tool name preserved on 2.x');
+  AssertMissing(Body, '"google_search"',
+    'google_search suppressed on 2.x when local tools present');
+end;
+
+procedure TestGoogleSearchEmittedOnPreGemini3WithoutLocalTools;
+(* The suppression only applies to the combo. Bare google_search on
+   2.x is a valid request — keep emitting it so default-on grounding
+   still works on 2.x for non-tool-loop conversations. *)
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  ST:    TGeminiServerTools;
+  Body:  string;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'who won the world cup');
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+  ST.GoogleSearch := True;
+
+  Body := BuildRequest(Msgs, Tools, 'gemini-2.5-flash', Opts, ST);
+
+  AssertContains(Body, '"google_search"',
+    'bare google_search still emitted on 2.x when no local tools present');
+  AssertMissing(Body, '"functionDeclarations"',
+    'no functionDeclarations entry when caller has no tools');
 end;
 
 begin
@@ -382,5 +439,7 @@ begin
   TestGoogleSearchEmittedWhenEnabled;
   TestGoogleSearchOmittedWhenDisabled;
   TestGoogleSearchCoexistsWithFunctionDeclarations;
+  TestGoogleSearchSuppressedOnPreGemini3WithLocalTools;
+  TestGoogleSearchEmittedOnPreGemini3WithoutLocalTools;
   WriteLn('gemini_schema_strip_tests: OK');
 end.

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -292,6 +292,85 @@ begin
     Fail('empty signature did not round-trip empty', Restored.ProviderSignature);
 end;
 
+procedure TestGoogleSearchEmittedWhenEnabled;
+(* ServerTools.GoogleSearch=True puts a tools[] entry whose key is
+   "google_search" with an empty-object value into the request body.
+   Coexists with the caller's functionDeclarations entry when local
+   tools are also registered. *)
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  ST:    TGeminiServerTools;
+  Body:  string;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'what is the weather today');
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+  ST.GoogleSearch := True;
+
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts, ST);
+
+  AssertContains(Body, '"tools"',
+    'tools array emitted even when no local tools are registered');
+  AssertContains(Body, '"google_search"',
+    'google_search entry present when toggle is on');
+end;
+
+procedure TestGoogleSearchOmittedWhenDisabled;
+{ NoGeminiServerTools (or any record with GoogleSearch=False) means
+  no google_search entry, and with no local tools, no tools array
+  at all — Gemini 400s on an empty tools[]. }
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  Body:  string;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'hello');
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts,
+                       NoGeminiServerTools);
+
+  AssertMissing(Body, '"google_search"',
+    'google_search omitted when toggle is off');
+  AssertMissing(Body, '"tools"',
+    'no tools array at all when neither server nor local tools present');
+end;
+
+procedure TestGoogleSearchCoexistsWithFunctionDeclarations;
+{ Gemini 2.5+ / 3.x accept both entries in the same tools array.
+  Verify the wire body emits BOTH on the same request. }
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  ST:    TGeminiServerTools;
+  Body:  string;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'list files then search');
+  SetLength(Tools, 1);
+  Tools[0].Name        := 'fs_list';
+  Tools[0].Description := 'list a directory';
+  Tools[0].Schema      := '{"type":"object","properties":{"path":{"type":"string"}}}';
+  Opts := DefaultChatOptions;
+  ST.GoogleSearch := True;
+
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts, ST);
+
+  AssertContains(Body, '"functionDeclarations"',
+    'local tools still emitted under functionDeclarations');
+  AssertContains(Body, '"fs_list"',
+    'local tool name preserved');
+  AssertContains(Body, '"google_search"',
+    'google_search emitted alongside functionDeclarations');
+end;
+
 begin
   TestRejectedFieldsScrubbed;
   TestUserPropertyNamedAdditionalPropertiesSurvives;
@@ -300,5 +379,8 @@ begin
   TestNoSignatureWhenEmpty;
   TestSessionPersistenceRoundTrip;
   TestSessionPersistenceEmpty;
+  TestGoogleSearchEmittedWhenEnabled;
+  TestGoogleSearchOmittedWhenDisabled;
+  TestGoogleSearchCoexistsWithFunctionDeclarations;
   WriteLn('gemini_schema_strip_tests: OK');
 end.


### PR DESCRIPTION
## Summary

Adds the same opt-in server-tools pattern Anthropic (web_search/web_fetch) and OpenAI (web_search) already have, for Gemini's native Google search grounding. **Default is on**, matching OpenAI's web_search posture — most operators picking Gemini want grounding, and the catalog default model (gemini-3.5-flash) accepts the field.

## Wire shape

A `tools[]` entry whose only key is `google_search` with an empty config object as its value. Coexists with the existing `functionDeclarations` entry on the same request — both are emitted side-by-side when the operator has local tools registered. Gemini 2.5+ / 3.x accept the combination.

## Compatibility note

Gemini 1.5 used the older `googleSearchRetrieval` shape we don't emit; pointing the toggle at a 1.5 model yields a 400 from `generateContent`. Operators on 1.5 should set `"google_search": false` in `config.json` or move to a 2.x+ model. Catalog default (`gemini-3.5-flash`) works out of the box.

## Mechanics

- **`PasClaw.Config`** — new `TGeminiServerToolsConfig` record with `GoogleSearch: Boolean`, JSON round-trip via `gemini_server_tools.google_search`. Always emitted on save so `false` sticks across reloads.
- **`PasClaw.Providers.Gemini`** — `TGeminiServerTools` record local to the unit (same posture as Anthropic), 4th constructor arg, `BuildRequest` overloaded so every existing 4-arg call (tests + embedders that predate the field) keeps compiling unchanged. `SupportsNativeSearch` now reports the toggle value.
- **`PasClaw.Providers.Factory`** — `pfGemini` branch translates `Cfg.GeminiServerTools` into the provider's local record.

## Test plan

- [x] `make test-gemini-schema-strip` — 3 new cases prove the wire shape: emitted when on, omitted when off (with no empty `tools[]` either), coexists with `functionDeclarations` when both are present. All 10 cases pass.
- [x] `make test-anthropic-server-tools test-openai-server-tools test-markdown-render` — neighbouring server-tool / render suites still green.
- [x] `make` — full pasclaw binary builds clean.
- [x] `make smoke` — every command surface still passes.
- [x] Manual config round-trip: `TConfig.Create` defaults to `True`; serialise + reparse with `false` round-trips to `false`; serialise + reparse with `true` round-trips to `true`.
- [ ] Live `pasclaw agent` against a Gemini API key with a grounded prompt ("what is the weather in Tokyo today") to confirm citations come back. *(Requires a real Gemini API key — not runnable in CI.)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_