### PR TITLE
Memory: vendor localvector + add vector_search_enabled flag (phase 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,14 @@ BIN      ?= $(BUILDDIR)/pasclaw
 
 INDY_DIR     ?= vendor/Indy
 INDY_REPO    ?= https://github.com/IndySockets/Indy.git
+# localvector provides the hybrid FTS5 + sqlite-vec memory backend (and
+# the local ONNX embedder that feeds vectors into it). Vendored the
+# same way Indy is — clone-on-demand under vendor/ so the upstream
+# stays the source of truth and `git status` doesn't drown in vendored
+# diff noise. Pin via LOCALVECTOR_REPO=... LOCALVECTOR_REF=... env when
+# we need a specific revision.
+LOCALVECTOR_DIR  ?= vendor/localvector
+LOCALVECTOR_REPO ?= https://github.com/FMXExpress/localvector.git
 # iconvenc lives in fp-units-misc on Debian; FPC's default config picks it up
 # on most distros but not always.
 ICONVENC_DIR ?= $(FPC_UNITS_DIR)/iconvenc
@@ -144,7 +152,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip print-version get-indy webui-res
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip print-version get-indy get-localvector webui-res
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -171,6 +179,20 @@ get-indy:
 	  git clone --depth 1 $(INDY_REPO) $(INDY_DIR); \
 	else \
 	  echo "Indy already present at $(INDY_DIR)"; \
+	fi
+
+# localvector — hybrid FTS5 + sqlite-vec store + local ONNX BERT
+# embedder. Vendored on demand same way as Indy; the runtime DLLs
+# (onnxruntime, sqlite-vec) and embedding model weights get fetched
+# by the embedder's own provisioning routines on first memory_search
+# call after the follow-up PR wires PasClaw.Memory.Vector up.
+get-localvector:
+	@if [ ! -d $(LOCALVECTOR_DIR) ]; then \
+	  mkdir -p $(dir $(LOCALVECTOR_DIR)); \
+	  echo "Cloning localvector into $(LOCALVECTOR_DIR)..."; \
+	  git clone --depth 1 $(LOCALVECTOR_REPO) $(LOCALVECTOR_DIR); \
+	else \
+	  echo "localvector already present at $(LOCALVECTOR_DIR)"; \
 	fi
 
 $(BUILDDIR):

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,11 @@ INDY_REPO    ?= https://github.com/IndySockets/Indy.git
 # same way Indy is — clone-on-demand under vendor/ so the upstream
 # stays the source of truth and `git status` doesn't drown in vendored
 # diff noise. Pin via LOCALVECTOR_REPO=... LOCALVECTOR_REF=... env when
-# we need a specific revision.
+# we need a specific revision; an empty REF (the default) takes the
+# remote default branch HEAD.
 LOCALVECTOR_DIR  ?= vendor/localvector
 LOCALVECTOR_REPO ?= https://github.com/FMXExpress/localvector.git
+LOCALVECTOR_REF  ?=
 # iconvenc lives in fp-units-misc on Debian; FPC's default config picks it up
 # on most distros but not always.
 ICONVENC_DIR ?= $(FPC_UNITS_DIR)/iconvenc
@@ -186,11 +188,26 @@ get-indy:
 # (onnxruntime, sqlite-vec) and embedding model weights get fetched
 # by the embedder's own provisioning routines on first memory_search
 # call after the follow-up PR wires PasClaw.Memory.Vector up.
+#
+# When LOCALVECTOR_REF is empty (the default) we shallow-clone the
+# remote default-branch HEAD — fast and small. When REF is set we do
+# a full clone first, then `git -C ... checkout $(LOCALVECTOR_REF)`
+# so REF can be a branch, a tag, OR a commit SHA. `git clone --branch`
+# alone won't accept arbitrary SHAs, and `--depth 1` makes a follow-up
+# checkout fail for anything outside the latest depth-1 commit, so the
+# two-step is the only shape that handles all three forms without
+# silently ignoring the requested revision (Codex P2 on PR #164).
 get-localvector:
 	@if [ ! -d $(LOCALVECTOR_DIR) ]; then \
 	  mkdir -p $(dir $(LOCALVECTOR_DIR)); \
-	  echo "Cloning localvector into $(LOCALVECTOR_DIR)..."; \
-	  git clone --depth 1 $(LOCALVECTOR_REPO) $(LOCALVECTOR_DIR); \
+	  if [ -z "$(LOCALVECTOR_REF)" ]; then \
+	    echo "Cloning localvector into $(LOCALVECTOR_DIR) (HEAD)..."; \
+	    git clone --depth 1 $(LOCALVECTOR_REPO) $(LOCALVECTOR_DIR); \
+	  else \
+	    echo "Cloning localvector into $(LOCALVECTOR_DIR) @ $(LOCALVECTOR_REF)..."; \
+	    git clone $(LOCALVECTOR_REPO) $(LOCALVECTOR_DIR); \
+	    git -C $(LOCALVECTOR_DIR) checkout $(LOCALVECTOR_REF); \
+	  fi; \
 	else \
 	  echo "localvector already present at $(LOCALVECTOR_DIR)"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The main program lives at `src/pasclaw/PasClaw.dpr`. It initializes terminal col
 | `shell_exec` | `/bin/sh -c` (or `cmd.exe`), output capped at 1 MiB, denylist-gated |
 | `web_search` | DuckDuckGo / Brave / Tavily / SearXNG / Perplexity / Gemini-grounding — 6 providers |
 | `web_fetch` | HTTP GET → readable plain text (HTML stripped, entities decoded), SSRF-guarded |
-| `memory_search` | SQLite FTS5 BM25 over `workspace/memory/*.md` and `MEMORY.md` |
+| `memory_search` | SQLite FTS5 BM25 over `workspace/memory/*.md` and `MEMORY.md`; hybrid FTS + local-vector mode opt-in via `vector_search_enabled` (default yes; embedding model downloaded on first use after the runtime hookup PR lands) |
 | `vault_search` / `vault_get` | search + read pasclaw.dev Code Vault entries (Object Pascal samples + components); opt-in via `vault_tools_enabled` |
 | `skill_<name>` | Pascal-side tools registered from `kind: shell` / `kind: prompt` skills |
 | MCP-bridged | every tool a configured MCP server exports — see below |

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -183,6 +183,52 @@ begin
   end;
 end;
 
+procedure PromptVectorSearch(Cfg: TConfig);
+{ Opt-in toggle for hybrid FTS+vector memory_search. Default YES
+  because the hybrid index is what picoclaw / nanobot ship and it's
+  what memory_search "should" feel like. The vector half adds local
+  ANN search via sqlite-vec + an ONNX-runtime'd BERT embedder
+  (MiniLM / bge), fused with FTS5 BM25 through Reciprocal Rank
+  Fusion — same shape as picoclaw.
+
+  Honest disclosure: the runtime pieces (ONNX Runtime DLL, sqlite-vec
+  extension, model weights — together ~300-500MB) get downloaded on
+  first memory_search call AFTER the follow-up PR lands the
+  provisioning hooks. This pass only records the operator's
+  preference. Until then the flag is inert — memory_search keeps
+  using FTS5-only on every code path. Operators who said yes won't
+  see a download in this release and that's OK; the next pass picks
+  the flag up and does the right thing. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Memory: hybrid FTS + vector search' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Hybrid keyword (FTS5 BM25) + semantic (local embeddings, no API calls)' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'fused via Reciprocal Rank Fusion — matches picoclaw / nanobot memory_search.' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'A follow-up release downloads the embedding model (~300MB) on first use.' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable vector search for memory_search [Y/n]: ')));
+  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.VectorSearchEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+      ' vector search enabled (model download deferred until first memory_search)');
+  end
+  else
+  begin
+    Cfg.VectorSearchEnabled := False;
+    PrintLn('  ' + Ansi.Dim +
+      '(skipped — memory_search will use FTS5 keyword search only)' + Ansi.Reset);
+  end;
+end;
+
 procedure PromptMCPInstalls(Cfg: TConfig);
 var
   Entries: TMCPCatalogEntryArray;
@@ -341,6 +387,7 @@ begin
       env var is set). }
     PromptMCPInstalls(Cfg);
     PromptVaultTools(Cfg);
