### PR TITLE
Catalog: add xAI (Grok) + Cohere, bump Moonshot default to kimi-k2

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -147,11 +147,18 @@ begin
                        '',
                        MkAuth(asBearer),
                        'Fast inference (Llama-4, Kimi K2, Qwen3, compound-beta)');
+  (* Moonshot model defaults are time-sensitive — Codex P2 on PR #163
+     caught the previous catalog rolling forward to kimi-k2, which
+     Moonshot discontinued the entire k2 series on 2026-05-25
+     (per https://platform.kimi.ai/docs/models). The active line at
+     time of writing is k2.5 / k2.6 / k2-thinking; default to k2.6
+     which Moonshot lists as the current flagship. Refresh this row
+     when Moonshot rolls the next generation. *)
   Result[8]  := MkSpec('moonshot',   'Moonshot (Kimi)',
                        pfOpenAI,     'https://api.moonshot.cn',
-                       'kimi-k2',
+                       'kimi-k2.6',
                        MkAuth(asBearer),
-                       'Kimi K2 / K2.5 / K2-Thinking');
+                       'Kimi K2.6 / K2.5 / K2-Thinking');
   Result[9]  := MkSpec('minimax',    'MiniMax',
                        pfOpenAI,     'https://api.minimax.chat',
                        '',
@@ -187,17 +194,30 @@ begin
                        '',
                        MkAuth(asNone),
                        'Local models, self-hosted');
