### PR TITLE
ToolView: hex byte glyph constants per compiler (fixes TestArgTruncation)

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
@@ -30,9 +30,31 @@ interface
 const
   (* Glyphs mirror the agent CLI handlers (PasClaw.Cmd.Agent) and Claude
      Code's transcript style: a filled dot marks the call, a corner marks the
-     result line that sits under it. *)
-  TV_CALL_GLYPH   = '⏺';
-  TV_RESULT_GLYPH = '⎿';
+     result line that sits under it.
+
+     Encoded the way the active compiler's `string` type wants them, same
+     trick as PasClaw.Markdown.Render after PR #157. On FPC mode delphi
+     `string`=AnsiString, `Char`=AnsiChar (1 byte) — a literal '⏺' is a
+     3-byte UTF-8 sequence tagged with whichever codepage the source file
+     resolves to, and concatenating it with a CP_0-tagged variable can
+     drop it to '?' on a non-UTF-8 locale; raw `#$XX#$XX#$XX` byte
+     constants are codepage-agnostic. On Delphi `string`=UnicodeString,
+     `Char`=WideChar — the single WideChar form is the natural way to
+     name the codepoint and WriteConsoleW renders it directly.
+
+     Codepoints: U+23FA ⏺ BLACK CIRCLE FOR RECORD, U+23BF ⎿ LIGHT
+     LEFT TORTOISE SHELL BRACKET LOWER CORNER. *)
+  {$IFDEF FPC}
+  TV_CALL_GLYPH   = #$E2#$8F#$BA;
+  TV_RESULT_GLYPH = #$E2#$8E#$BF;
+  TV_ELLIPSIS     = #$E2#$80#$A6;        { U+2026 HORIZONTAL ELLIPSIS    }
+  TV_ERROR_GLYPH  = #$E2#$9C#$97;        { U+2717 BALLOT X               }
+  {$ELSE}
+  TV_CALL_GLYPH   = #$23FA;
+  TV_RESULT_GLYPH = #$23BF;
+  TV_ELLIPSIS     = #$2026;
+  TV_ERROR_GLYPH  = #$2717;
+  {$ENDIF}
 
 { One visible line describing a tool invocation, e.g.
     ⏺ fs_read(README.md)
@@ -89,7 +111,7 @@ end;
 function Ellipsize(const S: string; MaxLen: Integer): string;
 begin
   if Length(S) <= MaxLen then Result := S
-  else Result := Copy(S, 1, MaxLen) + '…';
+  else Result := Copy(S, 1, MaxLen) + TV_ELLIPSIS;
 end;
 
 function FirstLineOf(const S: string): string;
@@ -197,7 +219,7 @@ var
 begin
   if Err <> '' then
   begin
-    Result := '  ' + TV_RESULT_GLYPH + ' ✗ ' +
+    Result := '  ' + TV_RESULT_GLYPH + ' ' + TV_ERROR_GLYPH + ' ' +
               Ellipsize(CollapseWhitespace(Err), MaxResultWidth);
     Exit;
   end;

--- a/src/tests/toolview_tests.pas
+++ b/src/tests/toolview_tests.pas
@@ -69,6 +69,15 @@ begin
 end;
 
 procedure TestArgTruncation;
+{ Glyph form depends on the compiler's `string` type — see TV_ELLIPSIS
+  in PasClaw.Gateway.ToolView. Use the same constant the renderer emits
+  so the assertion is codepage-tag-independent. }
+const
+  {$IFDEF FPC}
+  EllipsisGlyph = #$E2#$80#$A6;
+  {$ELSE}
+  EllipsisGlyph = #$2026;
+  {$ENDIF}
 var
   Big, Line: string;
   i: Integer;
@@ -76,7 +85,7 @@ begin
   Big := '';
   for i := 1 to 500 do Big := Big + 'x';
   Line := FormatToolCallLine('shell_exec', '{"command":"' + Big + '"}');
-  AssertContains(Line, '…', 'long argument is ellipsized');
+  AssertContains(Line, EllipsisGlyph, 'long argument is ellipsized');
   if Length(Line) > 220 then
     Fail('long argument not capped (len=' + IntToStr(Length(Line)) + ')');
 end;
@@ -97,9 +106,16 @@ begin
 end;
 
 procedure TestResultError;
+{ Same compiler-split rationale as TestArgTruncation. }
+const
+  {$IFDEF FPC}
+  ErrorGlyph = #$E2#$9C#$97;
+  {$ELSE}
+  ErrorGlyph = #$2717;
+  {$ENDIF}
 begin
   AssertContains(FormatToolResultLine('fs_read', '', 'file not found'),
-                 '✗', 'error result carries the failure glyph');
+                 ErrorGlyph, 'error result carries the failure glyph');
   AssertContains(FormatToolResultLine('fs_read', '', 'file not found'),
                  'file not found', 'error result carries the message');
 end;


### PR DESCRIPTION
## Summary

Closes the last remaining red test on `make test`. After PR #161 fixed JSON UTF-8 byte preservation at the parse boundary, the only failure left was `toolview_tests.TestArgTruncation` — the unrelated ellipsis-glyph mojibake noted in #161's PR body.

The fault: ToolView opens with `{$CODEPAGE UTF8}` so its `'…'` and `'✗'` literals are tagged CP_UTF8, but the JSON-parsed Summary strings they get concatenated with arrive tagged CP_0 (system default). FPC's mixed-codepage concat trap strips every UTF-8 lead byte the destination CP can't represent, leaving `?` characters in the user-visible output. Same exact class as PR #157's box-drawing-glyph fix in `PasClaw.Markdown.Render`.

## Fix

Same shape as PR #157 — replace each non-ASCII glyph literal with a per-compiler hex byte constant:

| Codepoint | Glyph | FPC bytes | Delphi |
| --- | --- | --- | --- |
| U+23FA | ⏺ | `E2 8F BA` | `#$23FA` |
| U+23BF | ⎿ | `E2 8E BF` | `#$23BF` |
| U+2026 | … | `E2 80 A6` | `#$2026` |
| U+2717 | ✗ | `E2 9C 97` | `#$2717` |

Promoted the inline `'…'` and `'✗'` literals into named `TV_ELLIPSIS` / `TV_ERROR_GLYPH` constants alongside the existing `TV_CALL_GLYPH` / `TV_RESULT_GLYPH` so all four codepoints live in one place and the IFDEF guards aren't sprinkled through the call sites.

Tests pick their assertion literal the same way (`{$IFDEF FPC}` three-byte form, else single WideChar) so the assertions are codepage-tag-independent.

## Test plan

- [x] `make test-toolview` — `PASS` (was `FAIL: long argument is ellipsized`)
- [x] Byte-dump confirms wire output on FPC: `⏺` → `E2 8F BA`, `…` → `E2 80 A6`, `⎿` → `E2 8E BF`, `✗` → `E2 9C 97`. No mojibake.
- [x] **`make test` is now fully green for the first time** — smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip all OK.
- [ ] Delphi build — same per-compiler pattern PR #157 used; `#$23FA` etc. are single WideChars natively, `WriteConsoleW` and `TEncoding.UTF8.GetBytes` both handle them losslessly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_