### PR TITLE
Delphi dproj + PR #166 review fix (status checks ONNX Runtime)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -297,6 +297,42 @@ begin
       PrintCheckMark(Ansi.Yellow, '·', 'vocab missing at ' + VocabP);
   end;
 
+  { ONNX Runtime — same gate TVectorMemoryIndex.Open calls before
+    enabling the hybrid backend. Codex P2 on PR #166: on Linux/macOS a
+    host with vec0 + model + vocab on disk but no system libonnxruntime
+    will see every file-based check go green here even though
+    memory_search keeps falling back to FTS, because Open() bails on
+    EnsureOnnxRuntime first. Run the same check (AllowDownload=False
+    so this stays read-only) and surface the result so the status
+    output mirrors what the backend gate actually decides. }
+  try
+    EnsureOnnxRuntime(CacheDir,
+                      {AAllowDownload=} False,
+                      {AVerbose=}        False);
+    PrintCheckMark(Ansi.Green, '✓', 'ONNX Runtime is loadable');
+  except
+    on E: Exception do
+    begin
+      PrintCheckMark(Ansi.Yellow, '·',
+        'ONNX Runtime not loadable — ' + E.Message);
+      if not CanAutoProvisionRuntime then
+      begin
+        PrintLn('    ' + Ansi.Dim +
+          'auto-download is win-x64 only on this build; install via:' +
+          Ansi.Reset);
+        PrintLn('    ' + Ansi.Dim +
+          '  Debian / Ubuntu:  apt install libonnxruntime-dev' +
+          Ansi.Reset);
+        PrintLn('    ' + Ansi.Dim +
+          '  macOS (Homebrew): brew install onnxruntime' +
+          Ansi.Reset);
+        PrintLn('    ' + Ansi.Dim +
+          '  Other Linux:      see https://onnxruntime.ai/docs/install/' +
+          Ansi.Reset);
+      end;
+    end;
+  end;
+
   PrintLn;
   PrintLn(Ansi.Dim +
     'Run `pasclaw memory provision` to download missing artifacts.' + Ansi.Reset);

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -144,6 +144,7 @@
         <DCCReference Include="..\cmd\PasClaw.Cmd.Update.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Post.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.Membench.pas"/>
+        <DCCReference Include="..\cmd\PasClaw.Cmd.Memory.pas"/>
         <DCCReference Include="..\cmd\PasClaw.Cmd.TUI.pas"/>
 
         <!-- pkg/cliui -->
@@ -266,6 +267,26 @@
         <!-- pkg/memory -->
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.pas"/>
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.Index.pas"/>
+        <DCCReference Include="..\pkg\memory\PasClaw.Memory.Vector.pas"/>
+
+        <!-- pkg/memory/localvector — in-tree port of FMXExpress/localvector
+             (MIT, src/pkg/memory/localvector/LICENSE). Used by
+             PasClaw.Memory.Vector for the hybrid FTS5 + sqlite-vec
+             backend; provisioning surface lives in
+             PasClaw.Cmd.Memory.pas. -->
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.Models.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.Runtime.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.Sqlite3.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.Tokenizer.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.Embedder.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.VectorStore.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.VectorStore.Sqlite.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.VectorStore.FireDAC.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.Downloader.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.OrtProvision.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\LocalVector.VecProvision.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\onnxruntime.pas"/>
+        <DCCReference Include="..\pkg\memory\localvector\onnxruntime_pas_api.pas"/>
 
         <!-- pkg/updater -->
         <DCCReference Include="..\pkg\updater\PasClaw.Updater.pas"/>

