### PR TITLE
Memory: `pasclaw memory provision` + onboarding download hook

### DIFF
--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -1,0 +1,328 @@
+(*
+  PasClaw.Cmd.Memory - manage the hybrid memory_search runtime.
+
+    pasclaw memory provision    Download sqlite-vec, ONNX Runtime, and
+                                the default embedding model into
+                                $PASCLAW_HOME/cache/localvector/.
+    pasclaw memory status       Show which runtime artifacts are present
+                                and where the active backend (hybrid or
+                                FTS-only) would pick them up.
+
+  The provision command is idempotent — re-running skips anything
+  already on disk, redownloads anything suspiciously small (treated as
+  a partial fetch). All artifacts land under $PASCLAW_HOME/cache/localvector/,
+  which is exactly where PasClaw.Memory.Vector.Open looks. Once the
+  three pieces are present, memory_search picks the hybrid backend
+  automatically on the next call — no restart required.
+
+  Cross-platform footprint:
+    sqlite-vec extension       auto-downloaded from asg017/sqlite-vec
+                               releases on win-x64 / linux-x86_64 /
+                               linux-aarch64 / macos-x86_64 /
+                               macos-aarch64.
+    ONNX Runtime               auto-downloaded only on win-x64 (per
+                               LocalVector.OrtProvision.CanAutoProvisionRuntime);
+                               other platforms print install
+                               instructions for the system package
+                               manager.
+    Embedding model + vocab    auto-downloaded from HuggingFace for any
+                               platform (no architecture-specific
+                               weights).
+*)
+unit PasClaw.Cmd.Memory;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+function Cmd_Memory_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  PasClaw.CliUI,
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Logger,
+  LocalVector.Models,
+  LocalVector.OrtProvision,
+  LocalVector.VecProvision,
+  LocalVector.Downloader;
+
+const
+  CACHE_SUBDIR = 'cache/localvector';
+
+procedure Help;
+begin
+  PrintLn('Usage: pasclaw memory <subcommand>');
+  PrintLn;
+  PrintLn('Subcommands:');
+  PrintLn('  provision   Download sqlite-vec, ONNX Runtime, and the default');
+  PrintLn('              embedding model into $PASCLAW_HOME/cache/localvector/');
+  PrintLn('  status      Show which runtime artifacts are present and which');
+  PrintLn('              backend memory_search would pick on the next call');
+end;
+
+function CacheDir: string;
+begin
+  Result := JoinPath(GetHome, CACHE_SUBDIR);
+end;
+
+function ModelDir(const SubDir: string): string;
+begin
+  Result := JoinPath(JoinPath(CacheDir, 'models'), SubDir);
+end;
+
+function VecExtPath: string;
+{ Mirrors PasClaw.Memory.Vector.VecExtPath — kept in sync by hand so
+  this unit doesn't have to import the IMemoryIndex type just for one
+  string. If you change either, change both. }
+begin
+  {$IFDEF MSWINDOWS}
+  Result := JoinPath(CacheDir, 'vec0.dll');
+  {$ELSE}
+    {$IFDEF DARWIN}
+    Result := JoinPath(CacheDir, 'vec0.dylib');
+    {$ELSE}
+    Result := JoinPath(CacheDir, 'vec0.so');
+    {$ENDIF}
+  {$ENDIF}
+end;
+
+procedure PrintCheckMark(const Color: string; const Glyph, Msg: string);
+{ Compose a single status line: '  ' + colored glyph + ' ' + Msg.
+  Color is Ansi.Green / Ansi.Red / Ansi.Yellow / etc. — the call site
+  picks. }
+begin
+  PrintLn('  ' + Color + Glyph + Ansi.Reset + ' ' + Msg);
+end;
+
+function ProvisionVecExt: Boolean;
+{ Returns True on success. Always emits a status line — does not throw.
+  Idempotent: EnsureVec0 short-circuits on FileExists(Dest). }
+var
+  Dest: string;
+begin
+  Result := False;
+  if FileExists(VecExtPath) then
+  begin
+    PrintCheckMark(Ansi.Green, '✓',
+      'sqlite-vec extension already present at ' + VecExtPath);
+    Exit(True);
+  end;
+  try
+    Dest := EnsureVec0(CacheDir,
+                       {AAllowDownload=} True,
+                       {AVerbose=}        True);
+    if FileExists(Dest) then
+    begin
+      PrintCheckMark(Ansi.Green, '✓',
+        'sqlite-vec extension installed at ' + Dest);
+      Result := True;
+    end
+    else
+      PrintCheckMark(Ansi.Red, '✗',
+        'sqlite-vec install reported success but file is missing');
+  except
+    on E: Exception do
+      PrintCheckMark(Ansi.Red, '✗', 'sqlite-vec: ' + E.Message);
+  end;
+end;
+
+function ProvisionOnnxRuntime: Boolean;
+{ Returns True if the runtime ends up loadable (auto-downloaded on
+  win-x64 OR resolvable through the system loader on Linux/macOS).
+  EnsureOnnxRuntime is the single entry; CanAutoProvisionRuntime tells
+  us whether auto-download is even an option on this platform. }
+begin
+  Result := False;
+  if not CanAutoProvisionRuntime then
+  begin
+    PrintLn('  ' + Ansi.Dim + '·' + Ansi.Reset +
+      ' ONNX Runtime auto-download is win-x64 only on this build;');
+    PrintLn('    install via your system package manager:');
+    PrintLn('      Debian / Ubuntu:  apt install libonnxruntime-dev');
+    PrintLn('      macOS (Homebrew): brew install onnxruntime');
+    PrintLn('      Other Linux:      see https://onnxruntime.ai/docs/install/');
+  end;
+  try
+    EnsureOnnxRuntime(CacheDir,
+                      {AAllowDownload=} True,
+                      {AVerbose=}        True);
+    PrintCheckMark(Ansi.Green, '✓', 'ONNX Runtime is loadable');
+    Result := True;
+  except
+    on E: Exception do
+    begin
+      PrintCheckMark(Ansi.Red, '✗', 'ONNX Runtime: ' + E.Message);
+      if not CanAutoProvisionRuntime then
+        PrintLn('    (install per the instructions above, then re-run ' +
+                '`pasclaw memory provision`)');
+    end;
+  end;
+end;
+
+function ProvisionEmbeddingModel: Boolean;
+{ Downloads (if missing) the model.onnx + vocab.txt for the DEFAULT_MODEL
+  spec into <cache>/models/<spec.SubDir>/. Returns True on success. The
+  TModelDownloader does its own progress logging to ErrOutput. }
+var
+  Spec: TModelSpec;
+  Dir:  string;
+  D:    TModelDownloader;
+begin
+  Result := False;
+  if not FindModelSpec(DEFAULT_MODEL, Spec) then
+  begin
+    PrintCheckMark(Ansi.Red, '✗',
+      Format('embedding model: DEFAULT_MODEL "%s" not registered',
+             [DEFAULT_MODEL]));
+    Exit;
+  end;
+
+  Dir := ModelDir(Spec.SubDir);
+  ForceDirectories(Dir);
+
+  D := TModelDownloader.Create(Spec, Dir, {AVerbose=} True);
+  try
+    try
+      D.EnsureFiles;
+      if FileExists(D.ModelPath) and FileExists(D.VocabPath) then
+      begin
+        PrintCheckMark(Ansi.Green, '✓',
+          Format('embedding model %s (%s) installed at %s',
+                 [Spec.DisplayName, Spec.SizeDesc, Dir]));
+        Result := True;
+      end
+      else
+        PrintCheckMark(Ansi.Red, '✗',
+          'embedding model: download reported success but files missing');
+    except
+      on E: Exception do
+        PrintCheckMark(Ansi.Red, '✗', 'embedding model: ' + E.Message);
+    end;
+  finally
+    D.Free;
+  end;
+end;
+
+function RunProvision: Integer;
+{ Drives the three provisioning steps in order, prints a summary at
+  the end, returns 0 if all three succeeded, 1 if any failed (the
+  hybrid backend needs all three).
+
+  ForceDirectories on the cache root happens up-front so the provision
+  routines (which assume the dir exists) don't trip on the very first
+  fresh-install run. }
+var
+  OkVec, OkOrt, OkModel: Boolean;
+  Cache: string;
+begin
+  Cache := CacheDir;
+  ForceDirectories(Cache);
+
+  PrintLn(Ansi.Bold + 'Provisioning hybrid memory_search runtime' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'All artifacts land under ' + Cache + ' and are loaded' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'on demand by PasClaw.Memory.Vector — no restart needed.' + Ansi.Reset);
+  PrintLn;
+
+  OkVec   := ProvisionVecExt;
+  OkOrt   := ProvisionOnnxRuntime;
+  OkModel := ProvisionEmbeddingModel;
+
+  PrintLn;
+  if OkVec and OkOrt and OkModel then
+  begin
+    PrintLn(Ansi.Green + '✓' + Ansi.Reset +
+      ' hybrid backend ready — memory_search will use FTS + vector on next call');
+    Result := 0;
+  end
+  else
+  begin
+    PrintLn(Ansi.Yellow + '!' + Ansi.Reset +
+      ' provisioning incomplete — memory_search will fall back to FTS-only');
+    PrintLn('  Re-run after fixing the failures above.');
+    Result := 1;
+  end;
+end;
+
+function RunStatus: Integer;
+{ Read-only mirror of what PasClaw.Memory.Vector.Open checks. Useful
+  for diagnostics and as the "did the provision actually work" answer
+  separate from running memory_search. }
+var
+  Spec: TModelSpec;
+  ModelP, VocabP: string;
+  Cfg: TConfig;
+  Active: string;
+begin
+  Cfg := LoadConfig;
+  try
+    if Cfg.VectorSearchEnabled then
+      Active := 'hybrid (when artifacts present) else FTS-only'
+    else
+      Active := 'FTS-only (vector_search_enabled is false in config.json)';
+  finally
+    Cfg.Free;
+  end;
+
+  PrintLn(Ansi.Bold + 'memory_search backend' + Ansi.Reset);
+  PrintLn('  config setting: ' + Active);
+  PrintLn('  cache dir:      ' + CacheDir);
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Runtime artifacts' + Ansi.Reset);
+
+  if FileExists(VecExtPath) then
+    PrintCheckMark(Ansi.Green, '✓', 'sqlite-vec at ' + VecExtPath)
+  else
+    PrintCheckMark(Ansi.Yellow, '·', 'sqlite-vec missing at ' + VecExtPath);
+
+  if FindModelSpec(DEFAULT_MODEL, Spec) then
+  begin
+    ModelP := JoinPath(ModelDir(Spec.SubDir), 'model.onnx');
+    VocabP := JoinPath(ModelDir(Spec.SubDir), 'vocab.txt');
+    if FileExists(ModelP) then
+      PrintCheckMark(Ansi.Green, '✓',
+        Spec.DisplayName + ' model at ' + ModelP)
+    else
+      PrintCheckMark(Ansi.Yellow, '·',
+        Spec.DisplayName + ' model missing at ' + ModelP);
+    if FileExists(VocabP) then
+      PrintCheckMark(Ansi.Green, '✓', 'vocab at ' + VocabP)
+    else
+      PrintCheckMark(Ansi.Yellow, '·', 'vocab missing at ' + VocabP);
+  end;
+
+  PrintLn;
+  PrintLn(Ansi.Dim +
+    'Run `pasclaw memory provision` to download missing artifacts.' + Ansi.Reset);
+  Result := 0;
+end;
+
+function Cmd_Memory_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then
+  begin
+    Help;
+    Exit(1);
+  end;
+  Sub := LowerCase(Argv[0]);
+  if (Sub = '-h') or (Sub = '--help') or (Sub = 'help') then
+  begin
+    Help;
+    Exit(0);
+  end;
+  if Sub = 'provision' then Exit(RunProvision);
+  if Sub = 'status'    then Exit(RunStatus);
+  PrintErr('unknown memory subcommand: ' + Sub + sLineBreak);
+  Help;
+  Result := 1;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -29,7 +29,8 @@ uses
   PasClaw.CliUI,
   PasClaw.Logger,
   PasClaw.Providers.Catalog,