+    PromptVectorSearch(Cfg);
 
     SaveConfig(Cfg);
     PrintLn;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -325,6 +325,25 @@ type
        constrained shells), or where the operator wants the tracked
        web_fetch path with its size cap / save_to convenience. *)
     WebFetchEnabled:   Boolean;
+    (* On-by-default: when True, memory_search uses a hybrid keyword
+       (FTS5 BM25) + vector (sqlite-vec ANN) index over
+       workspace/memory/ files, fused via Reciprocal Rank Fusion.
+       Mirrors picoclaw/nanobot's hybrid memory store.
+
+       The vector half runs locally — an ONNX-Runtime'd embedding
+       model (e.g. all-MiniLM-L6-v2 / bge-small) embeds query text
+       and indexed chunks at write time. No outbound API calls;
+       embeddings never leave the host.
+
+       Provisioning is deferred until first use. Onboarding records
+       the operator's preference here; the runtime path (download
+       ONNX Runtime DLL, embedding model weights, sqlite-vec
+       extension) lives in PasClaw.Memory.Vector (follow-up PR).
+       When False, memory_search degrades to FTS5-only (the
+       current behaviour on main) — operators who don't want
+       300+MB of model weights on disk can flip this in
+       config.json or answer 'n' at onboarding. *)
+    VectorSearchEnabled: Boolean;
     (* Render markdown the model emits as ANSI-styled text in the
        terminal (PasClaw.Markdown.Render). On by default — terminal
        surfaces (pasclaw agent, pasclaw tui) call into it; serve /
@@ -401,6 +420,7 @@ begin
   VaultToolsEnabled    := False; { off by default; onboarding asks to opt in }
   WebFetchEnabled      := False; { off by default; the model uses shell+curl }
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
+  VectorSearchEnabled  := True;  { on by default; onboarding asks (default Y) — see TConfig comment }
   AnthropicServerTools.WebSearch        := False;
   AnthropicServerTools.WebSearchMaxUses := 0;
   AnthropicServerTools.WebFetch         := False;
@@ -559,6 +579,11 @@ begin
       and we round-trip correctly. }
     if not RenderMarkdown then
       Root.PutBool('render_markdown', False);
