### PR TITLE
Memory: hybrid FTS+vector backend, localvector brought in-tree (no vendoring)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,16 +74,6 @@ BIN      ?= $(BUILDDIR)/pasclaw
 
 INDY_DIR     ?= vendor/Indy
 INDY_REPO    ?= https://github.com/IndySockets/Indy.git
-# localvector provides the hybrid FTS5 + sqlite-vec memory backend (and
-# the local ONNX embedder that feeds vectors into it). Vendored the
-# same way Indy is — clone-on-demand under vendor/ so the upstream
-# stays the source of truth and `git status` doesn't drown in vendored
-# diff noise. Pin via LOCALVECTOR_REPO=... LOCALVECTOR_REF=... env when
-# we need a specific revision; an empty REF (the default) takes the
-# remote default branch HEAD.
-LOCALVECTOR_DIR  ?= vendor/localvector
-LOCALVECTOR_REPO ?= https://github.com/FMXExpress/localvector.git
-LOCALVECTOR_REF  ?=
 # iconvenc lives in fp-units-misc on Debian; FPC's default config picks it up
 # on most distros but not always.
 ICONVENC_DIR ?= $(FPC_UNITS_DIR)/iconvenc
@@ -125,6 +115,7 @@ UNIT_DIRS = \
 	src/pkg/identity \
 	src/pkg/agent \
 	src/pkg/memory \
+	src/pkg/memory/localvector \
 	src/pkg/updater \
 	src/pkg/membench \
 	src/pkg/tui \
@@ -154,7 +145,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip print-version get-indy get-localvector webui-res
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip print-version get-indy webui-res
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -181,35 +172,6 @@ get-indy:
 	  git clone --depth 1 $(INDY_REPO) $(INDY_DIR); \
 	else \
 	  echo "Indy already present at $(INDY_DIR)"; \
-	fi
-
-# localvector — hybrid FTS5 + sqlite-vec store + local ONNX BERT
-# embedder. Vendored on demand same way as Indy; the runtime DLLs
-# (onnxruntime, sqlite-vec) and embedding model weights get fetched
-# by the embedder's own provisioning routines on first memory_search
-# call after the follow-up PR wires PasClaw.Memory.Vector up.
-#
-# When LOCALVECTOR_REF is empty (the default) we shallow-clone the
-# remote default-branch HEAD — fast and small. When REF is set we do
-# a full clone first, then `git -C ... checkout $(LOCALVECTOR_REF)`
-# so REF can be a branch, a tag, OR a commit SHA. `git clone --branch`
-# alone won't accept arbitrary SHAs, and `--depth 1` makes a follow-up
-# checkout fail for anything outside the latest depth-1 commit, so the
-# two-step is the only shape that handles all three forms without
-# silently ignoring the requested revision (Codex P2 on PR #164).
-get-localvector:
-	@if [ ! -d $(LOCALVECTOR_DIR) ]; then \
-	  mkdir -p $(dir $(LOCALVECTOR_DIR)); \
-	  if [ -z "$(LOCALVECTOR_REF)" ]; then \
-	    echo "Cloning localvector into $(LOCALVECTOR_DIR) (HEAD)..."; \
-	    git clone --depth 1 $(LOCALVECTOR_REPO) $(LOCALVECTOR_DIR); \
-	  else \
-	    echo "Cloning localvector into $(LOCALVECTOR_DIR) @ $(LOCALVECTOR_REF)..."; \
-	    git clone $(LOCALVECTOR_REPO) $(LOCALVECTOR_DIR); \
-	    git -C $(LOCALVECTOR_DIR) checkout $(LOCALVECTOR_REF); \
-	  fi; \
-	else \
-	  echo "localvector already present at $(LOCALVECTOR_DIR)"; \
 	fi
 
 $(BUILDDIR):

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The main program lives at `src/pasclaw/PasClaw.dpr`. It initializes terminal col
 | `shell_exec` | `/bin/sh -c` (or `cmd.exe`), output capped at 1 MiB, denylist-gated |
 | `web_search` | DuckDuckGo / Brave / Tavily / SearXNG / Perplexity / Gemini-grounding — 6 providers |
 | `web_fetch` | HTTP GET → readable plain text (HTML stripped, entities decoded), SSRF-guarded |
-| `memory_search` | SQLite FTS5 BM25 over `workspace/memory/*.md` and `MEMORY.md`; hybrid FTS + local-vector mode opt-in via `vector_search_enabled` (default yes; embedding model downloaded on first use after the runtime hookup PR lands) |
+| `memory_search` | SQLite FTS5 BM25 over `workspace/memory/*.md` and `MEMORY.md`. When `vector_search_enabled` is on (default yes), the hybrid backend in `src/pkg/memory/PasClaw.Memory.Vector.pas` runs a local sentence-transformer embedder (MiniLM by default — embeddings never leave the host) over the same notes, fuses keyword + vector ranks via Reciprocal Rank Fusion, and falls back to FTS-only silently when the runtime artifacts (sqlite-vec extension, ONNX Runtime, model weights) aren't yet provisioned under `$PASCLAW_HOME/cache/localvector/`. |
 | `vault_search` / `vault_get` | search + read pasclaw.dev Code Vault entries (Object Pascal samples + components); opt-in via `vault_tools_enabled` |
 | `skill_<name>` | Pascal-side tools registered from `kind: shell` / `kind: prompt` skills |
 | MCP-bridged | every tool a configured MCP server exports — see below |

--- a/src/pkg/memory/PasClaw.Memory.Vector.pas
+++ b/src/pkg/memory/PasClaw.Memory.Vector.pas
@@ -1,0 +1,356 @@
+(*
+  PasClaw.Memory.Vector - hybrid FTS5 + sqlite-vec memory_search backend.
+
+  Implements the same IMemoryIndex contract that PasClaw.Memory.Index
+  serves over keyword-only FTS5, but routes through the localvector
+  units (vendored in src/pkg/memory/localvector/) for the vector half:
+
+    - LocalVector.VectorStore.IVectorStore wraps a SQLite database with
+      parallel FTS5 (BM25) and vec0 (sqlite-vec / KNN) tables sharing
+      the same row ids.
+    - TEmbedder + TBertTokenizer run a sentence-transformer ONNX model
+      locally — MiniLM by default, ~90 MB of weights, 384-d output. No
+      outbound API calls; embeddings never leave the host.
+    - Search fuses the FTS5 and vec0 ranked id lists via Reciprocal
+      Rank Fusion before returning hits.
+
+  Open() returns False when any runtime piece is missing (sqlite-vec
+  extension, ONNX Runtime DLL, model weights, vocab.txt). The caller —
+  PasClaw.Tools.Memory — falls back to the FTS-only NewMemoryIndex on
+  False so missing provisioning never breaks memory_search, just
+  degrades it. Provisioning itself lives in a future phase.
+
+  Cache layout under PASCLAW_HOME (also where the provisioning phase
+  will write the auto-downloaded artifacts):
+
+    <home>/cache/localvector/
+      onnxruntime.{so,dll,dylib}   ONNX Runtime — Linux/macOS users
+                                   install via system pkg manager
+                                   until the auto-downloader extends
+                                   beyond win-x64 (LocalVector.OrtProvision
+                                   only auto-fetches win-x64 today).
+      vec0.{so,dll,dylib}          sqlite-vec extension. Provisioning fetches.
+      models/<modelKey>/
+        model.onnx                 sentence-transformer weights
+        vocab.txt                  BERT WordPiece vocab
+
+  Model selection defaults to MiniLM (DEFAULT_MODEL from
+  LocalVector.Models). A config knob can expose the other registered
+  models (bge, mxbai) once provisioning lands.
+*)
+unit PasClaw.Memory.Vector;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Memory.Index;
+
+(* Construct an IMemoryIndex backed by the in-tree localvector hybrid
+   store. Open() returns False if any provisioning piece is missing —
+   callers should fall back to PasClaw.Memory.Index.NewMemoryIndex on
+   False. *)
+function NewVectorMemoryIndex: IMemoryIndex;
+
+implementation
+
+uses
+  LocalVector.VectorStore,
+  LocalVector.Embedder,
+  LocalVector.Tokenizer,
+  LocalVector.Models,
+  LocalVector.OrtProvision,
+  PasClaw.Config,
+  PasClaw.Utils,
+  PasClaw.Logger;
+
+const
+  { Bound the embedder's sequence length so a giant memory file doesn't
+    burn seconds per chunk. 256 tokens covers a paragraph comfortably
+    and matches localvector's own default. }
+  MAX_SEQ_LEN = 256;
+
+  CACHE_SUBDIR = 'cache/localvector';
+
+type
+  TVectorMemoryIndex = class(TInterfacedObject, IMemoryIndex)
+  private
+    FStore:     IVectorStore;
+    FEmbedder:  TEmbedder;
+    FTokenizer: TBertTokenizer;
+    FModelSpec: TModelSpec;
+    FOpen:      Boolean;
+    function CacheDir: string;
+    function VecExtPath: string;
+    function ModelOnnxPath: string;
+    function VocabPath: string;
+    function EmbedText(const T: string): TArray<Single>;
+  public
+    constructor Create;
+    destructor  Destroy; override;
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    procedure SyncDir(const Dir: string);
+    function  Search(const Query: string; K: Integer): TMemoryHitArray;
+  end;
+
+constructor TVectorMemoryIndex.Create;
+begin
+  inherited Create;
+  if not FindModelSpec(DEFAULT_MODEL, FModelSpec) then
+    { Should never happen — DEFAULT_MODEL is hard-coded in the registry.
+      If localvector ever drops the default we'd want loud failure. }
+    raise Exception.CreateFmt(
+      'localvector default model "%s" not in registry', [DEFAULT_MODEL]);
+end;
+
+destructor TVectorMemoryIndex.Destroy;
+begin
+  Close;
+  FEmbedder.Free;
+  FTokenizer.Free;
+  inherited;
+end;
+
+function TVectorMemoryIndex.CacheDir: string;
+begin
+  Result := JoinPath(GetHome, CACHE_SUBDIR);
+end;
+
+function TVectorMemoryIndex.VecExtPath: string;
+{ sqlite-vec extension. SQLite's load_extension takes the path WITHOUT
+  the platform suffix and adds the right one (.so / .dll / .dylib),
+  but it's clearer to record the actual filename we expect on disk. }
+begin
+  {$IFDEF MSWINDOWS}
+  Result := JoinPath(CacheDir, 'vec0.dll');
+  {$ELSE}
+    {$IFDEF DARWIN}
+    Result := JoinPath(CacheDir, 'vec0.dylib');
+    {$ELSE}
+    Result := JoinPath(CacheDir, 'vec0.so');
+    {$ENDIF}
+  {$ENDIF}
+end;
+
+function TVectorMemoryIndex.ModelOnnxPath: string;
+begin
+  Result := JoinPath(JoinPath(JoinPath(CacheDir, 'models'),
+                              FModelSpec.SubDir), 'model.onnx');
+end;
+
+function TVectorMemoryIndex.VocabPath: string;
+begin
+  Result := JoinPath(JoinPath(JoinPath(CacheDir, 'models'),
+                              FModelSpec.SubDir), 'vocab.txt');
+end;
+
+function TVectorMemoryIndex.EmbedText(const T: string): TArray<Single>;
+var
+  TokenIds: TArray<Int64>;
+begin
+  TokenIds := FTokenizer.Encode(UnicodeString(T), MAX_SEQ_LEN);
+  Result := FEmbedder.Embed(TokenIds, FModelSpec.Pooling,
+                            FModelSpec.NeedsTokenTypeIds,
+                            {ANormalize=} True,
+                            {AVerbose=}  False);
+end;
+
+function TVectorMemoryIndex.Open(const DbPath: string): Boolean;
+{ Returns False (silently, with one debug-level log line per missing
+  piece) rather than raising so PasClaw.Tools.Memory can degrade to
+  the FTS-only path without a stack trace landing in the agent
+  transcript. Every failure mode here is "operator hasn't provisioned
+  the runtime artifacts yet" — expected for now. }
+begin
+  Result := False;
+  if FOpen then Exit(True);
+  if not FileExists(VecExtPath) then
+  begin
+    LogDebug('vector memory: sqlite-vec extension not found at %s — ' +
+             'falling back to FTS5-only', [VecExtPath]);
+    Exit;
+  end;
+  if not FileExists(ModelOnnxPath) then
+  begin
+    LogDebug('vector memory: embedding model not found at %s — ' +
+             'falling back to FTS5-only', [ModelOnnxPath]);
+    Exit;
+  end;
+  if not FileExists(VocabPath) then
+  begin
+    LogDebug('vector memory: tokenizer vocab not found at %s — ' +
+             'falling back to FTS5-only', [VocabPath]);
+    Exit;
+  end;
+  try
+    { ONNX Runtime: try the cache dir first (where provisioning will
+      drop it), then let the system loader try (LD_LIBRARY_PATH /
+      system libonnxruntime). AAllowDownload stays False here — the
+      agent transcript is the wrong place to surface a multi-hundred-MB
+      download.
+
+      EnsureOnnxRuntime raises on every "couldn't find the runtime"
+      path, so we sit inside the outer try/except. }
+    EnsureOnnxRuntime(CacheDir, {AAllowDownload=} False, {AVerbose=} False);
+
+    FTokenizer := TBertTokenizer.Create(VocabPath, FModelSpec.DoLowerCase);
+    FEmbedder  := TEmbedder.Create(ModelOnnxPath);
+    FEmbedder.Load({AVerbose=} False);
+
+    FStore := CreateVectorStore;
+    FStore.OpenStore(DbPath, VecExtPath);
+    FStore.InitSchema(FModelSpec.Dim, FModelSpec.Key);
+
+    FOpen  := True;
+    Result := True;
+    LogDebug('vector memory: opened %s with model %s (dim=%d)',
+             [DbPath, FModelSpec.Key, FModelSpec.Dim]);
+  except
+    on E: Exception do
+    begin
+      LogDebug('vector memory open failed: %s — falling back to FTS5-only',
+               [E.Message]);
+      Close;
+      Result := False;
+    end;
+  end;
+end;
+
+procedure TVectorMemoryIndex.Close;
+begin
+  if FStore <> nil then
+  begin
+    try FStore.CloseStore; except end;
+    FStore := nil;
+  end;
+  FOpen := False;
+end;
+
+procedure InternalFindMdFiles(L: TStringList; const Dir: string);
+{ Recursively collect *.md files. Standalone inside this unit —
+  PasClaw.Memory.Index doesn't expose its own walker and reusing it
+  would tighten the unit-dependency direction we don't want yet. }
+var
+  Rec: TSearchRec;
+  Sub: string;
+begin
+  if FindFirst(JoinPath(Dir, '*'), faAnyFile, Rec) = 0 then
+  try
+    repeat
+      if (Rec.Name = '.') or (Rec.Name = '..') then Continue;
+      Sub := JoinPath(Dir, Rec.Name);
+      if (Rec.Attr and faDirectory) <> 0 then
+        InternalFindMdFiles(L, Sub)
+      else if SameText(ExtractFileExt(Rec.Name), '.md') then
+        L.Add(Sub);
+    until FindNext(Rec) <> 0;
+  finally
+    FindClose(Rec);
+  end;
+end;
+
+procedure TVectorMemoryIndex.SyncDir(const Dir: string);
+{ Walk *.md files in Dir; chunk, embed, batch-add into the store.
+
+  Phase 2 takes the simple sledgehammer approach — wipe + rebuild on
+  every SyncDir. Embedding is slow (MiniLM is ~5 ms/chunk on a modern
+  CPU; a memory dir with hundreds of small notes is still well under
+  a second) so this is acceptable short-term. A future pass adds an
+  mtime-tracked incremental path similar to PasClaw.Memory.Index. }
+var
+  Files: TStringList;
+  i, j: Integer;
+  Body: string;
+  Chunks: TArray<string>;
+  Emb: TArray<Single>;
+begin
+  if not FOpen then Exit;
+
+  Files := TStringList.Create;
+  try
+    if DirectoryExists(Dir) then
+      InternalFindMdFiles(Files, Dir);
+
+    FStore.BeginBatch;
+    try
+      for i := 0 to Files.Count - 1 do
+      begin
+        try
+          Body := ReadFileText(Files[i]);
+        except
+          { Unreadable file — log and skip rather than tear down the
+            whole sync (one borked memory note shouldn't break
+            search). }
+          on E: Exception do
+          begin
+            LogDebug('vector memory: skipping %s — %s',
+                     [Files[i], E.Message]);
+            Continue;
+          end;
+        end;
+        Chunks := ChunkText(Body, 'paragraphs');
+        for j := 0 to High(Chunks) do
+        begin
+          try
+            Emb := EmbedText(Chunks[j]);
+            FStore.AddChunk(Files[i], j, Chunks[j], Emb);
+          except
+            on E: Exception do
+              LogDebug('vector memory: skipping chunk %d of %s — %s',
+                       [j, Files[i], E.Message]);
+          end;
+        end;
+      end;
+      FStore.CommitBatch;
+    except
+      on E: Exception do
+      begin
+        LogDebug('vector memory: SyncDir failed mid-batch — %s', [E.Message]);
+        try FStore.CommitBatch; except end;
+      end;
+    end;
+  finally
+    Files.Free;
+  end;
+end;
+
+function TVectorMemoryIndex.Search(const Query: string; K: Integer): TMemoryHitArray;
+var
+  Emb: TArray<Single>;
+  Hits: TSearchHits;
+  i: Integer;
+begin
+  SetLength(Result, 0);
+  if not FOpen then Exit;
+  try
+    Emb := EmbedText(Query);
+  except
+    on E: Exception do
+    begin
+      LogDebug('vector memory: query embedding failed — %s', [E.Message]);
+      Exit;
+    end;
+  end;
+  Hits := FStore.Search(Query, Emb, smHybrid, K);
+  SetLength(Result, Length(Hits));
+  for i := 0 to High(Hits) do
+  begin
+    Result[i].Path    := Hits[i].Source;
+    Result[i].Score   := Hits[i].Score;
+    { localvector returns the chunk text itself as the "snippet"; that
+      gives the model the same kind of context the FTS path's
+      bm25-highlighted snippet does without the highlighting markup. }
+    Result[i].Snippet := Hits[i].Text;
+  end;
+end;
+
+function NewVectorMemoryIndex: IMemoryIndex;
+begin
+  Result := TVectorMemoryIndex.Create;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LICENSE
+++ b/src/pkg/memory/localvector/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 FMXExpress
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/pkg/memory/localvector/LocalVector.Downloader.pas
+++ b/src/pkg/memory/localvector/LocalVector.Downloader.pas
@@ -1,0 +1,170 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.Downloader;
+
+{ First-run model acquisition. Downloads the two files a WordPiece model needs --
+  the ONNX graph and vocab.txt -- from the Hugging Face repo named in the model
+  spec, into a local models directory.
+
+  HTTP is provided by the Delphi RTL (System.Net.HttpClient, TLS via SChannel)
+  or, under Free Pascal, by fphttpclient + opensslsockets (needs the OpenSSL
+  runtime libraries to be present). }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes,
+{$ELSE}
+  System.SysUtils, System.Classes,
+{$ENDIF}
+  LocalVector.Models;
+
+const
+  MODEL_FILE = 'model.onnx';
+  VOCAB_FILE = 'vocab.txt';
+
+type
+  TModelDownloader = class
+  private
+    FSpec: TModelSpec;
+    FModelDir: string;
+    FModelPath: string;
+    FVocabPath: string;
+    FVerbose: Boolean;
+    procedure DownloadTo(const AUrl, ADestPath: string);
+  public
+    constructor Create(const ASpec: TModelSpec; const AModelDir: string;
+      AVerbose: Boolean = False);
+    { Ensures both files exist locally, downloading whatever is missing. }
+    procedure EnsureFiles;
+    property ModelPath: string read FModelPath;
+    property VocabPath: string read FVocabPath;
+  end;
+
+implementation
+
+uses
+  {$IFDEF FPC}
+  fphttpclient, opensslsockets
+  {$ELSE}
+  System.Net.HttpClient, System.Net.URLClient
+  {$ENDIF};
+
+function JoinPath(const ADir, AName: string): string;
+begin
+  Result := IncludeTrailingPathDelimiter(ADir) + AName;
+end;
+
+function FileSizeOf(const APath: string): Int64;
+var
+  FS: TFileStream;
+begin
+  Result := -1;
+  if not FileExists(APath) then
+    Exit;
+  FS := TFileStream.Create(APath, fmOpenRead or fmShareDenyWrite);
+  try
+    Result := FS.Size;
+  finally
+    FS.Free;
+  end;
+end;
+
+constructor TModelDownloader.Create(const ASpec: TModelSpec; const AModelDir: string;
+  AVerbose: Boolean);
+begin
+  inherited Create;
+  FSpec := ASpec;
+  FModelDir := AModelDir;
+  FVerbose := AVerbose;
+  FModelPath := JoinPath(FModelDir, MODEL_FILE);
+  FVocabPath := JoinPath(FModelDir, VOCAB_FILE);
+end;
+
+{$IFDEF FPC}
+procedure TModelDownloader.DownloadTo(const AUrl, ADestPath: string);
+var
+  Client: TFPHTTPClient;
+  FS: TFileStream;
+begin
+  WriteLn(ErrOutput, '[localvector] downloading ', ExtractFileName(ADestPath), ' ...');
+  WriteLn(ErrOutput, '[localvector]   from ', AUrl);
+  Client := TFPHTTPClient.Create(nil);
+  try
+    Client.AllowRedirect := True; // HF resolve/ URLs redirect to a CDN
+    Client.AddHeader('User-Agent', 'localvector/1.0');
+    FS := TFileStream.Create(ADestPath, fmCreate);
+    try
+      Client.Get(AUrl, FS);
+    finally
+      FS.Free;
+    end;
+  finally
+    Client.Free;
+  end;
+  WriteLn(ErrOutput, '[localvector]   saved ', ADestPath, ' (',
+          FileSizeOf(ADestPath), ' bytes)');
+end;
+{$ELSE}
+procedure TModelDownloader.DownloadTo(const AUrl, ADestPath: string);
+var
+  Client: THTTPClient;
+  Response: IHTTPResponse;
+  FS: TFileStream;
+begin
+  WriteLn(ErrOutput, '[localvector] downloading ', ExtractFileName(ADestPath), ' ...');
+  WriteLn(ErrOutput, '[localvector]   from ', AUrl);
+  Client := THTTPClient.Create;
+  try
+    Client.ConnectionTimeout := 30000;
+    Client.ResponseTimeout := 1800000; // up to 30 min for big models
+    FS := TFileStream.Create(ADestPath, fmCreate);
+    try
+      Response := Client.Get(AUrl, FS);
+      if Response.StatusCode <> 200 then
+        raise Exception.CreateFmt('Download failed (%d %s) for %s',
+          [Response.StatusCode, Response.StatusText, AUrl]);
+    finally
+      FS.Free;
+    end;
+  finally
+    Client.Free;
+  end;
+  WriteLn(ErrOutput, '[localvector]   saved ', ADestPath, ' (',
+          FileSizeOf(ADestPath), ' bytes)');
+end;
+{$ENDIF}
+
+procedure TModelDownloader.EnsureFiles;
+begin
+  if not DirectoryExists(FModelDir) then
+    ForceDirectories(FModelDir);
+
+  if FVerbose then
+    WriteLn(ErrOutput, '[localvector] model: ', FSpec.DisplayName,
+            ' (', FSpec.SizeDesc, ')  dir: ', FModelDir);
+
+  if not FileExists(FVocabPath) then
+    DownloadTo(FSpec.BaseURL + FSpec.VocabRelURL, FVocabPath);
+
+  // Treat a suspiciously tiny model file as a failed/partial download.
+  if (not FileExists(FModelPath)) or (FileSizeOf(FModelPath) < 1024 * 1024) then
+  begin
+    if FileExists(FModelPath) then
+      DeleteFile(FModelPath);
+    DownloadTo(FSpec.BaseURL + FSpec.ModelRelURL, FModelPath);
+  end;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.Embedder.pas
+++ b/src/pkg/memory/localvector/LocalVector.Embedder.pas
@@ -1,0 +1,252 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.Embedder;
+
+{ Runs a sentence-transformer style ONNX model and turns the token-level output
+  into a single normalized sentence embedding.
+
+  Inputs fed to the model (all int64, shape [1, seq_len]):
+    input_ids, attention_mask, and (optionally) token_type_ids
+  Output read back:
+    last_hidden_state [1, seq_len, hidden]  -> pooled over tokens via
+    mean / CLS (token 0) / last-token pooling.
+  (If a model instead emits an already-pooled [1, hidden] vector, that is used
+  directly.) The pooled vector is L2-normalized by default. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Math,
+{$ELSE}
+  System.SysUtils, System.Math,
+{$ENDIF}
+  onnxruntime_pas_api, onnxruntime,
+  LocalVector.Runtime, LocalVector.Models;
+
+type
+  EEmbedderError = class(Exception);
+
+  TEmbedder = class
+  private
+    FSession: TORTSession;
+    FModelPath: string;
+    FLoaded: Boolean;
+  public
+    constructor Create(const AModelPath: string);
+    destructor Destroy; override;
+    procedure Load(AVerbose: Boolean = False);
+    { Runs the model and pools the token embeddings into one vector.
+      APooling selects mean / CLS / last-token pooling; ANeedsTokenTypeIds
+      controls whether a token_type_ids input is fed (BERT-style models need it,
+      some models do not). }
+    function Embed(const ATokenIds: TArray<Int64>; APooling: TPooling;
+      ANeedsTokenTypeIds: Boolean; ANormalize: Boolean = True;
+      AVerbose: Boolean = False): TArray<Single>;
+    property ModelPath: string read FModelPath;
+  end;
+
+implementation
+
+constructor TEmbedder.Create(const AModelPath: string);
+begin
+  inherited Create;
+  FModelPath := AModelPath;
+  FLoaded := False;
+end;
+
+destructor TEmbedder.Destroy;
+begin
+  // TORTSession is a managed record; it releases itself.
+  inherited;
+end;
+
+procedure TEmbedder.Load(AVerbose: Boolean);
+var
+  Info: TOrtRuntimeInfo;
+  DllStr, VerStr: string;
+begin
+  if FLoaded then
+    Exit;
+  if not FileExists(FModelPath) then
+    raise EEmbedderError.CreateFmt('Model file not found: %s', [FModelPath]);
+
+  if AVerbose then
+  begin
+    WriteLn(ErrOutput, '[localvector] loading model: ', FModelPath);
+    PrintOrtRuntimeInfo;
+  end;
+
+  // ONNX Runtime 1.22+ no longer auto-selects the CPU execution provider; a
+  // session created with no EP fails ("No execution providers were provided or
+  // selected"). Make sure the default session options object exists (under FPC
+  // the wrapper's managed initializer may leave it nil) and register the CPU EP
+  // explicitly. This is harmless on older runtimes that added CPU implicitly.
+  if not Assigned(DefaultSessionOptions.p_) then
+    ThrowOnError(GetApi().CreateSessionOptions(PPOrtSessionOptions(@DefaultSessionOptions.p_)));
+  ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(DefaultSessionOptions.p_, 1));
+
+  try
+    FSession := TORTSession.Create(FModelPath);
+  except
+    on E: Exception do
+    begin
+      // The classic "old runtime, new model" failure. Make it actionable by
+      // naming the onnxruntime.dll that was actually loaded.
+      if Pos('IR version', E.Message) > 0 then
+      begin
+        Info := GetOrtRuntimeInfo;
+        if Info.DllPath <> '' then DllStr := Info.DllPath else DllStr := '(unknown path)';
+        if Info.Version <> '' then VerStr := Info.Version else VerStr := '(unknown)';
+        raise EEmbedderError.Create(
+          E.Message + sLineBreak +
+          'The loaded ONNX Runtime is too old for this model.' + sLineBreak +
+          '  loaded onnxruntime: ' + DllStr + '  version ' + VerStr + sLineBreak +
+          '  This model needs IR version 10 (ONNX Runtime >= ~1.17).' + sLineBreak +
+          '  Fix: put a current onnxruntime.dll next to the .exe (the build output' + sLineBreak +
+          '  folder), then re-run with --diag to confirm the version that loads.');
+      end;
+      raise EEmbedderError.Create(E.Message);
+    end;
+  end;
+
+  if AVerbose then
+    WriteLn(ErrOutput, '[localvector] model inputs=', FSession.GetInputCount,
+                       ' outputs=', FSession.GetOutputCount);
+  FLoaded := True;
+end;
+
+function TEmbedder.Embed(const ATokenIds: TArray<Int64>; APooling: TPooling;
+  ANeedsTokenTypeIds: Boolean; ANormalize: Boolean; AVerbose: Boolean): TArray<Single>;
+var
+  N, I, T, Dim, SeqLen: Integer;
+  PrePooled: Boolean;
+  InputIds, AttnMask, TypeIds: TORTTensor<Int64>;
+  OutVal: TORTValue;
+  OutTensor: TORTTensor<Single>;
+  Inputs, Outputs: TORTNameValueList;
+  RealShape: TArray<Int64>;
+  Acc, Norm: Double;
+begin
+  if not FLoaded then
+    Load(AVerbose);
+
+  N := Length(ATokenIds);
+  if N = 0 then
+    raise EEmbedderError.Create('No tokens to embed.');
+
+  // TORTTensor.ToValue reverses the declared shape, so declare [seq_len, 1] to
+  // hand ONNX a real input tensor of shape [1, seq_len]. The flat data layout
+  // is identical either way.
+  InputIds := TORTTensor<Int64>.Create([N, 1]);
+  AttnMask := TORTTensor<Int64>.Create([N, 1]);
+  for I := 0 to N - 1 do
+  begin
+    InputIds.Index1[I] := ATokenIds[I];
+    AttnMask.Index1[I] := 1;
+  end;
+
+  Inputs.Add('input_ids',      InputIds.ToValue);
+  Inputs.Add('attention_mask', AttnMask.ToValue);
+  if ANeedsTokenTypeIds then
+  begin
+    TypeIds := TORTTensor<Int64>.Create([N, 1]);
+    for I := 0 to N - 1 do
+      TypeIds.Index1[I] := 0;
+    Inputs.Add('token_type_ids', TypeIds.ToValue);
+  end;
+
+  if AVerbose then
+    WriteLn(ErrOutput, '[localvector] running inference (seq_len=', N,
+                       ', pooling=', PoolingName(APooling), ') ...');
+
+  Outputs := FSession.Run(Inputs);
+  if Outputs.Count = 0 then
+    raise EEmbedderError.Create('Model returned no outputs.');
+
+  OutVal := Outputs.Values[0];
+
+  // Read the *true* ONNX shape (GetShape is not reversed, unlike TORTTensor.Shape).
+  RealShape := OutVal.GetTensorTypeAndShapeInfo.GetShape;
+  OutTensor := TORTTensor<Single>.FromValue(OutVal);
+
+  // Resolve sequence length / hidden size from the output rank:
+  //   [1, hidden]            -> already pooled
+  //   [1, seq_len, hidden]   -> token embeddings
+  //   [seq_len, hidden]      -> token embeddings (no batch dim)
+  PrePooled := False;
+  SeqLen := 0;
+  case Length(RealShape) of
+    2:
+      if RealShape[0] = 1 then
+      begin
+        PrePooled := True;
+        Dim := RealShape[1];
+      end
+      else
+      begin
+        SeqLen := RealShape[0];
+        Dim := RealShape[1];
+      end;
+    3:
+      begin
+        SeqLen := RealShape[1];
+        Dim := RealShape[2];
+      end;
+  else
+    raise EEmbedderError.CreateFmt('Unexpected output rank: %d', [Length(RealShape)]);
+  end;
+
+  SetLength(Result, Dim);
+
+  // OutTensor.Index1 walks the raw, row-major ONNX buffer; token t / dim d lives
+  // at Index1[t*Dim + d] (batch 0).
+  if PrePooled then
+  begin
+    for I := 0 to Dim - 1 do
+      Result[I] := OutTensor.Index1[I];
+  end
+  else
+    case APooling of
+      poMean:
+        begin
+          for I := 0 to Dim - 1 do Result[I] := 0;
+          for T := 0 to SeqLen - 1 do
+            for I := 0 to Dim - 1 do
+              Result[I] := Result[I] + OutTensor.Index1[T * Dim + I];
+          for I := 0 to Dim - 1 do Result[I] := Result[I] / SeqLen;
+        end;
+      poCLS:
+        for I := 0 to Dim - 1 do
+          Result[I] := OutTensor.Index1[I];                 // token 0 ([CLS])
+      poLast:
+        for I := 0 to Dim - 1 do
+          Result[I] := OutTensor.Index1[(SeqLen - 1) * Dim + I];
+    end;
+
+  if ANormalize then
+  begin
+    Acc := 0;
+    for I := 0 to High(Result) do
+      Acc := Acc + Result[I] * Result[I];
+    Norm := Sqrt(Acc);
+    if Norm > 1e-12 then
+      for I := 0 to High(Result) do
+        Result[I] := Result[I] / Norm;
+  end;
+
+  if AVerbose then
+    WriteLn(ErrOutput, '[localvector] embedding dim = ', Length(Result));
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.Models.pas
+++ b/src/pkg/memory/localvector/LocalVector.Models.pas
@@ -1,0 +1,127 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.Models;
+
+{ Registry of the built-in embedding models. Each entry knows where to fetch the
+  ONNX model + vocab, how to pool the token embeddings, and whether the model
+  takes token_type_ids. Adding a new BERT/WordPiece model is just another row. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils;
+{$ELSE}
+  System.SysUtils;
+{$ENDIF}
+
+type
+  TPooling = (poMean, poCLS, poLast);
+
+  TModelSpec = record
+    Key: string;               // canonical selector, e.g. 'minilm'
+    DisplayName: string;       // human label
+    SubDir: string;            // models/<SubDir>/
+    BaseURL: string;           // Hugging Face resolve base, trailing '/'
+    ModelRelURL: string;       // remote model path, e.g. 'model.onnx' or 'onnx/model.onnx'
+    VocabRelURL: string;       // remote vocab path, e.g. 'vocab.txt'
+    Pooling: TPooling;
+    NeedsTokenTypeIds: Boolean;
+    DoLowerCase: Boolean;
+    Dim: Integer;
+    SizeDesc: string;
+  end;
+
+{ Resolves a selector (including a few aliases) to a model spec. }
+function FindModelSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
+
+{ Comma-separated list of the canonical keys, for help text/errors. }
+function ModelKeys: string;
+
+function ParsePooling(const AStr: string; out APooling: TPooling): Boolean;
+function PoolingName(APooling: TPooling): string;
+
+const
+  DEFAULT_MODEL = 'minilm';
+
+implementation
+
+function MakeSpec(const AKey, ADisplay, ASubDir, ABaseURL, AModelRel, AVocabRel: string;
+  APooling: TPooling; ANeedsTT, ALower: Boolean; ADim: Integer; const ASize: string): TModelSpec;
+begin
+  Result.Key := AKey;
+  Result.DisplayName := ADisplay;
+  Result.SubDir := ASubDir;
+  Result.BaseURL := ABaseURL;
+  Result.ModelRelURL := AModelRel;
+  Result.VocabRelURL := AVocabRel;
+  Result.Pooling := APooling;
+  Result.NeedsTokenTypeIds := ANeedsTT;
+  Result.DoLowerCase := ALower;
+  Result.Dim := ADim;
+  Result.SizeDesc := ASize;
+end;
+
+function FindModelSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
+var
+  K: string;
+begin
+  Result := True;
+  K := LowerCase(Trim(AKey));
+
+  if (K = 'minilm') or (K = 'all-minilm') or (K = 'all-minilm-l6-v2') then
+    ASpec := MakeSpec('minilm', 'all-MiniLM-L6-v2', 'all-MiniLM-L6-v2',
+      'https://huggingface.co/onnx-models/all-MiniLM-L6-v2-onnx/resolve/main/',
+      'model.onnx', 'vocab.txt', poMean, True, True, 384, '~90 MB')
+  else if (K = 'bge') or (K = 'bge-small') or (K = 'bge-small-en') or (K = 'bge-small-en-v1.5') then
+    ASpec := MakeSpec('bge', 'bge-small-en-v1.5', 'bge-small-en-v1.5',
+      'https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/',
+      'onnx/model.onnx', 'vocab.txt', poCLS, True, True, 384, '~133 MB')
+  else if (K = 'mxbai') or (K = 'mxbai-large') or (K = 'mxbai-embed-large') or (K = 'mixedbread') then
+    // Quantized (int8) export. Same BERT/WordPiece + CLS pooling as bge, 1024-d.
+    ASpec := MakeSpec('mxbai', 'mxbai-embed-large-v1 (int8)', 'mxbai-embed-large-v1',
+      'https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1/resolve/main/',
+      'onnx/model_quantized.onnx', 'vocab.txt', poCLS, True, True, 1024, '~337 MB')
+  else
+    Result := False;
+end;
+
+function ModelKeys: string;
+begin
+  Result := 'minilm, bge, mxbai';
+end;
+
+function ParsePooling(const AStr: string; out APooling: TPooling): Boolean;
+var
+  S: string;
+begin
+  Result := True;
+  S := LowerCase(Trim(AStr));
+  if S = 'mean' then APooling := poMean
+  else if (S = 'cls') or (S = 'first') then APooling := poCLS
+  else if S = 'last' then APooling := poLast
+  else Result := False;
+end;
+
+function PoolingName(APooling: TPooling): string;
+begin
+  case APooling of
+    poMean: Result := 'mean';
+    poCLS:  Result := 'cls';
+    poLast: Result := 'last';
+  else
+    Result := '?';
+  end;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.OrtProvision.pas
+++ b/src/pkg/memory/localvector/LocalVector.OrtProvision.pas
@@ -1,0 +1,243 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.OrtProvision;
+
+{ Makes sure an ONNX Runtime is loaded and its C API is initialized.
+
+  Because the bindings now load onnxruntime dynamically, the program can start
+  with no runtime present. Strategy:
+    1. If a runtime is already loaded, just (re)init the API + defaults.
+    2. Prefer a runtime next to the executable. On Windows, if it is missing and
+       downloads are allowed, fetch a current build from the ONNX Runtime GitHub
+       release and extract onnxruntime.dll there.
+    3. Otherwise fall back to the system loader (LD_LIBRARY_PATH / in-box DLL).
+  Then InitOrtApi + EnsureOrtDefaults. Raises on failure. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes;
+{$ELSE}
+  System.SysUtils, System.Classes;
+{$ENDIF}
+
+const
+  ORT_VERSION = '1.26.0';
+
+{ Ensures the runtime is loaded + API ready. Returns True; raises on failure. }
+function EnsureOnnxRuntime(const AExeDir: string; AAllowDownload, AVerbose: Boolean): Boolean;
+
+{ True on platforms where we can auto-download a runtime (currently Windows x64). }
+function CanAutoProvisionRuntime: Boolean;
+
+implementation
+
+uses
+  onnxruntime_pas_api, onnxruntime, LocalVector.Runtime
+{$IFDEF FPC}
+  , fphttpclient, opensslsockets, zipper
+{$ELSE}
+  , System.Net.HttpClient, System.Net.URLClient, System.Zip
+{$ENDIF};
+
+function CanAutoProvisionRuntime: Boolean;
+begin
+{$IFDEF MSWINDOWS}
+  {$IFDEF WIN64}
+  Result := True;
+  {$ELSE}
+  Result := False;  // only the win-x64 release asset is wired up
+  {$ENDIF}
+{$ELSE}
+  Result := False;
+{$ENDIF}
+end;
+
+{$IFDEF FPC}
+procedure DownloadFile(const AUrl, ADest: string);
+var
+  C: TFPHTTPClient;
+  FS: TFileStream;
+begin
+  C := TFPHTTPClient.Create(nil);
+  try
+    C.AllowRedirect := True;
+    C.AddHeader('User-Agent', 'localvector/1.0');
+    FS := TFileStream.Create(ADest, fmCreate);
+    try
+      C.Get(AUrl, FS);
+    finally
+      FS.Free;
+    end;
+  finally
+    C.Free;
+  end;
+end;
+{$ELSE}
+procedure DownloadFile(const AUrl, ADest: string);
+var
+  C: THTTPClient;
+  R: IHTTPResponse;
+  FS: TFileStream;
+begin
+  C := THTTPClient.Create;
+  try
+    C.ConnectionTimeout := 30000;
+    C.ResponseTimeout := 600000;
+    FS := TFileStream.Create(ADest, fmCreate);
+    try
+      R := C.Get(AUrl, FS);
+      if R.StatusCode <> 200 then
+        raise Exception.CreateFmt('HTTP %d %s for %s', [R.StatusCode, R.StatusText, AUrl]);
+    finally
+      FS.Free;
+    end;
+  finally
+    C.Free;
+  end;
+end;
+{$ENDIF}
+
+{$IFDEF FPC}
+type
+  TZipEntryWriter = class
+    Target: string;
+    Stream: TFileStream;
+    procedure DoCreate(Sender: TObject; var AStream: TStream; AItem: TFullZipFileEntry);
+    procedure DoDone(Sender: TObject; var AStream: TStream; AItem: TFullZipFileEntry);
+  end;
+
+procedure TZipEntryWriter.DoCreate(Sender: TObject; var AStream: TStream; AItem: TFullZipFileEntry);
+begin
+  Stream := TFileStream.Create(Target, fmCreate);
+  AStream := Stream;
+end;
+
+procedure TZipEntryWriter.DoDone(Sender: TObject; var AStream: TStream; AItem: TFullZipFileEntry);
+begin
+  FreeAndNil(Stream);
+  AStream := nil;
+end;
+
+procedure ExtractZipEntryToFile(const AZip, AEntry, ADest: string);
+var
+  UnZip: TUnZipper;
+  List: TStringList;
+  W: TZipEntryWriter;
+begin
+  UnZip := TUnZipper.Create;
+  W := TZipEntryWriter.Create;
+  List := TStringList.Create;
+  try
+    W.Target := ADest;
+    UnZip.FileName := AZip;
+    UnZip.OnCreateStream := W.DoCreate;
+    UnZip.OnDoneStream := W.DoDone;
+    List.Add(AEntry);
+    UnZip.UnZipFiles(List);
+  finally
+    List.Free;
+    W.Free;
+    UnZip.Free;
+  end;
+end;
+{$ELSE}
+procedure ExtractZipEntryToFile(const AZip, AEntry, ADest: string);
+var
+  Zip: TZipFile;
+  Bytes: TBytes;
+  FS: TFileStream;
+begin
+  Zip := TZipFile.Create;
+  try
+    Zip.Open(AZip, zmRead);
+    Zip.Read(AEntry, Bytes);
+    FS := TFileStream.Create(ADest, fmCreate);
+    try
+      if Length(Bytes) > 0 then
+        FS.WriteBuffer(Bytes[0], Length(Bytes));
+    finally
+      FS.Free;
+    end;
+  finally
+    Zip.Free;
+  end;
+end;
+{$ENDIF}
+
+procedure ProvisionRuntime(const AExeDir: string; AVerbose: Boolean);
+const
+  RELEASE = 'https://github.com/microsoft/onnxruntime/releases/download/v' + ORT_VERSION + '/';
+  ASSET   = 'onnxruntime-win-x64-' + ORT_VERSION + '.zip';
+  ENTRY   = 'onnxruntime-win-x64-' + ORT_VERSION + '/lib/onnxruntime.dll';
+var
+  ZipPath, Dest: string;
+begin
+  Dest := IncludeTrailingPathDelimiter(AExeDir) + ORT_LIB;
+  ZipPath := IncludeTrailingPathDelimiter(AExeDir) + ASSET;
+
+  WriteLn(ErrOutput, '[localvector] onnxruntime not found - downloading ONNX Runtime ',
+          ORT_VERSION, ' ...');
+  WriteLn(ErrOutput, '[localvector]   from ', RELEASE + ASSET);
+  DownloadFile(RELEASE + ASSET, ZipPath);
+  try
+    WriteLn(ErrOutput, '[localvector]   extracting ', ORT_LIB, ' -> ', Dest);
+    ExtractZipEntryToFile(ZipPath, ENTRY, Dest);
+  finally
+    if FileExists(ZipPath) then
+      DeleteFile(ZipPath);
+  end;
+  WriteLn(ErrOutput, '[localvector]   installed ', Dest);
+end;
+
+function EnsureOnnxRuntime(const AExeDir: string; AAllowDownload, AVerbose: Boolean): Boolean;
+var
+  Dll: string;
+begin
+  if not OrtRuntimeLoaded then
+  begin
+    Dll := IncludeTrailingPathDelimiter(AExeDir) + ORT_LIB;
+
+    // Prefer a current runtime next to the exe; download one if it's missing.
+    if (not FileExists(Dll)) and AAllowDownload and CanAutoProvisionRuntime then
+    begin
+      try
+        ProvisionRuntime(AExeDir, AVerbose);
+      except
+        on E: Exception do
+          WriteLn(ErrOutput, '[localvector] runtime download failed: ', E.Message);
+      end;
+    end;
+
+    if FileExists(Dll) then
+      LoadOnnxRuntime(Dll)
+    else
+      LoadOnnxRuntime('');   // system loader (LD_LIBRARY_PATH / Windows in-box)
+  end;
+
+  if not OrtRuntimeLoaded then
+    raise Exception.Create(
+      'Could not load onnxruntime. Put ' + ORT_LIB + ' next to the executable' +
+      {$IFDEF MSWINDOWS}'.'{$ELSE}' or on the loader path.'{$ENDIF});
+
+  if not InitOrtApi then
+    raise Exception.CreateFmt(
+      'Loaded onnxruntime but its C API (v%d) is unavailable - the library may be too old.',
+      [ORT_API_VERSION]);
+
+  EnsureOrtDefaults;
+  Result := True;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.Runtime.pas
+++ b/src/pkg/memory/localvector/LocalVector.Runtime.pas
@@ -1,0 +1,179 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.Runtime;
+
+{ ONNX Runtime diagnostics.
+
+  The bindings load onnxruntime dynamically (LoadOnnxRuntime), so this unit
+  reports the file that was actually loaded and the version it returns -- no
+  guessing whether the app picked up a local DLL or the one inside Windows. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils,
+{$ELSE}
+  System.SysUtils,
+{$ENDIF}
+  onnxruntime_pas_api;
+
+type
+  TOrtRuntimeInfo = record
+    DllPath: string;        // full path of the loaded onnxruntime shared library (Windows)
+    Version: string;        // version string reported by the DLL, e.g. "1.26.0"
+    RequestedApi: Integer;  // ORT_API_VERSION the Pascal bindings ask GetApi() for
+    ApiAvailable: Boolean;  // True if GetApi(RequestedApi) returned a usable pointer
+    BaseAvailable: Boolean; // True if OrtGetApiBase() returned non-nil
+  end;
+
+{ Queries the loaded onnxruntime library. Never raises. }
+function GetOrtRuntimeInfo: TOrtRuntimeInfo;
+
+{ Heuristic: ORT older than ~1.17 cannot load ONNX models with IR version 10.
+  Returns True when the parsed version looks too old for modern HF exports. }
+function OrtVersionLooksTooOldForIR10(const AVersion: string): Boolean;
+
+{ Writes the runtime info to ErrOutput (stderr). }
+procedure PrintOrtRuntimeInfo(const APrefix: string = '[localvector] ');
+
+const
+  {$IFDEF MSWINDOWS}
+  ORT_LIB = 'onnxruntime.dll';
+  {$ELSE}
+    {$IFDEF DARWIN}
+  ORT_LIB = 'onnxruntime.dylib';
+    {$ELSE}
+  ORT_LIB = 'onnxruntime.so';
+    {$ENDIF}
+  {$ENDIF}
+
+implementation
+
+{$IFDEF MSWINDOWS}
+uses
+  {$IFDEF FPC}Windows{$ELSE}Winapi.Windows{$ENDIF};
+{$ENDIF}
+
+{$IFDEF MSWINDOWS}
+function ModulePathForHandle(H: HMODULE): string;
+var
+  Buf: array[0..1023] of WideChar;
+  N: DWORD;
+  W: WideString;
+begin
+  Result := '';
+  if H = 0 then
+    Exit;
+  N := GetModuleFileNameW(H, @Buf[0], Length(Buf));
+  if N > 0 then
+  begin
+    W := PWideChar(@Buf[0]);
+    Result := string(W);
+  end;
+end;
+{$ENDIF}
+
+function GetOrtRuntimeInfo: TOrtRuntimeInfo;
+var
+  Base: POrtApiBase;
+  VerPtr: POrtChar;
+begin
+  Result.DllPath := '';
+  Result.Version := '';
+  Result.RequestedApi := ORT_API_VERSION;
+  Result.ApiAvailable := False;
+  Result.BaseAvailable := False;
+
+  {$IFDEF MSWINDOWS}
+  if OrtRuntimeLibHandle <> 0 then
+    Result.DllPath := ModulePathForHandle(HMODULE(OrtRuntimeLibHandle))
+  else
+    Result.DllPath := ModulePathForHandle(GetModuleHandleW(PWideChar(WideString(ORT_LIB))));
+  {$ENDIF}
+
+  Base := nil;
+  if Assigned(OrtGetApiBase) then
+    try
+      Base := OrtGetApiBase();
+    except
+      Base := nil;
+    end;
+
+  if Base <> nil then
+  begin
+    Result.BaseAvailable := True;
+    if Assigned(Base^.GetVersionString) then
+    begin
+      VerPtr := Base^.GetVersionString();
+      if VerPtr <> nil then
+        Result.Version := string(AnsiString(PAnsiChar(VerPtr)));
+    end;
+    if Assigned(Base^.GetApi) then
+      Result.ApiAvailable := Base^.GetApi(ORT_API_VERSION) <> nil;
+  end;
+end;
+
+function OrtVersionLooksTooOldForIR10(const AVersion: string): Boolean;
+var
+  P: Integer;
+  S, MajS, MinS: string;
+  Major, Minor: Integer;
+begin
+  // Be conservative: only report "too old" when we can confidently parse a
+  // major.minor that is below 1.17. Unknown/unparseable -> not flagged.
+  Result := False;
+  S := Trim(AVersion);
+  if S = '' then Exit;
+
+  P := Pos('.', S);
+  if P <= 0 then Exit;
+  MajS := Copy(S, 1, P - 1);
+  S := Copy(S, P + 1, Length(S));
+  P := Pos('.', S);
+  if P > 0 then
+    MinS := Copy(S, 1, P - 1)
+  else
+    MinS := S;
+
+  if not TryStrToInt(Trim(MajS), Major) then Exit;
+  if not TryStrToInt(Trim(MinS), Minor) then Exit;
+
+  Result := (Major < 1) or ((Major = 1) and (Minor < 17));
+end;
+
+procedure PrintOrtRuntimeInfo(const APrefix: string);
+var
+  Info: TOrtRuntimeInfo;
+begin
+  Info := GetOrtRuntimeInfo;
+  WriteLn(ErrOutput, APrefix, 'onnxruntime library:');
+  if Info.DllPath <> '' then
+    WriteLn(ErrOutput, APrefix, '  loaded from : ', Info.DllPath)
+  else
+    WriteLn(ErrOutput, APrefix, '  loaded from : (unknown on this platform)');
+  if Info.Version <> '' then
+    WriteLn(ErrOutput, APrefix, '  version     : ', Info.Version)
+  else
+    WriteLn(ErrOutput, APrefix, '  version     : (could not query)');
+  WriteLn(ErrOutput, APrefix, '  bindings ask: ORT_API_VERSION ', Info.RequestedApi,
+                              '  (GetApi ', BoolToStr(Info.ApiAvailable, True), ')');
+  if (Info.Version <> '') and OrtVersionLooksTooOldForIR10(Info.Version) then
+  begin
+    WriteLn(ErrOutput, APrefix, '  NOTE: this runtime predates ONNX IR v10 support.');
+    WriteLn(ErrOutput, APrefix, '        Modern Hugging Face models (IR v10) will fail to load.');
+    WriteLn(ErrOutput, APrefix, '        Place a current onnxruntime.dll (>= 1.17) next to this exe.');
+  end;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
+++ b/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
@@ -1,0 +1,330 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.Sqlite3;
+
+{ Minimal, dynamically-loaded binding to the SQLite C API -- just the calls the
+  portable vector store needs (open, prepare/step/finalize, bind/column,
+  enable/load extension). The library is resolved at run time (libsqlite3.so on
+  POSIX, sqlite3.dll on Windows), so there is no link-time dependency.
+
+  This backs the FPC build; the Delphi build uses FireDAC instead. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+// The sqlite-vec (vec0) loadable extension references libm (e.g. sqrtf); make
+// sure libm is in the process so the runtime can resolve those symbols.
+{$IFDEF FPC}{$IFDEF UNIX}{$LINKLIB m}{$ENDIF}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils
+{$ELSE}
+  System.SysUtils
+{$ENDIF}
+{$IFDEF MSWINDOWS}
+  , {$IFDEF FPC}Windows{$ELSE}Winapi.Windows{$ENDIF}
+{$ELSE}
+  {$IFDEF FPC}, dynlibs{$ENDIF}
+{$ENDIF}
+  ;
+
+const
+  SQLITE_OK     = 0;
+  SQLITE_ROW    = 100;
+  SQLITE_DONE   = 101;
+  SQLITE_OPEN_READWRITE = $0002;
+  SQLITE_OPEN_CREATE    = $0004;
+
+type
+  PSQLite3 = Pointer;
+  PSQLite3Stmt = Pointer;
+  ESQLiteError = class(Exception);
+
+{ Loads libsqlite3 / sqlite3.dll and resolves the entry points. Returns True on
+  success. Safe to call repeatedly. }
+function LoadSqlite3(const APath: string = ''): Boolean;
+function Sqlite3Loaded: Boolean;
+
+// Thin Pascal wrappers (raise ESQLiteError on failure where useful).
+function sqlite_open(const AFileName: string): PSQLite3;
+procedure sqlite_close(db: PSQLite3);
+procedure sqlite_exec(db: PSQLite3; const ASql: string);
+function sqlite_prepare(db: PSQLite3; const ASql: string): PSQLite3Stmt;
+function sqlite_step(stmt: PSQLite3Stmt): Integer;
+procedure sqlite_finalize(stmt: PSQLite3Stmt);
+procedure sqlite_reset(stmt: PSQLite3Stmt);
+procedure sqlite_bind_int64(stmt: PSQLite3Stmt; idx: Integer; v: Int64);
+procedure sqlite_bind_double(stmt: PSQLite3Stmt; idx: Integer; v: Double);
+procedure sqlite_bind_text(stmt: PSQLite3Stmt; idx: Integer; const v: string);
+procedure sqlite_bind_blob(stmt: PSQLite3Stmt; idx: Integer; const v; n: Integer);
+function sqlite_column_int64(stmt: PSQLite3Stmt; col: Integer): Int64;
+function sqlite_column_double(stmt: PSQLite3Stmt; col: Integer): Double;
+function sqlite_column_text(stmt: PSQLite3Stmt; col: Integer): string;
+function sqlite_last_insert_rowid(db: PSQLite3): Int64;
+procedure sqlite_load_extension(db: PSQLite3; const APath, AEntry: string);
+
+implementation
+
+type
+  TOrdHandle = {$IFDEF MSWINDOWS}HMODULE{$ELSE}{$IFDEF FPC}TLibHandle{$ELSE}NativeUInt{$ENDIF}{$ENDIF};
+
+  Tsqlite3_open = function(filename: PAnsiChar; var ppDb: PSQLite3): Integer; cdecl;
+  Tsqlite3_close = function(db: PSQLite3): Integer; cdecl;
+  Tsqlite3_exec = function(db: PSQLite3; sql: PAnsiChar; cb, arg, errmsg: Pointer): Integer; cdecl;
+  Tsqlite3_prepare_v2 = function(db: PSQLite3; sql: PAnsiChar; n: Integer; var stmt: PSQLite3Stmt; tail: Pointer): Integer; cdecl;
+  Tsqlite3_step = function(stmt: PSQLite3Stmt): Integer; cdecl;
+  Tsqlite3_finalize = function(stmt: PSQLite3Stmt): Integer; cdecl;
+  Tsqlite3_reset = function(stmt: PSQLite3Stmt): Integer; cdecl;
+  Tsqlite3_bind_int64 = function(stmt: PSQLite3Stmt; idx: Integer; v: Int64): Integer; cdecl;
+  Tsqlite3_bind_double = function(stmt: PSQLite3Stmt; idx: Integer; v: Double): Integer; cdecl;
+  Tsqlite3_bind_text = function(stmt: PSQLite3Stmt; idx: Integer; v: PAnsiChar; n: Integer; destructor_: Pointer): Integer; cdecl;
+  Tsqlite3_bind_blob = function(stmt: PSQLite3Stmt; idx: Integer; v: Pointer; n: Integer; destructor_: Pointer): Integer; cdecl;
+  Tsqlite3_column_int64 = function(stmt: PSQLite3Stmt; col: Integer): Int64; cdecl;
+  Tsqlite3_column_double = function(stmt: PSQLite3Stmt; col: Integer): Double; cdecl;
+  Tsqlite3_column_text = function(stmt: PSQLite3Stmt; col: Integer): PAnsiChar; cdecl;
+  Tsqlite3_last_insert_rowid = function(db: PSQLite3): Int64; cdecl;
+  Tsqlite3_errmsg = function(db: PSQLite3): PAnsiChar; cdecl;
+  Tsqlite3_enable_load_extension = function(db: PSQLite3; onoff: Integer): Integer; cdecl;
+  Tsqlite3_load_extension = function(db: PSQLite3; afile, aproc: PAnsiChar; var errmsg: PAnsiChar): Integer; cdecl;
+
+var
+  _lib: TOrdHandle = 0;
+  _open: Tsqlite3_open = nil;
+  _close: Tsqlite3_close = nil;
+  _exec: Tsqlite3_exec = nil;
+  _prepare: Tsqlite3_prepare_v2 = nil;
+  _step: Tsqlite3_step = nil;
+  _finalize: Tsqlite3_finalize = nil;
+  _reset: Tsqlite3_reset = nil;
+  _bind_int64: Tsqlite3_bind_int64 = nil;
+  _bind_double: Tsqlite3_bind_double = nil;
+  _bind_text: Tsqlite3_bind_text = nil;
+  _bind_blob: Tsqlite3_bind_blob = nil;
+  _col_int64: Tsqlite3_column_int64 = nil;
+  _col_double: Tsqlite3_column_double = nil;
+  _col_text: Tsqlite3_column_text = nil;
+  _last_rowid: Tsqlite3_last_insert_rowid = nil;
+  _errmsg: Tsqlite3_errmsg = nil;
+  _enable_load: Tsqlite3_enable_load_extension = nil;
+  _load_ext: Tsqlite3_load_extension = nil;
+
+function ldLib(const AName: string): TOrdHandle;
+begin
+{$IFDEF MSWINDOWS}
+  Result := LoadLibrary(PChar(AName));
+{$ELSE}
+  Result := LoadLibrary(AName);
+{$ENDIF}
+end;
+
+function ldProc(h: TOrdHandle; const AName: string): Pointer;
+begin
+{$IFDEF MSWINDOWS}
+  Result := GetProcAddress(h, PAnsiChar(AnsiString(AName)));
+{$ELSE}
+  Result := GetProcedureAddress(h, AName);
+{$ENDIF}
+end;
+
+function Sqlite3Loaded: Boolean;
+begin
+  Result := (_lib <> 0) and Assigned(_open);
+end;
+
+function LoadSqlite3(const APath: string): Boolean;
+
+  function P(const n: string): Pointer;
+  begin
+    Result := ldProc(_lib, n);
+  end;
+
+begin
+  if Sqlite3Loaded then
+    Exit(True);
+
+  if APath <> '' then
+    _lib := ldLib(APath);
+  if _lib = 0 then
+  {$IFDEF MSWINDOWS}
+    _lib := ldLib('sqlite3.dll');
+  {$ELSE}
+    begin
+      _lib := ldLib('libsqlite3.so.0');
+      if _lib = 0 then _lib := ldLib('libsqlite3.so');
+      if _lib = 0 then _lib := ldLib('libsqlite3.dylib');
+    end;
+  {$ENDIF}
+  if _lib = 0 then
+    Exit(False);
+
+  _open := Tsqlite3_open(P('sqlite3_open'));
+  _close := Tsqlite3_close(P('sqlite3_close'));
+  _exec := Tsqlite3_exec(P('sqlite3_exec'));
+  _prepare := Tsqlite3_prepare_v2(P('sqlite3_prepare_v2'));
+  _step := Tsqlite3_step(P('sqlite3_step'));
+  _finalize := Tsqlite3_finalize(P('sqlite3_finalize'));
+  _reset := Tsqlite3_reset(P('sqlite3_reset'));
+  _bind_int64 := Tsqlite3_bind_int64(P('sqlite3_bind_int64'));
+  _bind_double := Tsqlite3_bind_double(P('sqlite3_bind_double'));
+  _bind_text := Tsqlite3_bind_text(P('sqlite3_bind_text'));
+  _bind_blob := Tsqlite3_bind_blob(P('sqlite3_bind_blob'));
+  _col_int64 := Tsqlite3_column_int64(P('sqlite3_column_int64'));
+  _col_double := Tsqlite3_column_double(P('sqlite3_column_double'));
+  _col_text := Tsqlite3_column_text(P('sqlite3_column_text'));
+  _last_rowid := Tsqlite3_last_insert_rowid(P('sqlite3_last_insert_rowid'));
+  _errmsg := Tsqlite3_errmsg(P('sqlite3_errmsg'));
+  _enable_load := Tsqlite3_enable_load_extension(P('sqlite3_enable_load_extension'));
+  _load_ext := Tsqlite3_load_extension(P('sqlite3_load_extension'));
+
+  Result := Assigned(_open) and Assigned(_prepare) and Assigned(_step);
+end;
+
+function ErrMsg(db: PSQLite3): string;
+begin
+  if Assigned(_errmsg) and (db <> nil) then
+    Result := string(AnsiString(_errmsg(db)))
+  else
+    Result := '(unknown sqlite error)';
+end;
+
+function sqlite_open(const AFileName: string): PSQLite3;
+var
+  rc: Integer;
+begin
+  Result := nil;
+  rc := _open(PAnsiChar(UTF8Encode(AFileName)), Result);
+  if rc <> SQLITE_OK then
+    raise ESQLiteError.CreateFmt('sqlite open failed (%d): %s', [rc, ErrMsg(Result)]);
+end;
+
+procedure sqlite_close(db: PSQLite3);
+begin
+  if (db <> nil) and Assigned(_close) then
+    _close(db);
+end;
+
+procedure sqlite_exec(db: PSQLite3; const ASql: string);
+var
+  rc: Integer;
+begin
+  rc := _exec(db, PAnsiChar(UTF8Encode(ASql)), nil, nil, nil);
+  if rc <> SQLITE_OK then
+    raise ESQLiteError.CreateFmt('sqlite exec failed (%d): %s'#10'SQL: %s',
+      [rc, ErrMsg(db), ASql]);
+end;
+
+function sqlite_prepare(db: PSQLite3; const ASql: string): PSQLite3Stmt;
+var
+  rc: Integer;
+  U: RawByteString;
+begin
+  Result := nil;
+  U := UTF8Encode(ASql);
+  rc := _prepare(db, PAnsiChar(U), Length(U), Result, nil);
+  if rc <> SQLITE_OK then
+    raise ESQLiteError.CreateFmt('sqlite prepare failed (%d): %s'#10'SQL: %s',
+      [rc, ErrMsg(db), ASql]);
+end;
+
+function sqlite_step(stmt: PSQLite3Stmt): Integer;
+begin
+  Result := _step(stmt);
+end;
+
+procedure sqlite_finalize(stmt: PSQLite3Stmt);
+begin
+  if (stmt <> nil) and Assigned(_finalize) then
+    _finalize(stmt);
+end;
+
+procedure sqlite_reset(stmt: PSQLite3Stmt);
+begin
+  _reset(stmt);
+end;
+
+procedure sqlite_bind_int64(stmt: PSQLite3Stmt; idx: Integer; v: Int64);
+begin
+  _bind_int64(stmt, idx, v);
+end;
+
+procedure sqlite_bind_double(stmt: PSQLite3Stmt; idx: Integer; v: Double);
+begin
+  _bind_double(stmt, idx, v);
+end;
+
+procedure sqlite_bind_text(stmt: PSQLite3Stmt; idx: Integer; const v: string);
+var
+  U: RawByteString;
+begin
+  U := UTF8Encode(v);
+  // -1 length = NUL-terminated; SQLITE_TRANSIENT (-1) = sqlite copies the bytes.
+  _bind_text(stmt, idx, PAnsiChar(U), Length(U), Pointer(-1));
+end;
+
+procedure sqlite_bind_blob(stmt: PSQLite3Stmt; idx: Integer; const v; n: Integer);
+begin
+  _bind_blob(stmt, idx, @v, n, Pointer(-1)); // SQLITE_TRANSIENT
+end;
+
+function sqlite_column_int64(stmt: PSQLite3Stmt; col: Integer): Int64;
+begin
+  Result := _col_int64(stmt, col);
+end;
+
+function sqlite_column_double(stmt: PSQLite3Stmt; col: Integer): Double;
+begin
+  Result := _col_double(stmt, col);
+end;
+
+function sqlite_column_text(stmt: PSQLite3Stmt; col: Integer): string;
+var
+  P: PAnsiChar;
+begin
+  P := _col_text(stmt, col);
+  if P = nil then
+    Result := ''
+  else
+    Result := string(UTF8ToString(P));
+end;
+
+function sqlite_last_insert_rowid(db: PSQLite3): Int64;
+begin
+  Result := _last_rowid(db);
+end;
+
+procedure sqlite_load_extension(db: PSQLite3; const APath, AEntry: string);
+var
+  rc: Integer;
+  err: PAnsiChar;
+  ep: PAnsiChar;
+  eU: RawByteString;
+begin
+  if Assigned(_enable_load) then
+    _enable_load(db, 1);
+  err := nil;
+  if AEntry <> '' then
+  begin
+    eU := UTF8Encode(AEntry);
+    ep := PAnsiChar(eU);
+  end
+  else
+    ep := nil;
+  rc := _load_ext(db, PAnsiChar(UTF8Encode(APath)), ep, err);
+  if Assigned(_enable_load) then
+    _enable_load(db, 0);
+  if rc <> SQLITE_OK then
+    raise ESQLiteError.CreateFmt('load_extension(%s) failed (%d): %s',
+      [APath, rc, string(AnsiString(err))]);
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.Tokenizer.pas
+++ b/src/pkg/memory/localvector/LocalVector.Tokenizer.pas
@@ -1,0 +1,387 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.Tokenizer;
+
+{ A self-contained BERT (WordPiece) tokenizer that reads a plain vocab.txt
+  (one token per line; line index = token id). This is all that all-MiniLM-L6-v2
+  needs, and avoids any dependency on regex / JSON units so the unit compiles
+  cleanly under both Delphi and Free Pascal.
+
+  The pipeline mirrors Hugging Face's BertTokenizer:
+    BasicTokenizer  -> clean text, (lowercase), split on whitespace & punctuation,
+                       isolate CJK characters.
+    WordpieceTokenizer -> greedy longest-match-first using "##" continuations,
+                       falling back to [UNK] for an unmatchable word.
+  The result is wrapped with [CLS] ... [SEP] and truncated to the model limit. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes, Generics.Collections;
+{$ELSE}
+  System.SysUtils, System.Classes, System.Generics.Collections;
+{$ENDIF}
+
+type
+  ETokenizerError = class(Exception);
+
+  TBertTokenizer = class
+  private
+    FVocab: TDictionary<UnicodeString, Integer>;
+    FDoLowerCase: Boolean;
+    FMaxCharsPerWord: Integer;
+    FClsId, FSepId, FUnkId, FPadId: Integer;
+    procedure LoadVocab(const AVocabPath: string);
+    function LookupSpecial(const AToken: UnicodeString): Integer;
+    function BasicTokenize(const AText: UnicodeString): TArray<UnicodeString>;
+    procedure WordPiece(const AWord: UnicodeString; AOut: TList<Int64>);
+  public
+    constructor Create(const AVocabPath: string; ADoLowerCase: Boolean = True);
+    destructor Destroy; override;
+    { Encode text into BERT input ids, including [CLS]/[SEP], truncated so the
+      whole sequence is at most AMaxLen tokens. }
+    function Encode(const AText: UnicodeString; AMaxLen: Integer = 256): TArray<Int64>;
+    property ClsId: Integer read FClsId;
+    property SepId: Integer read FSepId;
+    property UnkId: Integer read FUnkId;
+    property PadId: Integer read FPadId;
+  end;
+
+implementation
+
+const
+  UNI_HASH: UnicodeString = '##';
+
+{ ---- character classification (operate on a single UTF-16 code unit) ---- }
+
+function IsWhitespaceCp(C: WideChar): Boolean;
+var V: Word;
+begin
+  V := Ord(C);
+  case V of
+    $09, $0A, $0D, $20, $A0, $1680,
+    $2000..$200A, $2028, $2029, $202F, $205F, $3000:
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function IsControlCp(C: WideChar): Boolean;
+var V: Word;
+begin
+  V := Ord(C);
+  // Tab/newline/CR are handled as whitespace, never as control.
+  if (V = $09) or (V = $0A) or (V = $0D) then
+    Exit(False);
+  Result := (V < $20) or ((V >= $7F) and (V <= $9F));
+end;
+
+function IsPunctuationCp(C: WideChar): Boolean;
+var V: Word;
+begin
+  V := Ord(C);
+  // BERT treats all ASCII non-alphanumeric/non-space as punctuation, plus the
+  // common Unicode punctuation blocks.
+  Result :=
+    ((V >= 33) and (V <= 47))  or ((V >= 58) and (V <= 64))  or
+    ((V >= 91) and (V <= 96))  or ((V >= 123) and (V <= 126)) or
+    ((V >= $2000) and (V <= $206F)) or  // General Punctuation
+    ((V >= $3000) and (V <= $303F)) or  // CJK Symbols and Punctuation
+    ((V >= $FF00) and (V <= $FF0F)) or
+    ((V >= $FF1A) and (V <= $FF20)) or
+    ((V >= $FF3B) and (V <= $FF40)) or
+    ((V >= $FF5B) and (V <= $FF65));
+end;
+
+function IsCJKCp(C: WideChar): Boolean;
+var V: Word;
+begin
+  V := Ord(C);
+  Result :=
+    ((V >= $3400) and (V <= $4DBF)) or
+    ((V >= $4E00) and (V <= $9FFF)) or
+    ((V >= $F900) and (V <= $FAFF));
+end;
+
+function ToLowerCp(C: WideChar): WideChar;
+var V: Word;
+begin
+  V := Ord(C);
+  if (V >= Ord('A')) and (V <= Ord('Z')) then
+    Result := WideChar(V + 32)
+  else if (V >= $C0) and (V <= $DE) and (V <> $D7) then
+    // Latin-1 Supplement uppercase -> lowercase (covers common accented forms).
+    Result := WideChar(V + 32)
+  else
+    Result := C;
+end;
+
+{ ---- file helpers ---- }
+
+function ReadAllBytesLV(const APath: string): TBytes;
+var
+  FS: TFileStream;
+begin
+  FS := TFileStream.Create(APath, fmOpenRead or fmShareDenyWrite);
+  try
+    SetLength(Result, FS.Size);
+    if FS.Size > 0 then
+      FS.ReadBuffer(Result[0], FS.Size);
+  finally
+    FS.Free;
+  end;
+end;
+
+{ ---- TBertTokenizer ---- }
+
+constructor TBertTokenizer.Create(const AVocabPath: string; ADoLowerCase: Boolean);
+begin
+  inherited Create;
+  if not FileExists(AVocabPath) then
+    raise ETokenizerError.CreateFmt('vocab.txt not found: %s', [AVocabPath]);
+
+  FVocab := TDictionary<UnicodeString, Integer>.Create;
+  FDoLowerCase := ADoLowerCase;
+  FMaxCharsPerWord := 100;
+
+  LoadVocab(AVocabPath);
+
+  FClsId := LookupSpecial('[CLS]');
+  FSepId := LookupSpecial('[SEP]');
+  FUnkId := LookupSpecial('[UNK]');
+  FPadId := LookupSpecial('[PAD]');
+
+  if (FClsId < 0) or (FSepId < 0) or (FUnkId < 0) then
+    raise ETokenizerError.Create(
+      'vocab.txt is missing required special tokens ([CLS]/[SEP]/[UNK]).');
+end;
+
+destructor TBertTokenizer.Destroy;
+begin
+  FVocab.Free;
+  inherited;
+end;
+
+function TBertTokenizer.LookupSpecial(const AToken: UnicodeString): Integer;
+begin
+  if not FVocab.TryGetValue(AToken, Result) then
+    Result := -1;
+end;
+
+procedure TBertTokenizer.LoadVocab(const AVocabPath: string);
+var
+  Bytes: TBytes;
+  Content: UnicodeString;
+  I, LineStart, Id: Integer;
+  Token: UnicodeString;
+
+  procedure CommitLine(const ARawLine: UnicodeString);
+  var
+    T: UnicodeString;
+    L: Integer;
+  begin
+    T := ARawLine;
+    // strip a trailing CR (vocab.txt may be CRLF)
+    L := Length(T);
+    if (L > 0) and (T[L] = #13) then
+      Delete(T, L, 1);
+    // The very last "line" may be empty due to a trailing newline -> skip it,
+    // but still consume the id slot only for real tokens.
+    if T <> '' then
+      FVocab.AddOrSetValue(T, Id);
+    Inc(Id);
+  end;
+
+begin
+  Bytes := ReadAllBytesLV(AVocabPath);
+  Content := TEncoding.UTF8.GetString(Bytes);
+
+  Id := 0;
+  LineStart := 1;
+  for I := 1 to Length(Content) do
+  begin
+    if Content[I] = #10 then
+    begin
+      Token := Copy(Content, LineStart, I - LineStart);
+      CommitLine(Token);
+      LineStart := I + 1;
+    end;
+  end;
+  if LineStart <= Length(Content) then
+    CommitLine(Copy(Content, LineStart, Length(Content) - LineStart + 1));
+
+  if FVocab.Count = 0 then
+    raise ETokenizerError.CreateFmt('vocab.txt appears empty: %s', [AVocabPath]);
+end;
+
+function TBertTokenizer.BasicTokenize(const AText: UnicodeString): TArray<UnicodeString>;
+var
+  Seg: UnicodeString;
+  I: Integer;
+  C: WideChar;
+  Words: TList<UnicodeString>;
+  W, Cur, PunctStr: UnicodeString;
+  J, RStart: Integer;
+begin
+  // Pass 1: clean + segment. Drop control chars, collapse whitespace to a
+  // single space, and surround CJK characters with spaces so each becomes its
+  // own token.
+  Seg := '';
+  for I := 1 to Length(AText) do
+  begin
+    C := AText[I];
+    if (Ord(C) = 0) or (Ord(C) = $FFFD) or IsControlCp(C) then
+      Continue
+    else if IsWhitespaceCp(C) then
+      Seg := Seg + ' '
+    else if IsCJKCp(C) then
+      Seg := Seg + ' ' + C + ' '
+    else
+      Seg := Seg + C;
+  end;
+
+  Words := TList<UnicodeString>.Create;
+  try
+    // Pass 2: split on spaces; for each whitespace word, lowercase then split
+    // punctuation into standalone tokens.
+    RStart := 1;
+    for J := 1 to Length(Seg) + 1 do
+    begin
+      if (J > Length(Seg)) or (Seg[J] = ' ') then
+      begin
+        if J > RStart then
+        begin
+          W := Copy(Seg, RStart, J - RStart);
+
+          Cur := '';
+          for I := 1 to Length(W) do
+          begin
+            C := W[I];
+            if FDoLowerCase then
+              C := ToLowerCp(C);
+            if IsPunctuationCp(C) then
+            begin
+              if Cur <> '' then
+              begin
+                Words.Add(Cur);
+                Cur := '';
+              end;
+              PunctStr := C; // WideChar -> 1-char UnicodeString
+              Words.Add(PunctStr);
+            end
+            else
+              Cur := Cur + C;
+          end;
+          if Cur <> '' then
+            Words.Add(Cur);
+        end;
+        RStart := J + 1;
+      end;
+    end;
+
+    Result := Words.ToArray;
+  finally
+    Words.Free;
+  end;
+end;
+
+procedure TBertTokenizer.WordPiece(const AWord: UnicodeString; AOut: TList<Int64>);
+var
+  N, StartI, EndI, Id: Integer;
+  Found, BadWord: Boolean;
+  Sub, Key: UnicodeString;
+  SubIds: TList<Int64>;
+  K: Integer;
+begin
+  N := Length(AWord);
+  if N = 0 then
+    Exit;
+  if N > FMaxCharsPerWord then
+  begin
+    AOut.Add(FUnkId);
+    Exit;
+  end;
+
+  SubIds := TList<Int64>.Create;
+  try
+    StartI := 1;
+    BadWord := False;
+    while StartI <= N do
+    begin
+      EndI := N;
+      Found := False;
+      Id := -1;
+      while StartI <= EndI do
+      begin
+        Sub := Copy(AWord, StartI, EndI - StartI + 1);
+        if StartI > 1 then
+          Key := UNI_HASH + Sub
+        else
+          Key := Sub;
+        if FVocab.TryGetValue(Key, Id) then
+        begin
+          Found := True;
+          Break;
+        end;
+        Dec(EndI);
+      end;
+      if not Found then
+      begin
+        BadWord := True;
+        Break;
+      end;
+      SubIds.Add(Id);
+      StartI := EndI + 1;
+    end;
+
+    if BadWord then
+      AOut.Add(FUnkId)
+    else
+      for K := 0 to SubIds.Count - 1 do
+        AOut.Add(SubIds[K]);
+  finally
+    SubIds.Free;
+  end;
+end;
+
+function TBertTokenizer.Encode(const AText: UnicodeString; AMaxLen: Integer): TArray<Int64>;
+var
+  Words: TArray<UnicodeString>;
+  Ids: TList<Int64>;
+  I, ContentMax: Integer;
+begin
+  Ids := TList<Int64>.Create;
+  try
+    Words := BasicTokenize(AText);
+    for I := 0 to High(Words) do
+      WordPiece(Words[I], Ids);
+
+    // Leave room for [CLS] and [SEP].
+    ContentMax := AMaxLen - 2;
+    if ContentMax < 0 then
+      ContentMax := 0;
+    while Ids.Count > ContentMax do
+      Ids.Delete(Ids.Count - 1);
+
+    Ids.Insert(0, FClsId);
+    Ids.Add(FSepId);
+
+    Result := Ids.ToArray;
+  finally
+    Ids.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.VecProvision.pas
+++ b/src/pkg/memory/localvector/LocalVector.VecProvision.pas
@@ -1,0 +1,267 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.VecProvision;
+
+{ Ensures the sqlite-vec loadable extension (vec0.dll / vec0.so / vec0.dylib) is
+  available next to the executable, downloading + extracting it from the
+  sqlite-vec GitHub release on first use (same idea as the onnxruntime
+  auto-provision). The release assets are single-file .tar.gz archives. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes;
+{$ELSE}
+  System.SysUtils, System.Classes;
+{$ENDIF}
+
+const
+  SQLITE_VEC_VERSION = '0.1.9';
+
+  {$IFDEF MSWINDOWS}
+  VEC0_LIB = 'vec0.dll';
+  {$ELSE}
+    {$IFDEF DARWIN}
+  VEC0_LIB = 'vec0.dylib';
+    {$ELSE}
+  VEC0_LIB = 'vec0.so';
+    {$ENDIF}
+  {$ENDIF}
+
+  // sqlite-vec's exported extension entry point (independent of the file name).
+  VEC0_ENTRY = 'sqlite3_vec_init';
+
+{ Returns the full path to the vec0 extension, downloading it if missing.
+  Raises if it cannot be obtained. }
+function EnsureVec0(const AExeDir: string; AAllowDownload, AVerbose: Boolean): string;
+
+implementation
+
+uses
+  {$IFDEF FPC}
+  fphttpclient, opensslsockets, zstream
+  {$ELSE}
+  System.Net.HttpClient, System.Net.URLClient, System.ZLib
+  {$ENDIF};
+
+function PlatformTag: string;
+begin
+{$IFDEF MSWINDOWS}
+  Result := 'windows';
+{$ELSE}
+  {$IFDEF DARWIN}
+  Result := 'macos';
+  {$ELSE}
+  Result := 'linux';
+  {$ENDIF}
+{$ENDIF}
+end;
+
+{$IFDEF CPUAARCH64}{$DEFINE LV_ARM64}{$ENDIF}
+{$IFDEF CPUARM64}{$DEFINE LV_ARM64}{$ENDIF}
+
+function ArchTag: string;
+begin
+{$IFDEF LV_ARM64}
+  Result := 'aarch64';
+{$ELSE}
+  Result := 'x86_64';
+{$ENDIF}
+end;
+
+procedure DownloadFile(const AUrl, ADest: string);
+{$IFDEF FPC}
+var
+  C: TFPHTTPClient;
+  FS: TFileStream;
+begin
+  C := TFPHTTPClient.Create(nil);
+  try
+    C.AllowRedirect := True;
+    C.AddHeader('User-Agent', 'localvector/1.0');
+    FS := TFileStream.Create(ADest, fmCreate);
+    try
+      C.Get(AUrl, FS);
+    finally
+      FS.Free;
+    end;
+  finally
+    C.Free;
+  end;
+end;
+{$ELSE}
+var
+  C: THTTPClient;
+  R: IHTTPResponse;
+  FS: TFileStream;
+begin
+  C := THTTPClient.Create;
+  try
+    C.ConnectionTimeout := 30000;
+    C.ResponseTimeout := 300000;
+    FS := TFileStream.Create(ADest, fmCreate);
+    try
+      R := C.Get(AUrl, FS);
+      if R.StatusCode <> 200 then
+        raise Exception.CreateFmt('HTTP %d %s for %s', [R.StatusCode, R.StatusText, AUrl]);
+    finally
+      FS.Free;
+    end;
+  finally
+    C.Free;
+  end;
+end;
+{$ENDIF}
+
+{ Decompress a gzip file fully into memory. }
+function GunzipFile(const AGzPath: string): TBytes;
+const
+  CHUNK = 65536;
+var
+  Buf: TBytes;
+  Got: Integer;
+  Outp: TMemoryStream;
+{$IFDEF FPC}
+  GZ: TGZFileStream;
+{$ELSE}
+  Src: TFileStream;
+  Dec: TZDecompressionStream;
+{$ENDIF}
+begin
+  Outp := TMemoryStream.Create;
+  try
+    SetLength(Buf, CHUNK);
+  {$IFDEF FPC}
+    GZ := TGZFileStream.Create(AGzPath, gzOpenRead);
+    try
+      repeat
+        Got := GZ.Read(Buf[0], CHUNK);
+        if Got > 0 then
+          Outp.WriteBuffer(Buf[0], Got);
+      until Got <= 0;
+    finally
+      GZ.Free;
+    end;
+  {$ELSE}
+    Src := TFileStream.Create(AGzPath, fmOpenRead or fmShareDenyWrite);
+    try
+      Dec := TZDecompressionStream.Create(Src, 31); // 31 = gzip
+      try
+        repeat
+          Got := Dec.Read(Buf[0], CHUNK);
+          if Got > 0 then
+            Outp.WriteBuffer(Buf[0], Got);
+        until Got <= 0;
+      finally
+        Dec.Free;
+      end;
+    finally
+      Src.Free;
+    end;
+  {$ENDIF}
+    SetLength(Result, Outp.Size);
+    if Outp.Size > 0 then
+      Move(Outp.Memory^, Result[0], Outp.Size);
+  finally
+    Outp.Free;
+  end;
+end;
+
+{ Find a member of an (uncompressed) tar archive whose name contains ANeedle and
+  copy its bytes to ADest. tar = 512-byte header blocks; size is octal ASCII at
+  offset 124. }
+function TarExtractTo(const ATar: TBytes; const ANeedle, ADest: string): Boolean;
+var
+  Ofs, I, Size: Integer;
+  Name, OctS: string;
+  FS: TFileStream;
+begin
+  Result := False;
+  Ofs := 0;
+  while Ofs + 512 <= Length(ATar) do
+  begin
+    if ATar[Ofs] = 0 then // empty block -> end of archive
+      Break;
+    // name: bytes [0..99], NUL-terminated
+    Name := '';
+    I := 0;
+    while (I < 100) and (ATar[Ofs + I] <> 0) do
+    begin
+      Name := Name + Char(ATar[Ofs + I]);
+      Inc(I);
+    end;
+    // size: octal ascii at [124..135]
+    OctS := '';
+    for I := 124 to 135 do
+    begin
+      if (ATar[Ofs + I] = 0) or (ATar[Ofs + I] = Ord(' ')) then
+        Break;
+      OctS := OctS + Char(ATar[Ofs + I]);
+    end;
+    Size := 0;
+    for I := 1 to Length(OctS) do
+      if (OctS[I] >= '0') and (OctS[I] <= '7') then
+        Size := Size * 8 + (Ord(OctS[I]) - Ord('0'));
+
+    if (Pos(LowerCase(ANeedle), LowerCase(Name)) > 0) and (Size > 0) then
+    begin
+      FS := TFileStream.Create(ADest, fmCreate);
+      try
+        FS.WriteBuffer(ATar[Ofs + 512], Size);
+      finally
+        FS.Free;
+      end;
+      Exit(True);
+    end;
+
+    // advance: header + data rounded up to 512
+    Inc(Ofs, 512 + ((Size + 511) div 512) * 512);
+  end;
+end;
+
+function EnsureVec0(const AExeDir: string; AAllowDownload, AVerbose: Boolean): string;
+var
+  Dest, Asset, Url, TgzPath: string;
+  Tar: TBytes;
+begin
+  Dest := IncludeTrailingPathDelimiter(AExeDir) + VEC0_LIB;
+  if FileExists(Dest) then
+    Exit(Dest);
+
+  if not AAllowDownload then
+    raise Exception.CreateFmt('sqlite-vec extension not found: %s', [Dest]);
+
+  Asset := Format('sqlite-vec-%s-loadable-%s-%s.tar.gz',
+    [SQLITE_VEC_VERSION, PlatformTag, ArchTag]);
+  Url := 'https://github.com/asg017/sqlite-vec/releases/download/v' +
+    SQLITE_VEC_VERSION + '/' + Asset;
+  TgzPath := IncludeTrailingPathDelimiter(AExeDir) + Asset;
+
+  WriteLn(ErrOutput, '[localvector] sqlite-vec not found - downloading v',
+    SQLITE_VEC_VERSION, ' ...');
+  WriteLn(ErrOutput, '[localvector]   from ', Url);
+  DownloadFile(Url, TgzPath);
+  try
+    Tar := GunzipFile(TgzPath);
+    if not TarExtractTo(Tar, 'vec0', Dest) then
+      raise Exception.Create('vec0 binary not found inside the downloaded archive.');
+  finally
+    if FileExists(TgzPath) then
+      DeleteFile(TgzPath);
+  end;
+  WriteLn(ErrOutput, '[localvector]   installed ', Dest);
+  Result := Dest;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.VectorStore.FireDAC.pas
+++ b/src/pkg/memory/localvector/LocalVector.VectorStore.FireDAC.pas
@@ -1,0 +1,372 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.VectorStore.FireDAC;
+
+{ FireDAC IVectorStore backend (Delphi). The default Delphi build uses this;
+  define LV_PORTABLE_SQLITE to use the portable sqlite3 backend instead.
+
+  sqlite-vec loading follows the documented FireDAC recipe:
+    * a dynamic SQLite driver link bound to an external, extension-enabled
+      sqlite3.dll  (FireDAC's bundled SQLite has load_extension disabled);
+    * connection parameter Extensions=True;
+    * SELECT load_extension('vec0.dll', 'sqlite3_vec_init').
+  Deploy sqlite3.dll (with extension support) + vec0.dll next to the exe. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+{$IFNDEF FPC}
+
+uses
+  System.SysUtils, System.Classes, System.Generics.Collections,
+  Data.DB, FireDAC.Stan.Intf, FireDAC.Stan.Def, FireDAC.Stan.Async,
+  FireDAC.Stan.Param, FireDAC.Phys, FireDAC.Phys.SQLite,
+  FireDAC.Phys.SQLiteWrapper.Stat,   // statically link SQLite (no external DLL/bitness)
+  FireDAC.ConsoleUI.Wait,            // console wait handler (avoids UI factory error)
+  FireDAC.DApt, FireDAC.Comp.Client,
+  LocalVector.VectorStore;
+
+type
+  TFireDACVectorStore = class(TInterfacedObject, IVectorStore)
+  private
+    FConn: TFDConnection;
+    FDim: Integer;
+    FModel: string;
+    function ScalarStr(const ASql, AParam: string): string;
+    function TableExists(const AName: string): Boolean;
+    function MetaGet(const AKey: string): string;
+    procedure MetaSet(const AKey, AValue: string);
+    procedure RunVecQuery(const ABlob: TBytes; ALimit: Integer;
+      AIds: TList<Int64>; ADist: TDictionary<Int64, Double>);
+    procedure RunFtsQuery(const AMatch: string; ALimit: Integer; AIds: TList<Int64>);
+    function FetchHit(AId: Int64; AScore, ADist: Double): TSearchHit;
+  public
+    procedure OpenStore(const ADbPath, AVecExtPath: string);
+    procedure InitSchema(ADim: Integer; const AModel: string);
+    function MetaModel: string;
+    function MetaDim: Integer;
+    procedure BeginBatch;
+    procedure CommitBatch;
+    function AddChunk(const ASource: string; AChunkIndex: Integer;
+      const AText: string; const AEmbedding: TArray<Single>): Int64;
+    function Search(const AQueryText: string; const AQueryEmbedding: TArray<Single>;
+      AMode: TSearchMode; AK: Integer): TSearchHits;
+    procedure CloseStore;
+  end;
+
+{$ENDIF}
+
+implementation
+
+{$IFNDEF FPC}
+
+{ Bind a TBytes blob to a FireDAC param. (TFDParam.AsBytes is an indexed Byte
+  property, so a whole array can't be assigned to it; use a stream.) }
+procedure BindBlobParam(AParam: TFDParam; const ABytes: TBytes);
+var
+  MS: TBytesStream;
+begin
+  MS := TBytesStream.Create(ABytes);
+  try
+    AParam.LoadFromStream(MS, ftBlob);
+  finally
+    MS.Free;
+  end;
+end;
+
+procedure TFireDACVectorStore.OpenStore(const ADbPath, AVecExtPath: string);
+begin
+  // SQLite is statically linked (FireDAC.Phys.SQLiteWrapper.Stat), so it matches
+  // the exe bitness with no external sqlite3.dll. Extensions=True enables
+  // load_extension so the vec0 extension can be loaded below.
+  FConn := TFDConnection.Create(nil);
+  FConn.LoginPrompt := False;
+  FConn.Params.DriverID := 'SQLite';
+  FConn.Params.Database := ADbPath;
+  FConn.Params.Add('Extensions=True');   // enables sqlite3 load_extension
+  FConn.Connected := True;
+
+  // load_extension is a SELECT-style function, so use ExecSQLScalar (ExecSQL
+  // rejects result-set commands). SQLite appends the platform suffix itself.
+  FConn.ExecSQLScalar('SELECT load_extension(' + QuotedStr(ChangeFileExt(AVecExtPath, '')) +
+    ', ' + QuotedStr('sqlite3_vec_init') + ')');
+end;
+
+function TFireDACVectorStore.ScalarStr(const ASql, AParam: string): string;
+var
+  Q: TFDQuery;
+begin
+  Result := '';
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := ASql;
+    if AParam <> '' then
+      Q.Params[0].AsString := AParam;
+    Q.Open;
+    if not Q.Eof then
+      Result := Q.Fields[0].AsString;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFireDACVectorStore.TableExists(const AName: string): Boolean;
+begin
+  Result := ScalarStr(
+    'SELECT 1 FROM sqlite_master WHERE type IN (''table'',''view'') AND name=:n',
+    AName) <> '';
+end;
+
+function TFireDACVectorStore.MetaGet(const AKey: string): string;
+begin
+  Result := ScalarStr('SELECT value FROM meta WHERE key=:k', AKey);
+end;
+
+procedure TFireDACVectorStore.MetaSet(const AKey, AValue: string);
+var
+  Q: TFDQuery;
+begin
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := 'INSERT OR REPLACE INTO meta(key,value) VALUES(:k,:v)';
+    Q.ParamByName('k').AsString := AKey;
+    Q.ParamByName('v').AsString := AValue;
+    Q.ExecSQL;
+  finally
+    Q.Free;
+  end;
+end;
+
+procedure TFireDACVectorStore.InitSchema(ADim: Integer; const AModel: string);
+var
+  ExistingDim, ExistingModel: string;
+begin
+  FConn.ExecSQL('CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)');
+  if TableExists('chunks') then
+  begin
+    ExistingDim := MetaGet('dim');
+    ExistingModel := MetaGet('model');
+    if (ADim > 0) and (ExistingDim <> '') and (StrToIntDef(ExistingDim, -1) <> ADim) then
+      raise Exception.CreateFmt(
+        'Database was built with %s (dim %s); cannot mix with %s (dim %d).',
+        [ExistingModel, ExistingDim, AModel, ADim]);
+    FDim := StrToIntDef(ExistingDim, ADim);
+    FModel := ExistingModel;
+    Exit;
+  end;
+  if ADim <= 0 then
+    raise Exception.Create('Database has no index yet (run "index" first).');
+  FDim := ADim;
+  FModel := AModel;
+  FConn.ExecSQL('CREATE TABLE chunks(id INTEGER PRIMARY KEY AUTOINCREMENT, ' +
+    'source TEXT, chunk_index INTEGER, text TEXT)');
+  FConn.ExecSQL('CREATE VIRTUAL TABLE chunks_fts USING fts5(text)');
+  FConn.ExecSQL(Format(
+    'CREATE VIRTUAL TABLE chunks_vec USING vec0(embedding float[%d])', [ADim]));
+  MetaSet('model', AModel);
+  MetaSet('dim', IntToStr(ADim));
+end;
+
+function TFireDACVectorStore.MetaModel: string;
+begin
+  Result := FModel;
+end;
+
+function TFireDACVectorStore.MetaDim: Integer;
+begin
+  Result := FDim;
+end;
+
+procedure TFireDACVectorStore.BeginBatch;
+begin
+  FConn.StartTransaction;
+end;
+
+procedure TFireDACVectorStore.CommitBatch;
+begin
+  FConn.Commit;
+end;
+
+function TFireDACVectorStore.AddChunk(const ASource: string; AChunkIndex: Integer;
+  const AText: string; const AEmbedding: TArray<Single>): Int64;
+var
+  Q: TFDQuery;
+begin
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := 'INSERT INTO chunks(source, chunk_index, text) VALUES(:s,:i,:t)';
+    Q.ParamByName('s').AsString := ASource;
+    Q.ParamByName('i').AsInteger := AChunkIndex;
+    Q.ParamByName('t').AsString := AText;
+    Q.ExecSQL;
+    Result := StrToInt64Def(ScalarStr('SELECT last_insert_rowid()', ''), 0);
+
+    Q.SQL.Text := 'INSERT INTO chunks_fts(rowid, text) VALUES(:r,:t)';
+    Q.ParamByName('r').AsLargeInt := Result;
+    Q.ParamByName('t').AsString := AText;
+    Q.ExecSQL;
+
+    Q.SQL.Text := 'INSERT INTO chunks_vec(rowid, embedding) VALUES(:r,:e)';
+    Q.ParamByName('r').AsLargeInt := Result;
+    BindBlobParam(Q.ParamByName('e'), VectorToBytes(AEmbedding));
+    Q.ExecSQL;
+  finally
+    Q.Free;
+  end;
+end;
+
+procedure TFireDACVectorStore.RunVecQuery(const ABlob: TBytes; ALimit: Integer;
+  AIds: TList<Int64>; ADist: TDictionary<Int64, Double>);
+var
+  Q: TFDQuery;
+  Id: Int64;
+begin
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := Format('SELECT rowid, distance FROM chunks_vec ' +
+      'WHERE embedding MATCH :e ORDER BY distance LIMIT %d', [ALimit]);
+    BindBlobParam(Q.ParamByName('e'), ABlob);
+    Q.Open;
+    while not Q.Eof do
+    begin
+      Id := Q.Fields[0].AsLargeInt;
+      AIds.Add(Id);
+      ADist.AddOrSetValue(Id, Q.Fields[1].AsFloat);
+      Q.Next;
+    end;
+  finally
+    Q.Free;
+  end;
+end;
+
+procedure TFireDACVectorStore.RunFtsQuery(const AMatch: string; ALimit: Integer;
+  AIds: TList<Int64>);
+var
+  Q: TFDQuery;
+begin
+  if Trim(AMatch) = '' then
+    Exit;
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := Format('SELECT rowid FROM chunks_fts ' +
+      'WHERE chunks_fts MATCH :m ORDER BY rank LIMIT %d', [ALimit]);
+    Q.ParamByName('m').AsString := AMatch;
+    Q.Open;
+    while not Q.Eof do
+    begin
+      AIds.Add(Q.Fields[0].AsLargeInt);
+      Q.Next;
+    end;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFireDACVectorStore.FetchHit(AId: Int64; AScore, ADist: Double): TSearchHit;
+var
+  Q: TFDQuery;
+begin
+  Result.Id := AId;
+  Result.Score := AScore;
+  Result.VecDistance := ADist;
+  Result.Source := '';
+  Result.ChunkIndex := 0;
+  Result.Text := '';
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := 'SELECT source, chunk_index, text FROM chunks WHERE id=:i';
+    Q.ParamByName('i').AsLargeInt := AId;
+    Q.Open;
+    if not Q.Eof then
+    begin
+      Result.Source := Q.Fields[0].AsString;
+      Result.ChunkIndex := Q.Fields[1].AsInteger;
+      Result.Text := Q.Fields[2].AsString;
+    end;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFireDACVectorStore.Search(const AQueryText: string;
+  const AQueryEmbedding: TArray<Single>; AMode: TSearchMode; AK: Integer): TSearchHits;
+var
+  Pool, I: Integer;
+  VecIds, FtsIds: TList<Int64>;
+  VecDist: TDictionary<Int64, Double>;
+  Fused: TArray<TIdScore>;
+  D: Double;
+  Hits: TList<TSearchHit>;
+begin
+  Pool := AK * 4;
+  if Pool < 32 then Pool := 32;
+  VecIds := TList<Int64>.Create;
+  FtsIds := TList<Int64>.Create;
+  VecDist := TDictionary<Int64, Double>.Create;
+  Hits := TList<TSearchHit>.Create;
+  try
+    if AMode in [smHybrid, smVector] then
+      RunVecQuery(VectorToBytes(AQueryEmbedding), Pool, VecIds, VecDist);
+    if AMode in [smHybrid, smKeyword] then
+      RunFtsQuery(BuildFtsQuery(AQueryText), Pool, FtsIds);
+
+    case AMode of
+      smVector:
+        for I := 0 to VecIds.Count - 1 do
+        begin
+          if I >= AK then Break;
+          D := VecDist[VecIds[I]];
+          Hits.Add(FetchHit(VecIds[I], 1.0 / (1.0 + D), D));
+        end;
+      smKeyword:
+        for I := 0 to FtsIds.Count - 1 do
+        begin
+          if I >= AK then Break;
+          Hits.Add(FetchHit(FtsIds[I], 1.0 / (60 + I + 1), -1));
+        end;
+      smHybrid:
+        begin
+          Fused := FuseRRF(VecIds.ToArray, FtsIds.ToArray, AK, 60);
+          for I := 0 to High(Fused) do
+            if VecDist.TryGetValue(Fused[I].Id, D) then
+              Hits.Add(FetchHit(Fused[I].Id, Fused[I].Score, D))
+            else
+              Hits.Add(FetchHit(Fused[I].Id, Fused[I].Score, -1));
+        end;
+    end;
+    Result := Hits.ToArray;
+  finally
+    VecIds.Free;
+    FtsIds.Free;
+    VecDist.Free;
+    Hits.Free;
+  end;
+end;
+
+procedure TFireDACVectorStore.CloseStore;
+begin
+  if Assigned(FConn) then
+  begin
+    FConn.Connected := False;
+    FreeAndNil(FConn);
+  end;
+end;
+
+{$ENDIF}
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.VectorStore.Sqlite.pas
+++ b/src/pkg/memory/localvector/LocalVector.VectorStore.Sqlite.pas
@@ -1,0 +1,340 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.VectorStore.Sqlite;
+
+{ Portable IVectorStore backend over the dynamically-loaded sqlite3 binding +
+  sqlite-vec (vec0) + FTS5. Used by the FPC build (and any build that prefers a
+  FireDAC-free path). }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes, Generics.Collections,
+{$ELSE}
+  System.SysUtils, System.Classes, System.Generics.Collections,
+{$ENDIF}
+  LocalVector.Sqlite3, LocalVector.VectorStore;
+
+type
+  TSqliteVectorStore = class(TInterfacedObject, IVectorStore)
+  private
+    FDb: PSQLite3;
+    FDim: Integer;
+    FModel: string;
+    function MetaGet(const AKey: string): string;
+    procedure MetaSet(const AKey, AValue: string);
+    function TableExists(const AName: string): Boolean;
+    procedure RunVecQuery(const ABlob: TBytes; ALimit: Integer;
+      AIds: TList<Int64>; ADist: TDictionary<Int64, Double>);
+    procedure RunFtsQuery(const AMatch: string; ALimit: Integer; AIds: TList<Int64>);
+    function FetchHit(AId: Int64; AScore, ADist: Double): TSearchHit;
+  public
+    procedure OpenStore(const ADbPath, AVecExtPath: string);
+    procedure InitSchema(ADim: Integer; const AModel: string);
+    function MetaModel: string;
+    function MetaDim: Integer;
+    procedure BeginBatch;
+    procedure CommitBatch;
+    function AddChunk(const ASource: string; AChunkIndex: Integer;
+      const AText: string; const AEmbedding: TArray<Single>): Int64;
+    function Search(const AQueryText: string; const AQueryEmbedding: TArray<Single>;
+      AMode: TSearchMode; AK: Integer): TSearchHits;
+    procedure CloseStore;
+  end;
+
+implementation
+
+procedure TSqliteVectorStore.OpenStore(const ADbPath, AVecExtPath: string);
+begin
+  if not LoadSqlite3 then
+    raise ESQLiteError.Create('Could not load the sqlite3 library.');
+  FDb := sqlite_open(ADbPath);
+  // SQLite appends the platform suffix (.so/.dll/.dylib) itself, so strip it.
+  sqlite_load_extension(FDb, ChangeFileExt(AVecExtPath, ''), 'sqlite3_vec_init');
+end;
+
+function TSqliteVectorStore.MetaGet(const AKey: string): string;
+var
+  st: PSQLite3Stmt;
+begin
+  Result := '';
+  st := sqlite_prepare(FDb, 'SELECT value FROM meta WHERE key=?');
+  try
+    sqlite_bind_text(st, 1, AKey);
+    if sqlite_step(st) = SQLITE_ROW then
+      Result := sqlite_column_text(st, 0);
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+procedure TSqliteVectorStore.MetaSet(const AKey, AValue: string);
+var
+  st: PSQLite3Stmt;
+begin
+  st := sqlite_prepare(FDb, 'INSERT OR REPLACE INTO meta(key,value) VALUES(?,?)');
+  try
+    sqlite_bind_text(st, 1, AKey);
+    sqlite_bind_text(st, 2, AValue);
+    sqlite_step(st);
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+function TSqliteVectorStore.TableExists(const AName: string): Boolean;
+var
+  st: PSQLite3Stmt;
+begin
+  st := sqlite_prepare(FDb,
+    'SELECT 1 FROM sqlite_master WHERE type IN (''table'',''view'') AND name=?');
+  try
+    sqlite_bind_text(st, 1, AName);
+    Result := sqlite_step(st) = SQLITE_ROW;
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+procedure TSqliteVectorStore.InitSchema(ADim: Integer; const AModel: string);
+var
+  ExistingDim, ExistingModel: string;
+begin
+  sqlite_exec(FDb, 'CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)');
+
+  if TableExists('chunks') then
+  begin
+    ExistingDim := MetaGet('dim');
+    ExistingModel := MetaGet('model');
+    if (ADim > 0) and (ExistingDim <> '') and (StrToIntDef(ExistingDim, -1) <> ADim) then
+      raise ESQLiteError.CreateFmt(
+        'Database was built with %s (dim %s); cannot mix with %s (dim %d).',
+        [ExistingModel, ExistingDim, AModel, ADim]);
+    FDim := StrToIntDef(ExistingDim, ADim);
+    FModel := ExistingModel;
+    Exit;
+  end;
+
+  if ADim <= 0 then
+    raise ESQLiteError.Create('Database has no index yet (run "index" first).');
+
+  FDim := ADim;
+  FModel := AModel;
+  sqlite_exec(FDb,
+    'CREATE TABLE chunks(id INTEGER PRIMARY KEY AUTOINCREMENT, ' +
+    'source TEXT, chunk_index INTEGER, text TEXT)');
+  sqlite_exec(FDb, 'CREATE VIRTUAL TABLE chunks_fts USING fts5(text)');
+  sqlite_exec(FDb, Format(
+    'CREATE VIRTUAL TABLE chunks_vec USING vec0(embedding float[%d])', [ADim]));
+  MetaSet('model', AModel);
+  MetaSet('dim', IntToStr(ADim));
+end;
+
+function TSqliteVectorStore.MetaModel: string;
+begin
+  Result := FModel;
+end;
+
+function TSqliteVectorStore.MetaDim: Integer;
+begin
+  Result := FDim;
+end;
+
+procedure TSqliteVectorStore.BeginBatch;
+begin
+  sqlite_exec(FDb, 'BEGIN');
+end;
+
+procedure TSqliteVectorStore.CommitBatch;
+begin
+  sqlite_exec(FDb, 'COMMIT');
+end;
+
+function TSqliteVectorStore.AddChunk(const ASource: string; AChunkIndex: Integer;
+  const AText: string; const AEmbedding: TArray<Single>): Int64;
+var
+  st: PSQLite3Stmt;
+  Blob: TBytes;
+begin
+  st := sqlite_prepare(FDb,
+    'INSERT INTO chunks(source, chunk_index, text) VALUES(?,?,?)');
+  try
+    sqlite_bind_text(st, 1, ASource);
+    sqlite_bind_int64(st, 2, AChunkIndex);
+    sqlite_bind_text(st, 3, AText);
+    sqlite_step(st);
+  finally
+    sqlite_finalize(st);
+  end;
+  Result := sqlite_last_insert_rowid(FDb);
+
+  st := sqlite_prepare(FDb, 'INSERT INTO chunks_fts(rowid, text) VALUES(?,?)');
+  try
+    sqlite_bind_int64(st, 1, Result);
+    sqlite_bind_text(st, 2, AText);
+    sqlite_step(st);
+  finally
+    sqlite_finalize(st);
+  end;
+
+  Blob := VectorToBytes(AEmbedding);
+  st := sqlite_prepare(FDb, 'INSERT INTO chunks_vec(rowid, embedding) VALUES(?,?)');
+  try
+    sqlite_bind_int64(st, 1, Result);
+    if Length(Blob) > 0 then
+      sqlite_bind_blob(st, 2, Blob[0], Length(Blob));
+    sqlite_step(st);
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+procedure TSqliteVectorStore.RunVecQuery(const ABlob: TBytes; ALimit: Integer;
+  AIds: TList<Int64>; ADist: TDictionary<Int64, Double>);
+var
+  st: PSQLite3Stmt;
+  Id: Int64;
+begin
+  st := sqlite_prepare(FDb, Format(
+    'SELECT rowid, distance FROM chunks_vec WHERE embedding MATCH ? ' +
+    'ORDER BY distance LIMIT %d', [ALimit]));
+  try
+    if Length(ABlob) > 0 then
+      sqlite_bind_blob(st, 1, ABlob[0], Length(ABlob));
+    while sqlite_step(st) = SQLITE_ROW do
+    begin
+      Id := sqlite_column_int64(st, 0);
+      AIds.Add(Id);
+      ADist.AddOrSetValue(Id, sqlite_column_double(st, 1));
+    end;
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+procedure TSqliteVectorStore.RunFtsQuery(const AMatch: string; ALimit: Integer;
+  AIds: TList<Int64>);
+var
+  st: PSQLite3Stmt;
+begin
+  if Trim(AMatch) = '' then
+    Exit;
+  st := sqlite_prepare(FDb, Format(
+    'SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY rank LIMIT %d',
+    [ALimit]));
+  try
+    sqlite_bind_text(st, 1, AMatch);
+    while sqlite_step(st) = SQLITE_ROW do
+      AIds.Add(sqlite_column_int64(st, 0));
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+function TSqliteVectorStore.FetchHit(AId: Int64; AScore, ADist: Double): TSearchHit;
+var
+  st: PSQLite3Stmt;
+begin
+  Result.Id := AId;
+  Result.Score := AScore;
+  Result.VecDistance := ADist;
+  Result.Source := '';
+  Result.ChunkIndex := 0;
+  Result.Text := '';
+  st := sqlite_prepare(FDb, 'SELECT source, chunk_index, text FROM chunks WHERE id=?');
+  try
+    sqlite_bind_int64(st, 1, AId);
+    if sqlite_step(st) = SQLITE_ROW then
+    begin
+      Result.Source := sqlite_column_text(st, 0);
+      Result.ChunkIndex := sqlite_column_int64(st, 1);
+      Result.Text := sqlite_column_text(st, 2);
+    end;
+  finally
+    sqlite_finalize(st);
+  end;
+end;
+
+function TSqliteVectorStore.Search(const AQueryText: string;
+  const AQueryEmbedding: TArray<Single>; AMode: TSearchMode; AK: Integer): TSearchHits;
+var
+  Pool, I: Integer;
+  VecIds, FtsIds: TList<Int64>;
+  VecDist: TDictionary<Int64, Double>;
+  Blob: TBytes;
+  Fused: TArray<TIdScore>;
+  D: Double;
+  Hits: TList<TSearchHit>;
+begin
+  Pool := AK * 4;
+  if Pool < 32 then Pool := 32;
+
+  VecIds := TList<Int64>.Create;
+  FtsIds := TList<Int64>.Create;
+  VecDist := TDictionary<Int64, Double>.Create;
+  Hits := TList<TSearchHit>.Create;
+  try
+    if AMode in [smHybrid, smVector] then
+    begin
+      Blob := VectorToBytes(AQueryEmbedding);
+      RunVecQuery(Blob, Pool, VecIds, VecDist);
+    end;
+    if AMode in [smHybrid, smKeyword] then
+      RunFtsQuery(BuildFtsQuery(AQueryText), Pool, FtsIds);
+
+    case AMode of
+      smVector:
+        for I := 0 to VecIds.Count - 1 do
+        begin
+          if I >= AK then Break;
+          D := VecDist[VecIds[I]];
+          Hits.Add(FetchHit(VecIds[I], 1.0 / (1.0 + D), D));
+        end;
+      smKeyword:
+        for I := 0 to FtsIds.Count - 1 do
+        begin
+          if I >= AK then Break;
+          Hits.Add(FetchHit(FtsIds[I], 1.0 / (60 + I + 1), -1));
+        end;
+      smHybrid:
+        begin
+          Fused := FuseRRF(VecIds.ToArray, FtsIds.ToArray, AK, 60);
+          for I := 0 to High(Fused) do
+          begin
+            if VecDist.TryGetValue(Fused[I].Id, D) then
+              Hits.Add(FetchHit(Fused[I].Id, Fused[I].Score, D))
+            else
+              Hits.Add(FetchHit(Fused[I].Id, Fused[I].Score, -1));
+          end;
+        end;
+    end;
+    Result := Hits.ToArray;
+  finally
+    VecIds.Free;
+    FtsIds.Free;
+    VecDist.Free;
+    Hits.Free;
+  end;
+end;
+
+procedure TSqliteVectorStore.CloseStore;
+begin
+  if FDb <> nil then
+  begin
+    sqlite_close(FDb);
+    FDb := nil;
+  end;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.VectorStore.pas
+++ b/src/pkg/memory/localvector/LocalVector.VectorStore.pas
@@ -1,0 +1,283 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+unit LocalVector.VectorStore;
+
+{ Hybrid (FTS5 keyword + vec0 vector) store abstraction.
+
+  IVectorStore is implemented by a portable sqlite3 backend (FPC) and a FireDAC
+  backend (Delphi); CreateVectorStore returns the right one. Shared helpers here:
+  chunking, FTS5 query building, and reciprocal-rank fusion. }
+
+{$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes, Generics.Collections;
+{$ELSE}
+  System.SysUtils, System.Classes, System.Generics.Collections;
+{$ENDIF}
+
+type
+  TSearchMode = (smHybrid, smVector, smKeyword);
+
+  TSearchHit = record
+    Id: Int64;
+    Source: string;
+    ChunkIndex: Integer;
+    Text: string;
+    Score: Double;       // fused score (higher is better)
+    VecDistance: Double; // L2 distance from the vector index, or -1
+  end;
+  TSearchHits = TArray<TSearchHit>;
+
+  TIdScore = record
+    Id: Int64;
+    Score: Double;
+  end;
+
+  IVectorStore = interface
+    ['{6F1B2C44-9A3D-4E77-B0C1-2D5E8F0A7B31}']
+    procedure OpenStore(const ADbPath, AVecExtPath: string);
+    { Creates the schema for a new DB, or validates model/dim against an existing
+      one. }
+    procedure InitSchema(ADim: Integer; const AModel: string);
+    function MetaModel: string;
+    function MetaDim: Integer;
+    procedure BeginBatch;
+    procedure CommitBatch;
+    function AddChunk(const ASource: string; AChunkIndex: Integer;
+      const AText: string; const AEmbedding: TArray<Single>): Int64;
+    function Search(const AQueryText: string; const AQueryEmbedding: TArray<Single>;
+      AMode: TSearchMode; AK: Integer): TSearchHits;
+    procedure CloseStore;
+  end;
+
+function ParseSearchMode(const AStr: string; out AMode: TSearchMode): Boolean;
+function SearchModeName(AMode: TSearchMode): string;
+
+{ Splits text into chunks. AMode = 'paragraphs' (blank-line separated, default)
+  or 'lines'. Trims, drops empties. }
+function ChunkText(const AText: string; const AMode: string): TArray<string>;
+
+{ Turns free text into a safe FTS5 MATCH expression: quoted terms OR-ed together.
+  Returns '' when there are no usable terms. }
+function BuildFtsQuery(const AText: string): string;
+
+{ Reciprocal-rank fusion of two ranked id lists into top-AK (id, score) desc. }
+function FuseRRF(const AVecIds, AFtsIds: TArray<Int64>; AK, ARrfK: Integer): TArray<TIdScore>;
+
+{ Encodes a float32 vector as little-endian bytes (sqlite-vec compact format). }
+function VectorToBytes(const AVec: TArray<Single>): TBytes;
+
+function CreateVectorStore: IVectorStore;
+
+implementation
+
+uses
+{$IFDEF FPC}
+  LocalVector.VectorStore.Sqlite;
+{$ELSE}
+  {$IFDEF LV_PORTABLE_SQLITE}
+  LocalVector.VectorStore.Sqlite;
+  {$ELSE}
+  LocalVector.VectorStore.FireDAC;
+  {$ENDIF}
+{$ENDIF}
+
+function CreateVectorStore: IVectorStore;
+begin
+{$IFDEF FPC}
+  Result := TSqliteVectorStore.Create;
+{$ELSE}
+  {$IFDEF LV_PORTABLE_SQLITE}
+  Result := TSqliteVectorStore.Create;
+  {$ELSE}
+  Result := TFireDACVectorStore.Create;
+  {$ENDIF}
+{$ENDIF}
+end;
+
+function ParseSearchMode(const AStr: string; out AMode: TSearchMode): Boolean;
+var
+  S: string;
+begin
+  Result := True;
+  S := LowerCase(Trim(AStr));
+  if (S = 'hybrid') or (S = '') then AMode := smHybrid
+  else if (S = 'vector') or (S = 'vec') or (S = 'semantic') then AMode := smVector
+  else if (S = 'keyword') or (S = 'fts') or (S = 'bm25') or (S = 'text') then AMode := smKeyword
+  else Result := False;
+end;
+
+function SearchModeName(AMode: TSearchMode): string;
+begin
+  case AMode of
+    smHybrid:  Result := 'hybrid';
+    smVector:  Result := 'vector';
+    smKeyword: Result := 'keyword';
+  else
+    Result := '?';
+  end;
+end;
+
+function ChunkText(const AText: string; const AMode: string): TArray<string>;
+var
+  Lines: TStringList;
+  List: TList<string>;
+  I: Integer;
+  Cur, Ln, T: string;
+
+  procedure Flush;
+  var
+    S: string;
+  begin
+    S := Trim(Cur);
+    if S <> '' then
+      List.Add(S);
+    Cur := '';
+  end;
+
+begin
+  List := TList<string>.Create;
+  Lines := TStringList.Create;
+  try
+    Lines.Text := AText;
+    Cur := '';
+    if SameText(AMode, 'lines') then
+    begin
+      for I := 0 to Lines.Count - 1 do
+      begin
+        T := Trim(Lines[I]);
+        if T <> '' then
+          List.Add(T);
+      end;
+    end
+    else // paragraphs (blank-line separated)
+    begin
+      for I := 0 to Lines.Count - 1 do
+      begin
+        Ln := Lines[I];
+        if Trim(Ln) = '' then
+          Flush
+        else if Cur = '' then
+          Cur := Ln
+        else
+          Cur := Cur + ' ' + Trim(Ln);
+      end;
+      Flush;
+    end;
+    Result := List.ToArray;
+  finally
+    Lines.Free;
+    List.Free;
+  end;
+end;
+
+function BuildFtsQuery(const AText: string): string;
+var
+  I: Integer;
+  C: Char;
+  Tok: string;
+  SB: TStringBuilder;
+
+  procedure Emit;
+  begin
+    if Tok <> '' then
+    begin
+      if SB.Length > 0 then
+        SB.Append(' OR ');
+      SB.Append('"').Append(Tok).Append('"');
+      Tok := '';
+    end;
+  end;
+
+begin
+  SB := TStringBuilder.Create;
+  try
+    Tok := '';
+    for I := 1 to Length(AText) do
+    begin
+      C := AText[I];
+      if ((C >= 'a') and (C <= 'z')) or ((C >= 'A') and (C <= 'Z')) or
+         ((C >= '0') and (C <= '9')) then
+        Tok := Tok + C
+      else
+        Emit;
+    end;
+    Emit;
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function FuseRRF(const AVecIds, AFtsIds: TArray<Int64>; AK, ARrfK: Integer): TArray<TIdScore>;
+var
+  Scores: TDictionary<Int64, Double>;
+  Order: TList<Int64>;
+  I, J: Integer;
+  Id: Int64;
+  Cur: Double;
+  Tmp: TIdScore;
+  Arr: TArray<TIdScore>;
+begin
+  Scores := TDictionary<Int64, Double>.Create;
+  Order := TList<Int64>.Create;
+  try
+    for I := 0 to High(AVecIds) do
+    begin
+      Id := AVecIds[I];
+      if not Scores.ContainsKey(Id) then Order.Add(Id);
+      if not Scores.TryGetValue(Id, Cur) then Cur := 0;
+      Scores.AddOrSetValue(Id, Cur + 1.0 / (ARrfK + I + 1));
+    end;
+    for I := 0 to High(AFtsIds) do
+    begin
+      Id := AFtsIds[I];
+      if not Scores.ContainsKey(Id) then Order.Add(Id);
+      if not Scores.TryGetValue(Id, Cur) then Cur := 0;
+      Scores.AddOrSetValue(Id, Cur + 1.0 / (ARrfK + I + 1));
+    end;
+
+    SetLength(Arr, Order.Count);
+    for I := 0 to Order.Count - 1 do
+    begin
+      Arr[I].Id := Order[I];
+      Arr[I].Score := Scores[Order[I]];
+    end;
+
+    // simple descending sort by score
+    for I := 0 to High(Arr) - 1 do
+      for J := 0 to High(Arr) - 1 - I do
+        if Arr[J].Score < Arr[J + 1].Score then
+        begin
+          Tmp := Arr[J]; Arr[J] := Arr[J + 1]; Arr[J + 1] := Tmp;
+        end;
+
+    if (AK > 0) and (Length(Arr) > AK) then
+      SetLength(Arr, AK);
+    Result := Arr;
+  finally
+    Scores.Free;
+    Order.Free;
+  end;
+end;
+
+function VectorToBytes(const AVec: TArray<Single>): TBytes;
+begin
+  SetLength(Result, Length(AVec) * SizeOf(Single));
+  if Length(AVec) > 0 then
+    Move(AVec[0], Result[0], Length(Result));
+end;
+
+end.

--- a/src/pkg/memory/localvector/onnxruntime.pas
+++ b/src/pkg/memory/localvector/onnxruntime.pas
@@ -1,0 +1,3564 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+{ Onnxruntime for FreePascal/Delphi
+
+  Copyright (c) 2022 Haitham Shatti <haitham.shatti at gmail dot com> <https://github.com/hshatti>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+}
+
+(*
+  This is a reworked/refactored implementation of the
+  original C++ onnxruntime library (link checked as of Sep-2022):
+  https://github.com/microsoft/onnxruntime/tree/main/include/onnxruntime/core/session
+
+  the problem seems to be with the original C++ code is that it uses a
+  trivial implementation of management operators to track the library pointers,
+  but it can accindenly dispose them while they are still in scope, because the
+  <Base> implementation handsover the ownership of these pointers on every
+  assignment, and clears it self instead of keeping track of each reference made
+  or gone out of scope, I would choose to do the same thing in pascal but since
+  pascal is more well behaved I decided to implement a simple global
+  housekeeper that keeps everything in tracked, if any pointer
+  goes out of scope, the owned reference will be managed and freed only if the
+  pointer is completely no longer used without compromizing the library
+  performance.
+
+
+
+
+*)
+
+unit onnxruntime;
+{.$define MEM_DEBUG}  // debug memory housekeeping mechanism
+{$ifdef MEM_DEBUG}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+
+{$H+}
+{$ifdef fpc}
+  {$MACRO ON}
+  {$mode delphi}
+  {$ModeSwitch advancedrecords}
+  {$ModeSwitch typehelpers}
+  {$define outvar:=var}
+  {$PointerMath on}
+{$else}
+  {$define outvar:=out}
+{$endif}
+// NO_HASHMAP will use internal ValueKey implementation, disabeling in Delphi  may result unwanted behaviour
+{$define NO_HASHMAP}
+
+
+{.$define NO_SMARTPTR}
+//{$define ORT_NO_EXCEPTION}
+
+interface
+
+uses
+{$ifdef fpc}
+  SysUtils, TypInfo, onnxruntime_pas_api, Generics.Collections, Generics.Defaults;
+{$else}
+  System.SysUtils, System.TypInfo, onnxruntime_pas_api, System.Generics.Collections, System.Generics.Defaults, System.SyncObjs;
+{$endif}
+
+type ortstring = ansistring;
+
+
+const ORTTensorTypes: array[ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED..ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16] of ortstring =
+  (
+    'undefined', 'float', 'uint8', 'int8', 'uint16', 'int16', 'int32', 'int64', 'string',
+   'bool', 'float16', 'double', 'uint32', 'uint64', 'complex64', 'complex128', 'bfloat16'
+   );
+const DEFAULT_LOGID :PAnsiChar= 'ONNXRuntimePascal';
+
+type
+  Tinfo =record
+    kind:TTypeKind;
+    name:shortstring
+  end;
+
+  uint16_t=UInt16;
+
+  TCompareFunc<T>=function (const a,b:T):integer;
+
+  { TTools }
+
+  TTools=class
+    class function min<T>(const a,b:T):T; static;
+    class function max<T>(const a,b:T):T; static;
+    class function IfThen<T>(const cond:boolean;const whenTrue,whenFalse:T):T; static;
+    class procedure QuickSort<T>(var Arr: array of T; L, R: Longint; const Descending: boolean; const Compare: TComparefunc<T>); static;
+    class function BinSearch<T>(const Arr:array of T;const Val:T; R:integer):integer; static;
+    class function cmp<T>(const a, b: T): integer; static;
+    class function reverse<T>(const a:TArray<T>):TArray<T>;
+  end;
+
+  {$ifndef NO_SMARTPTR}
+  PORTAllocatedFree = ^TORTAllocatedFree;
+  { TORTAllocatedFree }
+  // Light functor to release memory with OrtAllocator
+  TORTAllocatedFree = record
+    allocator_:POrtAllocator;
+    constructor Create(const allocator:POrtAllocator);
+    procedure call(var ptr:pointer);
+  end;
+
+  { TSmartPtr }
+
+  TSmartPtr<T> = record
+    Type PT=^T;
+    var
+    // similar as overloading [] operators for property x[v: string]: integer read gx write sx; default;
+    Instance: PT ; // default keyword for non property.
+    RefCount: PLongint;
+    procedure DecRef();
+
+    class operator Initialize({$ifdef fpc}var{$else}out{$endif} dst: TSmartPtr<T>);
+    class operator Finalize(var dst: TSmartPtr<T>);
+    {$ifdef fpc}
+    class operator AddRef(outvar src: TSmartPtr<T>);
+    class operator Copy(constref src: TSmartPtr<T>; outvar dst: TSmartPtr<T>);
+    {$else}
+    class operator Assign(var dst: TSmartPtr<T>;const [ref] src: TSmartPtr<T>);
+    {$endif}
+
+
+    // implicit or explicit operator should be used before "default" field
+    class operator Implicit(const src: PT): TSmartPtr<T>;
+    //class operator Implicit(const src: TSmartPtr<T>):T;
+    procedure Assign(const val: PT);
+  end;
+
+  { TSmartPtr }
+  // P is a disposer record/class with one "call" functor at least e.g:
+  // (TDisposer = record procedure Call(var value:T) end;)
+  TSmartPtr<T,P> = record
+  type PT=^T;
+  var
+    // similar as overloading [] operators for property x[v: string]: integer read gx write sx; default;
+    Instance: PT ; // default keyword for non property.
+    RefCount: PLongint;
+    DisposerFunc: TORTAllocatedFree;
+    constructor Create(const val:PT;const aDisposer:TORTAllocatedFree);
+    procedure DecRef();
+
+    class operator Initialize({$ifdef fpc}var{$else}out{$endif} dst: TSmartPtr<T,P>);
+    class operator Finalize(var dst: TSmartPtr<T,P>);
+    {$ifdef fpc}
+    class operator AddRef(var src: TSmartPtr<T,P>);
+    class operator Copy(constref src: TSmartPtr<T,P>;var dst: TSmartPtr<T,P>);
+    {$else}
+    class operator Assign(var dst: TSmartPtr<T,P>; const [ref] src: TSmartPtr<T,P>);
+    {$endif}
+
+    // implicit or explicit operator should be used before "default" field
+    class operator Implicit(const src: PT): TSmartPtr<T,P>;
+    //class operator Implicit(const src: TSmartPtr<T,P>):T;
+    procedure Assign(const val:PT);
+  end;
+  {$endif}
+  // You may want to use generic class based hashmaps or dictionaries, TOrderedKeyValues below should keep everything in the stack
+
+  {$ifdef NO_HASHMAP}
+  { TOrderedKeyValueList }
+
+  TOrderedKeyValueList<TK,TV>=record
+  type
+    TKeyArray = TArray<TK>;
+    TValueArray =TArray<TV>;
+    TSearcher = function (const arr:array of TK;const val:TK;R:integer):integer;
+  public
+    Keys:TKeyArray;
+    Values:TValueArray;
+  private
+    FindKey:TSearcher ;
+    function GetValues( key: TK): TV;
+    procedure SetValues( key: TK; AValue: TV);
+  public
+    class function Create():TOrderedKeyValueList<TK,TV>; static;
+    function ContainsKey(const key: TK): boolean;
+    function IndexOfKey(const Key:TK):integer;
+    function AddOrSetValue(const Key:TK;const AValue:TV):integer;
+    procedure Add(const Key:TK;const AValue:TV);
+    function TryGetValue(const Key:TK;out Value:TV):boolean;
+    property Items[key:TK]:TV read GetValues write SetValues ;default;
+    function Count:integer;
+    procedure RemoveIndex(const index:integer);
+    procedure Remove(const key:TK);
+    class operator initialize({$ifdef fpc}outvar{$else}out{$endif} v:TOrderedKeyValueList<TK,TV>);
+    class operator Finalize(var dst:TOrderedKeyValueList<TK,TV>);
+
+  end;
+  PMemHouseKeeper = ^TMemHouseKeeper;
+  //TMemHouseKeeper = TOrderedKeyValueList<Pointer,PLongInt>;
+  TMemHouseKeeper = TOrderedKeyValueList<Pointer,TArray<LongInt>>;
+
+  {$endif}
+
+  AllocatedStringPtr={$ifdef NO_SMARTPTR}ortstring{$else}TSmartPtr<OrtChar,TORTAllocatedFree>{$endif};
+
+  { OrtException }
+
+  OrtException = class(Exception)
+  public
+    code_ :OrtErrorCode;
+    property GetErrorCode:OrtErrorCode read code_;
+    function what :ortstring;
+    constructor Create(const str:ortstring; code :OrtErrorCode);
+  end;
+
+  { Float16_t }
+
+  Float16_t=record
+    value:uint16_t;
+    constructor Create(const v:uint16_t);
+    class operator Implicit(const v:Float16_t):uint16_t;overload;
+    class operator Implicit(const v:uint16_t):Float16_t;overload;
+  end;
+
+  { BFloat16_t }
+
+  BFloat16_t=record
+    value:uint16_t;
+    constructor Create(const v:uint16_t);
+    class operator Implicit(const v:BFloat16_t):uint16_t;overload;
+    class operator Implicit(const v:uint16_t):BFloat16_t;overload;
+  end;
+
+  { TORTBase }
+
+  TORTBase<T>=record
+  type
+    PT=^T;
+  private
+    procedure NewRef();
+    procedure Assign(const val: Pointer);
+    procedure DecRef();
+    //function RefCount():PLongInt;
+  public
+    p_:Pointer; // don't change to PT, because of later implementation of OrtRelease which will give compiler error;
+    function release:PT;
+    procedure OrtRelease();
+    constructor Create(const v:PT);
+    class operator Initialize({$ifdef fpc}outvar{$else}out{$endif} v:TORTBase<T>);
+    class operator Finalize(var v:TORTBase<T>);
+    {$ifdef fpc}
+    class operator Copy(constref src: TORTBase<T>;var dst:TORTBase<T>);
+    class operator AddRef(var src:TORTBase<T>);
+    {$else}
+    class operator Assign(var dst: TORTBase<T>;const [ref] src:TORTBase<T>);
+    {$endif}
+    //class operator Implicit(const v: TORTBase<T>):PT;
+    class operator Implicit(const v: PT):TORTBase<T>;
+    class operator Equal(const a,b:TORTBase<T>):boolean;
+  end;
+
+
+  //PORTEnv                    = ^TORTEnv                    ;
+  //PORTOrtCustomOpDomain      = ^TORTCustomOpDomain         ;
+  //PORTRunOptions             = ^TORTRunOptions             ;
+  //PORTSessionOptions         = ^TORTSessionOptions         ;
+  //PORTModelMetadata          = ^TORTModelMetadata          ;
+  //PORTSession                = ^TORTSession                ;
+  //PORTORTTensorTypeAndShapeInfo = ^TORTTensorTypeAndShapeInfo ;
+  //PORTSequenceTypeInfo       = ^TORTSequenceTypeInfo       ;
+  //PORTMapTypeInfo            = ^TORTMapTypeInfo            ;
+  //PORTTypeInfo               = ^TORTTypeInfo               ;
+  //PORTORTValue               = ^TORTValue                  ;
+  //PORTOrtMemoryInfo          = ^TORTMemoryInfo             ;
+  //PORTOrtAllocator           = ^TORTAllocator              ;
+  //PORTIoBinding              = ^TORTIoBinding              ;
+
+  TORTEnv                    = TORTBase<OrtEnv>;
+  TORTValue                  = TORTBase<OrtValue>;
+  TORTIoBinding              = TORTBase<OrtIoBinding>  ;
+  TORTTypeInfo               = TORTBase<OrtTypeInfo>;
+  TORTCustomOpDomain         = TORTBase<OrtCustomOpDomain>;
+  TORTRunOptions             = TORTBase<OrtRunOptions>;
+  TORTSessionOptions         = TORTBase<OrtSessionOptions>;
+  TORTModelMetadata          = TORTBase<OrtModelMetadata> ;
+  TORTSession                = TORTBase<OrtSession>;
+  TORTMapTypeInfo            = TORTBase<OrtMapTypeInfo>;
+  TORTSequenceTypeInfo       = TORTBase<OrtSequenceTypeInfo>;
+  TORTAllocator              = TORTBase<OrtAllocator> ;
+  TORTMemoryInfo             = TORTBase<OrtMemoryInfo> ;
+  TORTArenaCfg               = TORTBase<OrtArenaCfg> ;
+  TORTTensorTypeAndShapeInfo = TORTBase<OrtTensorTypeAndShapeInfo>;
+  { TOrtTensor }
+
+  TORTTensor<T> = record
+  Type PT=^T;
+  private
+    FData:TArray<T>;
+    FShape:TArray<int64_t>;
+    FSize:Size_t;
+    function Getindex1(x: int64_t): T;
+    function Getindex2(x,y: int64_t): T;
+    function Getindex3( x,y,z: int64_t): T;    
+    function GetIndex4(x,y,z,w: int64_t): T;
+    procedure Setindex1(x: int64_t; AValue: T);
+    procedure Setindex3(x,y,z: int64_t; AValue: T);
+    procedure Setindex2(x,y: int64_t; AValue: T);
+    procedure SetIndex4(x,y,z,w: int64_t; AValue: T);
+    procedure SetShape(AValue: TArray<int64_t>);
+  public
+    function ElementCount:size_t;
+    function ByteCount:size_t;
+    function DimensionCount:size_t;
+    function Idx(const x,y,z:Int64_t):int64_t;
+    constructor Create(const AShape:TArray<int64_t>);
+    property Shape:TArray<int64_t> read FShape write SetShape;
+    property Index4[x,y,z,w:int64_t]:T read GetIndex4 write SetIndex4;
+    property Index3[x,y,z:int64_t]:T read Getindex3 write Setindex3 ; default;
+    property index2[x,y:int64_t]:T read Getindex2 write Setindex2  ;
+    property index1[x:int64_t]:T read GetIndex1 write SetIndex1;
+    {$ifdef fpc}
+    function ToString(const Separator:ortstring=', '):ortstring;
+    {$endif}
+    function ToValue:TORTValue;
+    class function FromValue(const val:TORTValue;const copyData:boolean=true):TORTTensor<T>;static;
+    class operator Implicit(const aValue:TORTValue):TORTTensor<T>;
+    class operator Implicit(const aValue:TORTTensor<T>):TORTValue;
+  end;
+
+
+  {$ifdef MEM_TABLE}
+  THKHelp = record helper for TMemHouseKeeper
+    procedure print();
+  end;
+  {$endif}
+
+  {$ifndef NO_HASHMAP}
+
+  TORTNameValue<TKey,TValue> =  class(TDictionary<TKey,TValue>)
+  private
+    function GetKeys(idx: size_t): TKey;
+    function GetValues(idx: Size_t): TValue;
+  public
+    property Values[idx:Size_t]:TValue read GetValues;
+    property Keys[idx:size_t]:TKey read GetKeys;
+  end;
+  TNameValueList = TORTNameValue<ansistring,TORTValue>;
+  TORTProviderOptions= TDictionary<ortstring,ortstring>;
+
+  {$else}
+//  TMemHousekeeper = TOrderedKeyValueList<Pointer,Plongint>;
+  {$ifdef MEM_TABLE}
+  {$endif}
+  TORTNameValueList = TOrderedKeyValueList<ortstring,TORTValue>;
+  TORTProviderOptions=TOrderedKeyValueList<ortstring,ortstring>;
+  {$endif}
+
+  { TEnvHelper }
+
+  TORTEnvHelper = record helper for TORTEnv
+    class function Create(logging_level:OrtLoggingLevel {= ORT_LOGGING_LEVEL_WARNING}; const logid: POrtChar  = nil):TORTEnv;                                                                                                       overload;static;
+    class function Create(logging_level :OrtLoggingLevel ; const logid :POrtChar ; logging_function:OrtLoggingFunction ; logger_param: Pointer ):TORTEnv;                                                                          overload; static;
+    class function Create(const tp_options :POrtThreadingOptions ; logging_level: OrtLoggingLevel = ORT_LOGGING_LEVEL_WARNING; const logid: POrtChar  = nil):TORTEnv;                                                               overload;static;
+    class function Create(const tp_options :POrtThreadingOptions ; logging_function: OrtLoggingFunction ; logger_param:Pointer; logging_level :OrtLoggingLevel  = ORT_LOGGING_LEVEL_WARNING; const logid:POrtChar  = nil):TORTEnv;  overload;static;
+    function  EnableTelemetryEvents():TORTEnv;inline;   ///< Wraps OrtApi::EnableTelemetryEvents
+    function DisableTelemetryEvents():TORTEnv;inline;  ///< Wraps OrtApi::DisableTelemetryEvents
+    function CreateAndRegisterAllocator(const mem_info :TOrtMemoryInfo; const arena_cfg:TOrtArenaCfg):TORTEnv;inline;  ///< Wraps OrtApi::CreateAndRegisterAllocator
+    function UpdateLogLevel(const log_level:OrtLoggingLevel):TORTEnv;
+  end;
+
+
+
+  { TCustomOpDomainHelper }
+
+  TORTCustomOpDomainHelper = record helper for TORTCustomOpDomain
+    /// \brief Wraps OrtApi::CreateCustomOpDomain
+    class function Create(const domain: POrtChar):TORTCustomOpDomain; static;
+    procedure Add( op:POrtCustomOp);  ///< Wraps CustomOpDomain_Add
+  end;
+
+
+
+  { TRunOptionsHelper }
+
+  TORTRunOptionsHelper = record helper for TORTRunOptions
+     // RunOption() created in TORTBase intializer    ///< Wraps OrtApi::CreateRunOptions
+
+     function SetRunLogVerbosityLevel(level:longint):TORTRunOptions;  ///< Wraps OrtApi::RunOptionsSetRunLogVerbosityLevel
+     function GetRunLogVerbosityLevel():longint;      ///< Wraps OrtApi::RunOptionsGetRunLogVerbosityLevel
+     //
+     function SetRunLogSeverityLevel(level:longint):TORTRunOptions;  ///< Wraps OrtApi::RunOptionsSetRunLogSeverityLevel
+     function GetRunLogSeverityLevel():longint ;       ///< Wraps OrtApi::RunOptionsGetRunLogSeverityLevel
+     //
+     function SetRunTag(const run_tag:POrtChar):TORTRunOptions;  ///< wraps OrtApi::RunOptionsSetRunTag
+     function GetRunTag():POrtChar;               ///< Wraps OrtApi::RunOptionsGetRunTag
+     //
+     function AddConfigEntry(const config_key:POrtChar; const config_value:POrtChar):TORTRunOptions;  ///< Wraps OrtApi::AddRunConfigEntry
+     //
+     ///** \brief Terminates all currently executing Session::Run calls that were made using this RunOptions instance
+     // *
+     // * If a currently executing session needs to be force terminated, this can be called from another thread to force it to fail with an error
+     // * Wraps OrtApi::RunOptionsSetTerminate
+     // */
+     function SetTerminate():TORTRunOptions;
+     //
+     ///** \brief Clears the terminate flag so this RunOptions instance can be used in a new Session::Run call without it instantly terminating
+     // *
+     // * Wraps OrtApi::RunOptionsUnsetTerminate
+     // */
+     function UnsetTerminate():TORTRunOptions;
+
+  end;
+
+
+  { TSessionOptionsHelper }
+
+  TORTSessionOptionsHelper = record helper for TORTSessionOptions
+     function Clone():TORTSessionOptions;  ///< Creates and returns a copy of this SessionOptions object. Wraps OrtApi::CloneSessionOptions
+     function SetIntraOpNumThreads(intra_op_num_threads :longint):TORTSessionOptions;                              ///< Wraps OrtApi::SetIntraOpNumThreads
+     function SetInterOpNumThreads(inter_op_num_threads :longint):TORTSessionOptions;                              ///< Wraps OrtApi::SetInterOpNumThreads
+     function SetGraphOptimizationLevel(graph_optimization_level :GraphOptimizationLevel):TORTSessionOptions;  ///< Wraps OrtApi::SetSessionGraphOptimizationLevel
+     function EnableCpuMemArena():TORTSessionOptions;   ///< Wraps OrtApi::EnableCpuMemArena
+     function DisableCpuMemArena():TORTSessionOptions;  ///< Wraps OrtApi::DisableCpuMemArena
+     function SetOptimizedModelFilePath(const optimized_model_filepath: PORTCHAR_T): TORTSessionOptions;  ///< Wraps OrtApi::SetOptimizedModelFilePath
+     function EnableProfiling(const profile_file_prefix:PORTCHAR_T):TORTSessionOptions;  ///< Wraps OrtApi::EnableProfiling
+     function DisableProfiling():TORTSessionOptions;                                     ///< Wraps OrtApi::DisableProfiling
+     function EnableOrtCustomOps():TORTSessionOptions;  ///< Wraps OrtApi::EnableOrtCustomOps
+     function EnableMemPattern():TORTSessionOptions;   ///< Wraps OrtApi::EnableMemPattern
+     function DisableMemPattern():TORTSessionOptions;  ///< Wraps OrtApi::DisableMemPattern
+     function SetExecutionMode(execution_mode:ExecutionMode):TORTSessionOptions;  ///< Wraps OrtApi::SetSessionExecutionMode
+     function SetLogId(const logid:POrtChar):TORTSessionOptions;     ///< Wraps OrtApi::SetSessionLogId
+     function SetLogSeverityLevel(level:Longint):TORTSessionOptions;  ///< Wraps OrtApi::SetSessionLogSeverityLevel
+     function Add(custom_op_domain:POrtCustomOpDomain):TORTSessionOptions;  ///< Wraps OrtApi::AddCustomOpDomain
+     function DisablePerSessionThreads():TORTSessionOptions;  ///< Wraps OrtApi::DisablePerSessionThreads
+     function AddConfigEntry(const config_key:POrtChar; const config_value:POrtChar):TORTSessionOptions;                                      ///< Wraps OrtApi::AddSessionConfigEntry
+     function AddInitializer(const name:POrtChar; const ort_val:POrtValue):TORTSessionOptions;                                             ///< Wraps OrtApi::AddInitializer
+     function AddExternalInitializers(const names: TArray<ortstring>; const ort_values: array of TORTValue): TORTSessionOptions;  ///< Wraps OrtApi::AddExternalInitializers
+     function AppendExecutionProvider_CUDA(const provider_options:OrtCUDAProviderOptions):TORTSessionOptions;               ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_CUDA
+     function AppendExecutionProvider_CUDA_V2(const provider_options:OrtCUDAProviderOptionsV2):TORTSessionOptions;          ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_CUDA_V2
+     function AppendExecutionProvider_ROCM(const provider_options:OrtROCMProviderOptions):TORTSessionOptions;               ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_ROCM
+     function AppendExecutionProvider_OpenVINO(const provider_options:OrtOpenVINOProviderOptions):TORTSessionOptions;       ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_OpenVINO
+     function AppendExecutionProvider_TensorRT(const provider_options:OrtTensorRTProviderOptions):TORTSessionOptions;       ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_TensorRT
+     function AppendExecutionProvider_TensorRT_V2(const provider_options:OrtTensorRTProviderOptionsV2):TORTSessionOptions;  ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_TensorRT
+     function AppendExecutionProvider_MIGraphX(const provider_options:OrtMIGraphXProviderOptions):TORTSessionOptions;       ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_MIGraphX
+     ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_CANN
+     function AppendExecutionProvider_CANN(const provider_options:OrtCANNProviderOptions):TORTSessionOptions;
+     /// Wraps OrtApi::SessionOptionsAppendExecutionProvider. Currently supports SNPE and XNNPACK.
+     function AppendExecutionProvider(const provider_name:ortstring; const provider_options:TORTProviderOptions):TORTSessionOptions;
+     function SetCustomCreateThreadFn( ort_custom_create_thread_fn:OrtCustomCreateThreadFn):TORTSessionOptions;  ///< Wraps OrtApi::SessionOptionsSetCustomCreateThreadFn
+     function SetCustomThreadCreationOptions(ort_custom_thread_creation_options:Pointer):TORTSessionOptions;      ///< Wraps OrtApi::SessionOptionsSetCustomThreadCreationOptions
+     function SetCustomJoinThreadFn( ort_custom_join_thread_fn:OrtCustomJoinThreadFn):TORTSessionOptions;        ///< Wraps OrtApi::SessionOptionsSetCustomJoinThreadFn
+
+  end;
+
+  { TModelMetadataHelper }
+
+  TORTModelMetadataHelper = record helper for TORTModelMetadata
+    function GetProducerNameAllocated(allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::ModelMetadataGetProducerName
+    function GetGraphNameAllocated(allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::ModelMetadataGetGraphName
+    function GetDomainAllocated(allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::ModelMetadataGetDomain
+    function GetDescriptionAllocated(allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::ModelMetadataGetDescription
+    function GetGraphDescriptionAllocated(allocator: TOrtAllocator
+      ): AllocatedStringPtr;  ///< Wraps OrtApi::ModelMetadataGetGraphDescription
+    function GetCustomMetadataMapKeysAllocated(allocator: TOrtAllocator): TArray<
+      AllocatedStringPtr>;  ///< Wraps OrtApi::ModelMetadataGetCustomMetadataMapKeys
+    function LookupCustomMetadataMapAllocated(const key: POrtChar;
+      allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::ModelMetadataLookupCustomMetadataMap
+
+    function GetVersion():int64_t ;  ///< Wraps OrtApi::ModelMetadataGetVersion
+
+
+  end;
+  { TIoBindingHelper }
+
+  TORTIoBindingHelper = record helper for TORTIoBinding
+    class function IoBinding(var session:TORTSession):TORTIoBinding;  static;
+    procedure BindInput(const name: POrtChar; const value: TORTValue);
+    procedure BindOutput(const name: POrtChar; const value: TORTValue); overload;
+    procedure BindOutput(const name: POrtChar; const mem_info: TORTMemoryInfo); overload;
+    function GetOutputNames()                    :TArray<ortstring>;overload;
+    function GetOutputNames(var alloc:TORTAllocator):TArray<ortstring>;overload;
+    function GetOutputValues()                   :TArray<TORTValue>;overload;
+    function GetOutputValues(var alloc:TORTAllocator):TArray<TORTValue>;overload;
+    procedure ClearBoundInputs();
+    procedure ClearBoundOutputs();
+    procedure SynchronizeInputs();
+    procedure SynchronizeOutputs();
+  private
+    function GetOutputNamesHelper(allocator: POrtAllocator) :TArray<ortstring>; // result must must release when out of scope
+    function GetOutputValuesHelper(allocator: POrtAllocator):TArray<TORTValue>; // result must must release when out of scope
+  end;
+
+
+  { TSessionHelper }
+
+  TORTSessionHelper = record helper for TORTSession
+                                                                                                      ///< Create an empty Session object, must be assigned a valid one to be used
+    class function Create(const env:TORTEnv ; const  model_path:PORTCHAR_T; const options:TORTSessionOptions):TORTSession;                                                           overload;static;  ///< Wraps OrtApi::CreateSession
+    class function Create(const env:TORTEnv ; const  model_path:PORTCHAR_T; const options:TORTSessionOptions; prepacked_weights_container:POrtPrepackedWeightsContainer):TORTSession;overload;static;  ///< Wraps OrtApi::CreateSessionWithPrepackedWeightsContainer
+    class function Create(const env:TORTEnv ; const  model_data:Pointer; model_data_length:size_t; const options:TORTSessionOptions):TORTSession;                                    overload;static;    ///< Wraps OrtApi::CreateSessionFromArray
+    class function Create(const env:TORTEnv ; const  model_data:Pointer; model_data_length:size_t; const options:TORTSessionOptions;
+             prepacked_weights_container:POrtPrepackedWeightsContainer):TORTSession; overload;static;  ///< Wraps OrtApi::CreateSessionFromArrayWithPrepackedWeightsContainer
+    class function Create(const model_path:TFileName):TORTSession;            overload;static;
+    (** \brief Run the model returning results in an Ort allocated vector.
+     *
+     * Wraps OrtApi::Run
+     *
+     * The caller provides a list of inputs and a list of the desired outputs to return.
+     *
+     * See the output logs for more information on warnings/errors that occur while processing the model.
+     * Common errors are.. (TODO)
+     *
+     * \param[in] run_options
+     * \param[in] input_names Array of null terminated strings of length input_count that is the list of input names
+     * \param[in] input_values Array of Value objects of length input_count that is the list of input values
+     * \param[in] input_count Number of inputs (the size of the input_names & input_values arrays)
+     * \param[in] output_names Array of C style strings of length output_count that is the list of output names
+     * \param[in] output_count Number of outputs (the size of the output_names array)
+     * \return A std::vector of Value objects that directly maps to the output_count (eg. output_name[0] is the first entry of the returned vector)
+     *)
+     function Run(const run_options:TORTRunOptions; const Inputs: TORTNameValueList):TORTNameValueList; overload;
+     function Run(const run_options:TORTRunOptions; const Inputs: TORTNameValueList; const Allocator: TOrtAllocator): TORTNameValueList; overload;
+     function Run(const run_options:TORTRunOptions; const input_names :PPOrtChar ; const input_values:PORTValue;  input_count:size_t; const output_names:PPOrtChar ; output_names_count:size_t ):TArray<TORTValue>;                            overload;
+     function Run(const Inputs:TORTNameValueList):TORTNameValueList; overload;
+    (** \brief Run the model returning results in user provided outputs
+     * Same as Run(const RunOptions&, const char* const*, const Value*, size_t,const char* const*, size_t)
+     *)
+    procedure Run(const run_options:TORTRunOptions; const input_names:PPOrtChar; const input_values:PORTValue; input_count:size_t;
+             const output_names:PPOrtChar; output_values:PORTValue; output_count:size_t);                                           overload;
+
+    procedure Run(const run_options:TORTRunOptions; const io_binding:TORTIoBinding);  overload;///< Wraps OrtApi::RunWithBinding
+
+    function GetInputCount():size_t ;                   ///< Returns the number of model inputs
+    function GetOutputCount():size_t ;                  ///< Returns the number of model outputs
+    function GetOverridableInitializerCount() :size_t;  ///< Returns the number of inputs that have defaults that can be overridden
+
+    (** \brief Returns a copy of input name at the specified index.
+     *
+     * \param index must less than the value returned by GetInputCount()
+     * \param allocator to allocate memory for the copy of the name returned
+     * \return a instance of smart pointer that would deallocate the buffer when out of scope.
+     *  The OrtAllocator instances must be valid at the point of memory release.
+     *)
+    function GetInputNameAllocated(index: size_t; const allocator: TOrtAllocator
+      ): AllocatedStringPtr;
+
+    (** \brief Returns a copy of output name at then specified index.
+     *
+     * \param index must less than the value returned by GetOutputCount()
+     * \param allocator to allocate memory for the copy of the name returned
+     * \return a instance of smart pointer that would deallocate the buffer when out of scope.
+     *  The OrtAllocator instances must be valid at the point of memory release.
+     *)
+    function GetOutputNameAllocated(index: size_t; const allocator: TOrtAllocator
+      ): AllocatedStringPtr;
+
+    (** \brief Returns a copy of the overridable initializer name at then specified index.
+     *
+     * \param index must less than the value returned by GetOverridableInitializerCount()
+     * \param allocator to allocate memory for the copy of the name returned
+     * \return a instance of smart pointer that would deallocate the buffer when out of scope.
+     *  The OrtAllocator instances must be valid at the point of memory release.
+     *)
+    function GetOverridableInitializerNameAllocated(index: size_t;
+      allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::SessionGetOverridableInitializerName
+
+    (** \brief Returns a copy of the profiling file name.
+     *
+     * \param allocator to allocate memory for the copy of the ortstring returned
+     * \return a instance of smart pointer that would deallocate the buffer when out of scope.
+     *  The OrtAllocator instances must be valid at the point of memory release.
+     *)
+    function EndProfilingAllocated(allocator: TOrtAllocator): AllocatedStringPtr;  ///< Wraps OrtApi::SessionEndProfiling
+    function GetProfilingStartTimeNs(): uint64_t;                                 ///< Wraps OrtApi::SessionGetProfilingStartTimeNs
+    function GetModelMetadata() :TORTModelMetadata;                                   ///< Wraps OrtApi::SessionGetModelMetadata
+    function GetInputTypeInfo(index:size_t) :TOrtTypeInfo;                   ///< Wraps OrtApi::SessionGetInputTypeInfo
+    function GetOutputTypeInfo(index:size_t) :TOrtTypeInfo;                  ///< Wraps OrtApi::SessionGetOutputTypeInfo
+    function GetOverridableInitializerTypeInfo( index:size_t) :TOrtTypeInfo;  ///< Wraps OrtApi::SessionGetOverridableInitializerTypeInfo
+
+  end;
+
+
+  { TTensorTypeAndShapeInfoHelper }
+
+  TORTTensorTypeAndShapeInfoHelper = record helper for TORTTensorTypeAndShapeInfo                                                   ///< Create an empty TensorTypeAndShapeInfo object, must be assigned a valid one to be used
+    function GetElementType():ONNXTensorElementDataType;  ///< Wraps OrtApi::GetTensorElementType
+    function GetElementCount():size_t;                    ///< Wraps OrtApi::GetTensorShapeElementCount
+
+    function GetDimensionsCount():size_t;                                           ///< Wraps OrtApi::GetDimensionsCount
+    procedure GetDimensions( values:PInt64_t; values_count: size_t ) ;              ///< Wraps OrtApi::GetDimensions
+    procedure GetSymbolicDimensions(const values:PPOrtChar; values_count:size_t) ; overload; ///< Wraps OrtApi::GetSymbolicDimensions
+    function GetSymbolicDimensions(const values_count: size_t): TArray<ortstring>;
+      overload;
+    function GetShape():TArray<int64_t>;  ///< Uses GetDimensionsCount & GetDimensions to return a std::vector of the shape
+
+  end;
+
+  { TSequenceTypeInfoHelper }
+
+  TORTSequenceTypeInfoHelper = record helper for TORTSequenceTypeInfo
+    function GetSequenceElementType():TORTTypeInfo;  ///< Wraps OrtApi::GetSequenceElementType
+  end;
+
+
+  { TMapTypeInfoHelper }
+
+  TORTMapTypeInfoHelper = record helper for TORTMapTypeInfo
+    function GetMapKeyType() :ONNXTensorElementDataType;  ///< Wraps OrtApi::GetMapKeyType
+    function GetMapValueType() :TORTTypeInfo;                 ///< Wraps OrtApi::GetMapValueType
+  end;
+
+  { TOrtTypeInfoHelper }
+
+  TORTTypeInfoHelper = record helper for TORTTypeInfo
+    function GetTensorTypeAndShapeInfo():TORTTensorTypeAndShapeInfo;  ///< Wraps OrtApi::CastTypeInfoToTensorInfo
+    function GetSequenceTypeInfo():TORTSequenceTypeInfo;              ///< Wraps OrtApi::CastTypeInfoToSequenceTypeInfo
+    function GetMapTypeInfo():TORTMapTypeInfo;                        ///< Wraps OrtApi::CastTypeInfoToMapTypeInfo
+    function GetONNXType():ONNXType;
+  end;
+
+
+  { TValueHelper }
+
+  TORTValueHelper = record helper for TORTValue
+  type
+    TOrtSparseValuesParam =record
+      values_shape      : Pint64_t ;
+      values_shape_len  : size_t ;
+      data : record case boolean of
+        false:(p_data:Pointer);
+        true :(str:PPOrtChar);
+      end;
+    end;
+    TShape = record
+      shape:Pint64_t;
+      shape_len:size_t;
+    end;
+
+    class function CreateTensor(const info:POrtMemoryInfo; p_data:pointer; p_data_byte_count:size_t ; const shape:Pint64_t; shape_len:size_t ; _type:ONNXTensorElementDataType ):TORTValue;   overload; static;
+    class function CreateTensor(allocator:POrtAllocator; const shape:Pint64_t; shape_len:size_t ; _type:ONNXTensorElementDataType ):TORTValue;    overload;static;
+    class function CreateMap(var keys :TORTValue;var values:TORTValue):TORTValue; static;      ///< Wraps OrtApi::CreateValue
+    class function CreateSequence(var values:TArray<TORTValue>):TORTValue; static; ///< Wraps OrtApi::CreateValue
+    function IsTensor():boolean;  ///< Returns true if Value is a tensor, false for other types like map/sequence/etc
+    function HasValue():boolean;  /// < Return true if OrtValue contains data and returns false if the OrtValue is a None
+    function GetCount():size_t;  // If a non tensor, returns 2 for map and N for sequence, where N is the number of elements
+    function GetValue(index:longint; allocator:POrtAllocator) :TORTValue;
+    function GetStringTensorDataLength() :size_t;
+    procedure GetStringTensorContent( buffer:Pointer;  buffer_length:size_t; offsets:Psize_t; offsets_count:size_t) ;
+    function GetTypeInfo():TOrtTypeInfo;
+    function GetTensorTypeAndShapeInfo():TORTTensorTypeAndShapeInfo;
+    function GetStringTensorElementLength(element_index: size_t): size_t;
+    procedure GetStringTensorElement(buffer_length:size_t; element_index:size_t; buffer:pointer );
+    procedure FillStringTensor(const s:PPOrtChar; s_len:size_t );
+    procedure FillStringTensorElement(const s:POrtChar; index: size_t);
+{$ifndef DISABLE_SPARSE_TENSORS}
+    class function CreateSparseTensor(const info:POrtMemoryInfo;p_data: pointer ; const dense_shape:TShape; const values_shape:TShape; _type: ONNXTensorElementDataType):TORTValue;overload;static;
+    procedure UseCooIndices(indices_data:Pint64_t;indices_num :size_t );
+    procedure UseCsrIndices(inner_data:Pint64_t; inner_num:size_t; outer_data:Pint64_t; outer_num:size_t );
+    procedure UseBlockSparseIndices(const indices_shape :TShape ;indices_data :Pint32_t);
+    class function CreateSparseTensor(allocator:POrtAllocator; const dense_shape:TShape; _type: ONNXTensorElementDataType):TORTValue;    overload;static;
+    procedure FillSparseTensorCoo(const data_mem_info:POrtMemoryInfo; const values_param:TOrtSparseValuesParam ;const indices_data:Pint64_t; indices_num:size_t );
+    procedure FillSparseTensorCsr(const data_mem_info:POrtMemoryInfo;
+                           const  values:TOrtSparseValuesParam;
+                           const inner_indices_data:PInt64_t; inner_indices_num :size_t ;
+                           const outer_indices_data:PInt64_t; outer_indices_num :size_t );
+    procedure FillSparseTensorBlockSparse(const data_mem_info :POrtMemoryInfo;
+                                   const values :TOrtSparseValuesParam;
+                                   const  indices_shape :TShape;
+                                   const  indices_data:Pint32_t);
+    function GetSparseFormat():OrtSparseFormat;
+    function GetSparseTensorValuesTypeAndShapeInfo(): TORTTensorTypeAndShapeInfo;
+    function GetSparseTensorIndicesTypeShapeInfo(indices_format: OrtSparseIndicesFormat): TORTTensorTypeAndShapeInfo;
+    function IsSparseTensor():boolean;
+    class function CreateSparseTensor<T>(const info:POrtMemoryInfo;var p_data:T; const dense_shape:TShape; const values_shape:TShape ):TORTValue; overload; static;
+    class function CreateSparseTensor<T>(allocator:POrtAllocator; const dense_shape:TShape):TORTValue;    overload;static;
+    function GetSparseTensorIndicesData<PT>( indices_format:OrtSparseIndicesFormat;var num_indices: size_t):PT;  //T*
+    function GetSparseTensorValues<PT>():PT; // T*
+{$endif}
+    class function CreateTensor<T>(const info:POrtMemoryInfo;var p_data: T ; p_data_element_count:size_t ; const  shape:Pint64_t; shape_len:size_t ):TORTValue;overload;static;
+    class function CreateTensor<T>(allocator:POrtAllocator; const shape:Pint64_t;shape_len :size_t):TORTValue;      overload; static;
+    class function CreateOpaque<T>(const domain:POrtChar; const type_name:POrtChar; const data_container:T):TORTValue;static;  ///< Wraps OrtApi::CreateOpaqueValue
+    procedure GetOpaqueData<T>(const domain:POrtChar; const type_name:POrtChar;var _out:T);  ///< Wraps OrtApi::GetOpaqueValue
+    function GetTensorMutableData<T>: Pointer;  /// T*< Wraps OrtApi::GetTensorMutableData
+    function GetTensorData<T>: Pointer;  ///T* < Wraps OrtApi::GetTensorMutableData
+    function GetTensorShape:TArray<int64_t>;
+    function GettensorType:ONNXTensorElementDataType;
+    function At<T>(const location:TArray<int64_t>):T;
+  end;
+
+
+  { TMemoryInfoHelper }
+
+  TORTMemoryInfoHelper = record helper for TORTMemoryInfo
+    class function CreateCpu(_type:OrtAllocatorType ; mem_type:OrtMemType ):TORTMemoryInfo;  static;
+    class function Create(const name:POrtChar; _type:OrtAllocatorType; id:longint; mem_type:OrtMemType):TORTMemoryInfo; static;
+
+    function GetAllocatorName():ortstring;
+    function GetAllocatorType() :OrtAllocatorType;
+    function GetDeviceId(): longint;
+    function GetMemoryType() :OrtMemType;
+    function GetDeviceType() :OrtMemoryInfoDeviceType;
+    function Equal(const other:TORTMemoryInfo):boolean;
+    //  equal == operator is implemented in TORTBase
+  end;
+
+  { TORTMemoryAllocation }
+
+  TORTMemoryAllocation = record
+    constructor Create(const allocator: POrtAllocator; const p: Pointer; const size: size_t);
+    function get():pointer; { return p_; }
+    function size():size_t; { return size_; }
+    //{$ifdef fpc}
+    //class operator Copy(constref Src:TORTMemoryAllocation; var dst:TORTMemoryAllocation);
+    //{$else}
+    //class operator Assign(var dst:TORTMemoryAllocation; const [ref] src:TORTMemoryAllocation);
+    //{$endif}
+    //class operator Initialize({$ifdef fpc}var{$else}out{$endif} dest:TORTMemoryAllocation);
+    class operator Finalize(var dest:TORTMemoryAllocation);
+
+  private
+    allocator_ : POrtAllocator ;
+    p_    : pointer ;
+    size_ : size_t;
+  end;
+
+  { TAllocatorHelper }
+
+  TORTAllocatorHelper = record helper for TORTAllocator
+    class function Create(const session :TORTSession; const mem_info :TORTMemoryInfo):TORTAllocator;static;
+
+    function Alloc(const size:size_t):pointer;
+    // The return value will own the allocation
+    function GetAllocation(size:size_t):TORTMemoryAllocation;
+    procedure Free(p:pointer);
+    function GetMemoryInfo():TORTMemoryInfo;    // result must have unowned content "implement a trick so it won't not be released if gone out of scope?"
+    function GetInfo():POrtMemoryInfo;
+  end;
+
+
+  { TArenaCfgHelper }
+
+  TORTArenaCfgHelper = record helper for TORTArenaCfg
+     class function ArenaCfg( max_mem:size_t; arena_extend_strategy:longint; initial_chunk_size_bytes:longint; max_dead_bytes_per_chunk:longint):TORTArenaCfg;static;
+  end;
+
+  { TAllocatorWithDefaultOptions }
+
+  TORTAllocatorWithDefaultOptions=record
+    class operator Initialize({$ifdef fpc}var{$else}out{$endif} dest:TORTAllocatorWithDefaultOptions);
+    class operator Finalize(var dest:TORTAllocatorWithDefaultOptions);
+    class operator Implicit(const src:TORTAllocatorWithDefaultOptions):POrtAllocator;
+    function Alloc(const size:size_t):Pointer;
+    // The return value will own the allocation
+    function GetAllocation(const size :size_t):TORTMemoryAllocation;
+    procedure Free(const p:pointer);
+    function GetInfo():POrtMemoryInfo;
+    function GetMemoryInfo():TORTMemoryInfo;
+    class operator Implicit(const v:TORTAllocatorWithDefaultOptions):TORTAllocator;
+  public
+    p_:POrtAllocator;
+  end;
+
+  {$ifdef fpc}
+  { TCustomOpBase }
+  TORTCustomOpBase<TOp,TKernel> =record
+    type
+      POp=^TOp;
+      PKernel=^TKernel;
+  public
+    version : uint32_t;
+    function CreateKernel(const this_:POrtCustomOp;const api:POrtApi;const info:POrtKernelInfo):pointer;stdcall;
+    function GetName(const this_:POrtCustomOp):POrtChar;stdcall;
+    function GetExecutionProviderType(const this_:POrtCustomOp):POrtChar;  overload; stdcall;
+    function GetInputType(const this_:POrtCustomOp; index:size_t):ONNXTensorElementDataType;stdcall;
+    function GetInputTypeCount(const this_:POrtCustomOp):size_t;stdcall;
+    function GetOutputType(const this_:POrtCustomOp; index:size_t):ONNXTensorElementDataType;stdcall;
+    function GetOutputTypeCount(const this_:POrtCustomOp):size_t;stdcall;
+    procedure KernelCompute(op_kernel:pointer; context:POrtKernelContext);stdcall;
+    procedure KernelDestroy(op_kernel:pointer);stdcall;
+    function GetInputCharacteristic(const this_:POrtCustomOp; index:size_t):OrtCustomOpInputOutputCharacteristic;overload;stdcall;
+    function GetOutputCharacteristic(const this_:POrtCustomOp; index:size_t):OrtCustomOpInputOutputCharacteristic;overload;stdcall;
+    class operator Initialize({$ifdef fpc}var{$else}out{$endif} dest:TORTCustomOpBase<TOp,TKernel>);
+
+    // Default implementation of GetExecutionProviderType that returns nullptr to default to the CPU provider
+    function GetExecutionProviderType():POrtChar;overload;
+
+    // Default implementations of GetInputCharacteristic() and GetOutputCharacteristic() below
+    // (inputs and outputs are required by default)
+    function GetInputCharacteristic(index: size_t):OrtCustomOpInputOutputCharacteristic;overload;
+
+    function  GetOutputCharacteristic(index :size_t):OrtCustomOpInputOutputCharacteristic;overload;
+  end;
+  {$endif}
+  { TCustomOpApi }
+
+  TORTCustomOpApi = record
+    constructor Create(const api:OrtApi);
+   // T is only implemented for std::vector<float>, std::vector<int64_t>, float, int64_t, and ortstring
+    function KernelInfoGetAttribute<T>(const info :POrtKernelInfo; const name: POrtChar): T;                                               inline;
+    function GetTensorTypeAndShape(const value : POrtValue):POrtTensorTypeAndShapeInfo;                                                 inline;
+    function GetTensorShapeElementCount(const info :POrtTensorTypeAndShapeInfo):size_t;                                                 inline;
+    function GetTensorElementType(const info :POrtTensorTypeAndShapeInfo):ONNXTensorElementDataType;                                    inline;
+    function GetDimensionsCount(const info :POrtTensorTypeAndShapeInfo):size_t;                                                         inline;
+    procedure GetDimensions(const info: POrtTensorTypeAndShapeInfo; dim_values: Pint64_t; dim_values_length: size_t);                   inline;
+    procedure SetDimensions(info :POrtTensorTypeAndShapeInfo; const dim_values:Pint64_t; dim_count:size_t);                             inline;
+    function GetTensorMutableData<T>(value:POrtValue):Pointer;                                                                          inline;
+    function GetTensorData<T>(const value:POrtValue):Pointer;                                                                           inline;
+    function GetTensorMemoryInfo(const value:POrtValue):TOrtMemoryInfo;                                                                 inline;
+    function GetTensorShape(const info: POrtTensorTypeAndShapeInfo):TArray<Int64_t>;                                                    inline;
+    procedure ReleaseTensorTypeAndShapeInfo(input :POrtTensorTypeAndShapeInfo);                                                         inline;
+    function KernelContext_GetInputCount(const context :POrtKernelContext):size_t;                                                      inline;
+    function KernelContext_GetInput(const context: POrtKernelContext; index:size_t):POrtValue;                                          inline;
+    function KernelContext_GetOutputCount(const context :POrtKernelContext):size_t;                                                     inline;
+    function KernelContext_GetOutput(context :POrtKernelContext; index:size_t ;const dim_values:PInt64_t; dim_count:size_t): POrtValue; inline;
+    function KernelContext_GetGPUComputeStream(const context:POrtKernelContext):Pointer;                                                inline;
+    procedure ThrowOnError(status :POrtStatus);                                                                                         inline;
+    function CreateOpAttr(const name :POrtChar; const data:Pointer; len :longint; _type :OrtOpAttrType ):POrtOpAttr;                       inline;
+    procedure ReleaseOpAttr(op_attr: POrtOpAttr);                                                                                       inline;
+    function CreateOp(const info:POrtKernelInfo;
+                      const op_name:POrtChar;
+                      const domain :POrtChar;
+                      version:longint;
+                      const type_constraint_names:PPOrtChar ;
+                      const type_constraint_values:PONNXTensorElementDataType;
+                      type_constraint_count :longint ;
+                      const attr_values:PPOrtOpAttr;
+                      attr_count:longint;
+                      input_count:longint;
+                      output_count:longint):POrtOp;                                                                                     inline;
+    procedure InvokeOp(const context :POrtKernelContext;
+                   const ort_op: POrtOp;
+                   const input_values: PPOrtValue;
+                   input_count: longint;
+                   var output_values: PPOrtValue ;
+                   output_count:longint);                                                                                               inline;
+    procedure ReleaseOp(ort_op :POrtOp);                                                                                                inline;
+    function CopyKernelInfo(const info :POrtKernelInfo):POrtKernelInfo;                                                                 inline;
+    procedure ReleaseKernelInfo(info_copy:POrtKernelInfo );                                                                             inline;
+
+  private
+    api_ : OrtApi;
+
+  end;
+
+  TOrtTypeSingle     = record helper for single     const OrtTensorType = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT   ; end;
+  TOrtTypeFloat16_t  = record helper for Float16_t  const OrtTensorType = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 ; end;
+  TOrtTypeBFloat16_t = record helper for BFloat16_t const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16; end;
+  TOrtTypedouble     = record helper for double     const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE  ; end;
+  TOrtTypeint8_t     = record helper for int8_t     const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8    ; end;
+  TOrtTypeint16_t    = record helper for int16_t    const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16   ; end;
+  TOrtTypeint32_t    = record helper for int32_t    const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32   ; end;
+  TOrtTypeint64_t    = record helper for int64_t    const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64   ; end;
+  TOrtTypeuint8_t    = record helper for uint8_t    const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8   ; end;
+  TOrtTypeuint16_t   = record helper for uint16_t   const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16  ; end;
+  TOrtTypeuint32_t   = record helper for uint32_t   const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32  ; end;
+  TOrtTypeuint64_t   = record helper for uint64_t   const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64  ; end;
+  TOrtTypeboolean    = record helper for boolean    const OrtTensortype = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL    ; end;
+  var
+    HouseKeeper: TMemHousekeeper;
+
+    DefaultAllocator      :TORTAllocatorWithDefaultOptions;
+    DefaultEnv            :TORTEnv;
+    DefaultSessionOptions :TORTSessionOptions;
+    DefaultRunOptions     :TORTRunOptions;
+
+    function GetAvailableProviders():TArray<ortstring>;inline;
+    procedure ThrowOnError(const ort:POrtApi ; status: POrtStatus);inline; overload;
+    procedure ThrowOnError(status:POrtStatus);inline; overload;
+    { Creates the default env / session-options / run-options objects once a
+      runtime has been loaded (no-op until GetApi is available). Call after
+      LoadOnnxRuntime + InitOrtApi. }
+    procedure EnsureOrtDefaults;
+    function GetApi:POrtApi;
+    function AllocatorGetMemoryInfo(const Allocator:POrtAllocator):TORTMemoryInfo;
+    function OrtTensorType(const typinf:PTypeInfo):ONNXTensorElementDataType;
+    //function strcmp(_para1, _para2:POrtChar):longint;cdecl;external 'libc';
+    procedure free(addr:pointer);cdecl;external 'libc';
+    procedure cfree(addr:pointer);cdecl;external 'libc';
+    function malloc(_para1:size_t):pointer;cdecl;external 'libc';
+implementation
+
+
+{$ifdef MEM_TABLE}
+procedure THKHelp.print();
+var i:integer;
+begin
+  for i:= 0 to High(keys) do
+    if assigned(values[i]) then
+      writeln(IntToStr(NativeUInt(keys[i])),' ==> ',IntToStr(values[i]^)) ;
+  writeln('')
+end;
+{$endif}
+function OrtTensorType(const typinf:PTypeInfo):ONNXTensorElementDataType;
+begin
+   if typinf=TypeInfo(single     ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT   ;exit end;
+   if typinf=TypeInfo(Float16_t  ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 ;exit  end;
+   if typinf=TypeInfo(BFloat16_t ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;exit  end;
+   if typinf=TypeInfo(double     ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE  ;exit  end;
+   if typinf=TypeInfo(int8_t     ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8    ;exit  end;
+   if typinf=TypeInfo(int16_t    ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16   ;exit  end;
+   if typinf=TypeInfo(int32_t    ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32   ;exit  end;
+   if typinf=TypeInfo(int64_t    ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64   ;exit  end;
+   if typinf=TypeInfo(uint8_t    ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8   ;exit  end;
+   if typinf=TypeInfo(uint16_t   ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16  ;exit  end;
+   if typinf=TypeInfo(uint32_t   ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32  ;exit  end;
+   if typinf=TypeInfo(uint64_t   ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64  ;exit  end;
+   if typinf=TypeInfo(boolean    ) then begin result := ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL    ;exit  end;
+
+end;
+  { TOrtTensor }
+
+function TORTTensor<T>.Getindex1( x: int64_t): T;
+begin
+  result:=FData[x]
+end;
+
+function TORTTensor<T>.Getindex3( x,y,z: int64_t): T;
+begin
+  result:=FData[idx(x,y,z)]
+end;
+
+function TORTTensor<T>.Getindex2( x,y: int64_t): T;
+begin
+  result:=FData[y*FShape[0]+x]
+end;
+
+function TORTTensor<T>.GetIndex4(x,y,z,w: int64_t): T;
+begin
+  result:=FData[w*FShape[2]*FShape[1]*FShape[0]+z*FShape[1]*FShape[0]+y*FShape[0]+x]
+end;
+
+procedure TORTTensor<T>.Setindex1( x: int64_t; AValue: T);
+begin
+  FData[x]:=AValue
+end;
+
+procedure TORTTensor<T>.Setindex3( x, y, z: int64_t; AValue: T);
+begin
+  FData[z*FShape[1]*FShape[0] + y*FShape[0] + x]:=AValue
+end;
+
+procedure TORTTensor<T>.Setindex2(x,y: int64_t; AValue: T);
+begin
+  FData[y*FShape[0]+x]:=AValue
+end;
+
+procedure TORTTensor<T>.SetIndex4(x,y,z,w: int64_t; AValue: T);
+begin
+  FData[w*FShape[2]*FShape[1]*FShape[0]+z*FShape[1]*FShape[0]+y*FShape[0]+x]:=AValue
+end;
+
+procedure TORTTensor<T>.SetShape( AValue: TArray<int64_t>);
+var i:size_t;
+begin
+  //if FShape=AValue then Exit;
+  if not Assigned(AValue) then exit;
+  FShape:=AValue;
+  FSize:=FShape[0];
+  for i:=1 to High(FShape) do
+    FSize:=FSize*FShape[i];
+end;
+
+function TORTTensor<T>.ElementCount: size_t;
+begin
+  result:=FSize
+end;
+
+function TORTTensor<T>.ByteCount: size_t;
+begin
+  result:=FSize*SizeOf(T)
+end;
+
+function TORTTensor<T>.DimensionCount: size_t;
+begin
+  result:=Length(FShape)
+end;
+
+function TORTTensor<T>.Idx(const x, y, z: Int64_t): int64_t;
+begin
+  result:=z*FShape[1]*FShape[0]+y*FShape[0]+x
+end;
+
+constructor TORTTensor<T>.Create(const AShape: TArray<int64_t>);
+var aData:TArray<T>;
+begin
+  SetShape(aShape);
+  setLength(aData,FSize);
+  FData:=aData
+end;
+
+{$ifdef fpc}
+
+function TORTTensor<T>.ToString(const Separator: ortstring): ortstring;
+var
+  z,y,x: Int64;s,s2:ortstring;
+begin
+  result:='';
+  case Length(FShape) of
+    3: begin
+         for z:=0 to FShape[2]-1 do begin
+           s2:='';
+           for y:=0 to FShape[1]-1 do begin
+             s:='';
+             for x:=0 to FShape[0]-1 do begin
+               s:=s+Separator+Format('%0.2n',[Index3[z,y,x] ])
+             end;
+             delete(s,1,length(LineEnding+Separator));
+             s2:=s2+LineEnding+Separator+'[ '+s+' ]';
+           end;
+           delete(s2,1,length(LineEnding+Separator));
+           result:=result+LineEnding+Separator+'[ '+s2+' ]';
+         end;
+         delete(result,1,length(Separator));
+         result:='[ '+result+' ]';
+       end;
+    2: begin
+         for y:=0 to FShape[1]-1 do begin
+           s:='';
+           for x:=0 to FShape[0]-1 do begin
+             s:=s+Separator+Format('%0.2n',[Index2[y,x] ])
+           end;
+           delete(s,1,length(Separator));
+           result:=result+LineEnding+Separator+'[ '+s+' ]';
+         end;
+         delete(result,1,length(LineEnding+Separator));
+         result:='[ '+result+' ]';
+       end;
+    1: begin
+         for x:=0 to FShape[0]-1 do begin
+           result:=result+Separator+Format('%0.2n',[FData[x] ])
+         end;
+         delete(result,1,length(Separator));
+         result:='[ '+result+' ]';
+       end
+  end;
+end;
+{$endif}
+
+function TORTTensor<T>.ToValue: TORTValue;
+var revShape:TArray<int64_t>;
+begin
+  revShape:=TTools.reverse<int64_t>(FShape);
+  result:=TORTValue.CreateTensor<T>(DefaultAllocator.GetInfo(), FData[0],ElementCount,@revShape[0],DimensionCount);
+end;
+
+class function TORTTensor<T>.FromValue(const val: TORTValue;
+  const copyData: boolean): TORTTensor<T>;
+var Info:TOrtTypeInfo ;
+    Meta:TORTTensorTypeAndShapeInfo;
+    _data:PT;
+begin
+  // the data pointer is owned by the OrtValue and
+ //  will be freed when the OrtValue is released
+
+  try
+    Info:=Val.GetTypeInfo();
+    if Info.GetONNXType<>ONNX_TYPE_TENSOR then
+      OrtException.CreateFmt('Value is not a Tensor %d',[Ord(Info.GetONNXType)]);
+    Meta:=Info.GetTensorTypeAndShapeInfo;
+    if OrtTensorType(TypeInfo(T))<>Meta.GetElementType then
+      OrtException.CreateFmt('Tensor must be of Type [%s]',[ORTTensorTypes[Meta.GetElementType]]);
+    ThrowOnError(GetApi().GetTensorMutableData(val.p_,@_data));
+    if copyData then begin
+      result:=TORTTensor<T>.Create(TTools.reverse<int64_t>(Val.GetTensorShape()));
+      move(_data^,result.Fdata[0],SizeOf(T)*result.FSize);
+    end else begin
+      result.Shape:=TTools.reverse<int64_t>(Val.GetTensorShape());
+      result.FData:=TArray<T>(_data)
+    end;
+
+  except
+  end;
+end;
+
+class operator TORTTensor<T>.Implicit(const aValue:TORTValue): TORTTensor<T>;
+begin
+  result:=TORTTensor<T>.FromValue(aValue)
+end;
+
+class operator TORTTensor<T>.Implicit(const aValue: TORTTensor<T>): TORTValue;
+begin
+  result:=aValue.ToValue
+end;
+
+{$ifndef NO_HASHMAP}
+{ TNameValueListHelper }
+
+function TORTNameValue<TKey,TValue>.GetKeys(idx: size_t): TKey;
+begin
+  result:=inherited Keys.ToArray[idx];
+end;
+
+function TORTNameValue<TKey,TValue>.GetValues(idx: Size_t): TValue;
+begin
+  result:=inherited Values.ToArray[idx];
+end;
+
+{$endif}
+
+class function TTools.BinSearch<T>(const Arr: array of T; const Val: T; R: integer): integer;
+var
+  L, I: Integer;
+  CompareRes: Integer;isFound:boolean;
+begin
+  isFound := false;
+  result:=-1;
+
+  // Use binary search.
+  L := 0;
+  R := R - 1;
+  while (L<=R) do
+  begin
+    I := L + (R - L) shr 1;
+    CompareRes := cmp<T>(Val, Arr[I]);
+    if (CompareRes>0) then
+      L := I+1
+    else begin
+      R := I-1;
+      if (CompareRes=0) then begin
+         isFound := true;
+//         if (Duplicates<>dupAccept) then
+            L := I; // forces end of while loop
+      end;
+    end;
+  end;
+  if isFound then result := L else result:=-L-1;
+end;
+
+
+class function TTools.IfThen<T>(const cond: boolean; const whenTrue, whenFalse: T): T;
+begin
+  if cond then result:=whenTrue else result:=whenFalse
+end;
+
+class function TTools.max<T>(const a, b: T): T;
+begin
+  {$ifdef fpc}
+  if a>=b then result:=a else result:=b
+  {$else}
+  result:=ifthen<T>(TComparer<T>.Default().Compare(a,b)>0,a,b)
+  {$endif}
+end;
+
+class function TTools.min<T>(const a, b: T): T;
+begin
+  {$ifdef fpc}
+  if a<=b then result:=a else result:=b
+  {$else}
+  result:=ifthen<T>(TComparer<T>.Default().Compare(a,b)<0,a,b)
+  {$endif}
+end;
+
+class procedure TTools.QuickSort<T>(var Arr: array of T; L, R : Longint; const Descending:boolean;const Compare:TComparefunc<T>);
+var I,J ,neg :integer;
+    P, Q :T;
+begin
+ //if not Assigned(Compare) then Compare:=@{$ifdef fpc}specialize{$endif}_Compare<T>;
+ neg:=ifthen<integer>(descending,-1,1);
+ repeat
+   I := L;
+   J := R;
+   P := Arr[ (L + R) div 2 ];
+   repeat
+     while neg*Compare(P, Arr[i]) > 0 do
+       I := I + 1;
+     while neg*Compare(P, Arr[J]) < 0 do
+       J := J - 1;
+     If I <= J then
+     begin
+       Q := Arr[I];
+       Arr[I] := Arr[J];
+       Arr[J] := Q;
+       I := I + 1;
+       J := J - 1;
+     end;
+   until I > J;
+   if J - L < R - I then
+   begin
+     if L < J then
+       QuickSort<T>(Arr, L, J, Descending, Compare);
+     L := I;
+   end
+   else
+   begin
+     if I < R then
+       QuickSort<T>(Arr, I, R, Descending, Compare);
+     R := J;
+   end;
+ until L >= R;
+end;
+
+class function TTools.cmp<T>(const a, b: T): integer;
+begin
+  {$ifdef fpc}
+  result:=1;
+  if a<b then result:=-1
+  else if a=b then result:=0
+  {$else}
+  result:=TComparer<T>.Default.Compare(a,b)
+  {$endif}
+end;
+
+class function TTools.reverse<T>(const a: TArray<T>): TArray<T>;
+var i,j:size_t;v:T;
+begin
+  result:=copy(a);
+  i:=0; j:=high(a);
+  while i<j do begin
+    v:=result[i];
+    result[i]:=result[j];
+    result[j]:=v;
+    inc(i);dec(j);
+  end
+end;
+
+{$ifdef NO_HASHMAP}
+{ TOrderedKeyValueList }
+
+class operator TOrderedKeyValueList<TK,TV>.Initialize({$ifdef fpc}outvar{$else}out{$endif} v:TOrderedKeyValueList<TK,TV>);
+begin
+  v.FindKey:=nil// change to TTools.BinSearch<TK> for fast sorted keys
+end;
+
+class operator TOrderedKeyValueList<TK,TV>.Finalize(var dst:TOrderedKeyValueList<TK,TV>);
+begin
+  {$ifdef MEM_DEBUG}writeln('***** [',PTypeInfo(TypeInfo(TOrderedKeyValueList<TK,TV>)).Name ,'] Deleted ******') {$endif}
+end;
+
+function TOrderedKeyValueList<TK,TV>.Count: integer;
+begin
+  result:=Length(Keys)
+end;
+
+procedure TOrderedKeyValueList<TK, TV>.RemoveIndex(const index: integer);
+begin
+  if (index>=0) and (index<Count) then begin
+    Delete(Keys,index,1);
+    Delete(Values,index,1);
+  end;
+end;
+
+procedure TOrderedKeyValueList<TK, TV>.Remove(const key: TK);
+begin
+  RemoveIndex(IndexOfKey(key))
+end;
+
+function TOrderedKeyValueList<TK,TV>.GetValues( key: TK): TV;
+var i:integer;
+begin
+  i:= IndexOfKey(Key);
+  if i>=0 then
+    result:=Values[i]
+end;
+
+procedure TOrderedKeyValueList<TK,TV>.SetValues( key: TK;  AValue: TV);
+var i:integer;
+begin
+  i:=IndexOfKey(Key);
+  if i<0 then
+    begin
+      i:=not i;
+      Insert(key, Keys,i);
+      Insert(AValue,Values,i)
+    end
+  else
+    //begin
+      Values[i]:=AValue
+    //end;
+end;
+
+class function TOrderedKeyValueList<TK, TV>.Create: TOrderedKeyValueList<TK, TV>;
+begin
+  // dummy constructor
+end;
+
+{$POINTERMATH ON}
+
+
+function TOrderedKeyValueList<TK, TV>.TryGetValue(const Key: TK; out Value: TV): boolean;
+var i,j:integer;
+  P,k:PPointer;
+
+begin
+  p:=PPointer(keys);
+  k:=@key;
+  i:=IndexOfKey(Key);
+  {$ifdef MEM_TABLE}
+  write('locating.. ',NativeUInt(k^),' in ');
+  for j := 0 to High(keys) do
+    write(NativeUInt(p[j]),' , ');
+  writeln('');
+  writeln('found in ... ',i);
+  {$endif}
+  result:= i>-1;
+  if result then
+    Value:=Values[i]
+end;
+
+function TOrderedKeyValueList<TK,TV>.ContainsKey(const key: TK): boolean;
+begin
+  result:=IndexOfKey(key)>=0;
+end;
+
+function TOrderedKeyValueList<TK,TV>.IndexOfKey(const Key: TK): integer;
+begin
+  if assigned(FindKey) then begin
+    result:=Findkey(Keys,key,Length(Keys));
+    exit
+  end;
+  for result:=0 to high(Keys) do
+    if TTools.cmp<TK>(Keys[result],key)=0 then exit ;
+  result:=-Length(Keys)-1
+end;
+
+procedure TOrderedKeyValueList<TK, TV>.Add(const Key: TK; const AValue: TV);
+var i:integer;
+begin
+  i:=IndexOfKey(Key);
+  if i<0 then
+    begin
+      i:=-(i+1);
+      Insert(key, Keys,i);
+      Insert(AValue,Values,i)
+    end
+//  else
+//      ValueList[i]:=AValue ;
+end;
+
+function TOrderedKeyValueList<TK, TV>.AddOrSetValue(const Key: TK; const AValue: TV): integer;
+var i:integer;
+begin
+  i:=IndexOfKey(Key);
+  if i<0 then
+    begin
+      i:=-(i+1);
+      Insert(key, Keys,i);
+      Insert(AValue,Values,i)
+    end
+  else
+    //begin
+      Values[i]:=AValue ;
+  result:=i
+    //end;
+end;
+
+{$endif}
+
+{$ifndef NO_SMARTPTR}
+{ TSmartPtr }
+
+procedure TSmartPtr<T>.DecRef;
+begin
+  if assigned(RefCount) then
+    {$ifdef fpc}
+    if InterLockedDecrement(RefCount^)=0 then
+    {$else}
+    if TInterlocked.Decrement(RefCount^)=0 then
+    {$endif}
+    begin
+      Dispose(RefCount);
+      FreeMem(Instance)
+    end;
+end;
+
+class operator TSmartPtr<T>.Initialize({$ifdef fpc}outvar{$else}out{$endif} dst: TSmartPtr<T>);
+begin
+  dst.RefCount := nil;
+end;
+
+class operator TSmartPtr<T>.Finalize(var dst: TSmartPtr<T>);
+begin
+  dst.DecRef();
+end;
+
+{$ifdef fpc}
+class operator TSmartPtr<T>.AddRef(var src: TSmartPtr<T>);
+begin
+  if assigned(src.RefCount) then
+    InterLockedIncrement(src.RefCount^);
+end;
+{$endif}
+
+{$ifdef fpc}
+class operator TSmartPtr<T>.Copy(constref src: TSmartPtr<T>; var dst: TSmartPtr<T>);
+{$else}
+class operator TSmartPtr<T>.Assign(var dst: TSmartPtr<T>;const [ref] src: TSmartPtr<T>);
+{$endif}
+begin
+  if assigned(dst.RefCount) then
+    dst.DecRef();
+  if assigned(src.RefCount) then
+  {$ifdef fpc}
+    InterLockedIncrement(src.RefCount^);
+  {$else}
+  TInterlocked.Increment(src.RefCount^);
+  {$endif}
+  dst.RefCount := src.RefCount;
+  dst.Instance := src.Instance;
+
+end;
+
+class operator TSmartPtr<T>.Implicit(const src: PT): TSmartPtr<T>;
+begin
+  Result.Assign(src);
+end;
+
+//class operator TSmartPtr<T>.Implicit(const src: TSmartPtr<T>): T;
+//begin
+//  Result:=Instance
+//end;
+
+procedure TSmartPtr<T>.Assign(const val: PT);
+begin
+  if RefCount <> nil then
+    DecRef();
+
+  New(RefCount);
+  RefCount^ := 0;
+
+  {$ifdef fpc}
+  InterLockedIncrement(RefCount^);
+  {$else}
+  TInterlocked.Increment(RefCount^);
+  {$endif}
+  Instance := Val;
+end;
+
+//**********************************************************************************
+
+
+{ TSmartPtr }
+
+procedure TSmartPtr<T,P>.DecRef;
+begin
+  if RefCount <> nil then
+    {$ifdef fpc}
+    if InterLockedDecrement(RefCount^)=0 then
+    {$else}
+    if TInterLocked.Decrement(RefCount^)=0 then
+    {$endif}
+    begin
+      Dispose(RefCount);
+//      if Assigned(DisposerFunc) then
+        DisposerFunc.call(Pointer(Instance));
+
+      //else FreeMem(Instance);
+    end;
+end;
+
+constructor TSmartPtr<T,P>.Create(const val:PT;const aDisposer: TORTAllocatedFree);
+begin
+  DisposerFunc:=aDisposer;
+  assign(val)
+end;
+
+class operator TSmartPtr<T,P>.Initialize({$ifdef fpc}outvar{$else}out{$endif} dst: TSmartPtr<T,P>);
+begin
+  dst.RefCount := nil;
+end;
+
+class operator TSmartPtr<T,P>.Finalize(var dst: TSmartPtr<T,P>);
+begin
+  dst.DecRef();
+end;
+{$ifdef fpc}
+class operator TSmartPtr<T,P>.AddRef(var src: TSmartPtr<T,P>);
+begin
+  if assigned(src.RefCount) then
+    InterLockedIncrement(src.RefCount^);
+  //if assigned(dst.RefCount) then
+
+end;
+{$endif}
+
+{$ifdef fpc}
+class operator TSmartPtr<T,P>.Copy(constref src: TSmartPtr<T,P>; var dst: TSmartPtr<T,P>);
+{$else}
+class operator TSmartPtr<T,P>.Assign(var dst: TSmartPtr<T,P>; const [ref] src: TSmartPtr<T,P>);
+{$endif}
+begin
+  if dst.RefCount <> nil then
+    dst.DecRef();
+  if src.RefCount <> nil then
+    {$ifdef fpc}
+    InterLockedIncrement(src.RefCount^);
+    {$else}
+    TInterLocked.Increment(src.RefCount^);
+    {$endif}
+  dst.RefCount := src.RefCount;
+  dst.Instance := src.Instance;
+  //if assigned(dst.RefCount) then
+
+end;
+
+class operator TSmartPtr<T,P>.Implicit(const src: PT): TSmartPtr<T,P>;
+begin
+  Result.Assign(src);
+  //if assigned(dst.RefCount) then
+end;
+
+//class operator TSmartPtr<T, P>.Implicit(const src: TSmartPtr<T, P>): T;
+//begin
+//  result:=Instance
+//end;
+
+procedure TSmartPtr<T,P>.Assign(const val: PT);
+begin
+  if RefCount <> nil then
+    DecRef();
+
+  New(RefCount);
+  RefCount^ := 0;
+
+  {$ifdef fpc}
+  InterLockedIncrement(RefCount^);
+  {$else}
+  TInterLocked.Increment(RefCount^);
+  {$endif}
+  Instance := Val;
+end;
+{$endif}
+
+
+function AllocatorGetMemoryInfo(const Allocator: POrtAllocator): TORTMemoryInfo;
+begin
+  ThrowOnError(GetApi().AllocatorGetInfo(Allocator, @Result.p_))
+end;
+
+procedure ThrowOnError(const ort:POrtApi ; status: POrtStatus);inline; overload;
+var error_message:ortstring;error_code:OrtErrorCode;
+begin
+  if assigned(status) then begin
+     error_message := ortstring(ort.GetErrorMessage(status));
+     error_code := ort.GetErrorCode(status);
+    ort.ReleaseStatus(status);
+{$ifdef ORT_NO_EXCEPTION}
+  Writeln(error_message, error_code);abort
+{$else}
+  raise OrtException.create(error_message, error_code)
+{$endif}
+  end;
+end;
+
+function GetApi:POrtApi;
+begin
+  result:=Api
+end;
+
+{ TORTAllocatedFree }
+
+constructor TORTAllocatedFree.Create(const allocator: POrtAllocator);
+begin
+  allocator_:=allocator
+end;
+
+procedure TORTAllocatedFree.call(var ptr: pointer);
+begin
+  if Assigned(ptr) then allocator_.Free(allocator_,ptr);
+end;
+
+procedure ThrowOnError(status:POrtStatus);inline; overload;
+begin
+  ThrowOnError(Api, status);
+end;
+
+function GetAvailableProviders: TArray<ortstring>;
+var len:longint;providers:PPOrtChar;i:integer;
+begin
+  Api.GetAvailableProviders(@Providers,@len);
+  setLength(result,len);
+  for i:=0 to High(result) do begin
+    result[i]:=ortstring(Providers^);
+    inc(Providers)
+  end;
+end;
+//
+//procedure OrtRelease(ptr: POrtAllocator);
+//begin
+//  GetApi.ReleaseAllocator(ptr);
+//end;
+//
+//procedure OrtRelease(ptr: POrtMemoryInfo);
+//begin
+//  GetApi.ReleaseMemoryInfo(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtCustomOpDomain);
+//begin
+//  GetApi.ReleaseCustomOpDomain(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtEnv);
+//begin
+//  GetApi.ReleaseEnv(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtRunOptions);
+//begin
+//  GetApi.ReleaseRunOptions(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtSession);
+//begin
+//  GetApi.ReleaseSession(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtSessionOptions);
+//begin
+//  GetApi.ReleaseSessionOptions(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtTensorTypeAndShapeInfo);
+//begin
+//  GetApi.ReleaseTensorTypeAndShapeInfo(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtSequenceTypeInfo);
+//begin
+//  GetApi.ReleaseSequenceTypeInfo(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtMapTypeInfo);
+//begin
+//  GetApi.ReleaseMapTypeInfo(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtTypeInfo);
+//begin
+//  GetApi.ReleaseTypeInfo(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtValue);
+//begin
+//  GetApi.ReleaseValue(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtModelMetadata);
+//begin
+//  GetApi.ReleaseModelMetadata(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtThreadingOptions);
+//begin
+//  GetApi.ReleaseThreadingOptions(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtIoBinding);
+//begin
+//  GetApi.ReleaseIoBinding(ptr)
+//end;
+//
+//procedure OrtRelease(ptr: POrtArenaCfg);
+//begin
+//  GetApi.ReleaseArenaCfg(ptr)
+//end;
+
+{ TBase }
+
+procedure TORTBase<T>.NewRef;
+var
+  //RefCount:PLongInt;
+  RefCount:TArray<LongInt>;
+begin
+
+ //New(RefCount);
+ setLength(RefCount,1);
+ {$IFDEF MEM_DEBUG}
+ writeln('New @',IntToHex(UIntPtr(p_)),'[',PTypeInfo(TypeInfo(T)).Name,'] @Count [', intToHex(UIntPtr(RefCount)),']');
+ {$ENDIF}
+ //RefCount^ := 0;
+ RefCount[0] := 0;
+
+ HouseKeeper.AddOrSetValue(p_,RefCount);
+ {$ifdef fpc}
+ //InterLockedIncrement(RefCount^);
+ InterLockedIncrement(RefCount[0]);
+ {$else}
+ //TInterLocked.Increment(RefCount^);
+ TInterLocked.Increment(RefCount[0]);
+ {$endif}
+ {$ifdef MEM_TABLE}writeln(GetTypeName(TypeInfo(T)),sLineBreak,'===== new =====',NativeUInt(p_));housekeeper.print;{$endif}
+end;
+
+procedure TORTBase<T>.Assign(const val: Pointer);
+var
+  //RefCount:PLongInt;
+  RefCount:TArray<LongInt>;
+begin
+  if not HouseKeeper.TryGetValue(p_,RefCount) then RefCount:=nil;
+  if RefCount <> nil then
+    DecRef();
+  p_ := Val;
+  NewRef();
+
+end;
+
+procedure TORTBase<T>.DecRef;
+var
+  //RefCount:PLongInt;
+  RefCount:TArray<LongInt>;
+begin
+  if not HouseKeeper.TryGetValue(p_,RefCount) then RefCount:=nil;
+  {$IFDEF MEM_DEBUG}
+  writeln('disposing @',IntToHex(UIntPtr(p_)),'[',PTypeInfo(TypeInfo(T)).Name,'] @count [',IntToHex(UIntPtr(RefCount)),']') ;
+  {$ENDIF}
+  {$ifdef MEM_TABLE}writeln(GetTypeName(TypeInfo(T)),sLineBreak,'===== Dec =====',NativeUInt(p_));{$endif}
+  if assigned(RefCount) then begin
+    {$IFDEF MEM_DEBUG}
+    writeln('  -----> Decrimenting count [',RefCount^,'] to [',RefCount^-1,']') ;
+    {$ENDIF}
+    {$ifdef fpc}
+    //if InterLockedDecrement(RefCount^)=0 then
+    if InterLockedDecrement(RefCount[0])=0 then
+    {$else}
+    //if TInterLocked.Decrement(RefCount^)=0 then
+    if TInterLocked.Decrement(RefCount[0])=0 then
+    {$endif}
+    begin
+      //Dispose(RefCount);
+      setLength(RefCount,0);
+      RefCount:=nil;
+      HouseKeeper.Remove(p_);
+      OrtRelease;
+      {$IFDEF MEM_DEBUG}writeln('  ---> disposed') ;{$ENDIF}
+    end;
+    {$ifdef MEM_TABLE}housekeeper.print;writeln('');{$endif}
+  end ;
+  {$IFDEF MEM_DEBUG}Writeln('');  {$ENDIF}
+end;
+
+//function TORTBase<T>.RefCount: PLongInt;
+//begin
+//  result:=ReferenceCount(p_);
+//end;
+
+function TORTBase<T>.release: PT;
+var p:PT;
+begin
+  p:=p_;
+  p_:=nil;
+  result:=p
+end;
+
+procedure TORTBase<T>.OrtRelease();
+begin
+  (* Filler Procedure *)
+  if p_=nil then exit;
+  if TypeInfo(T)=TypeInfo(OrtAllocator)                 then begin Api.ReleaseAllocator(p_)             ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtMemoryInfo)                then begin Api.ReleaseMemoryInfo(p_)            ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtCustomOpDomain)            then begin Api.ReleaseCustomOpDomain(p_)        ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtEnv)                       then begin Api.ReleaseEnv(p_)                   ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtRunOptions)                then begin Api.ReleaseRunOptions(p_)            ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtSession)                   then begin Api.ReleaseSession(p_)               ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtSessionOptions)            then begin Api.ReleaseSessionOptions(p_)        ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtTensorTypeAndShapeInfo)    then begin Api.ReleaseTensorTypeAndShapeInfo(p_);  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtSequenceTypeInfo)          then begin Api.ReleaseSequenceTypeInfo(p_)      ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtMapTypeInfo)               then begin Api.ReleaseMapTypeInfo(p_)           ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtTypeInfo)                  then begin Api.ReleaseTypeInfo(p_)              ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtValue)                     then
+  begin
+    Api.ReleaseValue(p_)
+        ;  exit
+  end;
+  if TypeInfo(T)=TypeInfo(OrtModelMetadata)             then begin Api.ReleaseModelMetadata(p_)         ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtIoBinding)                 then begin Api.ReleaseIoBinding(p_)             ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtArenaCfg)                  then begin Api.ReleaseArenaCfg(p_)              ;  exit  end;
+  if TypeInfo(T)=TypeInfo(OrtThreadingOptions)          then begin Api.ReleaseThreadingOptions(p_)      ;  exit  end;
+  //if TypeInfo(T)=TypeInfo(OrtCheckpointState)           then begin Api.ReleaseCheckpointState(p_)       ;  exit  end;
+  //if TypeInfo(T)=TypeInfo(OrtTrainingSession)           then begin Api.ReleaseTrainingSession(p_)       ;  exit  end;
+end;
+
+constructor TORTBase<T>.Create(const v: PT);
+begin
+  p_:=v
+  //Assign(v);
+end;
+
+class operator TORTBase<T>.Initialize({$ifdef fpc}outvar{$else}out{$endif} v: TORTBase<T>);
+var RefCount:PLongInt;
+begin
+  v.p_:=nil;
+  if GetApi=nil then exit;
+  if TypeInfo(T)=TypeInfo(OrtSessionOptions) then begin
+      ThrowOnError(GetApi().CreateSessionOptions(@v.p_));
+      if Assigned(DefaultSessionOptions.p_) then v.NewRef;
+      exit
+  end;
+  if TypeInfo(T)=TypeInfo(OrtRunOptions) then begin
+      ThrowOnError(GetApi().CreateRunOptions(@v.p_));
+      if Assigned(DefaultRunOptions.p_) then v.NewRef;
+      exit
+  end;
+end;
+
+class operator TORTBase<T>.Finalize(var v: TORTBase<T>);
+begin
+  if TypeInfo(T)=TypeInfo(OrtTensorTypeAndShapeInfo) then
+    begin v.release; exit end;    //unowned casted types
+  if TypeInfo(T)=TypeInfo(OrtSequenceTypeInfo) then
+      begin v.release; exit end;
+  if TypeInfo(T)=TypeInfo(OrtMapTypeInfo) then
+      begin v.release; exit end;
+  //if TypeInfo(T)=TypeInfo(OrtMemoryInfo) then
+  //    begin v.release;exit end;
+
+  //if TypeInfo(T)=TypeInfo(OrtTypeInfo) then
+  //    begin v.release;exit end;
+
+  if TypeInfo(T)=TypeInfo(OrtEnv) then
+    if HouseKeeper.ContainsKey(v.p_) and IsConsole then
+      //writeln('Finalize, OrtEnv, RefCount: ', HouseKeeper[v.p_]^);
+      writeln('Finalize, OrtEnv, RefCount: ', HouseKeeper[v.p_][0]);
+  v.DecRef ;
+
+end;
+
+{$ifdef fpc}
+class operator TORTBase<T>.Copy(constref src: TORTBase<T>; var dst: TORTBase<T>);
+{$else}
+class operator TORTBase<T>.Assign(var dst: TORTBase<T>; const [ref] src: TORTBase<T>);
+{$endif}
+var
+  //dRefCount,sRefCount:PLongInt;
+  dRefCount,sRefCount:TArray<LongInt>;
+begin
+  if not HouseKeeper.TryGetValue(dst.p_,dRefCount) then dRefCount:=nil;
+  if not HouseKeeper.TryGetValue(src.p_,sRefCount) then sRefCount:=nil;
+  if assigned(dRefCount) then
+    dst.DecRef();
+  {$IFDEF MEM_DEBUG}
+  writeln('Passing @',IntToHex(UIntPtr(src.p_)),'[',PTypeInfo(TypeInfo(T)).Name,'] @sCount [', intToHex(UIntPtr(sRefCount)),']');
+  writeln('To        @',IntToHex(UIntPtr(dst.p_)),'[',PTypeInfo(TypeInfo(T)).Name,'] @dCount [',intToHex(UIntPtr(dRefCount)),']');
+  {$ENDIF}
+  {$ifdef MEM_TABLE}writeln(GetTypeName(TypeInfo(T)),sLineBreak,'===== asn =====',NativeUInt(src.p_),' , ',NativeUInt(dst.p_));{$endif}
+  if assigned(sRefCount) then begin
+    {$IFDEF MEM_DEBUG}
+    //writeLn('  -----> incrementing sCount[',sRefCount^,'] to [',sRefCount^+1,']');
+    writeLn('  -----> incrementing sCount[',sRefCount[0],'] to [',sRefCount[0]+1,']');
+    {$ENDIF}
+    {$ifdef fpc}
+    //InterLockedIncrement(sRefCount^);
+    InterLockedIncrement(sRefCount[0]);
+    {$else}
+    //TInterLocked.Increment(sRefCount^);
+    TInterLocked.Increment(sRefCount[0]);
+    {$endif}
+//    {$ifdef MEM_TABLE}writeln(GetTypeName(TypeInfo(T)),sLineBreak,'===== asn =====');housekeeper.print;{$endif}
+  end;
+  if Assigned(dst.p_)then begin
+    housekeeper.AddOrSetValue(dst.p_, sRefCount);
+    {$ifdef MEM_TABLE}housekeeper.print;{$endif}
+  end;
+  dst.p_ := src.p_;
+  {$IFDEF MEM_DEBUG}Writeln('');  {$ENDIF}
+ end;
+
+{$ifdef fpc}
+class operator TORTBase<T>.AddRef(var src: TORTBase<T>);
+var
+  //RefCount:PLongInt;
+  RefCount:TArray<LongInt>;
+begin
+  if not HouseKeeper.TryGetValue(src.p_,RefCount) then RefCount:=nil;
+  {$IFDEF MEM_DEBUG}
+  writeln('Adding Ref @',IntToHex(UIntPtr(src.p_)),'[',PTypeInfo(TypeInfo(T)).Name,'] @sCount [', intToHex(UIntPtr(RefCount)),']');
+  {$ENDIF}
+  {$ifdef MEM_TABLE}writeln(GetTypeName(TypeInfo(T)),sLineBreak,'===== new =====');{$endif}
+  if assigned(RefCount) then begin
+    {$IFDEF MEM_DEBUG}Writeln('   -----> Incrementing count [',RefCount^,'] to [',RefCount^+1,']');  {$ENDIF}
+    //InterLockedIncrement(RefCount^);
+    InterLockedIncrement(RefCount[0]);
+    {$IFDEF MEM_DEBUG}
+    writeln('   Added --->  @',IntToHex(UIntPtr(src.p_)),'[',PTypeInfo(TypeInfo(T)).Name,'] sCount [', RefCount^,']');
+    {$ENDIF}
+    {$ifdef MEM_TABLE}housekeeper.print;{$endif}
+  end;
+  //if TypeInfo(T)=TypeInfo(OrtEnv) then
+  //  writeln('AddRef, OrtEnv, RefCount: ', HouseKeeper[src.p_]^);
+  {$IFDEF MEM_DEBUG}Writeln('');  {$ENDIF}
+end;
+{$endif}
+//class operator TORTBase<T>.Implicit(const v: TORTBase<T>): PT;
+//begin
+//  result:=v.p_;
+//end;
+
+{.$PackRecords 1}
+class operator TORTBase<T>.Implicit(const v: PT): TORTBase<T>;
+begin
+  result.Assign(v) ;
+  //if TypeInfo(T)=TypeInfo(OrtEnv) then
+  //  writeln('Implicit, OrtEnv, RefCount: ', HouseKeeper[result.p_]^);
+
+  if not Assigned(v) then
+    raise OrtException.Create(format('Allocation failure: %s',[TTypeInfo(TypeInfo(T)^).name]),ORT_FAIL)
+end;
+
+{.$PackRecords C}
+
+class operator TORTBase<T>.Equal(const a, b: TORTBase<T>): boolean;
+var comp:longint;
+begin
+  if TypeInfo(T)=TypeInfo(OrtMemoryInfo) then begin
+      result:=false;
+      ThrowOnError(GetApi().CompareMemoryInfo(a.p_, b.p_, @comp));
+      result:=comp=0
+  end else
+    result:=CompareMem(@a,@b,SizeOf(a));
+end;
+
+{ TORTIoBindingHelper }
+
+class function TORTIoBindingHelper.IoBinding(var session: TORTSession):TORTIoBinding;
+begin
+  ThrowOnError(GetApi().CreateIoBinding(session.p_, @result.p_));
+  result.NewRef;
+end;
+
+procedure TORTIoBindingHelper.BindInput(const name: POrtChar; const value: TORTValue);
+begin
+  ThrowOnError(GetApi().BindInput(p_, name, value.p_));
+end;
+
+procedure TORTIoBindingHelper.BindOutput(const name: POrtChar; const value: TORTValue);
+begin
+  ThrowOnError(GetApi().BindOutput(p_, name, value.p_));
+end;
+
+procedure TORTIoBindingHelper.BindOutput(const name: POrtChar; const mem_info: TORTMemoryInfo);
+begin
+  ThrowOnError(GetApi().BindOutputToDevice(p_, name, mem_info.p_));
+end;
+
+function TORTIoBindingHelper.GetOutputNames: TArray<ortstring>;
+var allocator:TORTAllocatorWithDefaultOptions;
+begin
+  result := GetOutputNamesHelper(allocator.p_);
+end;
+
+function TORTIoBindingHelper.GetOutputNames(var alloc: TORTAllocator): TArray<ortstring>;
+begin
+  result := GetOutputNamesHelper(alloc.p_);
+end;
+
+function TORTIoBindingHelper.GetOutputValues: TArray<TORTValue>;
+var allocator: TORTAllocatorWithDefaultOptions;
+begin
+  result:= GetOutputValuesHelper(allocator.p_);
+end;
+
+function TORTIoBindingHelper.GetOutputValues(var alloc: TORTAllocator): TArray<TORTValue>;
+begin
+  result:= GetOutputValuesHelper(alloc.p_);
+end;
+
+procedure TORTIoBindingHelper.ClearBoundInputs;
+begin
+  GetApi().ClearBoundInputs(p_);
+end;
+
+procedure TORTIoBindingHelper.ClearBoundOutputs;
+begin
+  GetApi().ClearBoundOutputs(p_);
+end;
+
+procedure TORTIoBindingHelper.SynchronizeInputs;
+begin
+  ThrowOnError(GetApi().SynchronizeBoundInputs(p_));
+end;
+
+procedure TORTIoBindingHelper.SynchronizeOutputs;
+begin
+  ThrowOnError(GetApi().SynchronizeBoundOutputs(p_));
+end;
+
+function TORTIoBindingHelper.GetOutputNamesHelper(allocator: POrtAllocator): TArray<ortstring>;
+var count,i,sz:size_t;buffer:POrtChar;lengths:Psize_t;
+  {$ifndef NO_SMARTPTR}
+  free_fn:TORTAllocatedFree;
+  buffer_g:TSmartPtr<OrtChar,TORTAllocatedFree>;lengths_g:TSmartPtr<size_t,TORTAllocatedFree>;
+  {$endif}
+begin
+  {$ifndef NO_SMARTPTR}free_fn.allocator_:=allocator; {$endif}
+
+  ThrowOnError(GetApi().GetBoundOutputNames(p_, allocator, @buffer, @lengths, @count));
+  {$ifndef NO_SMARTPTR}
+  buffer_g.DisposerFunc:=free_fn;
+  buffer_g:=@buffer;
+  lengths_g.DisposerFunc:=free_fn;
+  lengths_g:=@lengths;
+  {$endif}
+  if count = 0 then exit;
+  setLength(result,count);
+  for i := 0 to high(result)do begin
+    sz := lengths^;
+    result[i]:=copy(ortstring(buffer),0,sz);
+    inc(lengths);
+    inc(buffer, sz);
+  end;
+end;
+
+function TORTIoBindingHelper.GetOutputValuesHelper(allocator: POrtAllocator): TArray<TORTValue>;
+var output_count,i:size_t;output_buffer:PPOrtValue;
+  {$ifndef NO_SMARTPTR}
+  free_fn:TORTAllocatedFree;
+  buffer_g:TSmartPtr<POrtValue,TORTAllocatedFree>;
+  {$endif}
+begin
+  // Lambda to release the buffer when no longer needed and
+  // make sure that we destroy all instances on exception
+  {$ifndef NO_SMARTPTR}
+  free_fn.allocator_:=allocator;
+  buffer_g.DisposerFunc:=free_fn;
+  {$endif}
+  ThrowOnError(GetApi().GetBoundOutputValues(p_, allocator, @output_buffer, @output_count));
+  if output_count=0 then exit;
+  {$ifndef NO_SMARTPTR}
+  buffer_g:=@output_buffer;
+  {$endif}
+  setLength(result,output_count);
+  for i := 0 to high(result) do begin
+    result[i]:=pointer(output_buffer^); // OrtValue will be released on Finalization operator implemented by TBase<>
+    inc(output_buffer)
+  end;
+  allocator.free(allocator,output_buffer)
+
+end;
+
+{ TORTArenaCfgHelper }
+
+class function TORTArenaCfgHelper.ArenaCfg(max_mem: size_t;
+  arena_extend_strategy: longint; initial_chunk_size_bytes: longint;
+  max_dead_bytes_per_chunk: longint):TORTArenaCfg;
+begin
+  ThrowOnError(GetApi().CreateArenaCfg(max_mem, arena_extend_strategy, initial_chunk_size_bytes, max_dead_bytes_per_chunk, @result.p_));
+  result.NewRef;
+end;
+
+{ TORTAllocatorHelper }
+
+class function TORTAllocatorHelper.Create(const session: TORTSession; const mem_info: TORTMemoryInfo):TORTAllocator;
+begin
+  ThrowOnError(GetApi().CreateAllocator(session.p_, mem_info.p_, @result.p_));
+  result.NewRef();
+end;
+
+function TORTAllocatorHelper.Alloc(const size: size_t): pointer;
+begin
+  ThrowOnError(GetApi().AllocatorAlloc(p_, size, @result));
+end;
+
+function TORTAllocatorHelper.GetAllocation(size: size_t): TORTMemoryAllocation;
+var _out:pointer;
+begin
+  ThrowOnError(GetApi().AllocatorAlloc(p_, size, @_out));
+  result:=TORTMemoryAllocation.Create(p_, _out, size);
+end;
+
+procedure TORTAllocatorHelper.Free(p: pointer);
+begin
+  ThrowOnError(GetApi().AllocatorFree(p_, p));
+end;
+
+function TORTAllocatorHelper.GetMemoryInfo: TORTMemoryInfo;
+//var _out:POrtMemoryInfo;
+begin
+  ThrowOnError(GetApi().AllocatorGetInfo(p_, @result));
+  //result:= _out;
+end;
+
+function TORTAllocatorHelper.GetInfo: POrtMemoryInfo;
+begin
+  ThrowOnError(GetApi().AllocatorGetInfo(p_,@result))
+end;
+
+{ TORTMemoryInfoHelper }
+
+class function TORTMemoryInfoHelper.CreateCpu(_type: OrtAllocatorType;
+  mem_type: OrtMemType):TORTMemoryInfo;
+begin
+  ThrowOnError(GetApi().CreateCpuMemoryInfo(_type, mem_type, @result.p_));
+end;
+
+class function TORTMemoryInfoHelper.Create(const name: POrtChar;
+  _type: OrtAllocatorType; id: longint; mem_type: OrtMemType):TORTMemoryInfo;
+begin
+  ThrowOnError(GetApi().CreateMemoryInfo(name, _type, id, mem_type, @result.p_));
+end;
+
+function TORTMemoryInfoHelper.GetAllocatorName: ortstring;
+var name:POrtChar;
+begin
+  ThrowOnError(GetApi().MemoryInfoGetName(p_, @name));
+  result:=ortstring(name)
+end;
+
+function TORTMemoryInfoHelper.GetAllocatorType: OrtAllocatorType;
+begin
+  ThrowOnError(GetApi().MemoryInfoGetType(p_, @result));
+end;
+
+function TORTMemoryInfoHelper.GetDeviceId: longint;
+begin
+  ThrowOnError(GetApi().MemoryInfoGetId(p_, @result));
+end;
+
+function TORTMemoryInfoHelper.GetMemoryType: OrtMemType;
+begin
+  ThrowOnError(GetApi().MemoryInfoGetMemType(p_, @result));
+end;
+
+function TORTMemoryInfoHelper.GetDeviceType():OrtMemoryInfoDeviceType;
+begin
+  GetApi().MemoryInfoGetDeviceType(p_, @result);
+end;
+
+function TORTMemoryInfoHelper.Equal(const other: TORTMemoryInfo): boolean;
+var comp_result:longint;
+begin
+  ThrowOnError(GetApi().CompareMemoryInfo( self.p_, other.p_, @comp_result));
+  result:= comp_result = 0;
+end;
+
+{ TORTValueHelper }
+
+class function TORTValueHelper.CreateTensor(const info: POrtMemoryInfo;
+  p_data: pointer; p_data_byte_count: size_t; const shape: Pint64_t;
+  shape_len: size_t; _type: ONNXTensorElementDataType):TORTValue;
+begin
+  ThrowOnError(GetApi().CreateTensorWithDataAsOrtValue(info, p_data, p_data_byte_count, shape, shape_len, _type, @result.p_));
+  result.NewRef();
+end;
+
+class function TORTValueHelper.CreateTensor(allocator: POrtAllocator;
+  const shape: Pint64_t; shape_len: size_t; _type: ONNXTensorElementDataType):TORTValue;
+begin
+  ThrowOnError(GetApi().CreateTensorAsOrtValue(allocator, shape, shape_len, _type, @result.p_));
+  result.NewRef();
+end;
+
+class function TORTValueHelper.CreateMap(var keys: TORTValue; var values: TORTValue):TORTValue;
+var inputs:array [0..1] of POrtValue;
+begin
+  inputs[0]:=keys.p_;inputs[1]:=values.p_;
+  ThrowOnError(GetApi().CreateValue(@inputs[0], 2, ONNX_TYPE_MAP, @result.p_));
+  result.NewRef;
+end;
+
+class function TORTValueHelper.CreateSequence(var values: TArray<TORTValue>):TORTValue;
+begin
+  ThrowOnError(GetApi().CreateValue(@values[0], length(values), ONNX_TYPE_SEQUENCE, @result.p_));
+  result.NewRef();
+end;
+
+function TORTValueHelper.IsTensor: boolean;
+begin
+  ThrowOnError(GetApi().IsTensor(p_, @result));
+end;
+
+function TORTValueHelper.HasValue: boolean;
+begin
+  ThrowOnError(GetApi().HasValue(p_, @result));
+end;
+
+// for non tensor types  Only ( will return 2 case of a map ,  Count of sequences in case of sequence)
+function TORTValueHelper.GetCount: size_t;
+begin
+  ThrowOnError(GetApi().GetValueCount(p_, @result));
+end;
+
+// for non tensor types  Only ( index is 0 or 1 in case of a map , 0 to N in case of sequence)
+function TORTValueHelper.GetValue(index: longint; allocator: POrtAllocator): TORTValue;
+begin
+  ThrowOnError(GetApi().GetValue(p_, index, allocator, @result.p_));
+  result.NewRef;
+end;
+
+function TORTValueHelper.GetStringTensorDataLength: size_t;
+begin
+  ThrowOnError(GetApi().GetStringTensorDataLength(p_, @result));
+end;
+
+procedure TORTValueHelper.GetStringTensorContent(buffer: Pointer;
+  buffer_length: size_t; offsets: Psize_t; offsets_count: size_t);
+begin
+  ThrowOnError(GetApi().GetStringTensorContent(p_, buffer, buffer_length, offsets, offsets_count));
+end;
+
+function TORTValueHelper.GetTypeInfo: TOrtTypeInfo;
+begin
+  ThrowOnError(GetApi().GetTypeInfo(p_, @result.p_));
+end;
+
+function TORTValueHelper.GetTensorTypeAndShapeInfo: TORTTensorTypeAndShapeInfo;
+begin
+  ThrowOnError(GetApi().GetTensorTypeAndShape(p_, @result.p_));
+end;
+
+function TORTValueHelper.GetStringTensorElementLength(element_index: size_t): size_t;
+begin
+  ThrowOnError(GetApi().GetStringTensorElementLength(p_, element_index, @result));
+end;
+
+procedure TORTValueHelper.GetStringTensorElement(buffer_length: size_t;
+  element_index: size_t; buffer: pointer);
+begin
+  ThrowOnError(GetApi().GetStringTensorElement(p_, buffer_length, element_index, buffer));
+end;
+
+procedure TORTValueHelper.FillStringTensor(const s: PPOrtChar; s_len: size_t);
+begin
+  ThrowOnError(GetApi().FillStringTensor(p_, s, s_len));
+end;
+
+procedure TORTValueHelper.FillStringTensorElement(const s: POrtChar; index: size_t);
+begin
+  ThrowOnError(GetApi().FillStringTensorElement(p_, s, index));
+end;
+{$ifndef DISABLE_SPARSE_TENSORS}
+class function TORTValueHelper.CreateSparseTensor(const info: POrtMemoryInfo;
+  p_data: pointer; const dense_shape: TShape; const values_shape: TShape;
+  _type: ONNXTensorElementDataType):TORTValue;
+begin
+  ThrowOnError(GetApi().CreateSparseTensorWithValuesAsOrtValue(info, p_data, dense_shape.shape, dense_shape.shape_len,
+                                                               values_shape.shape, values_shape.shape_len, _type, @result.p_));
+  result.NewRef();
+end;
+
+procedure TORTValueHelper.UseCooIndices(indices_data: Pint64_t; indices_num: size_t);
+begin
+  ThrowOnError(GetApi().UseCooIndices(p_, indices_data, indices_num));
+end;
+
+procedure TORTValueHelper.UseCsrIndices(inner_data: Pint64_t; inner_num: size_t;
+  outer_data: Pint64_t; outer_num: size_t);
+begin
+  ThrowOnError(GetApi().UseCsrIndices(p_, inner_data, inner_num, outer_data, outer_num));
+end;
+
+procedure TORTValueHelper.UseBlockSparseIndices(const indices_shape: TShape;
+  indices_data: Pint32_t);
+begin
+  ThrowOnError(GetApi().UseBlockSparseIndices(p_, indices_shape.shape, indices_shape.shape_len, indices_data));
+end;
+
+class function TORTValueHelper.CreateSparseTensor(allocator: POrtAllocator;
+  const dense_shape: TShape; _type: ONNXTensorElementDataType):TORTValue;
+begin
+  ThrowOnError(GetApi().CreateSparseTensorAsOrtValue(allocator, dense_shape.shape, dense_shape.shape_len, _type, result.p_));
+  result.NewRef();
+end;
+
+procedure TORTValueHelper.FillSparseTensorCoo(const data_mem_info: POrtMemoryInfo;
+  const values_param: TOrtSparseValuesParam; const indices_data: Pint64_t;
+  indices_num: size_t);
+begin
+  ThrowOnError(GetApi().FillSparseTensorCoo(p_, data_mem_info, values_param.values_shape,
+                                            values_param.values_shape_len, values_param.data.p_data,
+                                            indices_data, indices_num));
+end;
+
+procedure TORTValueHelper.FillSparseTensorCsr(const data_mem_info: POrtMemoryInfo;
+  const values: TOrtSparseValuesParam; const inner_indices_data: PInt64_t;
+  inner_indices_num: size_t; const outer_indices_data: PInt64_t;
+  outer_indices_num: size_t);
+begin
+  ThrowOnError(GetApi().FillSparseTensorCsr(p_, data_mem_info, values.values_shape, values.values_shape_len, values.data.p_data,
+                                            inner_indices_data, inner_indices_num,
+                                            outer_indices_data, outer_indices_num));
+end;
+
+procedure TORTValueHelper.FillSparseTensorBlockSparse(
+  const data_mem_info: POrtMemoryInfo; const values: TOrtSparseValuesParam;
+  const indices_shape: TShape; const indices_data: Pint32_t);
+begin
+  ThrowOnError(GetApi().FillSparseTensorBlockSparse(p_, data_mem_info, values.values_shape, values.values_shape_len, values.data.p_data,
+                                                    indices_shape.shape, indices_shape.shape_len,
+                                                    indices_data));
+end;
+
+function TORTValueHelper.GetSparseFormat: OrtSparseFormat;
+begin
+  ThrowOnError(GetApi().GetSparseTensorFormat(p_, @result));
+end;
+
+function TORTValueHelper.GetSparseTensorValuesTypeAndShapeInfo: TORTTensorTypeAndShapeInfo;
+begin
+  ThrowOnError(GetApi().GetSparseTensorValuesTypeAndShape(p_, @result));
+end;
+
+function TORTValueHelper.GetSparseTensorIndicesTypeShapeInfo(
+  indices_format: OrtSparseIndicesFormat): TORTTensorTypeAndShapeInfo;
+begin
+  ThrowOnError(GetApi().GetSparseTensorIndicesTypeShape(p_, indices_format, @result));
+end;
+
+function TORTValueHelper.IsSparseTensor: boolean;
+begin
+  ThrowOnError(GetApi().IsSparseTensor(p_, @result))
+end;
+
+class function TORTValueHelper.CreateSparseTensor<T>(const info: POrtMemoryInfo;
+  var p_data: T; const dense_shape: TShape; const values_shape: TShape): TORTValue;
+begin
+  result:= TORTValue.CreateSparseTensor(info, @p_data, dense_shape, values_shape, OrtTensorType(TypeInfo(T)));
+end;
+
+class function TORTValueHelper.CreateSparseTensor<T>(allocator: POrtAllocator; const dense_shape: TShape): TORTValue;
+begin
+  result:=TORTValue.CreateSparseTensor(allocator, dense_shape, OrtTensorType(TypeInfo(T)));
+end;
+
+function TORTValueHelper.GetSparseTensorIndicesData<PT>(
+  indices_format: OrtSparseIndicesFormat; var num_indices: size_t): PT;
+begin
+  ThrowOnError(GetApi().GetSparseTensorIndices(p_, indices_format, @num_indices, @result));
+end;
+
+function TORTValueHelper.GetSparseTensorValues<PT>: PT;
+begin
+  ThrowOnError(GetApi().GetSparseTensorValues(p_, @result))
+end;
+{$endif}
+class function TORTValueHelper.CreateTensor<T>(const info: POrtMemoryInfo;
+  var p_data: T; p_data_element_count: size_t; const shape: Pint64_t;
+  shape_len: size_t): TORTValue;
+begin     // no need for NewRef here the constructor will create one ?!
+  result:=TORTValue.CreateTensor(info, @p_data, p_data_element_count * sizeof(PT), shape, shape_len, OrtTensorType(TypeInfo(T)));
+end;
+
+class function TORTValueHelper.CreateTensor<T>(allocator: POrtAllocator;
+  const shape: Pint64_t; shape_len: size_t): TORTValue;
+begin     // no need for NewRef here the constructor will create one ?!
+  result:= TORTValue.CreateTensor(allocator, shape, shape_len, OrtTensorType(TypeInfo(T)));
+end;
+
+class function TORTValueHelper.CreateOpaque<T>(const domain: POrtChar;
+  const type_name: POrtChar; const data_container: T): TORTValue;
+begin
+  ThrowOnError(GetApi().CreateOpaqueValue(domain, type_name, @data_container, sizeof(T), @result));
+  result.NewRef
+end;
+
+procedure TORTValueHelper.GetOpaqueData<T>(const domain: POrtChar;
+  const type_name: POrtChar; var _out: T);
+begin
+  ThrowOnError(GetApi().GetOpaqueValue(domain, type_name, p_, @_out, sizeof(T)));
+end;
+
+function TORTValueHelper.GetTensorMutableData<T>: Pointer;
+begin
+  ThrowOnError(GetApi().GetTensorMutableData(p_,@result));
+end;
+
+function TORTValueHelper.GetTensorData<T>: Pointer;
+begin
+  ThrowOnError(GetApi().GetTensorMutableData(p_, @result));
+end;
+
+function TORTValueHelper.GetTensorShape: TArray<int64_t>;
+begin
+  result:=GetTensorTypeAndShapeInfo().GetShape();
+end;
+
+function TORTValueHelper.GetTensorType: ONNXTensorElementDataType;
+begin
+ result:=GetTensorTypeAndShapeInfo().GetElementType();
+end;
+
+function TORTValueHelper.At<T>(const location: TArray<int64_t>): T;
+type  PT=^T;
+var _out:PT;
+begin
+  // must not be a string
+  ThrowOnError(GetApi().TensorAt(p_, @location[0], length(location), @_out));
+  result:=_out^
+end;
+
+{ TOrtTypeInfoHelper }
+
+function TOrtTypeInfoHelper.GetTensorTypeAndShapeInfo: TORTTensorTypeAndShapeInfo;
+begin
+  ThrowOnError(GetApi().CastTypeInfoToTensorInfo(p_, @result));
+end;
+
+function TOrtTypeInfoHelper.GetSequenceTypeInfo: TORTSequenceTypeInfo;
+begin
+  ThrowOnError(GetApi().CastTypeInfoToSequenceTypeInfo(p_, @result));
+end;
+
+function TOrtTypeInfoHelper.GetMapTypeInfo: TORTMapTypeInfo;
+begin
+  ThrowOnError(GetApi().CastTypeInfoToMapTypeInfo(p_, @result));
+end;
+
+function TOrtTypeInfoHelper.GetONNXType: ONNXType;
+begin
+  ThrowOnError(GetApi().GetOnnxTypeFromTypeInfo(p_, @result));
+end;
+
+{ TORTMapTypeInfoHelper }
+
+function TORTMapTypeInfoHelper.GetMapKeyType: ONNXTensorElementDataType;
+begin
+  ThrowOnError(GetApi().GetMapKeyType(p_, @result));
+end;
+
+function TORTMapTypeInfoHelper.GetMapValueType: TORTTypeInfo;
+begin
+  ThrowOnError(GetApi().GetMapValueType(p_, @result));
+end;
+
+{ TORTSequenceTypeInfoHelper }
+
+function TORTSequenceTypeInfoHelper.GetSequenceElementType: TORTTypeInfo;
+begin
+  ThrowOnError(GetApi().GetSequenceElementType(p_, @result));
+end;
+
+{ TORTTensorTypeAndShapeInfoHelper }
+
+function TORTTensorTypeAndShapeInfoHelper.GetElementType: ONNXTensorElementDataType;
+begin
+  ThrowOnError(GetApi().GetTensorElementType(p_, @result));
+end;
+
+function TORTTensorTypeAndShapeInfoHelper.GetElementCount: size_t;
+begin
+  ThrowOnError(GetApi().GetTensorShapeElementCount(p_, @result));
+end;
+
+function TORTTensorTypeAndShapeInfoHelper.GetDimensionsCount: size_t;
+begin
+  ThrowOnError(GetApi().GetDimensionsCount(p_, @result));
+end;
+
+procedure TORTTensorTypeAndShapeInfoHelper.GetDimensions(values: PInt64_t;values_count: size_t);
+begin
+  ThrowOnError(GetApi().GetDimensions(p_, values, values_count));
+end;
+// below propably needs an allocation before calling? what is the count size needed??
+procedure TORTTensorTypeAndShapeInfoHelper.GetSymbolicDimensions(
+  const values: PPOrtChar; values_count: size_t);
+begin
+  ThrowOnError(GetApi().GetSymbolicDimensions(p_, values, values_count));
+end;
+
+function TORTTensorTypeAndShapeInfoHelper.GetSymbolicDimensions(const values_count:size_t): TArray<ortstring>;
+var i:size_t;strs:PPOrtChar;
+begin
+  GetSymbolicDimensions(strs,values_count);
+  setLength(result,values_count);
+  for i:=0 to High(result) do begin
+    result[i]:=ortstring(strs^);
+    inc(strs)
+  end;
+end;
+
+function TORTTensorTypeAndShapeInfoHelper.GetShape: TArray<int64_t>;
+begin
+  setLength(result,GetDimensionsCount());
+  GetDimensions(@result[0], length(result));
+end;
+
+{ TSessionHelper }
+
+class function TORTSessionHelper.Create(const env: TORTEnv;
+  const model_path: PORTCHAR_T; const options: TORTSessionOptions):TORTSession;
+begin
+  ThrowOnError(GetApi().CreateSession(env.p_, model_path, options.p_, @result.p_));
+  result.NewRef;
+end;
+
+class function TORTSessionHelper.Create(const env: TORTEnv;
+  const model_path: PORTCHAR_T; const options: TORTSessionOptions;
+  prepacked_weights_container: POrtPrepackedWeightsContainer):TORTSession;
+begin
+  ThrowOnError(GetApi().CreateSessionWithPrepackedWeightsContainer(env.p_, model_path, options.p_, prepacked_weights_container, @result.p_));
+  result.NewRef;
+end;
+
+class function TORTSessionHelper.Create(const env: TORTEnv; const model_data: Pointer;
+  model_data_length: size_t; const options: TORTSessionOptions):TORTSession;
+begin
+  ThrowOnError(GetApi().CreateSessionFromArray(env.p_, model_data, model_data_length, options.p_, @result.p_));
+  result.NewRef;
+end;
+
+class function TORTSessionHelper.Create(const env: TORTEnv; const model_data: Pointer;
+  model_data_length: size_t; const options: TORTSessionOptions;
+  prepacked_weights_container: POrtPrepackedWeightsContainer):TORTSession;
+begin
+  ThrowOnError(GetApi().CreateSessionFromArrayWithPrepackedWeightsContainer(env.p_, model_data, model_data_length, options.p_,
+                                                                            prepacked_weights_container, @result.p_));
+  result.NewRef;
+end;
+
+class function TORTSessionHelper.Create(const model_path: TFileName):TORTSession;
+{$ifdef MSWINDOWS}
+var _path:widestring;
+begin
+  _path:=model_path;   // ORTCHAR_T is wchar_t on Windows
+  ThrowOnError(GetApi().CreateSession(DefaultEnv.p_, PORTCHAR_T(_path), DefaultSessionOptions.p_, @result.p_));
+{$else}
+var _path:ansistring;
+begin
+  _path:=ansistring(model_path);  // ORTCHAR_T is char (UTF-8) on POSIX
+  ThrowOnError(GetApi().CreateSession(DefaultEnv.p_, PORTCHAR_T(PAnsiChar(_path)), DefaultSessionOptions.p_, @result.p_));
+{$endif}
+  result.NewRef;
+end;
+
+function Join(const arr:array of int64_t; const Delimiter:ortstring=', '):ortstring;  overload;
+var i:integer;
+begin
+  result:='';
+  for i:=0 to high(arr) do
+    result:=result+Delimiter+IntToStr(arr[i]);
+  if length(result)>0 then
+    delete(result,1,length(Delimiter))
+end;
+
+function TORTSessionHelper.run(const run_options: TORTRunOptions; const Inputs: TORTNameValueList): TORTNameValueList;
+begin
+  Run(run_options,Inputs,DefaultAllocator)
+end;
+
+function TORTSessionHelper.run(const run_options: TORTRunOptions; const Inputs: TORTNameValueList; const Allocator: TOrtAllocator): TORTNameValueList;
+var
+  InputNames:TArray<ortstring>;
+  InputValues:TArray<TORTValue>;
+  OutputNames:TArray<ortstring>;
+  OutputValues:TArray<TORTValue>;
+  i:size_t;
+begin
+  Assert(assigned(p_),'no model is loaded!, invoke [TORTSession.Create(modelPath)] 1st.');
+  setLength(InputNames,GetInputCount());
+  setLength(InputValues,length(InputNames));
+  setLength(OutputNames,GetOutputCount());
+  setLength(OutputValues,length(OutputNames));
+  for i:=0 to high(InputNames) do begin
+    InputNames[i]:=ortstring(GetInputNameAllocated(i,Allocator){$ifndef NO_SMARTPTR}.Instance{$endif});
+    InputValues[i]:=Inputs[ortstring(InputNames[i])];
+  end;
+  for i:=0 to High(OutputNames) do begin
+    OutputNames[i]:=ortstring(GetOutputNameAllocated(i,Allocator){$ifndef NO_SMARTPTR}.Instance{$endif});
+  end;
+  Run(run_options,@InputNames[0],@InputValues[0],length(InputNames),
+                  @OutputNames[0],@OutputValues[0],Length(OutputNames));
+  {$ifndef NO_HASHMAP}result:=TNameValueList.Create;{$endif}
+  for i:=0 to High(OutputNames) do begin
+    OutputValues[i].NewRef;  // make sure a reference is created to enforce freeing out of scope housekeeping
+    result.AddOrSetValue(OutputNames[i],OutputValues[i]);
+  end;
+
+end;
+
+function TORTSessionHelper.Run(const run_options: TORTRunOptions;
+  const input_names: PPOrtChar; const input_values: PORTValue; input_count: size_t;
+  const output_names: PPOrtChar; output_names_count: size_t): TArray<TORTValue>;
+var i:size_t;
+begin
+  setLength(result,output_names_count);
+  Run(run_options, input_names, input_values, input_count,
+                  output_names, @result[0], output_names_count);
+  for i := 0 to output_names_count-1 do
+    result[i].NewRef;// create reference for housekeeping
+
+end;
+
+function TORTSessionHelper.Run(const Inputs: TORTNameValueList): TORTNameValueList;
+begin
+  result:=Run(DefaultRunOptions, Inputs, DefaultAllocator)
+end;
+
+procedure TORTSessionHelper.Run(const run_options: TORTRunOptions;
+  const input_names: PPOrtChar; const input_values: PORTValue; input_count: size_t;
+  const output_names: PPOrtChar; output_values: PORTValue; output_count: size_t);
+begin
+  Assert(assigned(p_),'no model is loaded!, invoke [TORTSession.Create(modelPath)] 1st.');
+  {$if SizeOf(TORTValue)<>SizeOf(POrtValue)}
+    {$error Value is really just an array of OrtValue* in memory, so we can reinterpret_cast safely}
+  {$endif}
+  //assert(sizeof(TORTValue) = sizeof(POrtValue), 'Value is really just an array of OrtValue* in memory, so we can reinterpret_cast safely');
+  //auto ort_input_values = reinterpret_cast<const OrtValue**>(const_cast<Value*>(input_values));
+  //auto ort_output_values = reinterpret_cast<OrtValue**>(output_values);
+  ThrowOnError(GetApi().Run(p_, run_options.p_, input_names, @input_values^, input_count, output_names, output_count, @output_values^));
+end;
+
+procedure TORTSessionHelper.Run(const run_options: TORTRunOptions;  const io_binding: TORTIoBinding);
+begin
+  ThrowOnError(GetApi().RunWithBinding(p_, run_options.p_, io_binding.p_));
+end;
+
+function TORTSessionHelper.GetInputCount: size_t;
+begin
+  ThrowOnError(GetApi().SessionGetInputCount(p_, @result));
+end;
+
+function TORTSessionHelper.GetOutputCount: size_t;
+begin
+  ThrowOnError(GetApi().SessionGetOutputCount(p_, @result));
+end;
+
+function TORTSessionHelper.GetOverridableInitializerCount: size_t;
+begin
+  ThrowOnError(GetApi().SessionGetOverridableInitializerCount(p_, @result));
+end;
+
+function TORTSessionHelper.GetInputNameAllocated(index: size_t;
+  const allocator: TOrtAllocator): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().SessionGetInputName(p_, index, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(allocator,_out);{$endif}
+end;
+
+function TORTSessionHelper.GetOutputNameAllocated(index: size_t;
+  const allocator: TOrtAllocator): AllocatedStringPtr;
+var  _out:POrtChar;
+begin
+  ThrowOnError(GetApi().SessionGetOutputName(p_, index, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(allocator,_out);{$endif}
+end;
+
+function TORTSessionHelper.GetOverridableInitializerNameAllocated(index: size_t;
+  allocator: TOrtAllocator): AllocatedStringPtr;
+var  _out:POrtChar;
+begin
+  ThrowOnError(GetApi().SessionGetOverridableInitializerName(p_, index, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(allocator,_out);{$endif}
+end;
+
+function TORTSessionHelper.EndProfilingAllocated(allocator: TOrtAllocator
+  ): AllocatedStringPtr;
+var  _out:POrtChar;
+begin
+  ThrowOnError(GetApi().SessionEndProfiling(p_, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(allocator,_out);{$endif}
+end;
+
+function TORTSessionHelper.GetProfilingStartTimeNs: uint64_t;
+begin
+  ThrowOnError(GetApi().SessionGetProfilingStartTimeNs(p_, @result));
+end;
+
+function TORTSessionHelper.GetModelMetadata: TORTModelMetadata;
+begin
+  ThrowOnError(GetApi().SessionGetModelMetadata(p_, @result.p_));
+  result.NewRef;
+end;
+
+function TORTSessionHelper.GetInputTypeInfo(index: size_t): TOrtTypeInfo;
+begin
+  ThrowOnError(GetApi().SessionGetInputTypeInfo(p_, index, @result.p_)) ;
+end;
+
+function TORTSessionHelper.GetOutputTypeInfo(index: size_t): TOrtTypeInfo;
+begin
+  ThrowOnError(GetApi().SessionGetOutputTypeInfo(p_, index, @result.p_));
+end;
+
+function TORTSessionHelper.GetOverridableInitializerTypeInfo(index: size_t ): TOrtTypeInfo;
+begin
+  ThrowOnError(GetApi().SessionGetOverridableInitializerTypeInfo(p_, index, @result.p_));
+end;
+
+{ TORTModelMetadataHelper }
+
+function TORTModelMetadataHelper.GetProducerNameAllocated(allocator: TOrtAllocator
+  ): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetProducerName(p_, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(Allocator,_out);{$endif}
+end;
+
+function TORTModelMetadataHelper.GetGraphNameAllocated(allocator: TOrtAllocator
+  ): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetGraphName(p_, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(Allocator,_out);{$endif}
+end;
+
+function TORTModelMetadataHelper.GetDomainAllocated(allocator: TOrtAllocator
+  ): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetDomain(p_, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(Allocator,_out);{$endif}
+end;
+
+function TORTModelMetadataHelper.GetDescriptionAllocated(allocator: TOrtAllocator
+  ): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetDescription(p_, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(Allocator,_out);{$endif}
+end;
+
+function TORTModelMetadataHelper.GetGraphDescriptionAllocated(allocator: TOrtAllocator
+  ): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetGraphDescription(p_, allocator.p_, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(Allocator,_out);{$endif}
+end;
+
+function TORTModelMetadataHelper.GetCustomMetadataMapKeysAllocated(
+  allocator: TOrtAllocator): TArray<AllocatedStringPtr>;
+var _out:PPOrtChar; num_keys,i:int64_t;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetCustomMetadataMapKeys(p_, allocator.p_, @_out, @num_keys));
+  if num_keys <= 0 then
+    exit;
+
+  setLength(result,num_keys);
+  // array of pointers will be freed
+  // reserve may throw
+  for i := 0 to num_keys-1 do begin
+      {$ifndef NO_SMARTPTR}result[i].DisposerFunc:=TORTAllocatedFree.Create(allocator.p_);{$endif}
+      result[i]:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out^);{$else}ortstring(_out^) {$endif} ;
+      inc(_out)
+  end;
+  {$ifdef NO_SMARTPTR}
+  for i := 0 to num_keys-1 do
+    allocator.Free(Allocator,_out[i]);
+  {$endif}
+end;
+
+function TORTModelMetadataHelper.LookupCustomMetadataMapAllocated(
+  const key: POrtChar; allocator: TOrtAllocator): AllocatedStringPtr;
+var _out:POrtChar;
+begin
+  ThrowOnError(GetApi().ModelMetadataLookupCustomMetadataMap(p_, allocator.p_, key, @_out));
+  {$ifndef NO_SMARTPTR}result.DisposerFunc:=TORTAllocatedFree.create(allocator.p_);{$endif}
+  result:={$ifndef NO_SMARTPTR}AllocatedStringPtr.PT(_out);{$else}ortstring(_out) {$endif}
+  {$ifdef NO_SMARTPTR}allocator.Free(Allocator,_out);{$endif}
+end;
+
+function TORTModelMetadataHelper.GetVersion: int64_t;
+begin
+  ThrowOnError(GetApi().ModelMetadataGetVersion(p_, @result));
+end;
+
+{ TORTSessionOptionsHelper }
+
+function TORTSessionOptionsHelper.Clone: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().CloneSessionOptions(p_, @result.p_));
+end;
+
+function TORTSessionOptionsHelper.SetIntraOpNumThreads(
+  intra_op_num_threads: longint): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetIntraOpNumThreads(p_, intra_op_num_threads));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetInterOpNumThreads(
+  inter_op_num_threads: longint): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetInterOpNumThreads(p_, inter_op_num_threads));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetGraphOptimizationLevel(
+  graph_optimization_level: GraphOptimizationLevel): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetSessionGraphOptimizationLevel(p_, graph_optimization_level));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.EnableCpuMemArena: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().EnableCpuMemArena(p_));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.DisableCpuMemArena: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().DisableCpuMemArena(p_));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetOptimizedModelFilePath(
+  const optimized_model_filepath: PORTCHAR_T): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetOptimizedModelFilePath(p_, optimized_model_filepath));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.EnableProfiling(
+  const profile_file_prefix: PORTCHAR_T): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().EnableProfiling(p_, profile_file_prefix));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.DisableProfiling: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().DisableProfiling(p_));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.EnableOrtCustomOps: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().EnableOrtCustomOps(p_));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.EnableMemPattern: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().EnableMemPattern(p_));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.DisableMemPattern: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().DisableMemPattern(p_));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetExecutionMode(execution_mode: ExecutionMode): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetSessionExecutionMode(p_, execution_mode));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetLogId(const logid: POrtChar): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetSessionLogId(p_, logid));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetLogSeverityLevel(level: Longint
+  ): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SetSessionLogSeverityLevel(p_, level));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.Add(custom_op_domain: POrtCustomOpDomain
+  ): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().AddCustomOpDomain(p_, custom_op_domain));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.DisablePerSessionThreads: TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().DisablePerSessionThreads(p_));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AddConfigEntry(const config_key: POrtChar;
+  const config_value: POrtChar): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().AddSessionConfigEntry(p_, config_key, config_value));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AddInitializer(const name: POrtChar;
+  const ort_val: POrtValue): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().AddInitializer(p_, name, ort_val));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AddExternalInitializers(
+  const names: TArray<ortstring>; const ort_values: array of TORTValue): TORTSessionOptions;
+var
+  inputs_num,i:size_t;
+  names_ptr:array of POrtChar;
+  ort_values_ptrs:array of POrtValue;
+begin
+   inputs_num := length(names);
+   if length(ort_values)<>inputs_num then
+     OrtException.Create('Expecting names and ort_values to have the same length', ORT_INVALID_ARGUMENT);
+
+  setLength(names_ptr,inputs_num);
+  setLength(ort_values_ptrs,inputs_num);
+  for i := 0 to inputs_num-1 do begin
+    names_ptr[i]:=POrtChar(names[i]);
+    ort_values_ptrs[i]:=ort_values[i].p_;
+  end;
+  ThrowOnError(GetApi().AddExternalInitializers(p_, @names_ptr[0], @ort_values_ptrs[0], inputs_num));
+  result:=Self
+
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_CUDA(
+  const provider_options: OrtCUDAProviderOptions): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_CUDA(p_, @provider_options));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_CUDA_V2(
+  const provider_options: OrtCUDAProviderOptionsV2): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_CUDA_V2(p_, @provider_options));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_ROCM(
+  const provider_options: OrtROCMProviderOptions): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_ROCM(p_, @provider_options));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_OpenVINO(
+  const provider_options: OrtOpenVINOProviderOptions): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_OpenVINO(p_, @provider_options));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_TensorRT(
+  const provider_options: OrtTensorRTProviderOptions): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_TensorRT(p_, @provider_options));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_TensorRT_V2(
+  const provider_options: OrtTensorRTProviderOptionsV2): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_TensorRT_V2(p_, @provider_options));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_MIGraphX(
+  const provider_options: OrtMIGraphXProviderOptions): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_MIGraphX(p_, @provider_options));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider_CANN(
+  const provider_options: OrtCANNProviderOptions): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_CANN(p_, @provider_options));
+  Result:=Self
+end;
+
+function TORTSessionOptionsHelper.AppendExecutionProvider(
+  const provider_name: ortstring; const provider_options: TORTProviderOptions): TORTSessionOptions;
+var num_entries,i:size_t;keys,values:array of POrtChar;
+begin
+  num_entries := provider_options.count;
+
+  if num_entries > 0 then begin
+    setLength(keys,num_entries);
+    setLength(values,num_entries);
+
+    for i:=0 to num_entries-1 do begin
+      keys[i]:=POrtChar(provider_options.keys{$ifndef NO_HASHMAP}.ToArray{$endif}[i]);
+      values[i]:=POrtChar(provider_options.values{$ifndef NO_HASHMAP}.ToArray{$endif}[i]);
+    end;
+  end;
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider(p_, POrtChar(provider_name)
+                        ,@keys[0], @values[0], num_entries));
+  result:=Self;
+end;
+
+function TORTSessionOptionsHelper.SetCustomCreateThreadFn(
+  ort_custom_create_thread_fn: OrtCustomCreateThreadFn): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsSetCustomCreateThreadFn(p_, ort_custom_create_thread_fn));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetCustomThreadCreationOptions(
+  ort_custom_thread_creation_options: Pointer): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsSetCustomThreadCreationOptions(p_, ort_custom_thread_creation_options));
+  result:=Self
+end;
+
+function TORTSessionOptionsHelper.SetCustomJoinThreadFn(
+  ort_custom_join_thread_fn: OrtCustomJoinThreadFn): TORTSessionOptions;
+begin
+  ThrowOnError(GetApi().SessionOptionsSetCustomJoinThreadFn(p_, ort_custom_join_thread_fn));
+  result:=Self
+end;
+
+{ TORTRunOptionsHelper }
+
+function TORTRunOptionsHelper.SetRunLogVerbosityLevel(level: longint): TORTRunOptions;
+begin
+  ThrowOnError(GetApi().RunOptionsSetRunLogVerbosityLevel(p_, level));
+  result:=self
+end;
+
+function TORTRunOptionsHelper.GetRunLogVerbosityLevel: longint;
+begin
+  ThrowOnError(GetApi().RunOptionsGetRunLogVerbosityLevel(p_, @result));
+end;
+
+function TORTRunOptionsHelper.SetRunLogSeverityLevel(level: longint): TORTRunOptions;
+begin
+  ThrowOnError(GetApi().RunOptionsSetRunLogSeverityLevel(p_, level));
+  result:=Self
+end;
+
+function TORTRunOptionsHelper.GetRunLogSeverityLevel: longint;
+begin
+  ThrowOnError(GetApi().RunOptionsGetRunLogSeverityLevel(p_, @result));
+end;
+
+function TORTRunOptionsHelper.SetRunTag(const run_tag: POrtChar): TORTRunOptions;
+begin
+  ThrowOnError(GetApi().RunOptionsSetRunTag(p_, run_tag));
+  result:=Self
+end;
+
+function TORTRunOptionsHelper.GetRunTag: POrtChar;
+begin
+  ThrowOnError(GetApi().RunOptionsGetRunTag(p_, @result));
+end;
+
+function TORTRunOptionsHelper.AddConfigEntry(const config_key: POrtChar;
+  const config_value: POrtChar): TORTRunOptions;
+begin
+  ThrowOnError(GetApi().AddRunConfigEntry(p_, config_key, config_value));
+  result:=Self
+end;
+
+function TORTRunOptionsHelper.SetTerminate: TORTRunOptions;
+begin
+  ThrowOnError(GetApi().RunOptionsSetTerminate(p_));
+  result:=Self
+end;
+
+function TORTRunOptionsHelper.UnsetTerminate: TORTRunOptions;
+begin
+  ThrowOnError(GetApi().RunOptionsUnsetTerminate(p_));
+  result:=Self
+end;
+
+{ TORTCustomOpDomainHelper }
+
+class function TORTCustomOpDomainHelper.Create(const domain: POrtChar):TORTCustomOpDomain;
+begin
+  ThrowOnError(GetApi().CreateCustomOpDomain(domain, @result.p_));
+  result.NewRef();
+end;
+
+procedure TORTCustomOpDomainHelper.Add(op: POrtCustomOp);
+begin
+  ThrowOnError(GetApi().CustomOpDomain_Add(p_, op));
+end;
+
+{$ifdef fpc}
+{ TORTCustomOpBase }
+
+function TORTCustomOpBase<TOp, TKernel>.CreateKernel(const this_: POrtCustomOp;
+  const api: POrtApi; const info: POrtKernelInfo): pointer;
+begin
+  result:=POp(this_)^.CreateKernel( api^, info);
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetName(const this_: POrtCustomOp): POrtChar;
+begin
+  result:=POp(this_)^.GetName;
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetExecutionProviderType(
+  const this_: POrtCustomOp): POrtChar;
+begin
+  result:=POp(this_)^.GetExecutionProviderType;
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetInputType(const this_: POrtCustomOp;
+  index: size_t): ONNXTensorElementDataType;
+begin
+  result:=POp(this_)^.GetInputType(index)
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetInputTypeCount(const this_: POrtCustomOp
+  ): size_t;
+begin
+  result:=POp(this_)^.GetInputTypeCount
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetOutputType(const this_: POrtCustomOp;
+  index: size_t): ONNXTensorElementDataType;
+begin
+  result:=POp(this_)^.GetOutputType
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetOutputTypeCount(const this_: POrtCustomOp
+  ): size_t;
+begin
+  result:=POp(this_)^.GetOutputTypeCount
+end;
+
+procedure TORTCustomOpBase<TOp, TKernel>.KernelCompute(op_kernel: pointer;
+  context: POrtKernelContext);
+begin
+  PKernel(op_kernel)^.Compute(context)
+end;
+
+procedure TORTCustomOpBase<TOp, TKernel>.KernelDestroy(op_kernel: pointer);
+begin
+  { ToDo : this is maybe wrong equivalent to C++ : delete static_cast<TKernel*>(op_kernel) }
+  if assigned(op_kernel) then
+    free(PKernel(op_kernel));
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetInputCharacteristic(const this_: POrtCustomOp; index: size_t): OrtCustomOpInputOutputCharacteristic;
+begin
+  POp(this_)^.GetInputCharacteristic(index)
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetOutputCharacteristic(const this_: POrtCustomOp; index: size_t): OrtCustomOpInputOutputCharacteristic;
+begin
+  POp(this_)^.GetOutputCharacteristic(index)
+end;
+
+class operator TORTCustomOpBase<TOp, TKernel>.Initialize(var dest: TORTCustomOpBase<TOp, TKernel>);
+begin
+  dest.version:=ORT_API_VERSION;
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetExecutionProviderType: POrtChar;
+begin
+  result:=nil
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetInputCharacteristic(index: size_t): OrtCustomOpInputOutputCharacteristic;
+begin
+  result:=OrtCustomOpInputOutputCharacteristic.INPUT_OUTPUT_REQUIRED
+end;
+
+function TORTCustomOpBase<TOp, TKernel>.GetOutputCharacteristic(index: size_t ): OrtCustomOpInputOutputCharacteristic;
+begin
+  result:=OrtCustomOpInputOutputCharacteristic.INPUT_OUTPUT_REQUIRED;
+end;
+{$endif}
+{ TORTCustomOpApi }
+
+constructor TORTCustomOpApi.Create(const api: OrtApi);
+begin
+  api_:=api
+end;
+
+function TORTCustomOpApi.KernelInfoGetAttribute<T>(const info: POrtKernelInfo;
+  const name: POrtChar): T;
+begin
+  ThrowOnError(api_.KernelInfoGetAttribute_float(info, name, @result));
+end;
+
+function TORTCustomOpApi.GetTensorTypeAndShape(const value: POrtValue
+  ): POrtTensorTypeAndShapeInfo;
+begin
+  ThrowOnError(api_.GetTensorTypeAndShape(value, @result))
+end;
+
+function TORTCustomOpApi.GetTensorShapeElementCount(
+  const info: POrtTensorTypeAndShapeInfo): size_t;
+begin
+  ThrowOnError(api_.GetTensorShapeElementCount(info, @result));
+end;
+
+function TORTCustomOpApi.GetTensorElementType(
+  const info: POrtTensorTypeAndShapeInfo): ONNXTensorElementDataType;
+begin
+  ThrowOnError(api_.GetTensorElementType(info, @result));
+end;
+
+function TORTCustomOpApi.GetDimensionsCount(const info: POrtTensorTypeAndShapeInfo
+  ): size_t;
+begin
+  ThrowOnError(api_.GetDimensionsCount(info, @result));
+end;
+
+procedure TORTCustomOpApi.GetDimensions(const info: POrtTensorTypeAndShapeInfo;
+  dim_values: Pint64_t; dim_values_length: size_t);
+begin
+  ThrowOnError(api_.GetDimensions(info, dim_values, dim_values_length));
+end;
+
+procedure TORTCustomOpApi.SetDimensions(info: POrtTensorTypeAndShapeInfo;
+  const dim_values: Pint64_t; dim_count: size_t);
+begin
+  ThrowOnError(api_.SetDimensions(info, dim_values, dim_count));
+end;
+
+function TORTCustomOpApi.GetTensorMutableData<T>(value: POrtValue): Pointer;
+begin
+  ThrowOnError(api_.GetTensorMutableData(value, @result));
+end;
+
+function TORTCustomOpApi.GetTensorData<T>(const value: POrtValue): Pointer;
+begin
+  result:= GetTensorMutableData<T>(value);
+end;
+
+function TORTCustomOpApi.GetTensorMemoryInfo(const value: POrtValue): TOrtMemoryInfo;
+begin
+  ThrowOnError(api_.GetTensorMemoryInfo(value, @result))
+end;
+
+function TORTCustomOpApi.GetTensorShape(const info: POrtTensorTypeAndShapeInfo): TArray<Int64_t>;
+begin
+  setLength(result,GetDimensionsCount(info));
+  GetDimensions(info, @result[0], Length(result));
+end;
+
+procedure TORTCustomOpApi.ReleaseTensorTypeAndShapeInfo(input: POrtTensorTypeAndShapeInfo);
+begin
+  api_.ReleaseTensorTypeAndShapeInfo(input);
+end;
+
+function TORTCustomOpApi.KernelContext_GetInputCount(const context: POrtKernelContext): size_t;
+begin
+  ThrowOnError(api_.KernelContext_GetInputCount(context, @result));
+end;
+
+function TORTCustomOpApi.KernelContext_GetInput(const context: POrtKernelContext;index: size_t): POrtValue;
+begin
+  ThrowOnError(api_.KernelContext_GetInput(context, index, @result));
+end;
+
+function TORTCustomOpApi.KernelContext_GetOutputCount(const context: POrtKernelContext): size_t;
+begin
+  ThrowOnError(api_.KernelContext_GetOutputCount(context, @result));
+end;
+
+function TORTCustomOpApi.KernelContext_GetOutput(context: POrtKernelContext; index: size_t; const dim_values: PInt64_t; dim_count: size_t): POrtValue;
+begin
+  ThrowOnError(api_.KernelContext_GetOutput(context, index, dim_values, dim_count, @result));
+end;
+
+function TORTCustomOpApi.KernelContext_GetGPUComputeStream(const context: POrtKernelContext): Pointer;
+begin
+  ThrowOnError(api_.KernelContext_GetGPUComputeStream(context, @result));
+end;
+
+procedure TORTCustomOpApi.ThrowOnError(status: POrtStatus);
+begin
+  onnxruntime.ThrowOnError(@api_,status);
+end;
+
+function TORTCustomOpApi.CreateOpAttr(const name: POrtChar; const data: Pointer; len: longint; _type: OrtOpAttrType): POrtOpAttr;
+begin
+  ThrowOnError(api_.CreateOpAttr(name, data, len, _type, @result));
+end;
+
+procedure TORTCustomOpApi.ReleaseOpAttr(op_attr: POrtOpAttr);
+begin
+  api_.ReleaseOpAttr(op_attr);
+end;
+
+function TORTCustomOpApi.CreateOp(const info: POrtKernelInfo;
+  const op_name: POrtChar; const domain: POrtChar; version: longint;
+  const type_constraint_names: PPOrtChar;
+  const type_constraint_values: PONNXTensorElementDataType;
+  type_constraint_count: longint; const attr_values: PPOrtOpAttr;
+  attr_count: longint; input_count: longint; output_count: longint): POrtOp;
+begin
+  ThrowOnError(api_.CreateOp(info, op_name, domain, version, type_constraint_names, type_constraint_values,
+                               type_constraint_count, attr_values, attr_count, input_count, output_count, @result));
+end;
+
+procedure TORTCustomOpApi.InvokeOp(const context: POrtKernelContext;
+  const ort_op: POrtOp; const input_values: PPOrtValue; input_count: longint;
+  var output_values: PPOrtValue; output_count: longint);
+begin
+  ThrowOnError(api_.InvokeOp(context, ort_op, input_values, input_count, output_values, output_count));
+end;
+
+procedure TORTCustomOpApi.ReleaseOp(ort_op: POrtOp);
+begin
+  api_.ReleaseOp(ort_op);
+end;
+
+function TORTCustomOpApi.CopyKernelInfo(const info: POrtKernelInfo): POrtKernelInfo;
+begin
+  ThrowOnError(api_.CopyKernelInfo(info, @result));
+end;
+
+procedure TORTCustomOpApi.ReleaseKernelInfo(info_copy: POrtKernelInfo);
+begin
+  api_.ReleaseKernelInfo(info_copy);
+end;
+
+{ TORTAllocatorWithDefaultOptions }
+
+class operator TORTAllocatorWithDefaultOptions.Initialize({$ifdef fpc}var{$else}out{$endif} dest: TORTAllocatorWithDefaultOptions);
+begin
+  if not Assigned(GetApi()) then exit;
+  ThrowOnError(GetApi().GetAllocatorWithDefaultOptions(@dest.p_));
+end;
+
+class operator TORTAllocatorWithDefaultOptions.Finalize(var dest: TORTAllocatorWithDefaultOptions);
+begin
+   //GetApi().ReleaseAllocator(dest.p_);
+end;
+
+class operator TORTAllocatorWithDefaultOptions.Implicit(const src: TORTAllocatorWithDefaultOptions): POrtAllocator;
+begin
+  result:=src.p_;
+end;
+
+function TORTAllocatorWithDefaultOptions.Alloc(const size: size_t): Pointer;
+begin
+  ThrowOnError(GetApi().AllocatorAlloc(p_, size, @result));
+end;
+
+function TORTAllocatorWithDefaultOptions.GetAllocation(const size: size_t): TORTMemoryAllocation;
+var _out:Pointer;
+begin
+  ThrowOnError(GetApi().AllocatorAlloc(p_, size, @_out));
+  result:=TORTMemoryAllocation.Create(p_, _out, size);
+end;
+
+procedure TORTAllocatorWithDefaultOptions.Free(const p: pointer);
+begin
+  ThrowOnError(GetApi().AllocatorFree(p_, p));
+end;
+
+function TORTAllocatorWithDefaultOptions.GetInfo: POrtMemoryInfo;
+begin
+  ThrowOnError(GetApi().AllocatorGetInfo(p_, @result));
+end;
+
+function TORTAllocatorWithDefaultOptions.GetMemoryInfo : TORTMemoryInfo;
+begin
+  ThrowOnError(GetApi().AllocatorGetInfo(p_, @result.p_));
+end;
+
+class operator TORTAllocatorWithDefaultOptions.Implicit(const v:TORTAllocatorWithDefaultOptions):TORTAllocator;
+begin
+  result.p_:=v.p_
+end;
+
+{ TORTMemoryAllocation }
+
+constructor TORTMemoryAllocation.Create(const allocator: POrtAllocator; const p: Pointer; const size: size_t);
+begin
+  allocator_:=allocator;
+  p_:=p;
+  size_:=size;
+end;
+
+function TORTMemoryAllocation.get: pointer;
+begin
+  result:=p_
+end;
+
+function TORTMemoryAllocation.size: size_t;
+begin
+  result:=size_
+end;
+
+class operator TORTMemoryAllocation.Finalize(var dest: TORTMemoryAllocation);
+//var ret:POrtStatus;
+begin
+  if assigned(dest.p_) then begin
+    // We do not throw out of destructor
+    {ret :=} GetApi().AllocatorFree(dest.allocator_, dest.p_);
+  end;
+end;
+
+{ TORTEnvHelper }
+
+class function TORTEnvHelper.Create(logging_level: OrtLoggingLevel; const logid: POrtChar):TORTEnv;
+begin
+  ThrowOnError(GetApi().CreateEnv(logging_level, logid, @result.p_));
+  ThrowOnError(GetApi().SetLanguageProjection(@result.p_, DefaultLanguageProjection));
+  if Assigned(DefaultEnv.p_) then result.NewRef
+end;
+
+class function TORTEnvHelper.Create(logging_level: OrtLoggingLevel;
+  const logid: POrtChar; logging_function: OrtLoggingFunction;
+  logger_param: Pointer):TORTEnv;
+begin
+  ThrowOnError(GetApi().CreateEnvWithCustomLogger(logging_function, logger_param, logging_level, logid, @result.p_));
+  ThrowOnError(GetApi().SetLanguageProjection(@result.p_, DefaultLanguageProjection));
+  result.NewRef
+end;
+
+class function TORTEnvHelper.Create(const tp_options: POrtThreadingOptions;
+  logging_level: OrtLoggingLevel; const logid: POrtChar):TORTEnv;
+begin
+  ThrowOnError(GetApi().CreateEnvWithGlobalThreadPools(logging_level, logid, tp_options, @result.p_));
+  ThrowOnError(GetApi().SetLanguageProjection(@result.p_, DefaultLanguageProjection));
+  result.NewRef
+end;
+
+class function TORTEnvHelper.Create(const tp_options: POrtThreadingOptions;
+  logging_function: OrtLoggingFunction; logger_param: Pointer;
+  logging_level: OrtLoggingLevel; const logid: POrtChar):TORTEnv;
+begin
+  ThrowOnError(GetApi().CreateEnvWithCustomLoggerAndGlobalThreadPools(logging_function, logger_param, logging_level, logid, tp_options, @result.p_));
+  ThrowOnError(GetApi().SetLanguageProjection(@result.p_, DefaultLanguageProjection));
+  result.NewRef
+end;
+
+function TORTEnvHelper.EnableTelemetryEvents: TORTEnv;
+begin
+  ThrowOnError(GetApi().EnableTelemetryEvents(p_));
+  result:=Self.p_;
+end;
+
+function TORTEnvHelper.DisableTelemetryEvents:TORTEnv;
+begin
+  ThrowOnError(GetApi().DisableTelemetryEvents(p_));
+  result:=Self.p_
+end;
+
+function TORTEnvHelper.CreateAndRegisterAllocator(const mem_info: TOrtMemoryInfo;
+  const arena_cfg: TOrtArenaCfg): TORTEnv;
+begin
+  ThrowOnError(GetApi().CreateAndRegisterAllocator(p_, mem_info.p_, arena_cfg.p_));
+  result:=Self.p_
+end;
+
+function TORTEnvHelper.UpdateLogLevel(const log_level: OrtLoggingLevel): TORTEnv;
+begin
+  ThrowOnError(GetApi().UpdateEnvWithCustomLogLevel(p_, log_level));
+  result:=Self.p_;
+end;
+
+
+{ BFloat16_t }
+
+constructor BFloat16_t.Create(const v: uint16_t);
+begin
+  value:=v
+end;
+
+class operator BFloat16_t.Implicit(const v: BFloat16_t): uint16_t;
+begin
+  result:=v.value
+end;
+
+class operator BFloat16_t.Implicit(const v: uint16_t): BFloat16_t;
+begin
+  result.value:=v
+end;
+
+{ Float16_t }
+
+constructor Float16_t.Create(const v: uint16_t);
+begin
+  value:=v
+end;
+
+class operator Float16_t.Implicit(const v: Float16_t): uint16_t;
+begin
+  result:=v.value
+end;
+
+class operator Float16_t.Implicit(const v: uint16_t): Float16_t;
+begin
+  result.value:=v
+end;
+
+{ OrtException }
+
+function OrtException.what: ortstring;
+begin
+  result:=Message;
+end;
+
+constructor OrtException.Create(const str: ortstring; code: OrtErrorCode);
+begin
+  code_:=code;
+  inherited CreateFmt('Code [%d]: %s',[Ord(code),str]);
+end;
+
+procedure EnsureOrtDefaults;
+begin
+  if GetApi = nil then
+    Exit;
+  if not Assigned(DefaultAllocator.p_) then
+    ThrowOnError(GetApi().GetAllocatorWithDefaultOptions(@DefaultAllocator.p_));
+  if not Assigned(DefaultEnv.p_) then
+    DefaultEnv := TORTEnv.Create(ORT_LOGGING_LEVEL_WARNING, POrtChar(DEFAULT_LOGID));
+  if not Assigned(DefaultSessionOptions.p_) then
+  begin
+    ThrowOnError(GetApi().CreateSessionOptions(PPOrtSessionOptions(@DefaultSessionOptions.p_)));
+    DefaultSessionOptions.NewRef;
+  end;
+  if not Assigned(DefaultRunOptions.p_) then
+  begin
+    ThrowOnError(GetApi().CreateRunOptions(PPOrtRunOptions(@DefaultRunOptions.p_)));
+    DefaultRunOptions.NewRef;
+  end;
+end;
+
+
+initialization
+
+  // ONNX Runtime is loaded dynamically by the application; if no runtime is
+  // loaded yet, Api is nil and we defer creating the default env (see
+  // EnsureOrtDefaults, called once the library has been loaded).
+  if GetApi <> nil then
+    DefaultEnv:=TORTEnv.Create(ORT_LOGGING_LEVEL_WARNING, POrtChar(DEFAULT_LOGID) );
+
+  //if not assigned(DefaultSessionOptions.p_) then begin
+  //  ThrowOnError(Api.CreateSessionOptions(@DefaultSessionOptions.p_));
+  //  DefaultSessionOptions.NewRef();
+  //end ;
+  //
+  //if not Assigned(DefaultRunOptions.p_) then begin
+  //  ThrowOnError(Api.CreateRunOptions(@DefaultRunOptions.p_));
+  //  DefaultRunOptions.NewRef();
+  //end
+finalization
+  // Only release if a runtime was actually loaded (GetApi/Api may be nil when
+  // onnxruntime was never found/loaded).
+  if GetApi <> nil then
+  begin
+    GetApi().ReleaseRunOptions(DefaultRunOptions.p_);
+    GetApi().ReleaseSessionOptions(DefaultSessionOptions.p_);
+    GetApi().ReleaseEnv(DefaultEnv.p_);
+  end;
+
+
+end.

--- a/src/pkg/memory/localvector/onnxruntime_pas_api.pas
+++ b/src/pkg/memory/localvector/onnxruntime_pas_api.pas
@@ -1,0 +1,1127 @@
+{
+  Vendored from FMXExpress/localvector (MIT licensed; LICENSE preserved
+  alongside this file). Upstream commit: 0f00eece553da47e83169ddc8d72965c0dc40bcc.
+  https://github.com/FMXExpress/localvector
+
+  Modifications kept to a minimum — PasClaw uses these units verbatim
+  as the in-tree implementation of the hybrid FTS5+vector memory backend
+  (PasClaw.Memory.Vector). Diff against upstream for change tracking.
+}
+
+{ Onnxruntime for FreePascal/Delphi
+
+  Copyright (c) 2022 Haitham Shatti <haitham.shatti at gmail dot com> <https://github.com/hshatti>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+}
+
+unit onnxruntime_pas_api;
+interface
+  {$IFDEF FPC}
+    {$mode delphi}
+    {$ModeSwitch advancedrecords}
+    {$ModeSwitch typehelpers}
+    {.$linklib onnxruntime.dll}
+    {$MACRO ON}
+    {$PACKRECORDS C}
+    {$PackEnum 4}
+  {$else}
+    {$Z4}
+  {$ENDIF}
+  {$define ORT_API_CALL:=stdcall}
+
+// ONNX Runtime is loaded dynamically (see LoadOnnxRuntime below) so the program
+// can start with no runtime present and provision one at run time.
+uses
+{$IFDEF FPC}
+  dynlibs
+{$ELSE}
+  {$IFDEF MSWINDOWS}Winapi.Windows{$ELSE}Posix.Dlfcn{$ENDIF}
+{$ENDIF}
+  ;
+
+type
+{$IFDEF FPC}
+  size_t = NativeUInt; // FPC: pointer-sized unsigned, matches C size_t
+{$ELSE}
+  size_t = UInt64;     // Delphi
+{$ENDIF}
+
+  {$ifdef MSWINDOWS}
+  const dllname='onnxruntime.dll';
+  {$endif}
+
+  {$ifdef darwin}
+  const dllname='onnxruntime.dylib';
+  {$endif}
+  {$ifdef linux}
+  const dllname='onnxruntime.so';
+  {$endif}
+  {$ifdef ONNX_NEW_VERSION}
+  const ORT_API_VERSION = 13;
+  {$else}
+  const ORT_API_VERSION = 10;
+  {$endif}
+
+{$ifndef SIZE_MAX}
+  {$ifdef WIN64}
+    const SIZE_MAX = $fffffffffffffff;
+  {$else}
+    const SIZE_MAX : size_t = $ffffffff;
+  {$endif}
+{$endif}
+
+(*
+ * The following defines SessionOptions Config Keys and format of the Config Values.
+ *
+ * The Naming Convention for a SessionOptions Config Key,
+ * "[Area][.[SubArea1].[SubArea2]...].[Keyname]"
+ * Such as "ep.cuda.use_arena"
+ * The Config Key cannot be empty
+ * The maximum length of the Config Key is 128
+ *
+ * The string format of a SessionOptions Config Value is defined individually for each Config.
+ * The maximum length of the Config Value is 1024
+ *)
+
+
+      // Key for enabling shrinkages of user listed device memory arenas.
+      // Expects a list of semi-colon separated key value pairs separated by colon in the following format:
+      // "device_0:device_id_0;device_1:device_id_1"
+      // No white-spaces allowed in the provided list string.
+      // Currently, the only supported devices are : "cpu", "gpu" (case sensitive).
+      // If "cpu" is included in the list, DisableCpuMemArena() API must not be called (i.e.) arena for cpu should be enabled.// Example usage: "cpu:0;gpu:0" (or) "gpu:0"
+      // By default, the value for this key is empty (i.e.) no memory arenas are shrunk
+      kOrtRunOptionsConfigEnableMemoryArenaShrinkage = 'memory.enable_memory_arena_shrinkage';
+
+
+
+      // Key for disable PrePacking,
+      // If the config value is set to "1" then the prepacking is disabled, otherwise prepacking is enabled (default value)
+      kOrtSessionOptionsConfigDisablePrepacking = 'session.disable_prepacking';
+
+      // A value of "1" means allocators registered in the env will be used. "0" means the allocators created in the session
+      // will be used. Use this to override the usage of env allocators on a per session level.
+      kOrtSessionOptionsConfigUseEnvAllocators = 'session.use_env_allocators';
+
+      // Set to 'ORT' (case sensitive) to load an ORT format model.
+      // If unset, model type will default to ONNX unless inferred from filename ('.ort' == ORT format) or bytes to be ORT
+      kOrtSessionOptionsConfigLoadModelFormat = 'session.load_model_format';
+
+      // Set to 'ORT' (case sensitive) to save optimized model in ORT format when SessionOptions.optimized_model_path is set.
+      // If unset, format will default to ONNX unless optimized_model_filepath ends in '.ort'.
+      kOrtSessionOptionsConfigSaveModelFormat = 'session.save_model_format';
+
+      // If a value is "1", flush-to-zero and denormal-as-zero are applied. The default is "0".
+      // When multiple sessions are created, a main thread doesn't override changes from succeeding session options,
+      // but threads in session thread pools follow option changes.
+      // When ORT runs with OpenMP, the same rule is applied, i.e. the first session option to flush-to-zero and
+      // denormal-as-zero is only applied to global OpenMP thread pool, which doesn't support per-session thread pool.
+      // Note that an alternative way not using this option at runtime is to train and export a model without denormals
+      // and that's recommended because turning this option on may hurt model accuracy.
+      kOrtSessionOptionsConfigSetDenormalAsZero = 'session.set_denormal_as_zero';
+
+      // It controls to run quantization model in QDQ (QuantizelinearDeQuantizelinear) format or not.
+      // "0": enable. ORT does fusion logic for QDQ format.
+      // "1": disable. ORT doesn't do fusion logic for QDQ format.
+      // Its default value is "0"
+      kOrtSessionOptionsDisableQuantQDQ = 'session.disable_quant_qdq';
+
+      // If set to "1", enables the removal of QuantizeLinear/DequantizeLinear node pairs once all QDQ handling has been
+      // completed. e.g. If after all QDQ handling has completed and we have -> FloatOp -> Q -> DQ -> FloatOp -> the
+      // Q -> DQ could potentially be removed. This will provide a performance benefit by avoiding going from float to
+      // 8-bit and back to float, but could impact accuracy. The impact on accuracy will be model specific and depend on
+      // other factors like whether the model was created using Quantization Aware Training or Post Training Quantization.
+      // As such, it's best to test to determine if enabling this works well for your scenario.
+      // The default value is "0"
+      // Available since version 1.11.
+      kOrtSessionOptionsEnableQuantQDQCleanup = 'session.enable_quant_qdq_cleanup';
+
+      // Enable or disable gelu approximation in graph optimization. "0": disable; "1": enable. The default is "0".
+      // GeluApproximation has side effects which may change the inference results. It is disabled by default due to this.
+      kOrtSessionOptionsEnableGeluApproximation = 'optimization.enable_gelu_approximation';
+
+      // Enable or disable using device allocator for allocating initialized tensor memory. "1": enable; "0": disable. The default is "0".
+      // Using device allocators means the memory allocation is made using malloc/new.
+      kOrtSessionOptionsUseDeviceAllocatorForInitializers = 'session.use_device_allocator_for_initializers';
+
+      // Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking
+      // "0": thread will block if found no job to run
+      // "1": default, thread will spin a number of times before blocking
+      kOrtSessionOptionsConfigAllowInterOpSpinning = 'session.inter_op.allow_spinning';
+      kOrtSessionOptionsConfigAllowIntraOpSpinning = 'session.intra_op.allow_spinning';
+
+      // Key for using model bytes directly for ORT format
+      // If a session is created using an input byte array contains the ORT format model data,
+      // By default we will copy the model bytes at the time of session creation to ensure the model bytes
+      // buffer is valid.
+      // Setting this option to "1" will disable copy the model bytes, and use the model bytes directly. The caller
+      // has to guarantee that the model bytes are valid until the ORT session using the model bytes is destroyed.
+      kOrtSessionOptionsConfigUseORTModelBytesDirectly = 'session.use_ort_model_bytes_directly';
+
+      /// <summary>
+      /// Key for using the ORT format model flatbuffer bytes directly for initializers.
+      /// This avoids copying the bytes and reduces peak memory usage during model loading and initialization.
+      /// Requires `session.use_ort_model_bytes_directly` to be true.
+      /// If set, the flatbuffer bytes provided when creating the InferenceSession MUST remain valid for the entire
+      /// duration of the InferenceSession.
+      /// </summary>
+      kOrtSessionOptionsConfigUseORTModelBytesForInitializers =
+          'session.use_ort_model_bytes_for_initializers';
+
+      // This should only be specified when exporting an ORT format model for use on a different platform.
+      // If the ORT format model will be used on ARM platforms set to "1". For other platforms set to "0"
+      // Available since version 1.11.
+      kOrtSessionOptionsQDQIsInt8Allowed = 'session.qdqisint8allowed';
+
+      // x64 SSE4.1/AVX2/AVX512(with no VNNI) has overflow problem with quantizied matrix multiplication with U8S8.
+      // To avoid this we need to use slower U8U8 matrix multiplication instead. This option, if
+      // turned on, use slower U8U8 matrix multiplications. Only effective with AVX2 or AVX512
+      // platforms.
+      kOrtSessionOptionsAvx2PrecisionMode = 'session.x64quantprecision';
+
+      // Specifies how minimal build graph optimizations are handled in a full build.
+      // These optimizations are at the extended level or higher.
+      // Possible values and their effects are:
+      // "save": Save runtime optimizations when saving an ORT format model.
+      // "apply": Only apply optimizations available in a minimal build.
+      // ""/<unspecified>: Apply optimizations available in a full build.
+      // Available since version 1.11.
+      kOrtSessionOptionsConfigMinimalBuildOptimizations =
+          'optimization.minimal_build_optimizations';
+
+      // Note: The options specific to an EP should be specified prior to appending that EP to the session options object in
+      // order for them to take effect.
+
+      // Specifies a list of stop op types. Nodes of a type in the stop op types and nodes downstream from them will not be
+      // run by the NNAPI EP.
+      // The value should be a ","-delimited list of op types. For example, "Add,Sub".
+      // If not specified, the default set of stop ops is used. To specify an empty stop ops types list and disable stop op
+      // exclusion, set the value to "".
+      kOrtSessionOptionsConfigNnapiEpPartitioningStopOps = 'ep.nnapi.partitioning_stop_ops';
+
+      // Enabling dynamic block-sizing for multithreading.
+      // With a positive value, thread pool will split a task of N iterations to blocks of size starting from:
+      // N / (num_of_threads * dynamic_block_base)
+      // As execution progresses, the size will decrease according to the diminishing residual of N,
+      // meaning the task will be distributed in smaller granularity for better parallelism.
+      // For some models, it helps to reduce the variance of E2E inference latency and boost performance.
+      // The feature will not function by default, specify any positive integer, e.g. "4", to enable it.
+      // Available since version 1.11.
+      kOrtSessionOptionsConfigDynamicBlockBase = 'session.dynamic_block_base';
+
+      // This option allows to decrease CPU usage between infrequent
+      // requests and forces any TP threads spinning stop immediately when the last of
+      // concurrent Run() call returns.
+      // Spinning is restarted on the next Run() call.
+      // Applies only to internal thread-pools
+      kOrtSessionOptionsConfigForceSpinningStop = 'session.force_spinning_stop';
+
+      // "1": all inconsistencies encountered during shape and type inference
+      // will result in failures.
+      // "0": in some cases warnings will be logged but processing will continue. The default.
+      // May be useful to expose bugs in models.
+      kOrtSessionOptionsConfigStrictShapeTypeInference = 'session.strict_shape_type_inference';
+
+
+  Type
+
+  PPPOrtChar = ^PPOrtChar;
+  PPOrtChar = ^POrtChar;
+  POrtChar = PAnsiChar;
+  PORTCHAR_T  = ^ORTCHAR_T;
+{$ifdef MSWINDOWS}
+    wchar_t = WideChar;
+    ORTCHAR_T = wchar_t;
+    OrtChar=ansichar;
+{$else}
+    ORTCHAR_T = ansichar;
+    OrtChar   = ansichar;
+{$endif}
+  //Pchar  = ^char;
+  Pint32_t  = ^int32_t;
+  Pint64_t  = ^int64_t;
+  Plongint  = ^longint;
+  PONNXTensorElementDataType  = ^ONNXTensorElementDataType;
+  PONNXType  = ^ONNXType;
+  PPOrtAllocator = ^POrtAllocator;
+  POrtAllocator  = ^OrtAllocator;
+  POrtAllocatorType  = ^OrtAllocatorType;
+  POrtApi  = ^OrtApi;
+  POrtApiBase  = ^OrtApiBase;
+  PPOrtArenaCfg = ^POrtArenaCfg;
+  POrtArenaCfg  = ^OrtArenaCfg;
+  PPOrtCANNProviderOptions = ^POrtCANNProviderOptions;
+  POrtCANNProviderOptions  = ^OrtCANNProviderOptions;
+  PPOrtCUDAProviderOptions = ^POrtCUDAProviderOptions;
+  POrtCUDAProviderOptions  = ^OrtCUDAProviderOptions;
+  PPOrtCUDAProviderOptionsV2 = ^POrtCUDAProviderOptionsV2;
+  POrtCUDAProviderOptionsV2  = ^OrtCUDAProviderOptionsV2;
+  POrtCustomOp  = ^OrtCustomOp;
+  PPOrtCustomOpDomain = ^POrtCustomOpDomain;
+  POrtCustomOpDomain  = ^OrtCustomOpDomain;
+  PPOrtEnv = ^POrtEnv;
+  POrtEnv  = ^OrtEnv;
+  PPOrtIoBinding = ^POrtIoBinding;
+  POrtIoBinding  = ^OrtIoBinding;
+  POrtKernelContext  = ^OrtKernelContext;
+  PPOrtKernelInfo = ^POrtKernelInfo;
+  POrtKernelInfo  = ^OrtKernelInfo;
+  PPOrtMapTypeInfo = ^POrtMapTypeInfo;
+  POrtMapTypeInfo  = ^OrtMapTypeInfo;
+  PPOrtMemoryInfo = ^POrtMemoryInfo;
+  POrtMemoryInfo  = ^OrtMemoryInfo;
+  POrtMemType  = ^OrtMemType;
+  POrtMemoryInfoDeviceType = ^OrtMemoryInfoDeviceType;
+  POrtMIGraphXProviderOptions  = ^OrtMIGraphXProviderOptions;
+  PPOrtModelMetadata = ^POrtModelMetadata;
+  POrtModelMetadata  = ^OrtModelMetadata;
+  PPOrtOp = ^POrtOp;
+  POrtOp  = ^OrtOp;
+  PPOrtOpAttr =^POrtOpAttr;
+  POrtOpAttr  = ^OrtOpAttr;
+  POrtOpenVINOProviderOptions  = ^OrtOpenVINOProviderOptions;
+  PPOrtPrepackedWeightsContainer = ^POrtPrepackedWeightsContainer;
+  POrtPrepackedWeightsContainer  = ^OrtPrepackedWeightsContainer;
+  POrtROCMProviderOptions  = ^OrtROCMProviderOptions;
+  PPOrtRunOptions = ^POrtRunOptions;
+  POrtRunOptions  = ^OrtRunOptions;
+  PPOrtSequenceTypeInfo = ^POrtSequenceTypeInfo;
+  POrtSequenceTypeInfo  = ^OrtSequenceTypeInfo;
+  PPOrtSession = ^ POrtSession;
+  POrtSession  = ^OrtSession;
+  PPOrtSessionOptions = ^POrtSessionOptions;
+  POrtSessionOptions  = ^OrtSessionOptions;
+  POrtSparseFormat  = ^OrtSparseFormat;
+  POrtStatus  = ^OrtStatus;
+  PPOrtTensorRTProviderOptionsV2 = ^POrtTensorRTProviderOptionsV2;
+  POrtTensorRTProviderOptions  = ^OrtTensorRTProviderOptions;
+  POrtTensorRTProviderOptionsV2  = ^OrtTensorRTProviderOptionsV2;
+  PPOrtTensorTypeAndShapeInfo = ^POrtTensorTypeAndShapeInfo;
+  POrtTensorTypeAndShapeInfo  = ^OrtTensorTypeAndShapeInfo;
+  PPOrtThreadingOptions = ^POrtThreadingOptions;
+  POrtThreadingOptions  = ^OrtThreadingOptions;
+  POrtTrainingApi  = ^OrtTrainingApi;
+  PPOrtTypeInfo = ^POrtTypeInfo;
+  POrtTypeInfo  = ^OrtTypeInfo;
+  PPPOrtValue = ^PPOrtValue;
+  PPOrtValue = ^POrtValue;
+  POrtValue  = ^OrtValue;
+  Psingle  = ^single;
+  PPSize_t = ^PSize_t;
+  Psize_t  = ^size_t;
+  Puint64_t  = ^uint64_t;
+
+  int8_t   = shortint;
+  int16_t  = SmallInt;
+  int32_t  = longint ;
+  int64_t  = int64   ;
+
+  uint8_t  = byte    ;
+  uint16_t = word    ;
+  uint32_t = longword;
+  uint64_t = UInt64   ;
+
+
+  ONNXTensorElementDataType = (ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8,ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL,ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128,
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16
+    );
+
+  ONNXType = (ONNX_TYPE_UNKNOWN,ONNX_TYPE_TENSOR,ONNX_TYPE_SEQUENCE,
+    ONNX_TYPE_MAP,ONNX_TYPE_OPAQUE,ONNX_TYPE_SPARSETENSOR,
+    ONNX_TYPE_OPTIONAL);
+  OrtSparseFormat = (ORT_SPARSE_UNDEFINED = 0,ORT_SPARSE_COO = $1,
+    ORT_SPARSE_CSRC = $2,ORT_SPARSE_BLOCK_SPARSE = $4
+    );
+  OrtSparseIndicesFormat = (ORT_SPARSE_COO_INDICES,ORT_SPARSE_CSR_INNER_INDICES,
+    ORT_SPARSE_CSR_OUTER_INDICES,ORT_SPARSE_BLOCK_SPARSE_INDICES
+    );
+
+
+  OrtLoggingLevel = (ORT_LOGGING_LEVEL_VERBOSE,ORT_LOGGING_LEVEL_INFO,
+    ORT_LOGGING_LEVEL_WARNING,ORT_LOGGING_LEVEL_ERROR,
+    ORT_LOGGING_LEVEL_FATAL);
+
+  OrtErrorCode = (ORT_OK,ORT_FAIL,ORT_INVALID_ARGUMENT,ORT_NO_SUCHFILE,
+    ORT_NO_MODEL,ORT_ENGINE_ERROR,ORT_RUNTIME_EXCEPTION,
+    ORT_INVALID_PROTOBUF,ORT_MODEL_LOADED,
+    ORT_NOT_IMPLEMENTED,ORT_INVALID_GRAPH,
+    ORT_EP_FAIL);
+
+  OrtOpAttrType = (ORT_OP_ATTR_UNDEFINED = 0,ORT_OP_ATTR_INT,
+    ORT_OP_ATTR_INTS,ORT_OP_ATTR_FLOAT,ORT_OP_ATTR_FLOATS,
+    ORT_OP_ATTR_STRING,ORT_OP_ATTR_STRINGS
+    );
+  OrtEnv = record
+    end;
+
+  OrtStatus = record
+    end;
+
+  OrtMemoryInfo = record
+    end;
+
+  OrtIoBinding = record
+    end;
+
+
+  OrtSession = record
+    end;
+
+
+  OrtValue = record
+    end;
+
+
+  OrtRunOptions = record
+    end;
+
+
+  OrtTypeInfo = record
+    end;
+
+
+  OrtTensorTypeAndShapeInfo = record
+    end;
+
+
+  OrtSessionOptions = record
+    end;
+
+
+  OrtCustomOpDomain = record
+    end;
+
+
+  OrtMapTypeInfo = record
+    end;
+
+
+  OrtSequenceTypeInfo = record
+    end;
+
+
+  OrtModelMetadata = record
+    end;
+
+
+  OrtThreadPoolParams = record
+    end;
+
+
+  OrtThreadingOptions = record
+    end;
+
+
+  OrtArenaCfg = record
+    end;
+
+
+  OrtPrepackedWeightsContainer = record
+    end;
+
+
+  OrtTensorRTProviderOptionsV2 = record
+    end;
+
+
+  OrtCUDAProviderOptionsV2 = record
+    end;
+
+
+  OrtCANNProviderOptions = record
+    end;
+
+
+  OrtOp = record
+    end;
+
+
+  OrtOpAttr = record
+    end;
+
+  OrtAllocator = record
+      version : uint32_t;
+      Alloc : function (this_:POrtAllocator; size:size_t):pointer;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+      Free : procedure (this_:POrtAllocator; p:pointer);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+      Info : function (this_:POrtAllocator):POrtMemoryInfo;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+  end;
+
+ OrtLoggingFunction = procedure (param:pointer; severity:OrtLoggingLevel; category:POrtChar; logid:POrtChar; code_location:POrtChar;
+               message:POrtChar);cdecl;
+
+ GraphOptimizationLevel = (ORT_DISABLE_ALL = 0,ORT_ENABLE_BASIC = 1,
+   ORT_ENABLE_EXTENDED = 2,ORT_ENABLE_ALL = 99
+   );
+
+ ExecutionMode = (ORT_SEQUENTIAL = 0,ORT_PARALLEL = 1
+   );
+
+ OrtLanguageProjection = (ORT_PROJECTION_C = 0,ORT_PROJECTION_CPLUSPLUS = 1,
+   ORT_PROJECTION_CSHARP = 2,ORT_PROJECTION_PYTHON = 3,
+   ORT_PROJECTION_JAVA = 4,ORT_PROJECTION_WINML = 5,
+   ORT_PROJECTION_NODEJS = 6);
+
+ OrtKernelInfo = record
+   end;
+
+ OrtKernelContext = record
+   end;
+
+ //OrtCustomOp = record
+ //  end;
+ //
+
+ OrtAllocatorType = (OrtInvalidAllocator = -1,OrtDeviceAllocator = 0,
+   OrtArenaAllocator = 1);
+
+ OrtMemType = (OrtMemTypeCPUInput = -2,OrtMemTypeCPUOutput = -1,
+   OrtMemTypeCPU = OrtMemTypeCPUOutput,OrtMemTypeDefault = 0
+   );
+
+ OrtMemoryInfoDeviceType = (
+  OrtMemoryInfoDeviceType_CPU = 0,
+  OrtMemoryInfoDeviceType_GPU = 1,
+  OrtMemoryInfoDeviceType_FPGA = 2
+ );
+
+ OrtCudnnConvAlgoSearch = (OrtCudnnConvAlgoSearchExhaustive,OrtCudnnConvAlgoSearchHeuristic,
+   OrtCudnnConvAlgoSearchDefault);
+
+
+ { OrtCUDAProviderOptions }
+
+ OrtCUDAProviderOptions = record
+     device_id : longint;
+     cudnn_conv_algo_search : OrtCudnnConvAlgoSearch;
+     gpu_mem_limit : size_t;
+     arena_extend_strategy : longint;
+     do_copy_in_default_stream : longint;
+     has_user_compute_stream : longint;
+     user_compute_stream : pointer;
+     default_memory_arena_cfg : ^OrtArenaCfg;
+     class operator Initialize({$ifdef fpc}var{$else}out{$endif}dest:OrtCUDAProviderOptions);
+   end;
+
+ { OrtROCMProviderOptions }
+
+ OrtROCMProviderOptions = record
+     device_id : longint;
+     miopen_conv_exhaustive_search : longint;
+     gpu_mem_limit : size_t;
+     arena_extend_strategy : longint;
+     do_copy_in_default_stream : longint;
+     has_user_compute_stream : longint;
+     user_compute_stream : pointer;
+     default_memory_arena_cfg : ^OrtArenaCfg;
+     class operator Initialize({$ifdef fpc}var{$else}out{$endif}dest:OrtROCMProviderOptions);
+   end;
+
+ OrtTensorRTProviderOptions = record
+     device_id : longint;
+     has_user_compute_stream : longint;
+     user_compute_stream : pointer;
+     trt_max_partition_iterations : longint;
+     trt_min_subgraph_size : longint;
+     trt_max_workspace_size : size_t;
+     trt_fp16_enable : longint;
+     trt_int8_enable : longint;
+     trt_int8_calibration_table_name : ^char;
+     trt_int8_use_native_calibration_table : longint;
+     trt_dla_enable : longint;
+     trt_dla_core : longint;
+     trt_dump_subgraphs : longint;
+     trt_engine_cache_enable : longint;
+     trt_engine_cache_path : ^char;
+     trt_engine_decryption_enable : longint;
+     trt_engine_decryption_lib_path : ^char;
+     trt_force_sequential_engine_build : longint;
+   end;
+
+ OrtMIGraphXProviderOptions = record
+     device_id : longint;
+     migraphx_fp16_enable : longint;
+     migraphx_int8_enable : longint;
+   end;
+
+ OrtOpenVINOProviderOptions = record
+     device_type : ^char;
+     enable_vpu_fast_compile : byte;
+     device_id : ^char;
+     num_of_threads : size_t;
+     use_compiled_network : byte;
+     blob_dump_path : ^char;
+     context : pointer;
+     enable_opencl_throttling : byte;
+     enable_dynamic_shapes : byte;
+   end;
+
+ OrtTrainingApi = record
+   end;
+
+ OrtApiBase = record
+     GetApi : function (version:uint32_t):POrtApi;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetVersionString : function :POrtChar;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   end;
+
+
+ OrtThreadWorkerFn = procedure (ort_worker_fn_param:pointer);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+ OrtCustomHandleType = record
+     __place_holder : char;
+   end;
+ OrtCustomThreadHandle = ^OrtCustomHandleType;
+
+ OrtCustomCreateThreadFn = function (ort_custom_thread_creation_options:pointer; ort_thread_worker_fn:OrtThreadWorkerFn; ort_worker_fn_param:pointer):OrtCustomThreadHandle;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+ OrtCustomJoinThreadFn = procedure (ort_custom_thread_handle:OrtCustomThreadHandle);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+ OrtApi = record
+   CreateStatus : function (code:OrtErrorCode; const msg:POrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetErrorCode : function ( const status:POrtStatus):OrtErrorCode;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetErrorMessage : function (const status:POrtStatus):POrtChar;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateEnv : function (log_severity_level:OrtLoggingLevel;const  logid:POrtChar; _out:PPOrtEnv):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateEnvWithCustomLogger : function (logging_function:OrtLoggingFunction; logger_param:pointer; log_severity_level:OrtLoggingLevel;const  logid:POrtChar; _out:PPOrtEnv):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   EnableTelemetryEvents : function (const env:POrtEnv):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   DisableTelemetryEvents : function (const env:POrtEnv):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateSession : function (const env:POrtEnv;const  model_path:PORTCHAR_T;const  options:POrtSessionOptions;const  _out:PPOrtSession):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateSessionFromArray : function (const env:POrtEnv;const  model_data:pointer;const  model_data_length:size_t;const  options:POrtSessionOptions; _out:PPOrtSession):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   Run : function (session:POrtSession;const  run_options:POrtRunOptions;const  input_names:PPOrtChar;const inputs:PPOrtValue; input_len:size_t;const output_names:PPOrtChar; output_names_len:size_t; outputs:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateSessionOptions : function (options:PPOrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetOptimizedModelFilePath : function (options:POrtSessionOptions;const optimized_model_filepath:PORTCHAR_T):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CloneSessionOptions : function (const in_options:POrtSessionOptions; out_options:PPOrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetSessionExecutionMode : function (options:POrtSessionOptions; execution_mode:ExecutionMode):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   EnableProfiling : function (options:POrtSessionOptions;const profile_file_prefix:PORTCHAR_T):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   DisableProfiling : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   EnableMemPattern : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   DisableMemPattern : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   EnableCpuMemArena : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   DisableCpuMemArena : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetSessionLogId : function (options:POrtSessionOptions;const logid:POrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetSessionLogVerbosityLevel : function (options:POrtSessionOptions; session_log_verbosity_level:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetSessionLogSeverityLevel : function (options:POrtSessionOptions; session_log_severity_level:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetSessionGraphOptimizationLevel : function (options:POrtSessionOptions; graph_optimization_level:GraphOptimizationLevel):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetIntraOpNumThreads : function (options:POrtSessionOptions; intra_op_num_threads:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetInterOpNumThreads : function (options:POrtSessionOptions; inter_op_num_threads:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateCustomOpDomain : function (const domain:POrtChar; _out:PPOrtCustomOpDomain):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CustomOpDomain_Add : function (custom_op_domain:POrtCustomOpDomain;const op:POrtCustomOp):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AddCustomOpDomain : function (options:POrtSessionOptions; custom_op_domain:POrtCustomOpDomain):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RegisterCustomOpsLibrary : function (options:POrtSessionOptions;const library_path:POrtChar; library_handle:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetInputCount : function (const session:POrtSession; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetOutputCount : function (const session:POrtSession; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetOverridableInitializerCount : function (const session:POrtSession; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetInputTypeInfo : function (const session:POrtSession; index:size_t; type_info:PPOrtTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetOutputTypeInfo : function (const session:POrtSession; index:size_t; type_info:PPOrtTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetOverridableInitializerTypeInfo : function (const session:POrtSession; index:size_t; type_info:PPOrtTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetInputName : function (const session:POrtSession; index:size_t; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetOutputName : function (const session:POrtSession; index:size_t; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetOverridableInitializerName : function (const session:POrtSession; index:size_t; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateRunOptions : function (_out:PPOrtRunOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsSetRunLogVerbosityLevel : function (options:POrtRunOptions; log_verbosity_level:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsSetRunLogSeverityLevel : function (options:POrtRunOptions; log_severity_level:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsSetRunTag : function (options:POrtRunOptions;const run_tag:POrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsGetRunLogVerbosityLevel : function (const options:POrtRunOptions; log_verbosity_level:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsGetRunLogSeverityLevel : function (const options:POrtRunOptions; log_severity_level:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsGetRunTag : function (const options:POrtRunOptions;const  run_tag:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsSetTerminate : function (options:POrtRunOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunOptionsUnsetTerminate : function (options:POrtRunOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateTensorAsOrtValue : function (allocator:POrtAllocator;const shape:Pint64_t; shape_len:size_t; _type:ONNXTensorElementDataType; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateTensorWithDataAsOrtValue : function (const info:POrtMemoryInfo; p_data:pointer; p_data_len:size_t;const shape:Pint64_t; shape_len:size_t; _type:ONNXTensorElementDataType; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   IsTensor : function (const value:POrtValue; _out:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetTensorMutableData : function (value:POrtValue; _out:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   FillStringTensor : function (value:POrtValue;const s:PPOrtChar; s_len:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetStringTensorDataLength : function (const value:POrtValue; len:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetStringTensorContent : function (const value:POrtValue; s:pointer; s_len:size_t; offsets:Psize_t; offsets_len:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CastTypeInfoToTensorInfo : function (const type_info:POrtTypeInfo;const  _out:PPOrtTensorTypeAndShapeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetOnnxTypeFromTypeInfo : function (const type_info:POrtTypeInfo; _out:PONNXType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateTensorTypeAndShapeInfo : function (_out:PPOrtTensorTypeAndShapeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetTensorElementType : function (info:POrtTensorTypeAndShapeInfo; _type:ONNXTensorElementDataType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetDimensions : function (info:POrtTensorTypeAndShapeInfo;const  dim_values:Pint64_t; dim_count:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetTensorElementType : function (const info:POrtTensorTypeAndShapeInfo; _out:PONNXTensorElementDataType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetDimensionsCount : function (const info:POrtTensorTypeAndShapeInfo; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetDimensions : function (const info:POrtTensorTypeAndShapeInfo; dim_values:Pint64_t; dim_values_length:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetSymbolicDimensions : function (const info:POrtTensorTypeAndShapeInfo; const dim_params:PPOrtChar; dim_params_length:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetTensorShapeElementCount : function (const info:POrtTensorTypeAndShapeInfo; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetTensorTypeAndShape : function (const value:POrtValue; _out:PPOrtTensorTypeAndShapeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetTypeInfo : function (const value:POrtValue; _out:PPOrtTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetValueType : function (const value:POrtValue; _out:PONNXType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateMemoryInfo : function (const name:POrtChar; _type:OrtAllocatorType; id:longint; mem_type:OrtMemType; _out:PPOrtMemoryInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateCpuMemoryInfo : function (_type:OrtAllocatorType; mem_type:OrtMemType; _out:PPOrtMemoryInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CompareMemoryInfo : function (const info1:POrtMemoryInfo;const info2:POrtMemoryInfo; _out:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   MemoryInfoGetName : function (const ptr:POrtMemoryInfo;const _out:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   MemoryInfoGetId : function (const ptr:POrtMemoryInfo; _out:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   MemoryInfoGetMemType : function (const ptr:POrtMemoryInfo; _out:POrtMemType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   MemoryInfoGetType : function (const ptr:POrtMemoryInfo; _out:POrtAllocatorType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AllocatorAlloc : function (ort_allocator:POrtAllocator; size:size_t; _out:PPointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AllocatorFree : function (ort_allocator:POrtAllocator; p:pointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AllocatorGetInfo : function (const ort_allocator:POrtAllocator;const _out:PPOrtMemoryInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetAllocatorWithDefaultOptions : function (_out:PPOrtAllocator):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AddFreeDimensionOverride : function (options:POrtSessionOptions;const  dim_denotation:POrtChar; dim_value:int64_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetValue : function (const value:POrtValue; index:longint; allocator:POrtAllocator; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetValueCount : function (const value:POrtValue; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateValue : function (const _in:PPOrtValue; num_values:size_t; value_type:ONNXType; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateOpaqueValue : function (const domain_name:POrtChar;const type_name:POrtChar;const data_container:pointer; data_container_size:size_t; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetOpaqueValue : function (const domain_name:POrtChar;const type_name:POrtChar;const _in:POrtValue; data_container:pointer; data_container_size:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   KernelInfoGetAttribute_float : function (const info:POrtKernelInfo;const name:POrtChar; _out:Psingle):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelInfoGetAttribute_int64 : function (const info:POrtKernelInfo;const name:POrtChar; _out:Pint64_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelInfoGetAttribute_string : function (const info:POrtKernelInfo;const name:POrtChar; _out:POrtChar; size:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   KernelContext_GetInputCount : function (const context:POrtKernelContext; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelContext_GetOutputCount : function (const context:POrtKernelContext; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelContext_GetInput : function (const context:POrtKernelContext; index:size_t;const _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelContext_GetOutput : function (context:POrtKernelContext; index:size_t;const dim_values:Pint64_t; dim_count:size_t; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseEnv : procedure (input:POrtEnv);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseStatus : procedure (input:POrtStatus);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseMemoryInfo : procedure (input:POrtMemoryInfo);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseSession : procedure (input:POrtSession);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseValue : procedure (input:POrtValue);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseRunOptions : procedure (input:POrtRunOptions);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseTypeInfo : procedure (input:POrtTypeInfo);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseTensorTypeAndShapeInfo : procedure (input:POrtTensorTypeAndShapeInfo);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseSessionOptions : procedure (input:POrtSessionOptions);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseCustomOpDomain : procedure (input:POrtCustomOpDomain);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetDenotationFromTypeInfo : function (const type_info:POrtTypeInfo;const denotation:PPOrtChar; len:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CastTypeInfoToMapTypeInfo : function (const type_info:POrtTypeInfo;const _out:PPOrtMapTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CastTypeInfoToSequenceTypeInfo : function (const type_info:POrtTypeInfo;const _out:PPOrtSequenceTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetMapKeyType : function (const map_type_info:POrtMapTypeInfo; _out:PONNXTensorElementDataType):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetMapValueType : function (const map_type_info:POrtMapTypeInfo; type_info:PPOrtTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetSequenceElementType : function (const sequence_type_info:POrtSequenceTypeInfo; type_info:PPOrtTypeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ReleaseMapTypeInfo : procedure (input:POrtMapTypeInfo);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseSequenceTypeInfo : procedure (input:POrtSequenceTypeInfo);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionEndProfiling : function (session:POrtSession; allocator:POrtAllocator; _out:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionGetModelMetadata : function (const session:POrtSession; _out:PPOrtModelMetadata):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataGetProducerName : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataGetGraphName : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataGetDomain : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataGetDescription : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataLookupCustomMetadataMap : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator;const  key:POrtChar; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataGetVersion : function (const model_metadata:POrtModelMetadata; value:Pint64_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ReleaseModelMetadata : procedure (input:POrtModelMetadata);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateEnvWithGlobalThreadPools : function (log_severity_level:OrtLoggingLevel;const logid:POrtChar;const tp_options:POrtThreadingOptions; _out:PPOrtEnv):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   DisablePerSessionThreads : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateThreadingOptions : function (_out:PPOrtThreadingOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseThreadingOptions : procedure (input:POrtThreadingOptions);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ModelMetadataGetCustomMetadataMapKeys : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator; keys:PPPOrtChar; num_keys:Pint64_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AddFreeDimensionOverrideByName : function (options:POrtSessionOptions;const  dim_name:POrtChar; dim_value:int64_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetAvailableProviders : function (out_ptr:PPPOrtChar; provider_length:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseAvailableProviders : function (ptr:PPOrtChar; providers_length:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetStringTensorElementLength : function (const value:POrtValue; index:size_t; _out:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetStringTensorElement : function (const value:POrtValue; s_len:size_t; index:size_t; s:pointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   FillStringTensorElement : function (value:POrtValue;const s:POrtChar; index:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   AddSessionConfigEntry : function (options:POrtSessionOptions;const config_key:POrtChar;const config_value:POrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateAllocator : function (const session:POrtSession;const mem_info:POrtMemoryInfo; _out:PPOrtAllocator):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ReleaseAllocator : procedure (input:POrtAllocator);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   RunWithBinding : function (session:POrtSession;const run_options:POrtRunOptions;const binding_ptr:POrtIoBinding):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateIoBinding : function (session:POrtSession; _out:PPOrtIoBinding):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseIoBinding : procedure (input:POrtIoBinding);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   BindInput : function (binding_ptr:POrtIoBinding;const name:POrtChar;const val_ptr:POrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   BindOutput : function (binding_ptr:POrtIoBinding;const name:POrtChar;const val_ptr:POrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   BindOutputToDevice : function (binding_ptr:POrtIoBinding;const name:POrtChar;const mem_info_ptr:POrtMemoryInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetBoundOutputNames : function (const binding_ptr:POrtIoBinding; allocator:POrtAllocator; buffer:PPOrtChar; lengths:PPsize_t; count:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetBoundOutputValues : function (const binding_ptr:POrtIoBinding; allocator:POrtAllocator; output:PPPOrtValue; output_count:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ClearBoundInputs : procedure (binding_ptr:POrtIoBinding);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ClearBoundOutputs : procedure (binding_ptr:POrtIoBinding);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   TensorAt : function (value:POrtValue;const location_values:Pint64_t; location_values_count:size_t; _out:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateAndRegisterAllocator : function (env:POrtEnv;const mem_info:POrtMemoryInfo;const arena_cfg:POrtArenaCfg):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetLanguageProjection : function (const ort_env:POrtEnv; projection:OrtLanguageProjection):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionGetProfilingStartTimeNs : function (session:POrtSession; _out:Puint64_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SetGlobalIntraOpNumThreads : function (tp_options:POrtThreadingOptions; intra_op_num_threads:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SetGlobalInterOpNumThreads : function (tp_options:POrtThreadingOptions; inter_op_num_threads:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SetGlobalSpinControl : function (tp_options:POrtThreadingOptions; allow_spinning:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   AddInitializer : function (options:POrtSessionOptions;const name:POrtChar;const val:POrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateEnvWithCustomLoggerAndGlobalThreadPools : function (logging_function:OrtLoggingFunction; logger_param:pointer; log_severity_level:OrtLoggingLevel;const logid:POrtChar;const tp_options:POrtThreadingOptions; _out:PPOrtEnv):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_CUDA : function (options:POrtSessionOptions;const cuda_options:POrtCUDAProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_ROCM : function (options:POrtSessionOptions;const rocm_options:POrtROCMProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_OpenVINO : function (options:POrtSessionOptions;const provider_options:POrtOpenVINOProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetGlobalDenormalAsZero : function (tp_options:POrtThreadingOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateArenaCfg : function (max_mem:size_t; arena_extend_strategy:longint; initial_chunk_size_bytes:longint; max_dead_bytes_per_chunk:longint; _out:PPOrtArenaCfg):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ReleaseArenaCfg : procedure (input:POrtArenaCfg);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   ModelMetadataGetGraphDescription : function (const model_metadata:POrtModelMetadata; allocator:POrtAllocator; value:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_TensorRT : function (options:POrtSessionOptions;const tensorrt_options:POrtTensorRTProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SetCurrentGpuDeviceId : function (device_id:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetCurrentGpuDeviceId : function (device_id:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   KernelInfoGetAttributeArray_float : function (const info:POrtKernelInfo;const name:POrtChar; _out:Psingle; size:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelInfoGetAttributeArray_int64 : function (const info:POrtKernelInfo;const  name:POrtChar; _out:Pint64_t; size:Psize_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateArenaCfgV2 : function (const arena_config_keys:PPOrtChar;const arena_config_values:Psize_t; num_keys:size_t; _out:PPOrtArenaCfg):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   AddRunConfigEntry : function (options:POrtRunOptions;const config_key:POrtChar;const config_value:POrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreatePrepackedWeightsContainer : function (_out:PPOrtPrepackedWeightsContainer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleasePrepackedWeightsContainer : procedure (input:POrtPrepackedWeightsContainer);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateSessionWithPrepackedWeightsContainer : function (const env:POrtEnv;const model_path:PORTCHAR_T;const options:POrtSessionOptions; prepacked_weights_container:POrtPrepackedWeightsContainer; _out:PPOrtSession):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateSessionFromArrayWithPrepackedWeightsContainer : function (const env:POrtEnv;const model_data:pointer; model_data_length:size_t;const options:POrtSessionOptions; prepacked_weights_container:POrtPrepackedWeightsContainer;_out:PPOrtSession):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_TensorRT_V2 : function (options:POrtSessionOptions;const tensorrt_options:POrtTensorRTProviderOptionsV2):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateTensorRTProviderOptions : function (_out:PPOrtTensorRTProviderOptionsV2):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   UpdateTensorRTProviderOptions : function (tensorrt_options:POrtTensorRTProviderOptionsV2;const provider_options_keys:PPOrtChar;const provider_options_values:PPOrtChar; num_keys:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   GetTensorRTProviderOptionsAsString : function (const tensorrt_options:POrtTensorRTProviderOptionsV2; allocator:POrtAllocator; ptr:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseTensorRTProviderOptions : procedure (input:POrtTensorRTProviderOptionsV2);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   EnableOrtCustomOps : function (options:POrtSessionOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   RegisterAllocator : function (env:POrtEnv; allocator:POrtAllocator):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   UnregisterAllocator : function (env:POrtEnv;const mem_info:POrtMemoryInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   IsSparseTensor : function (const value:POrtValue; _out:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateSparseTensorAsOrtValue : function (allocator:POrtAllocator;const dense_shape:Pint64_t; dense_shape_len:size_t; _type:ONNXTensorElementDataType; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   FillSparseTensorCoo : function (ort_value:POrtValue;const data_mem_info:POrtMemoryInfo;const values_shape:Pint64_t; values_shape_len:size_t;const values:pointer;const indices_data:Pint64_t; indices_num:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   FillSparseTensorCsr : function (ort_value:POrtValue;const data_mem_info:POrtMemoryInfo;const values_shape:Pint64_t; values_shape_len:size_t;const values:pointer;const inner_indices_data:Pint64_t; inner_indices_num:size_t;const outer_indices_data:Pint64_t; outer_indices_num:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   FillSparseTensorBlockSparse : function (ort_value:POrtValue;const data_mem_info:POrtMemoryInfo;const values_shape:Pint64_t; values_shape_len:size_t;const values:pointer;const indices_shape_data:Pint64_t; indices_shape_len:size_t;const indices_data:Pint32_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   CreateSparseTensorWithValuesAsOrtValue : function (const info:POrtMemoryInfo; p_data:pointer;const dense_shape:Pint64_t; dense_shape_len:size_t;const values_shape:Pint64_t; values_shape_len:size_t; _type:ONNXTensorElementDataType; _out:PPOrtValue):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   UseCooIndices : function (ort_value:POrtValue; indices_data:Pint64_t; indices_num:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   UseCsrIndices : function (ort_value:POrtValue; inner_data:Pint64_t; inner_num:size_t; outer_data:Pint64_t; outer_num:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   UseBlockSparseIndices : function (ort_value:POrtValue;const indices_shape:Pint64_t; indices_shape_len:size_t; indices_data:Pint32_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetSparseTensorFormat : function (const ort_value:POrtValue; _out:POrtSparseFormat):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetSparseTensorValuesTypeAndShape : function (const ort_value:POrtValue; _out:PPOrtTensorTypeAndShapeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetSparseTensorValues : function (const ort_value:POrtValue;const _out:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetSparseTensorIndicesTypeShape : function (const ort_value:POrtValue; indices_format:OrtSparseIndicesFormat; _out:PPOrtTensorTypeAndShapeInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetSparseTensorIndices : function (const ort_value:POrtValue; indices_format:OrtSparseIndicesFormat; num_indices:Psize_t;const indices:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   HasValue : function (const value:POrtValue; _out:Plongint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   KernelContext_GetGPUComputeStream : function (const context:POrtKernelContext; _out:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetTensorMemoryInfo : function (const value:POrtValue;const mem_info:PPOrtMemoryInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetExecutionProviderApi : function (const provider_name:POrtChar; version:uint32_t;const provider_api:Ppointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   SessionOptionsSetCustomCreateThreadFn : function (options:POrtSessionOptions; ort_custom_create_thread_fn:OrtCustomCreateThreadFn):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsSetCustomThreadCreationOptions : function (options:POrtSessionOptions; ort_custom_thread_creation_options:pointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsSetCustomJoinThreadFn : function (options:POrtSessionOptions; ort_custom_join_thread_fn:OrtCustomJoinThreadFn):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SetGlobalCustomCreateThreadFn : function (tp_options:POrtThreadingOptions; ort_custom_create_thread_fn:OrtCustomCreateThreadFn):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SetGlobalCustomThreadCreationOptions : function (tp_options:POrtThreadingOptions; ort_custom_thread_creation_options:pointer):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SetGlobalCustomJoinThreadFn : function (tp_options:POrtThreadingOptions; ort_custom_join_thread_fn:OrtCustomJoinThreadFn):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SynchronizeBoundInputs : function (binding_ptr:POrtIoBinding):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SynchronizeBoundOutputs : function (binding_ptr:POrtIoBinding):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_CUDA_V2 : function (options:POrtSessionOptions;const cuda_options:POrtCUDAProviderOptionsV2):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateCUDAProviderOptions : function (_out:PPOrtCUDAProviderOptionsV2):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   UpdateCUDAProviderOptions : function (cuda_options:POrtCUDAProviderOptionsV2;const provider_options_keys:PPOrtChar;const provider_options_values:PPOrtChar; num_keys:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetCUDAProviderOptionsAsString : function (const cuda_options:POrtCUDAProviderOptionsV2; allocator:POrtAllocator; ptr:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseCUDAProviderOptions : procedure (input:POrtCUDAProviderOptionsV2);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_MIGraphX : function (options:POrtSessionOptions;const migraphx_options:POrtMIGraphXProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+
+   AddExternalInitializers : function (options:POrtSessionOptions;const initializer_names:PPOrtChar;const initializers:PPOrtValue; initializers_num:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateOpAttr : function (const name:POrtChar;const data:pointer; len:longint; _type:OrtOpAttrType; op_attr:PPOrtOpAttr):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseOpAttr : procedure (input:POrtOpAttr);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateOp : function (const info:POrtKernelInfo;const op_name:POrtChar;const domain:POrtChar; version:longint;const type_constraint_names:PPOrtChar;const type_constraint_values:PONNXTensorElementDataType;const type_constraint_count:longint;const attr_values:PPOrtOpAttr; attr_count:longint; input_count:longint;  output_count:longint; ort_op:PPOrtOp):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   InvokeOp : function (const context:POrtKernelContext;const ort_op:POrtOp;const input_values:PPOrtValue; input_count:longint;const output_values:PPOrtValue; output_count:longint):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseOp : procedure (input:POrtOp);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider : function (options:POrtSessionOptions;const provider_name:POrtChar;const provider_options_keys:PPOrtChar;const provider_options_values:PPOrtChar; num_keys:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CopyKernelInfo : function (const info:POrtKernelInfo; info_copy:PPOrtKernelInfo):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseKernelInfo : procedure (input:POrtKernelInfo);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetTrainingApi : function (version:uint32_t):POrtTrainingApi;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   SessionOptionsAppendExecutionProvider_CANN : function (options:POrtSessionOptions;const cann_options:POrtCANNProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   CreateCANNProviderOptions : function (_out:PPOrtCANNProviderOptions):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   UpdateCANNProviderOptions : function (cann_options:POrtCANNProviderOptions;const provider_options_keys:PPOrtChar;const provider_options_values:PPOrtChar; num_keys:size_t):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   GetCANNProviderOptionsAsString : function (const cann_options:POrtCANNProviderOptions; allocator:POrtAllocator; ptr:PPOrtChar):POrtStatus;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   ReleaseCANNProviderOptions : procedure (input:POrtCANNProviderOptions);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   MemoryInfoGetDeviceType : procedure (const ptr : POrtMemoryInfo ; _out : POrtMemoryInfoDeviceType); {$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   UpdateEnvWithCustomLogLevel : function(const env:POrtEnv; log_level: OrtLoggingLevel):POrtStatus; {$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+ end;
+
+ OrtCustomOpInputOutputCharacteristic = (INPUT_OUTPUT_REQUIRED = 0,INPUT_OUTPUT_OPTIONAL);
+ OrtCustomOp = record
+     version : uint32_t;
+     CreateKernel : function (const op:POrtCustomOp;const api:POrtApi;const info:POrtKernelInfo):pointer;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetName : function (const op:POrtCustomOp):POrtChar;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetExecutionProviderType : function (const op:POrtCustomOp):POrtChar;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetInputType : function (const op:POrtCustomOp; index:size_t):ONNXTensorElementDataType;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetInputTypeCount : function (const op:POrtCustomOp):size_t;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetOutputType : function (const op:POrtCustomOp; index:size_t):ONNXTensorElementDataType;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetOutputTypeCount : function (const op:POrtCustomOp):size_t;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     KernelCompute : procedure (op_kernel:pointer; context:POrtKernelContext);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     KernelDestroy : procedure (op_kernel:pointer);{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetInputCharacteristic : function (const op:POrtCustomOp; index:size_t):OrtCustomOpInputOutputCharacteristic;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+     GetOutputCharacteristic : function (const op:POrtCustomOp; index:size_t):OrtCustomOpInputOutputCharacteristic;{$ifdef FPC}ORT_API_CALL{$else}stdcall{$endif};
+   end;
+
+(* Const before type ignored *)
+
+  const DefaultLanguageProjection = OrtLanguageProjection.ORT_PROJECTION_CPLUSPLUS;
+
+type
+  TOrtLibHandle = {$IFDEF FPC}TLibHandle{$ELSE}HMODULE{$ENDIF};
+  TfnOrtGetApiBase = function: POrtApiBase; cdecl;
+  TfnOrtAppendCPU = function(options: POrtSessionOptions; use_arena: longint): POrtStatus; cdecl;
+  TfnOrtAppendDev = function(options: POrtSessionOptions; device_id: longint): POrtStatus; cdecl;
+  TfnOrtAppendDML = function(const options: POrtSessionOptions; const device_id: longint): POrtStatus; cdecl;
+  TfnOrtAppendDMLEx = function(const options: POrtSessionOptions; dml_device: Pointer; const cmd_queue: Pointer): POrtStatus; stdcall;
+
+var
+  Global : POrtApiBase = nil;
+  Api: POrtApi = nil;
+
+  // Entry points resolved dynamically from the loaded onnxruntime library
+  // (these were static `external dllname` imports). Nil until LoadOnnxRuntime.
+  OrtGetApiBase: TfnOrtGetApiBase = nil;
+  OrtSessionOptionsAppendExecutionProvider_CPU: TfnOrtAppendCPU = nil;
+  OrtSessionOptionsAppendExecutionProvider_CUDA: TfnOrtAppendDev = nil;
+  OrtSessionOptionsAppendExecutionProvider_MIGraphX: TfnOrtAppendDev = nil;
+  OrtSessionOptionsAppendExecutionProvider_Tensorrt: TfnOrtAppendDev = nil;
+
+{ Loads the onnxruntime shared library from APath (or the platform default name
+  when APath is empty) and resolves the entry points. Returns True once
+  OrtGetApiBase is available. Safe to call more than once. }
+function LoadOnnxRuntime(const APath: string): Boolean;
+{ Calls OrtGetApiBase()->GetApi(ORT_API_VERSION) and caches Global/Api.
+  Returns True if a usable OrtApi was obtained. }
+function InitOrtApi: Boolean;
+function OrtRuntimeLoaded: Boolean;
+function OrtRuntimeLibHandle: TOrtLibHandle;
+(**
+ * [[deprecated]]
+ * This export is deprecated.
+ * The OrtSessionOptionsAppendExecutionProvider_DML export on the OrtDmlApi should be used instead.
+ *
+ * Creates a DirectML Execution Provider which executes on the hardware adapter with the given device_id, also known as
+ * the adapter index. The device ID corresponds to the enumeration order of hardware adapters as given by
+ * IDXGIFactory::EnumAdapters. A device_id of 0 always corresponds to the default adapter, which is typically the
+ * primary display GPU installed on the system. A negative device_id is invalid.
+ *)
+var OrtSessionOptionsAppendExecutionProvider_DML: TfnOrtAppendDML = nil;
+
+  (**
+ * [[deprecated]]
+ * This export is deprecated.
+ * The OrtSessionOptionsAppendExecutionProvider_DML1 export on the OrtDmlApi should be used instead.
+ *
+ * Creates a DirectML Execution Provider using the given DirectML device, and which executes work on the supplied D3D12
+ * command queue. The DirectML device and D3D12 command queue must have the same parent ID3D12Device, or an error will
+ * be returned. The D3D12 command queue must be of type DIRECT or COMPUTE (see D3D12_COMMAND_LIST_TYPE). If this
+ * function succeeds, the inference session maintains a strong reference on both the dml_device and the command_queue
+ * objects.
+ * See also: DMLCreateDevice
+ * See also: ID3D12Device::CreateCommandQueue
+ *)
+var OrtSessionOptionsAppendExecutionProviderEx_DML: TfnOrtAppendDMLEx = nil;
+
+
+implementation
+
+{ OrtROCMProviderOptions }
+
+class operator OrtROCMProviderOptions.Initialize({$ifdef fpc}var{$else}out{$endif}  dest: OrtROCMProviderOptions);
+begin
+  dest.gpu_mem_limit:=SIZE_MAX;
+  dest.do_copy_in_default_stream:=1;
+end;
+
+{ OrtCUDAProviderOptions }
+
+class operator OrtCUDAProviderOptions.Initialize({$ifdef fpc}var{$else}out{$endif} dest: OrtCUDAProviderOptions);
+begin
+  dest.gpu_mem_limit:=SIZE_MAX;
+  dest.do_copy_in_default_stream:=1;
+end;
+
+var
+  _OrtLib: TOrtLibHandle = 0;
+
+function ortDoLoad(const AName: string): TOrtLibHandle;
+begin
+{$IFDEF FPC}
+  Result := LoadLibrary(AName);
+{$ELSE}
+  Result := LoadLibrary(PChar(AName));
+{$ENDIF}
+end;
+
+function ortDoGetProc(AHandle: TOrtLibHandle; const AName: string): Pointer;
+begin
+{$IFDEF FPC}
+  Result := GetProcedureAddress(AHandle, AName);
+{$ELSE}
+  Result := GetProcAddress(AHandle, PAnsiChar(AnsiString(AName)));
+{$ENDIF}
+end;
+
+function OrtRuntimeLoaded: Boolean;
+begin
+  Result := _OrtLib <> 0;
+end;
+
+function OrtRuntimeLibHandle: TOrtLibHandle;
+begin
+  Result := _OrtLib;
+end;
+
+function LoadOnnxRuntime(const APath: string): Boolean;
+begin
+  if _OrtLib = 0 then
+  begin
+    if APath <> '' then
+      _OrtLib := ortDoLoad(APath)
+    else
+      _OrtLib := ortDoLoad(dllname);
+  end;
+  if _OrtLib = 0 then
+    Exit(False);
+
+  if not Assigned(OrtGetApiBase) then
+    OrtGetApiBase := TfnOrtGetApiBase(ortDoGetProc(_OrtLib, 'OrtGetApiBase'));
+  if not Assigned(OrtSessionOptionsAppendExecutionProvider_CPU) then
+    OrtSessionOptionsAppendExecutionProvider_CPU :=
+      TfnOrtAppendCPU(ortDoGetProc(_OrtLib, 'OrtSessionOptionsAppendExecutionProvider_CPU'));
+  // Optional providers - resolved best-effort (nil if not present in this build).
+  if not Assigned(OrtSessionOptionsAppendExecutionProvider_CUDA) then
+    OrtSessionOptionsAppendExecutionProvider_CUDA :=
+      TfnOrtAppendDev(ortDoGetProc(_OrtLib, 'OrtSessionOptionsAppendExecutionProvider_CUDA'));
+  if not Assigned(OrtSessionOptionsAppendExecutionProvider_DML) then
+    OrtSessionOptionsAppendExecutionProvider_DML :=
+      TfnOrtAppendDML(ortDoGetProc(_OrtLib, 'OrtSessionOptionsAppendExecutionProvider_DML'));
+
+  Result := Assigned(OrtGetApiBase);
+end;
+
+function InitOrtApi: Boolean;
+begin
+  if Assigned(OrtGetApiBase) then
+  begin
+    Global := OrtGetApiBase();
+    if Assigned(Global) then
+      Api := Global.GetApi(ORT_API_VERSION);
+  end;
+  Result := Assigned(Api);
+end;
+
+initialization
+  // No auto-load: the application calls LoadOnnxRuntime + InitOrtApi after it has
+  // located (or downloaded) a runtime. The wrapper's Default* objects initialise
+  // lazily and tolerate Api = nil until then.
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -44,7 +44,8 @@ uses
   PasClaw.Utils,
   PasClaw.Config,
   PasClaw.Logger,
-  PasClaw.Memory.Index;
+  PasClaw.Memory.Index,
+  PasClaw.Memory.Vector;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
 var
@@ -107,6 +108,7 @@ var
   Hits:  TMemoryHitArray;
   Lines: TStringList;
   Dir:   string;
+  Cfg:   TConfig;
 begin
   ErrMsg := '';
   Result := '';
@@ -125,13 +127,45 @@ begin
     Exit('(no memory directory yet — write to ' + JoinPath(Dir, 'MEMORY.md') +
          ' first)');
 
-  Idx := NewMemoryIndex;
+  { Backend selection — try the hybrid FTS+vector backend first when
+    the operator opted in via `pasclaw onboard` / `vector_search_enabled`
+    (default True). On any "not provisioned yet" failure (missing
+    sqlite-vec, missing ONNX Runtime, missing embedding model) Open()
+    returns False quietly and we fall through to NewMemoryIndex, which
+    is the FTS5-only path PasClaw has shipped since memory_search
+    landed. Operators on stock builds without the runtime artifacts
+    on disk get the same behaviour they did before: keyword search.
+
+    Separate DB filenames (.index.db vs .index.db.vec) so flipping
+    vector_search_enabled on/off doesn't cross-talk between the two
+    schemas in one file. Both backends live alongside each other on
+    disk; only one is opened per call. The vector DB file is created
+    on first SyncDir after provisioning lands; until then it doesn't
+    exist and isn't touched. }
+  Cfg := LoadConfig;
   try
+    if Cfg.VectorSearchEnabled then
+    begin
+      Idx := NewVectorMemoryIndex;
+      if not Idx.Open(IndexDbPath + '.vec') then
+        Idx := nil;  { releases the interface; falls through to FTS }
+    end;
+  finally
+    Cfg.Free;
+  end;
+
+  if Idx = nil then
+  begin
+    Idx := NewMemoryIndex;
     if not Idx.Open(IndexDbPath) then
     begin
+      Idx := nil;
       ErrMsg := 'memory index unavailable (libsqlite3 missing or unreadable)';
       Exit;
     end;
+  end;
+
+  try
     Idx.SyncDir(Dir);
     Hits := Idx.Search(Query, K);
   finally


### PR DESCRIPTION
## Summary

Pivot from vendoring (PR #164's `make get-localvector` + `vendor/localvector/`) to **fork-in-place**. PasClaw owns the source for the hybrid memory backend under `src/pkg/memory/localvector/`, with the upstream MIT LICENSE preserved alongside it and a per-file header naming the source commit (`0f00eec`) so we can diff against upstream for change tracking. No external repo dependency at build time, no `vendor/` step, no `make get-localvector`.

## Why

Maintainer feedback on PR #164's vendored phase 2 was: *"why wire the localvector directory in, instead of just using its ideas in the main pasclaw?"* The vendoring approach had real costs — extra build step (`make get-localvector` required before first build), vendor tree shipped things we don't use (the standalone CLI app), and upstream bug fixes didn't reach us automatically. Fork-in-place addresses all three: code lives in our tree, only the units we actually use ship, and the per-file headers let us still cherry-pick upstream fixes manually when we want them.

## Removed

- `Makefile`: the `get-localvector` recipe, `LOCALVECTOR_DIR` / `LOCALVECTOR_REPO` / `LOCALVECTOR_REF` variables, the localvector vendoring comment block, the `get-localvector` `.PHONY` entry. All gone — fork-in-place doesn't need them.

## Brought in-tree under `src/pkg/memory/localvector/`

| File | Role |
| --- | --- |
| `LICENSE` | verbatim MIT from upstream |
| `LocalVector.VectorStore.pas` | `IVectorStore` interface + RRF fusion + chunker + FTS query builder |
| `LocalVector.VectorStore.Sqlite.pas` | FPC backend (dynamic sqlite3 + vec0 + FTS5) |
| `LocalVector.VectorStore.FireDAC.pas` | Delphi backend (FireDAC + vec0 + FTS5) |
| `LocalVector.Sqlite3.pas` | minimal dynamic sqlite3 binding (needed for `load_extension`) |
| `LocalVector.Embedder.pas` | ONNX inference + mean/CLS/last pooling |
| `LocalVector.Tokenizer.pas` | BERT WordPiece |
| `LocalVector.Models.pas` | embedding model registry (MiniLM / bge / mxbai) |
| `LocalVector.Runtime.pas` | runtime info |
| `LocalVector.OrtProvision.pas` | ONNX Runtime DLL load / auto-download (win-x64 today) |
| `LocalVector.VecProvision.pas` | sqlite-vec extension load / auto-download |
| `LocalVector.Downloader.pas` | generic HTTP fetch helper |
| `onnxruntime.pas` | ONNX Runtime C API wrapper |
| `onnxruntime_pas_api.pas` | ONNX Runtime C API binding |

Excluded: `LocalVector.App.pas` (the standalone CLI app — PasClaw is the consumer, not the CLI).

Each `.pas` carries a uniform attribution header pointing at the upstream URL + the exact source commit so we can diff against upstream for later bug-fix pulls without a submodule.

## New adapter: `src/pkg/memory/PasClaw.Memory.Vector.pas`

Implements the `IMemoryIndex` contract over the in-tree `IVectorStore` + `TEmbedder` + `TBertTokenizer`. `Open()` locates the sqlite-vec extension, the chosen embedding model, the BERT vocab, and the ONNX Runtime under `$PASCLAW_HOME/cache/localvector/`. Each missing piece returns `False` with a single debug-level log line; **no exception leaks to the caller** — so `PasClaw.Tools.Memory` can fall through to the FTS-only `NewMemoryIndex` without an agent-visible stack trace.

Default model is MiniLM (`DEFAULT_MODEL` from `LocalVector.Models` — 384-d, ~90 MB). Search fuses FTS5 + vec0 ranks via Reciprocal Rank Fusion (`k=60`) inside the localvector store and returns chunk text as snippet. `SyncDir` is full-rebuild-per-call for now (embedding is fast enough for typical memory dirs; mtime-tracked incremental sync is a follow-up).

## Updated: `src/pkg/tools/PasClaw.Tools.Memory.pas`

`Tool_MemorySearch` reads `Cfg.VectorSearchEnabled` (the flag PR #164 landed). When `True`, tries `NewVectorMemoryIndex` first; on `Open()` False, falls through to the existing `NewMemoryIndex` (FTS-only). Separate DB files (`.index.db` vs `.index.db.vec`) so flipping the flag doesn't cross-talk between the two schemas. Both backends live alongside each other on disk; only one is opened per call.

## Makefile

`src/pkg/memory/localvector` added to `UNIT_DIRS` so `LocalVector.*` and `onnxruntime*` units resolve at compile time. **No new build deps** — ONNX Runtime + sqlite-vec are dynamically loaded at runtime, not linked. A stock build with no `$PASCLAW_HOME/cache/localvector/` artifacts still runs; vector search just stays inert until the runtime is provisioned.

## README

`memory_search` row updated: the hybrid mode is no longer *"after the runtime hookup PR lands"* — it's wired now; only the runtime artifacts under `$PASCLAW_HOME/cache/localvector/` have to be present for the vector half to engage.

## Test plan

- [x] `make` clean on Linux/FPC. The in-tree localvector units compile, link into the binary, no new build-time deps.
- [x] `NewVectorMemoryIndex.Open` returns `False` quietly on a system with no artifacts under `<home>/cache/localvector` — no exception, no error to the user. `Tools.Memory` falls through to FTS as designed.
- [x] `NewMemoryIndex` still works the same — the FTS5 fallback is unchanged.
- [x] Full test suite green: smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip.
- [ ] Live exercise of the hybrid path against a memory dir + provisioned sqlite-vec + ONNX Runtime + MiniLM model weights — that's the provisioning PR's responsibility.

## Supersedes

PR #164 stayed merged since it landed the config flag + onboarding prompt (both still useful). This PR removes the now-unused vendoring tooling PR #164 also added, and supersedes the closed phase-2 vendor-based adapter work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_