-  PasClaw.MCP.Catalog;
+  PasClaw.MCP.Catalog,
+  PasClaw.Cmd.Memory;
 
 function ReadLineEcho(const Prompt: string): string;
 begin
@@ -188,17 +189,16 @@ procedure PromptVectorSearch(Cfg: TConfig);
   because the hybrid index is what picoclaw / nanobot ship and it's
   what memory_search "should" feel like. The vector half adds local
   ANN search via sqlite-vec + an ONNX-runtime'd BERT embedder
-  (MiniLM / bge), fused with FTS5 BM25 through Reciprocal Rank
+  (MiniLM by default), fused with FTS5 BM25 through Reciprocal Rank
   Fusion — same shape as picoclaw.
 
-  Honest disclosure: the runtime pieces (ONNX Runtime DLL, sqlite-vec
-  extension, model weights — together ~300-500MB) get downloaded on
-  first memory_search call AFTER the follow-up PR lands the
-  provisioning hooks. This pass only records the operator's
-  preference. Until then the flag is inert — memory_search keeps
-  using FTS5-only on every code path. Operators who said yes won't
-  see a download in this release and that's OK; the next pass picks
-  the flag up and does the right thing. }
+  After the user opts in we offer to provision the runtime artifacts
+  (sqlite-vec extension, ONNX Runtime, MiniLM weights ~91 MB) right
+  now via `pasclaw memory provision`. Default NO on that follow-up
+  question because (a) the download is fat enough to deserve an
+  explicit "yes" and (b) a user with no internet at onboard time can
+  defer it. When they decline, memory_search still works — it falls
+  back to the FTS-only path until the artifacts arrive. }
 var
   Choice: string;
 begin
