### PR TITLE
Hashline FPC fix + Gemini tool_config for google_search combo

### DIFF
--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -606,10 +606,22 @@ end;
 
 function ValidateHashlinePatchGrammar(const PatchText: string;
                                       out ErrMsg: string): Boolean;
+{ HL_PAYLOAD_ABOVE / HL_PAYLOAD_BELOW are multi-byte UTF-8 sequences
+  in FPC mode delphi (where Char = AnsiChar, single byte) and single
+  WideChars in Delphi. `L[p+1] = HL_PAYLOAD_BELOW` compares one
+  AnsiChar against a 3-byte string under FPC and never matches —
+  the validator silently accepted "60:↓bad inline payload" instead
+  of flagging it, and the canonical inline-payload check became
+  Delphi-only. Use Copy(L, p+1, Length(MARKER)) so the comparison
+  works in byte units on FPC and char units on Delphi without
+  changing semantics on either side. Same reason the error-message
+  Copy uses Length(Match) instead of a hard-coded 2 — under FPC
+  Copy(L, p, 2) only catches `:` plus the first byte of `↓`, so
+  the reported snippet would be a truncated mojibake. }
 var
   Lines: TStringList;
   i, p, j: Integer;
-  L: string;
+  L, Match: string;
 begin
   Result := False;
   ErrMsg := '';
@@ -623,18 +635,23 @@ begin
       L := Lines[i];
       p := Pos(':', L);
       if p <= 0 then Continue;
-      if (p < Length(L)) and ((L[p + 1] = HL_PAYLOAD_ABOVE) or
-                              (L[p + 1] = HL_PAYLOAD_BELOW) or
-                              (L[p + 1] = HL_PAYLOAD_REPLACE)) then
+      if p >= Length(L) then Continue;
+      Match := '';
+      if Copy(L, p + 1, Length(HL_PAYLOAD_ABOVE)) = HL_PAYLOAD_ABOVE then
+        Match := HL_PAYLOAD_ABOVE
+      else if Copy(L, p + 1, Length(HL_PAYLOAD_BELOW)) = HL_PAYLOAD_BELOW then
+        Match := HL_PAYLOAD_BELOW
+      else if Copy(L, p + 1, Length(HL_PAYLOAD_REPLACE)) = HL_PAYLOAD_REPLACE then
+        Match := HL_PAYLOAD_REPLACE;
+      if Match = '' then Continue;
+      j := p - 1;
+      while (j >= 1) and (L[j] in ['0'..'9']) do Dec(j);
+      if (j = 0) or ((j >= 1) and (L[j] = '-')) then
       begin
-        j := p - 1;
-        while (j >= 1) and (L[j] in ['0'..'9']) do Dec(j);
-        if (j = 0) or ((j >= 1) and (L[j] = '-')) then
-        begin
-          ErrMsg := Format('line %d: unsupported inline payload token near "%s"; use canonical grammar with anchor on its own line and payload lines beginning with %s/%s/%s',
-                           [i + 1, Copy(L, p, 2), HL_PAYLOAD_REPLACE, HL_PAYLOAD_ABOVE, HL_PAYLOAD_BELOW]);
-          Exit;
-        end;
+        ErrMsg := Format('line %d: unsupported inline payload token near "%s"; use canonical grammar with anchor on its own line and payload lines beginning with %s/%s/%s',
+                         [i + 1, Copy(L, p, 1 + Length(Match)),
+                          HL_PAYLOAD_REPLACE, HL_PAYLOAD_ABOVE, HL_PAYLOAD_BELOW]);
+        Exit;
       end;
     end;
     Result := True;

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -387,7 +387,7 @@ function BuildRequest(const Messages: array of TMessage;
 var
   Root, Content, Part, ToolObj, FuncDecl, FuncCall, FuncResp,
     FuncRespBody, EmptyObj, GenCfg, SysContent, SysPart,
-    GoogleSearchObj, GoogleSearchEntry: TJsonObject;
+    GoogleSearchObj, GoogleSearchEntry, ToolCfg: TJsonObject;
   Contents, Parts, ToolsArr, FuncDecls, SysParts: TJsonArray;
   i, j: Integer;
   Sys, ToolName, ArgsJSON: string;
@@ -619,6 +619,23 @@ begin
       end;
 
       Root.PutArray('tools', ToolsArr);
+
+      (* On Gemini 3.x the combo functionDeclarations + google_search
+         additionally requires tool_config.include_server_side_tool_invocations
+         to be set, otherwise the API returns:
+
+           400: Please enable tool_config.include_server_side_tool_invocations
+                to use Built-in tools with Function calling.
+
+         Emit the field only when BOTH categories are on the wire —
+         it's a no-op (and a wire-noise warning on some endpoints)
+         when only one tool type is present. *)
+      if EmitGoogleSearch and (Length(Tools) > 0) then
+      begin
+        ToolCfg := TJsonObject.Create;
+        ToolCfg.PutBool('include_server_side_tool_invocations', True);
+        Root.PutObject('tool_config', ToolCfg);
+      end;
     end;
 
     if (Options.MaxTokens > 0) or (Options.Temperature > 0) then

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -340,6 +340,8 @@ begin
     'google_search omitted when toggle is off');
   AssertMissing(Body, '"tools"',
     'no tools array at all when neither server nor local tools present');