-  Result[16] := MkSpec('vllm',       'vLLM (local)',
+  (* LM Studio runs an OpenAI-compatible server on port 1234 by
+     default and emits the same /v1/chat/completions shape — same
+     pfOpenAI + asNone profile as Ollama. DefaultModel left empty
+     because the loaded model id depends on whatever the operator
+     downloaded inside the LM Studio UI; the onboarding prompt
+     surfaces the catalog default so blank picks up whichever
+     model is loaded at request time (LM Studio routes a missing
+     model id to the currently-loaded one). *)
+  Result[16] := MkSpec('lmstudio',   'LM Studio (local)',
+                       pfOpenAI,     'http://localhost:1234',
+                       '',
+                       MkAuth(asNone),
+                       'Local OpenAI-compatible server (default port 1234)');
+  Result[17] := MkSpec('vllm',       'vLLM (local)',
                        pfOpenAI,     'http://localhost:8000',
                        '',
                        MkAuth(asNone),
                        'OpenAI-compatible local deployment');
-  Result[17] := MkSpec('litellm',    'LiteLLM proxy',
+  Result[18] := MkSpec('litellm',    'LiteLLM proxy',
                        pfOpenAI,     '',
                        '',
                        MkAuth(asBearer),
                        'Proxy for 100+ providers (set api_base)');
-  Result[18] := MkSpec('gemini',     'Google Gemini',
+  Result[19] := MkSpec('gemini',     'Google Gemini',
                        pfGemini,     'https://generativelanguage.googleapis.com',
                        'gemini-3.5-flash',
                        MkAuth(asHeader, 'x-goog-api-key'),
@@ -208,27 +228,16 @@ begin
      unchanged. Default points at grok-4-fast — operator can override
      to grok-3 / grok-code-fast-1 / grok-2 / etc. via config or the
      onboarding prompt. *)
-  Result[19] := MkSpec('xai',        'xAI (Grok)',
+  Result[20] := MkSpec('xai',        'xAI (Grok)',
                        pfOpenAI,     'https://api.x.ai',
                        'grok-4-fast',
                        MkAuth(asBearer),
                        'Grok 4 Fast / Grok 3 / Grok Code Fast 1');
-  (* Cohere v2 ships its chat API at https://api.cohere.com/v2/chat —
-     same Bearer auth as OpenAI but a different URL path
-     (/v2/chat vs /v1/chat/completions). The pfOpenAI provider
-     hard-codes the OpenAI path, so Cohere can't piggyback on it
-     without a path-override knob. Registered as pfPlaceholder so
-     the kind validates in config.json and shows up in
-     `pasclaw onboard`, with a clear "implementation not yet
-     bundled" error when actually selected. Future PR can add a
-     dedicated TCohereProvider that mirrors the v2 wire shape
-     (messages array, tool_calls similar to OpenAI, citations
-     surfaced on assistant turns). *)
-  Result[20] := MkSpec('cohere',     'Cohere',
-                       pfPlaceholder, 'https://api.cohere.com',
-                       'command-a-03-2025',
-                       MkAuth(asBearer),
-                       'Command A 03-2025 / Command A Reasoning / Command A Vision');
+  (* Cohere intentionally not in this catalog: their chat API lives
+     at /v2/chat rather than /v1/chat/completions, and the pfOpenAI
+     provider hard-codes the OpenAI path. Lands when a TCohereProvider
+     gets written or when pfOpenAI grows a path-override knob; until
+     then the placeholder row was more confusing than helpful. *)
 end;
 
 function LookupProvider(const Kind: string; out Spec: TProviderSpec): Boolean;

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -106,7 +106,7 @@ end;
   change required for OpenAI-compatible endpoints. }
 function BuildCatalog: TProviderSpecArray;
 begin
-  SetLength(Result, 19);
+  SetLength(Result, 21);
   Result[0]  := MkSpec('anthropic',  'Anthropic',
                        pfAnthropic,  'https://api.anthropic.com',
                        'claude-opus-4-7',
@@ -146,12 +146,12 @@ begin
                        pfOpenAI,     'https://api.groq.com/openai',
                        '',
                        MkAuth(asBearer),
-                       'Fast inference (Llama, Mixtral)');
+                       'Fast inference (Llama-4, Kimi K2, Qwen3, compound-beta)');
   Result[8]  := MkSpec('moonshot',   'Moonshot (Kimi)',
                        pfOpenAI,     'https://api.moonshot.cn',
-                       'moonshot-v1-32k',
+                       'kimi-k2',
                        MkAuth(asBearer),
-                       'Kimi models');
+                       'Kimi K2 / K2.5 / K2-Thinking');
   Result[9]  := MkSpec('minimax',    'MiniMax',
                        pfOpenAI,     'https://api.minimax.chat',
                        '',
@@ -161,7 +161,7 @@ begin
                        pfOpenAI,     'https://api.mistral.ai',
                        'mistral-large-latest',
                        MkAuth(asBearer),
-                       'Mistral Large, Codestral');
+                       'Mistral Large / Magistral / Devstral / Voxtral / Codestral');
   Result[11] := MkSpec('nvidia',     'NVIDIA NIM',
                        pfOpenAI,     'https://integrate.api.nvidia.com',
                        '',
@@ -201,7 +201,34 @@ begin
                        pfGemini,     'https://generativelanguage.googleapis.com',
                        'gemini-3.5-flash',
                        MkAuth(asHeader, 'x-goog-api-key'),
-                       'Gemini 1.5 / 2.0 (generateContent REST)');
+                       'Gemini 3.1 Pro / 3 Flash / 3.1 Flash Lite / 3.1 Flash Image');
+  (* xAI Grok exposes a strict OpenAI-compatible chat-completions API
+     at https://api.x.ai/v1/chat/completions, Bearer auth, identical
+     request/response shape. The pfOpenAI provider talks to it
+     unchanged. Default points at grok-4-fast — operator can override
+     to grok-3 / grok-code-fast-1 / grok-2 / etc. via config or the
+     onboarding prompt. *)
+  Result[19] := MkSpec('xai',        'xAI (Grok)',
+                       pfOpenAI,     'https://api.x.ai',
+                       'grok-4-fast',
+                       MkAuth(asBearer),
+                       'Grok 4 Fast / Grok 3 / Grok Code Fast 1');
+  (* Cohere v2 ships its chat API at https://api.cohere.com/v2/chat —
+     same Bearer auth as OpenAI but a different URL path
+     (/v2/chat vs /v1/chat/completions). The pfOpenAI provider
+     hard-codes the OpenAI path, so Cohere can't piggyback on it
+     without a path-override knob. Registered as pfPlaceholder so
+     the kind validates in config.json and shows up in
+     `pasclaw onboard`, with a clear "implementation not yet
+     bundled" error when actually selected. Future PR can add a
+     dedicated TCohereProvider that mirrors the v2 wire shape
+     (messages array, tool_calls similar to OpenAI, citations
+     surfaced on assistant turns). *)
+  Result[20] := MkSpec('cohere',     'Cohere',
+                       pfPlaceholder, 'https://api.cohere.com',
+                       'command-a-03-2025',
+                       MkAuth(asBearer),
+                       'Command A 03-2025 / Command A Reasoning / Command A Vision');
 end;
 
 function LookupProvider(const Kind: string; out Spec: TProviderSpec): Boolean;


### PR DESCRIPTION
## Summary