@@ -210,23 +210,50 @@ begin
   PrintLn(Ansi.Dim +
     'fused via Reciprocal Rank Fusion — matches picoclaw / nanobot memory_search.' +
     Ansi.Reset);
-  PrintLn(Ansi.Dim +
-    'A follow-up release downloads the embedding model (~300MB) on first use.' +
-    Ansi.Reset);
   PrintLn;
   Choice := Trim(LowerCase(ReadLineEcho('  Enable vector search for memory_search [Y/n]: ')));
-  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
-  begin
-    Cfg.VectorSearchEnabled := True;
-    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
-      ' vector search enabled (model download deferred until first memory_search)');
-  end
-  else
+  if not ((Choice = '') or (Choice = 'y') or (Choice = 'yes')) then
   begin
     Cfg.VectorSearchEnabled := False;
     PrintLn('  ' + Ansi.Dim +
       '(skipped — memory_search will use FTS5 keyword search only)' + Ansi.Reset);
+    Exit;
   end;
+
+  Cfg.VectorSearchEnabled := True;
+  PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' vector search enabled');
+
+  { Offer to fetch the runtime artifacts immediately. Default NO so a
+    user hitting Enter through the onboard doesn't get hit by a
+    91 MB download they didn't expect. If they decline, the same
+    download fires lazily on the first memory_search after they run
+    `pasclaw memory provision` themselves. }
+  PrintLn;
+  PrintLn(Ansi.Dim +
+    '  The hybrid backend needs three artifacts (~91 MB total):' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '    sqlite-vec extension     (asg017/sqlite-vec, ~150 KB)' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '    MiniLM model + vocab     (HuggingFace, ~90 MB)' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '    ONNX Runtime             (auto-download win-x64 only;' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '                              elsewhere install via system pkg mgr)' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Download now? [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    PrintLn;
+    Cmd_Memory_Run(['provision']);
+  end
+  else
+    PrintLn('  ' + Ansi.Dim +
+      '(deferred — run `pasclaw memory provision` when ready)' + Ansi.Reset);
 end;
 
 procedure PromptMCPInstalls(Cfg: TConfig);

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -52,6 +52,7 @@ uses
   PasClaw.Cmd.Update,
   PasClaw.Cmd.Post,
   PasClaw.Cmd.Membench,
+  PasClaw.Cmd.Memory,
   PasClaw.Cmd.TUI;
 
 type
@@ -106,7 +107,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 21);
+  SetLength(Sub, 22);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
@@ -127,7 +128,8 @@ begin
   Sub[17] := 'resume       Resume a saved session (alias for agent --session)';
   Sub[18] := 'steer        Push a mid-loop follow-up into a running agent';
   Sub[19] := 'update       Self-update PasClaw';
-  Sub[20] := 'version      Show version info';
+  Sub[20] := 'memory       Provision the hybrid memory_search runtime';
+  Sub[21] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -174,6 +176,7 @@ begin
   else if Cmd = 'model'    then Result := Cmd_Model_Run(Argv)
   else if Cmd = 'post'     then Result := Cmd_Post_Run(Argv)
   else if Cmd = 'membench' then Result := Cmd_Membench_Run(Argv)
+  else if Cmd = 'memory'   then Result := Cmd_Memory_Run(Argv)
   else if Cmd = 'tui'      then Result := Cmd_TUI_Run(Argv)
   else if Cmd = 'update'   then Result := Cmd_Update_Run(Argv)
   else if Cmd = 'version'  then Result := Cmd_Version_Run(Argv)


### PR DESCRIPTION
## Summary

PR #165's `PasClaw.Memory.Vector.Open()` needs three artifacts under `$PASCLAW_HOME/cache/localvector/` — sqlite-vec extension, ONNX Runtime, MiniLM model + vocab — before the hybrid backend will engage. Until now operators had to know to download those themselves. This PR closes that loop with one new command and an onboarding hook.

## New command: `src/cmd/PasClaw.Cmd.Memory.pas`

Two subcommands:

### `pasclaw memory provision`

Downloads sqlite-vec, ONNX Runtime, MiniLM model + vocab into `$PASCLAW_HOME/cache/localvector/`. Idempotent — re-running skips anything already present and redownloads anything suspiciously small (treated as a partial fetch by `TModelDownloader`, mirrors the localvector convention).

Calls the in-tree provisioning helpers that PR #165 brought in:

| Helper | What it fetches |
| --- | --- |
| `LocalVector.VecProvision.EnsureVec0` | sqlite-vec from asg017/sqlite-vec GitHub releases — cross-platform: linux / macos / windows × x86_64 / aarch64 |
| `LocalVector.OrtProvision.EnsureOnnxRuntime` | ONNX Runtime; auto-download is **win-x64 only** per `CanAutoProvisionRuntime`. Other platforms print install instructions for the system package manager. |
| `LocalVector.Downloader.TModelDownloader` | MiniLM `model.onnx` (~90 MB) + `vocab.txt` from HuggingFace |

Per-step status: green ✓ on success, red ✗ on failure, dim · for "platform doesn't support auto-download here". Final summary tells the operator whether the hybrid backend is ready or whether `memory_search` will still fall back to FTS. Exit code 0 on full success, 1 if any of the three steps failed.

### `pasclaw memory status`

Read-only view: shows the active backend (hybrid when `vector_search_enabled` and artifacts present, else FTS-only), the cache directory, and a per-artifact ✓/· checklist mirroring what `PasClaw.Memory.Vector.Open` looks for. Useful for *"did the provision actually take"* diagnostics without running a real `memory_search`.

## Onboarding hook

After the existing `PromptVectorSearch` question, when the operator said yes, ask once more: **"Download now? [y/N]"**. Default **NO** because the artifacts are ~91 MB and an Enter-through-everything onboarding shouldn't trigger a fat download the user didn't opt into. Yes invokes `Cmd_Memory_Run(['provision'])` inline; No prints "deferred, run `pasclaw memory provision` when ready".

Dropped the now-stale *"follow-up release downloads the model on first use"* disclaimer from the prompt — that follow-up release is this PR.

## Test plan

Verified end-to-end on Linux/FPC:

```
$ pasclaw memory status
  · sqlite-vec missing at .../vec0.so
  · all-MiniLM-L6-v2 model missing at .../model.onnx
  · vocab missing at .../vocab.txt

$ pasclaw memory provision
  ✓ sqlite-vec extension installed at .../vec0.so       (160 KB)
  · ONNX Runtime auto-download is win-x64 only on this build;
    install via your system package manager:
      Debian / Ubuntu:  apt install libonnxruntime-dev
      macOS (Homebrew): brew install onnxruntime
      Other Linux:      see https://onnxruntime.ai/docs/install/
  ✗ ONNX Runtime: Could not load onnxruntime. Put onnxruntime.so
    next to the executable or on the loader path.
    (install per the instructions above, then re-run
     `pasclaw memory provision`)
  ✓ embedding model all-MiniLM-L6-v2 (~90 MB) installed at .../models/...
  ! provisioning incomplete — memory_search will fall back to FTS-only

$ pasclaw memory status
  ✓ sqlite-vec at .../vec0.so
  ✓ all-MiniLM-L6-v2 model at .../model.onnx
  ✓ vocab at .../vocab.txt

$ NewVectorMemoryIndex.Open()  → returns False (ONNX missing → falls back
                                  to FTS-only as designed)
```

- [x] Real download of sqlite-vec (160 KB tar.gz extracted to `vec0.so`).
- [x] Real download of MiniLM `model.onnx` (90 MB) + `vocab.txt` (232 KB) from HuggingFace.
- [x] ONNX-Runtime-missing path prints install instructions cleanly and exits 1.
- [x] `pasclaw memory status` reports the post-provision state accurately.
- [x] `PasClaw.Memory.Vector.Open()` still returns False quietly when ONNX is missing — fallback to FTS works.
- [x] Full test suite green: smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip.
- [ ] Live `pasclaw memory provision` on Windows-x64 to confirm the ONNX auto-download branch (didn't fire on the Linux test rig).
- [ ] Live exercise of the hybrid `memory_search` path on a host with `libonnxruntime` installed system-wide — that's the full integration test which needs an environment we don't have in CI.

## Stacks on top of

PR #165 (the in-tree localvector port). #165 must merge first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_