--- a/src/pkg/memory/localvector/LocalVector.VectorStore.FireDAC.pas
+++ b/src/pkg/memory/localvector/LocalVector.VectorStore.FireDAC.pas
@@ -22,6 +22,27 @@ unit LocalVector.VectorStore.FireDAC;
 
 {$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
 
+{ PasClaw modification: stub on Delphi Linux64.
+
+  FireDAC.Phys.SQLiteWrapper.Stat (the static SQLite link) ships only
+  for Windows / macOS / mobile in RAD Studio — Linux64 has no static
+  build, only the dynamic libsqlite3.so path. PasClaw.dpr already
+  routes around this constraint (PR #135 added the {$IFNDEF LINUX}
+  guard there); we extend the same routing here so registering this
+  unit in PasClaw.dproj doesn't break the Delphi Linux64 build.
+
+  On Linux64 we compile to an empty unit and let
+  LocalVector.VectorStore force LV_PORTABLE_SQLITE on — the factory
+  then routes through the portable backend (dynamic libsqlite3.so),
+  which Linux64 supports fine.
+
+  Codex P1 on PR #167. }
+{$IF DEFINED(LINUX) AND NOT DEFINED(FPC)}
+interface
+implementation
+end.
+{$IFEND}
+
 interface
 
 {$IFNDEF FPC}

--- a/src/pkg/memory/localvector/LocalVector.VectorStore.pas
+++ b/src/pkg/memory/localvector/LocalVector.VectorStore.pas
@@ -18,6 +18,16 @@ unit LocalVector.VectorStore;
 
 {$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
 
+{ PasClaw modification: force the portable sqlite backend on Delphi Linux64.
+  The FireDAC backend pulls in FireDAC.Phys.SQLiteWrapper.Stat, which RAD
+  Studio ships only for Windows / macOS / mobile — exactly the same
+  constraint PasClaw.dpr already gates around (PR #135). Without this guard,
+  registering LocalVector.VectorStore.FireDAC in PasClaw.dproj breaks the
+  Delphi Linux64 build. (Codex P1 on PR #167.) }
+{$IF DEFINED(LINUX) AND NOT DEFINED(FPC)}
+  {$DEFINE LV_PORTABLE_SQLITE}
+{$IFEND}
+
 interface
 
 uses


### PR DESCRIPTION
## Summary

Two fixes against the PR #165 / PR #166 stack, batched here per maintainer routing.

### 1. Delphi `.dproj` registration (the original PR #167 scope)

Resolves the `dcc64` fatal error:

```
[dcc64 Fatal Error] PasClaw.Cmd.Memory.pas(49): F2613 Unit 'LocalVector.Models' not found.
```

Same shape as PR #156 missing after PR #155 — the FPC `Makefile` got the new unit dirs but `PasClaw.dproj` didn't. PR #165 added the in-tree localvector port under `src/pkg/memory/localvector/` + the new `PasClaw.Memory.Vector` adapter; PR #166 added `src/cmd/PasClaw.Cmd.Memory.pas`. None of them were wired into `PasClaw.dproj`.

Edits to `src/pasclaw/PasClaw.dproj`:

- **`DCC_UnitSearchPath`** — added `..\pkg\memory\localvector` right after `..\pkg\memory`.
- **`DCCReference` — pkg/memory** — added `PasClaw.Memory.Vector.pas` (PR #165) + all 13 in-tree localvector files (`LocalVector.Models` / `Runtime` / `Sqlite3` / `Tokenizer` / `Embedder` / `VectorStore[.Sqlite,.FireDAC]` / `Downloader` / `OrtProvision` / `VecProvision` + `onnxruntime.pas` + `onnxruntime_pas_api.pas`).
- **`DCCReference` — cmd** — added `PasClaw.Cmd.Memory.pas` (PR #166).

### 2. PR #166 Codex P2 — check ONNX Runtime in `memory status`

Codex flagged that `pasclaw memory status` was lying when artifacts were partially provisioned: with `vec0` + model + vocab on disk but no loadable ONNX Runtime (the common Linux/macOS state, since auto-download is win-x64 only), every checklist row went green even though `TVectorMemoryIndex.Open()` would still fail at the `EnsureOnnxRuntime` call and `memory_search` would keep falling back to FTS-only. The diagnostic said "provision took"; the runtime said otherwise.

**Fix.** Run the same `EnsureOnnxRuntime` check the backend gate uses (`AllowDownload=False` so status stays read-only) and surface a fourth checklist row with the result. On failure, when `CanAutoProvisionRuntime` is False (Linux/macOS today), also print the system-package install instructions in dim text so the operator knows the path forward without having to re-run `pasclaw memory provision` just to see them.

Verified by synthesising the exact partial-provision scenario Codex described:

```
$ pasclaw memory status
  ✓ sqlite-vec at .../vec0.so
  ✓ all-MiniLM-L6-v2 model at .../model.onnx
  ✓ vocab at .../vocab.txt
  · ONNX Runtime not loadable — Could not load onnxruntime. Put
    onnxruntime.so next to the executable or on the loader path.
    auto-download is win-x64 only on this build; install via:
      Debian / Ubuntu:  apt install libonnxruntime-dev
      macOS (Homebrew): brew install onnxruntime
      Other Linux:      see https://onnxruntime.ai/docs/install/
```

Same scenario pre-fix showed all three files as ✓ and zero signal that the hybrid backend wouldn't engage.

## Test plan

- [x] FPC build clean on Linux. Full test suite green: smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip.
- [x] Status output verified for the partial-provision case (files present, ONNX missing) — now reports the ONNX gap correctly.
- [ ] `dcc64` build of `PasClaw.dproj` (or full Delphi build via `build-delphi.bat`) to confirm the F2613 is resolved and all 14 new units link.

## Stacks on

PR #166 (`pasclaw memory provision` + onboarding hook), which stacks on PR #165 (in-tree localvector port). Merge order: **#165 → #166 → this**.