### PR TITLE
Delphi memory fixes: FireDAC.Stan.Param + paren-star stub comment

### DIFF
--- a/src/pkg/memory/PasClaw.Memory.Index.pas
+++ b/src/pkg/memory/PasClaw.Memory.Index.pas
@@ -75,7 +75,7 @@ uses
   sqldb, sqlite3conn,
   {$ELSE}
   FireDAC.Comp.Client, FireDAC.Phys.SQLite, FireDAC.Stan.Def,
-  FireDAC.Stan.Async, FireDAC.DApt,
+  FireDAC.Stan.Async, FireDAC.Stan.Param, FireDAC.DApt,
   {$ENDIF}
   PasClaw.Utils,
   PasClaw.Logger;

--- a/src/pkg/memory/localvector/LocalVector.VectorStore.FireDAC.pas
+++ b/src/pkg/memory/localvector/LocalVector.VectorStore.FireDAC.pas
@@ -22,21 +22,29 @@ unit LocalVector.VectorStore.FireDAC;
 
 {$IFDEF FPC}{$mode delphi}{$H+}{$ENDIF}
 
-{ PasClaw modification: stub on Delphi Linux64.
+(* PasClaw modification: stub on Delphi Linux64.
 
   FireDAC.Phys.SQLiteWrapper.Stat (the static SQLite link) ships only
   for Windows / macOS / mobile in RAD Studio — Linux64 has no static
   build, only the dynamic libsqlite3.so path. PasClaw.dpr already
-  routes around this constraint (PR #135 added the {$IFNDEF LINUX}
-  guard there); we extend the same routing here so registering this
-  unit in PasClaw.dproj doesn't break the Delphi Linux64 build.
+  routes around this constraint, and we extend the same routing here
+  so registering this unit in PasClaw.dproj doesn't break the Delphi
+  Linux64 build.
 
   On Linux64 we compile to an empty unit and let
   LocalVector.VectorStore force LV_PORTABLE_SQLITE on — the factory
   then routes through the portable backend (dynamic libsqlite3.so),
   which Linux64 supports fine.
 
-  Codex P1 on PR #167. }
+  Note this comment uses paren-star delimiters rather than the
+  curly-brace ones the rest of this file uses. The text below
+  references the source-level platform guard via its bare name
+  rather than spelling out the directive verbatim, because curly-
+  brace comments DO NOT NEST in Pascal, and a literal directive
+  expression inside a curly-brace comment would be parsed as a real
+  directive by dcc64.
+
+  Codex P1 on PR #167. *)
 {$IF DEFINED(LINUX) AND NOT DEFINED(FPC)}
 interface
 implementation


### PR DESCRIPTION
## Summary

Two dcc64 errors against the just-merged PR #167:

```
[dcc64 Hint]  PasClaw.Memory.Index.pas(622): H2443
  Inline function 'TFDParam.SetAsInteger' has not been expanded
  because unit 'FireDAC.Stan.Param' is not specified in USES list

[dcc64 Error] LocalVector.VectorStore.FireDAC.pas(31): E2029
  'INTERFACE' expected but identifier 'guard' found
[dcc64 Error] LocalVector.VectorStore.FireDAC.pas(32): E2052
  Unterminated string
[dcc64 Error] LocalVector.VectorStore.FireDAC.pas(39): E2038
  Illegal character in input file: '}' (#$7D)
[dcc64 Fatal] LocalVector.VectorStore.pas(103): F2063
  Could not compile used unit 'LocalVector.VectorStore.FireDAC.pas'
```

The H2443 hint was always present but never surfaced as an error before; the four E20xx errors are a regression my PR #167 stub introduced. Both addressed here.

## 1. `PasClaw.Memory.Index.pas` — add `FireDAC.Stan.Param`

Added `FireDAC.Stan.Param` to the `{$ELSE}` branch of the FireDAC uses list (alongside `FireDAC.Comp.Client` / `Stan.Def` / `Stan.Async` / `DApt`). The `TFDParam.SetAsInteger` call at line 622 ends up inlined now and dcc64's H2443 hint goes away. No FPC behaviour change.

## 2. `LocalVector.VectorStore.FireDAC.pas` — paren-star comment delimiters

My PR #167 stub-block comment used curly-brace delimiters and literally spelled out a `{$IFNDEF LINUX}` directive **inside** the comment text:

```pascal
{ PasClaw modification: stub on Delphi Linux64.
  ... PasClaw.dpr already routes around this constraint
  (PR #135 added the {$IFNDEF LINUX}    ← dcc64 reads this as a real directive
  guard there); we extend ...
}                                       ← chokes on this closing brace
```

Curly-brace comments **do not nest in Pascal**, so dcc64 parses the inner `{$IFNDEF LINUX}` as a real compiler directive, then chokes on the `}` that was meant for the outer comment. PR #158 hit the exact same trap in `PasClaw.Providers.Gemini` and switched to `(* ... *)`; same fix here.

The comment text also no longer spells the directive verbatim — it references the source-level platform guard by its bare name — so a future reformatter doesn't accidentally re-introduce the trap by switching the comment back to curly braces.

The actual stub directive:
```pascal
{$IF DEFINED(LINUX) AND NOT DEFINED(FPC)}
interface
implementation
end.
{$IFEND}
```
is unchanged. Behaviour matrix from PR #167 still holds:

| Target | Backend |
| --- | --- |
| Delphi Windows / macOS / mobile | FireDAC backend (unchanged) |
| Delphi Linux64 | Portable Sqlite (`LV_PORTABLE_SQLITE` forced on by `LocalVector.VectorStore`) |
| FPC any-OS | Portable Sqlite (unchanged) |

## Test plan

- [x] `make` clean on Linux/FPC.
- [x] Full test suite green: smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip.
- [ ] dcc64 rebuild of `PasClaw.dproj` — to confirm the four errors + the H2443 hint are gone. Mirrors the comment-trap fix from PR #158 + a mechanical uses-list addition; no behavioural change expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_