+    { Same round-trip rule as RenderMarkdown — default is True, only
+      emit on the explicit-off path so 'memory_search: false' sticks
+      across SaveConfig + LoadConfig. }
+    if not VectorSearchEnabled then
+      Root.PutBool('vector_search_enabled', False);
     if AnthropicServerTools.WebSearch
        or AnthropicServerTools.WebFetch
        or (AnthropicServerTools.WebSearchMaxUses > 0)
@@ -737,9 +762,10 @@ begin
       Arr.Free;
     end;
 
-    VaultToolsEnabled := Root.GetBool('vault_tools_enabled', VaultToolsEnabled);
-    WebFetchEnabled   := Root.GetBool('web_fetch_enabled',   WebFetchEnabled);
-    RenderMarkdown    := Root.GetBool('render_markdown',     RenderMarkdown);
+    VaultToolsEnabled   := Root.GetBool('vault_tools_enabled',   VaultToolsEnabled);
+    WebFetchEnabled     := Root.GetBool('web_fetch_enabled',     WebFetchEnabled);
+    RenderMarkdown      := Root.GetBool('render_markdown',       RenderMarkdown);
+    VectorSearchEnabled := Root.GetBool('vector_search_enabled', VectorSearchEnabled);
 
     Obj := Root.ChildObject('anthropic_server_tools');
     if Obj <> nil then


### PR DESCRIPTION
Closing — pivoting to fork-in-place per maintainer feedback. The config flag + onboarding question parts of this PR are folding into the new PR alongside the in-tree port of localvector's source files; no `make get-localvector` step, no `vendor/localvector/`, PasClaw owns the code with MIT attribution preserved in each ported file's header.

Replacement PR will follow shortly off `main`.