+  AssertMissing(Body, '"tool_config"',
+    'tool_config not emitted when there is no tool combo to gate');
 end;
 
 procedure TestGoogleSearchCoexistsWithFunctionDeclarations;
@@ -369,6 +371,13 @@ begin
     'local tool name preserved');
   AssertContains(Body, '"google_search"',
     'google_search emitted alongside functionDeclarations on 3.x');
+  (* The combo on 3.x additionally requires tool_config.include_server_side_tool_invocations
+     or the API returns 400: "Please enable tool_config.include_server_side_tool_invocations
+     to use Built-in tools with Function calling." *)
+  AssertContains(Body, '"tool_config"',
+    'tool_config block emitted when both tool categories present');
+  AssertContains(Body, '"include_server_side_tool_invocations"',
+    'include_server_side_tool_invocations field emitted for combo');
 end;
 
 procedure TestGoogleSearchSuppressedOnPreGemini3WithLocalTools;


### PR DESCRIPTION
Two small FPC + Gemini fixes batched together.

## 1. Hashline: byte-aware payload-marker check

`ValidateHashlinePatchGrammar` compared `L[p+1] = HL_PAYLOAD_BELOW` to flag malformed inline payloads like `60:↓bad inline payload`. The payload-marker constants are the literal arrow glyphs `↑` / `↓` (U+2191 / U+2193), and under **FPC mode delphi** `string = AnsiString` and `Char = AnsiChar` — one byte. The arrows are 3-byte UTF-8 sequences there, so the equality of a single AnsiChar against a 3-byte string can never match. The validator silently accepted the malformed patch and `TestInvalidInlinePayload` has been red on Linux/FPC. On Delphi (UnicodeString, WideChar) the same source compiled to a single-WideChar comparison and worked, masking the defect.

The error-message `Copy(L, p, 2)` had the mirror-image problem — on FPC it grabbed `:` plus the first byte of `↓` and reported mojibake.

**Fix.** Compare via `Copy(L, p+1, Length(MARKER)) = MARKER` so the comparison runs in byte units on FPC and char units on Delphi without changing semantics on either side. Capture the matched marker in a local `Match` and emit `Copy(L, p, 1 + Length(Match))` so the reported snippet covers the full multi-byte sequence on FPC. No grammar semantics change. Inputs the Delphi build already accepted/rejected stay the same; the FPC build catches up.

## 2. Gemini: `tool_config.include_server_side_tool_invocations` on the combo

Live trace from `gemini-3.5-flash`: a tool-using chat with `google_search` on returned

> 400 "Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling."

PR #158's combo-gating guarantees the request only ships when the model is Gemini 3.x+, but the 3.x API additionally requires this top-level field to be `true` before it accepts `functionDeclarations` and `google_search` in the same `generateContent` call.

**Fix.** Emit `tool_config.include_server_side_tool_invocations: true` only when both tool categories are on the wire (functionDeclarations non-empty AND google_search emission gated through). Bare `google_search` and bare `functionDeclarations` requests stay unchanged.

Extends existing tests:
- `TestGoogleSearchCoexistsWithFunctionDeclarations` now asserts both `tool_config` and `include_server_side_tool_invocations` appear.
- `TestGoogleSearchOmittedWhenDisabled` now asserts `tool_config` is absent when there's no combo to gate.

## Test plan

- [x] `make test-hashline` — `PASS` (was `FAIL: invalid inline payload accepted`)
- [x] `make test-gemini-schema-strip` — all 12 cases including the two extended ones above pass
- [x] Existing Hashline validator behaviour on valid inputs (`TestValidInsertion`, `TestValidMultilineReplacement`) unchanged
- [x] Existing Gemini behaviour on no-tools / disabled-toggle / pre-3 model paths unchanged
- [ ] Delphi build — no behavioural change expected since the WideChar path was correct on both fixes; `dcc64` build only
- [ ] Live `pasclaw agent` against Gemini API to confirm the 400 is gone *(requires a real Gemini API key — not runnable in CI)*