Cross-referenced [MakerAi](https://github.com/gustavoeenriquez/MakerAi)'s provider list against our 19-entry catalog. (Note: did not read MakerAi's code — only confirmed which providers it ships, then implemented PasClaw's own catalog entries for the ones we were missing.)

The user-listed model families fall into three buckets:

| User-listed family | Bucket | Action |
| --- | --- | --- |
| Claude (claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5) | Already covered as MODEL names | None — operator picks the model per-config |
| Gemini (gemini-3.1-pro, gemini-3-flash, gemini-3.1-flash-lite, gemini-3.1-flash-image) | Already covered as MODEL names | None |
| Mistral (magistral-medium/small, devstral, voxtral) | Already covered as MODEL names | Updated notes column to list them |
| Groq (llama-4-scout/maverick, kimi-k2, qwen3, compound-beta) | Already covered as MODEL names | Updated notes column to list them |
| Kimi (kimi-k2, kimi-k2.5, kimi-k2-thinking) | Already covered (Moonshot entry) | Bumped stale `moonshot-v1-32k` default → `kimi-k2` |
| Cohere (command-a-03-2025, command-a-reasoning, command-a-vision) | **Missing as a provider** | Added (`pfPlaceholder`) |
| Grok (grok-4-fast, grok-3, grok-code-fast-1) | **Missing as a provider** | Added (`pfOpenAI`, fully functional) |

## Adds

**xAI / Grok** — `https://api.x.ai/v1/chat/completions`, Bearer auth, strict OpenAI-compatible request/response. The existing `pfOpenAI` provider talks to it unchanged — just a new catalog row. Default model `grok-4-fast`; operator can override to `grok-3` / `grok-code-fast-1` / `grok-2` via config or onboarding.

**Cohere v2** — `https://api.cohere.com/v2/chat`, Bearer auth. Path differs from OpenAI's `/v1/chat/completions`, and `PasClaw.Providers.OpenAI` hard-codes the OpenAI path. Landed as `pfPlaceholder` so:
- The kind validates in config.json
- It appears in `pasclaw onboard` like every other provider
- Selecting it surfaces the existing `pfPlaceholder` error ("Cohere is in the catalog but its protocol implementation is not yet bundled in this build") instead of a confusing 404 at request time

Follow-up PR can add a dedicated `TCohereProvider` that mirrors the v2 wire shape (messages array, tool_calls similar to OpenAI but with `citations` / `search_queries` surfaced on assistant turns).

## Stale default bumped

Moonshot's default was `moonshot-v1-32k` — the Kimi V1 generation, deprecated. Bumped to `kimi-k2` (current generation; matches the user's primary listed Kimi model).

## Test plan

- [x] Catalog size `19 → 21`.
- [x] `LookupProvider('xai')` resolves: `Kind=xai, Family=pfOpenAI, DefaultBase=https://api.x.ai, DefaultModel=grok-4-fast`.
- [x] `LookupProvider('cohere')` resolves: `Kind=cohere, Family=pfPlaceholder, DefaultBase=https://api.cohere.com, DefaultModel=command-a-03-2025`.
- [x] `NewProviderFromConfig('xai')` constructs a working `TOpenAIProvider` (verified `GetName=xai`, `GetDefaultModel=grok-4-fast`).
- [x] `NewProviderFromConfig('cohere')` returns `False` with `ErrMsg = "provider \"Cohere\" is in the catalog but its protocol implementation is not yet bundled in this build"`.
- [x] All unrelated test suites green: hashline, anthropic-server-tools, openai-server-tools, println-helper, utf8-codepage-tag, gemini-schema-strip, markdown-render, json-utf8-roundtrip.
- [ ] Live `pasclaw agent` against an xAI API key to confirm the wire trip is clean end-to-end (no key in CI).

`test-toolview` is the pre-existing ellipsis-glyph mojibake — fixed in PR #162, not yet merged. Unrelated to this change.

## Not in this PR (separate concern)

The user also raised: *"maybe we need to upgrade pasclaw onboarding so that after you pick a provider and enter an api key then it uses the /models api endpoint of that provider to get a list of models for you to choose from?"*

That's a worthwhile feature but a substantial standalone change — needs per-provider `/models` endpoint discovery (OpenAI's `GET /v1/models`, Anthropic's `GET /v1/models`, Gemini's `GET /v1beta/models`, xAI's `GET /v1/models`, each with their own response shape), an interactive picker UI, and tests. Happy to do it next PR if you want.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_