### PR TITLE
Memory cache path: fix mixed slashes that broke Windows provisioning

### DIFF
--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -51,8 +51,19 @@ uses
   LocalVector.VecProvision,
   LocalVector.Downloader;
 
-const
-  CACHE_SUBDIR = 'cache/localvector';
+{ Cache directory under PASCLAW_HOME. Built up via nested JoinPath
+  calls — NOT as a single `'cache/localvector'` const — because on
+  Windows JoinPath only inserts a PathDelim BETWEEN the two args; an
+  embedded `/` inside one of them survives, producing mixed-separator
+  paths like `C:\Users\anony\.pasclaw\cache/localvector`. ForceDirectories
+  and the downstream CreateFile calls in the localvector downloaders
+  then disagree about where the directory actually lives, and the
+  whole provisioning step fails with "system cannot find the path
+  specified" on every artifact (Codex / user report on PR #168). }
+function CacheDir: string;
+begin
+  Result := JoinPath(JoinPath(GetHome, 'cache'), 'localvector');
+end;
 
 procedure Help;
 begin
@@ -63,11 +74,6 @@ begin
   PrintLn('              embedding model into $PASCLAW_HOME/cache/localvector/');
   PrintLn('  status      Show which runtime artifacts are present and which');
   PrintLn('              backend memory_search would pick on the next call');
-end;
-
-function CacheDir: string;
-begin
-  Result := JoinPath(GetHome, CACHE_SUBDIR);
 end;
 
 function ModelDir(const SubDir: string): string;

--- a/src/pkg/memory/PasClaw.Memory.Vector.pas
+++ b/src/pkg/memory/PasClaw.Memory.Vector.pas
@@ -73,8 +73,6 @@ const
     and matches localvector's own default. }
   MAX_SEQ_LEN = 256;
 
-  CACHE_SUBDIR = 'cache/localvector';
-
 type
   TVectorMemoryIndex = class(TInterfacedObject, IMemoryIndex)
   private
@@ -116,8 +114,14 @@ begin
 end;
 
 function TVectorMemoryIndex.CacheDir: string;
+{ Two JoinPath calls (not a single `'cache/localvector'` literal)
+  because on Windows JoinPath only inserts a PathDelim BETWEEN the
+  two args; an embedded `/` inside one of them survives, producing
+  mixed-separator paths like `C:\...\.pasclaw\cache/localvector` that
+  ForceDirectories and CreateFile then disagree about. Same root
+  cause Codex / user reported on PR #168's provisioning trace. }
 begin
-  Result := JoinPath(GetHome, CACHE_SUBDIR);
+  Result := JoinPath(JoinPath(GetHome, 'cache'), 'localvector');
 end;
 
 function TVectorMemoryIndex.VecExtPath: string;


### PR DESCRIPTION
## Summary

Live trace from a Windows operator running `pasclaw memory provision`:

```
Provisioning hybrid memory_search runtime
All artifacts land under C:\Users\anony\.pasclaw\cache/localvector
                                                  ^
                                                  here

[localvector] sqlite-vec not found - downloading v0.1.9 ...
  ✗ sqlite-vec: Cannot create file
    "C:\Users\anony\.pasclaw\cache\localvector\sqlite-vec-...tar.gz".
    The system cannot find the path specified

[localvector] onnxruntime not found - downloading ...
  runtime download failed: Cannot create file
    "C:\Users\anony\.pasclaw\cache\localvector\onnxruntime-...zip".
    The system cannot find the path specified

[localvector] downloading vocab.txt ...
  ✗ embedding model: Cannot create file
    "C:\Users\anony\.pasclaw\cache\localvector\models\...\vocab.txt".
    The system cannot find the path specified

! provisioning incomplete
```

All three downloads fail because the cache directory was never actually created. The user-visible header line (`All artifacts land under ...`) shows the smoking gun: `cache/localvector` — a forward slash on Windows.

## Cause

`JoinPath` only inserts a `PathDelim` **between** the two args; embedded separators inside either arg survive verbatim. The literal `CACHE_SUBDIR = 'cache/localvector'` embedded a POSIX `/` directly into the path. On Windows the mixed-separator result (`C:\...\.pasclaw\cache/localvector`) takes one shape going into `ForceDirectories` and a different normalised shape going into the downstream `CreateFile` calls inside the localvector downloaders — `ForceDirectories` either creates the dir at the mixed-separator path or fails silently; the subsequent file writes look for the dir at the all-backslashes path and report `system cannot find the path specified`.

Linux/macOS happened to work because POSIX `PathDelim` is `/`, so the old form was accidentally consistent there.

## Fix

Drop the `CACHE_SUBDIR` const in both the cmd handler and the backend adapter; build the cache path with nested `JoinPath` calls so each segment gets the host's `PathDelim`:

```pascal
// PasClaw.Cmd.Memory.CacheDir
// PasClaw.Memory.Vector.TVectorMemoryIndex.CacheDir
Result := JoinPath(JoinPath(GetHome, 'cache'), 'localvector');
```

Each call site carries a comment naming the trap so a future reader doesn't fold the two `JoinPaths` back into a single literal.

## Test plan

- [x] `make` clean on Linux/FPC.
- [x] `pasclaw memory status` reports `cache dir: /root/.pasclaw/cache/localvector` — all-`/` segments on POSIX, as expected.
- [x] Full test suite green: smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip.
- [ ] Live re-run of `pasclaw memory provision` on Windows to confirm the three downloads now succeed (operator can verify; the cache dir should now create cleanly and the three artifacts should land alongside it).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_