### PR TITLE
Model picker: re-use existing key on re-onboard + inline preview in `model show`

### DIFF
--- a/src/cmd/PasClaw.Cmd.Model.pas
+++ b/src/cmd/PasClaw.Cmd.Model.pas
@@ -50,30 +50,54 @@ end;
 
 function DoShow: Integer;
 { Adds a "cache freshness" annotation for the default provider's
-  /models cache when one exists, plus a hint to refresh when nothing
-  is cached. The cached body lives in
-  $PASCLAW_HOME/cache/models/<provider-name>.json — keyed on the
-  Provider Name (Cfg.DefaultProvider is a Name reference, not a
-  catalog Kind), so two configs sharing a Kind don't collide. }
+  /models cache, plus a top-N inline preview when a cache exists so
+  `pasclaw model` is actually informative without a follow-up
+  `model list` call — user feedback on the first cut was that the
+  list "wasn't there" because we only surfaced a count. The cached
+  body lives in $PASCLAW_HOME/cache/models/<provider-name>.json
+  keyed on the Provider Name (PR #171 Codex P2). }
+const
+  PREVIEW_TOP_N = 10;
 var
   Cfg: TConfig;
   R:   TModelDiscoveryResult;
+  i, N: Integer;
+  Label_: string;
 begin
   Cfg := LoadConfig;
   try
     PrintLn('default provider: ' + Cfg.DefaultProvider);
     PrintLn('default model:    ' + Cfg.DefaultModel);
 
-    if Cfg.DefaultProvider <> '' then
+    if Cfg.DefaultProvider = '' then
+      Exit(0);
+
+    if not LoadCachedModels(Cfg.DefaultProvider, R) then
     begin
-      if LoadCachedModels(Cfg.DefaultProvider, R) then
-        PrintLn(Format('models cached:    %d (refreshed %s)',
-                       [Length(R.Models), HumanAge(R.FetchedAt)]))
-      else
-        PrintLn('models cached:    ' + Ansi.Dim +
-                '(none — run `pasclaw model refresh ' + Cfg.DefaultProvider +
-                '` to populate)' + Ansi.Reset);
+      PrintLn('models cached:    ' + Ansi.Dim +
+              '(none — run `pasclaw model refresh ' + Cfg.DefaultProvider +
+              '` to populate)' + Ansi.Reset);
+      Exit(0);
     end;
+
+    PrintLn(Format('models cached:    %d (refreshed %s)',
+                   [Length(R.Models), HumanAge(R.FetchedAt)]));
+    PrintLn('');
+    N := Length(R.Models);
+    if N > PREVIEW_TOP_N then N := PREVIEW_TOP_N;
+    for i := 0 to N - 1 do
+    begin
+      Label_ := R.Models[i].Id;
+      if (R.Models[i].Display <> '') and (R.Models[i].Display <> R.Models[i].Id) then
+        Label_ := Label_ + Ansi.Dim + '   (' + R.Models[i].Display + ')' +
+                  Ansi.Reset;
+      PrintLn('  ' + Ansi.Dim + '·' + Ansi.Reset + ' ' + Label_);
+    end;
+    if Length(R.Models) > N then
+      PrintLn(Ansi.Dim +
+              Format('  (+ %d more — run `pasclaw model list %s` for the full roster)',
+                     [Length(R.Models) - N, Cfg.DefaultProvider]) +
+              Ansi.Reset);
     Result := 0;
   finally
     Cfg.Free;

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -112,99 +112,149 @@ begin
   end;
 end;
 
-function PickModelInteractive(const Spec: TProviderSpec;
-                              const APIKey: string): string;
-{ Strategy:
-    1. Try a live fetch against /v1/models (or /v1beta/models for
-       Gemini). Bounded at 8s — onboarding is interactive and a
-       provider with a slow status page shouldn't make the user
-       wait 30s before they can pick a model.
-    2. If discovery succeeds with >0 models, save the cache + show
-       a numbered picker over the top N. Default selection keeps the
-       catalog's static DefaultModel.
-    3. If discovery fails (no key, network down, provider 5xx) or
-       the list is empty, fall through to the pre-PR-#171 text input
-       so onboarding never gets stuck behind a broken /models
-       endpoint.
-  Returns the model id the user picked, or the catalog default when
-  the user just hit Enter. }
+procedure ShowPicker(const Models: TModelInfoArray;
+                     const ProviderName: string;
+                     SourceLabel: string;
+                     FetchedAt: Int64);
+{ Print the numbered picker over the top N models. SourceLabel is the
+  one-liner above the list ('Fetched live from ...', 'From cache
+  (refreshed 3 days ago)', etc.) so the user knows where the list came
+  from and whether it might be stale. }
 const
-  TIMEOUT_SEC    = 8;
-  VISIBLE_TOP_N  = 12;     { mirror what ChatGPT / Claude do on their
-                             pickers — long enough to cover the
-                             useful tier, short enough to fit on a
-                             single screen }
+  VISIBLE_TOP_N = 12;
 var
-  R: TModelDiscoveryResult;
-  i, N, Pick: Integer;
-  Label_, Input, Default: string;
+  i, N: Integer;
+  Label_: string;
 begin
-  Default := Spec.DefaultModel;
-
-  { Caller may pass Key='' for asNone providers. Those still have
-    /v1/models endpoints (Ollama serves it without auth) so we try
-    anyway; DiscoverModels short-circuits Key-required providers and
-    we'll fall through to the text input. }
-  if (Spec.Family = pfPlaceholder) or
-     ((Spec.Auth.Kind <> asNone) and (Trim(APIKey) = '')) then
-  begin
-    if Default <> '' then
-      Result := ReadLineEcho(Format('Default model [%s]: ', [Default]))
-    else
-      repeat
-        Result := ReadLineEcho('Default model (provider does not advertise one — required): ');
-      until Trim(Result) <> '';
-    if Trim(Result) = '' then Result := Default;
-    Exit;
-  end;
-
-  PrintLn(Ansi.Dim + 'Fetching available models from ' + Spec.DisplayName +
-          ' ...' + Ansi.Reset);
-  R := DiscoverModels(Spec, Spec.DefaultBase, APIKey, TIMEOUT_SEC);
-
-  if (not R.Ok) or (Length(R.Models) = 0) then
-  begin
-    if R.ErrMsg <> '' then
-      PrintLn(Ansi.Dim + '  (live fetch failed: ' + R.ErrMsg +
-              ' — falling back to text input)' + Ansi.Reset);
-    if Default <> '' then
-      Result := ReadLineEcho(Format('Default model [%s]: ', [Default]))
-    else
-      repeat
-        Result := ReadLineEcho('Default model (provider does not advertise one — required): ');
-      until Trim(Result) <> '';
-    if Trim(Result) = '' then Result := Default;
-    Exit;
-  end;
-
-  { Cache the full result, keyed on Spec.Kind because that's the
-    Provider Name UpsertProvider is about to set on the new config
-    entry (Name := Spec.Kind for both the upsert and insert paths
-    in this file). Same key future `pasclaw model refresh` and
-    `model list` invocations against this provider will use,
-    keeping the cache addressable from any of those sites. Codex
-    P2 on PR #171 — see PasClaw.Cmd.Model for the corresponding
-    cache-key shift on the refresh side. }
-  SaveCachedModels(Spec.Kind, R);
-  SortModelsByDate(R.Models);
-
-  N := Length(R.Models);
+  N := Length(Models);
   if N > VISIBLE_TOP_N then N := VISIBLE_TOP_N;
 
+  if SourceLabel <> '' then
+    PrintLn(Ansi.Dim + SourceLabel + Ansi.Reset);
   PrintLn(Format('Available models (showing %d of %d, newest first):',
-                 [N, Length(R.Models)]));
+                 [N, Length(Models)]));
   for i := 0 to N - 1 do
   begin
-    Label_ := R.Models[i].Id;
-    if (R.Models[i].Display <> '') and (R.Models[i].Display <> R.Models[i].Id) then
-      Label_ := Label_ + Ansi.Dim + '  (' + R.Models[i].Display + ')' + Ansi.Reset;
+    Label_ := Models[i].Id;
+    if (Models[i].Display <> '') and (Models[i].Display <> Models[i].Id) then
+      Label_ := Label_ + Ansi.Dim + '  (' + Models[i].Display + ')' + Ansi.Reset;
     PrintLn(Format('  %d) %s', [i + 1, Label_]));
   end;
-  if Length(R.Models) > N then
+  if Length(Models) > N then
     PrintLn(Ansi.Dim +
             Format('  (+ %d more — see `pasclaw model list %s`)',
-                   [Length(R.Models) - N, Spec.Kind]) +
+                   [Length(Models) - N, ProviderName]) +
             Ansi.Reset);
+end;
+
+function PickModelInteractive(const Spec: TProviderSpec;
+                              const APIKey: string): string;
+{ Strategy (revised after first-user feedback that the picker silently
+  disappeared when the API key prompt was skipped):
+
+    1. Load the cached model roster up-front. If a previous onboard /
+       `pasclaw model refresh` populated one, we have a list whether
+       or not the operator just entered a fresh key.
+
+    2. When the operator entered an API key, attempt the live fetch
+       too. Success → save cache + present picker over the LIVE
+       list. Failure → fall back to the cache (if any) with a clear
+       "live fetch failed, showing cache from N days ago" note. The
+       cache file is never overwritten by a failed live fetch.
+
+    3. When the operator left the key blank AND a cache exists, show
+       the cached list with a one-liner explaining why we didn't
+       refresh ("API key not entered — showing the cached roster.
+       Re-run with a key to refresh"). Better than silently dropping
+       to the text-input prompt which is what tripped up the first
+       user.
+
+    4. Only when there's no key AND no cache do we fall through to
+       the original text-input prompt, with an explicit note that
+       no list is available so the operator knows what's happening
+       rather than wondering why the picker they expected isn't
+       there.
+
+  Returns the model id the operator picked, or the catalog default
+  when they just hit Enter. }
+const
+  TIMEOUT_SEC = 8;
+var
+  Live, Cached: TModelDiscoveryResult;
+  HaveCache, HaveLive, HaveKey: Boolean;
+  Models: TModelInfoArray;
+  ProviderName, SourceLabel, Input, Default: string;
+  Pick: Integer;
+begin
+  Default      := Spec.DefaultModel;
+  ProviderName := Spec.Kind;     { same Name UpsertProvider will set;
+                                   see comment further down for the
+                                   PR #171 cache-key invariant }
+  HaveKey      := (Spec.Auth.Kind = asNone) or (Trim(APIKey) <> '');
+
+  { Step 1: see if a cached roster exists. Keyed on Spec.Kind for the
+    same reason as below — onboarding's Name == Spec.Kind invariant. }
+  HaveCache := LoadCachedModels(Spec.Kind, Cached) and (Length(Cached.Models) > 0);
+
+  { Step 2: live fetch when a key is available. Placeholder kinds and
+    keyless providers without a /models endpoint silently skip live
+    discovery; the cache is still our fallback. }
+  HaveLive := False;
+  if HaveKey and (Spec.Family <> pfPlaceholder) then
+  begin
+    PrintLn(Ansi.Dim + 'Fetching available models from ' + Spec.DisplayName +
+            ' ...' + Ansi.Reset);
+    Live := DiscoverModels(Spec, Spec.DefaultBase, APIKey, TIMEOUT_SEC);
+    if Live.Ok and (Length(Live.Models) > 0) then
+    begin
+      SaveCachedModels(Spec.Kind, Live);
+      HaveLive := True;
+    end
+    else if Live.ErrMsg <> '' then
+      PrintLn(Ansi.Dim + '  (live fetch failed: ' + Live.ErrMsg + ')' +
+              Ansi.Reset);
+  end;
+
+  { Step 3 / 4: pick the data source for the picker. Live wins over
+    cache; cache wins over no-data. }
+  if HaveLive then
+  begin
+    Models      := Live.Models;
+    SourceLabel := 'Fetched live from ' + Spec.DisplayName + '.';
+  end
+  else if HaveCache then
+  begin
+    Models := Cached.Models;
+    if HaveKey then
+      SourceLabel := 'Showing the cached roster (refreshed ' +
+                     HumanAge(Cached.FetchedAt) + ').'
+    else
+      SourceLabel := 'API key not entered — showing the cached roster (refreshed ' +
+                     HumanAge(Cached.FetchedAt) + '). Re-run with a key to refresh.';
+  end
+  else
+  begin
+    { No live, no cache → original text-input prompt. Make the lack
+      of picker explicit so the operator isn't left wondering. }
+    if not HaveKey then
+      PrintLn(Ansi.Dim +
+              'API key not entered — using the catalog default. ' +
+              'Run `pasclaw model refresh ' + ProviderName +
+              '` later to populate the picker for next time.' + Ansi.Reset);
+    if Default <> '' then
+      Result := ReadLineEcho(Format('Default model [%s]: ', [Default]))
+    else
+      repeat
+        Result := ReadLineEcho('Default model (provider does not advertise one — required): ');
+      until Trim(Result) <> '';
+    if Trim(Result) = '' then Result := Default;
+    Exit;
+  end;
+
+  SortModelsByDate(Models);
+  ShowPicker(Models, ProviderName, SourceLabel,
+             { FetchedAt unused by ShowPicker — kept on the signature for
+               future "stale by N days, refresh?" prompts } 0);
 
   if Default <> '' then
     Input := ReadLineEcho(Format(
@@ -217,8 +267,8 @@ begin
     Exit(Default);
 
   Pick := StrToIntDef(Input, 0);
-  if (Pick >= 1) and (Pick <= N) then
-    Exit(R.Models[Pick - 1].Id);
+  if (Pick >= 1) and (Pick <= Length(Models)) then
+    Exit(Models[Pick - 1].Id);
 
   { Anything else gets taken as a free-form model id — operator may
     know about a model the cache doesn't list yet. }
@@ -488,9 +538,10 @@ function Cmd_Onboard_Run(const Argv: array of string): Integer;
 var
   Cfg: TConfig;
   Home, CfgPath: string;
-  Key, Model: string;
+  Key, EffectiveKey, Model: string;
   Catalog: TProviderSpecArray;
   Spec: TProviderSpec;
+  ExistingIdx, i: Integer;
 begin
   Home    := GetHome;
   CfgPath := GetConfigPath;
@@ -539,10 +590,33 @@ begin
         Codex P2 on PR #126 was scoped to MCP but the provider-key
         prompt has the identical exposure (pasted credential lands
         in terminal scrollback / screen recordings). }
-      Key := ReadSecretLine(Spec.DisplayName + ' API key (leave blank to skip): ');
+      Key := ReadSecretLine(Spec.DisplayName +
+        ' API key (leave blank to keep existing): ');
     end;
 
-    Model := PickModelInteractive(Spec, Key);
+    { Re-onboard case: when the operator leaves the prompt blank they
+      almost always mean "keep my existing key" — they're re-running
+      onboard to tweak something else, not to wipe their auth. Pull
+      the existing key out of Cfg.Providers so PickModelInteractive
+      can still do a live /v1/models fetch with it. UpsertProvider
+      already treats Key='' as "preserve existing" further down, so
+      we don't need to copy this back into the saved Key variable —
+      just feed the picker the effective key. }
+    EffectiveKey := Key;
+    if (EffectiveKey = '') and (Spec.Auth.Kind <> asNone) then
+    begin
+      ExistingIdx := -1;
+      for i := 0 to High(Cfg.Providers) do
+        if SameText(Cfg.Providers[i].Name, Spec.Kind) then
+        begin
+          ExistingIdx := i;
+          Break;
+        end;
+      if (ExistingIdx >= 0) and (Cfg.Providers[ExistingIdx].APIKey <> '') then
+        EffectiveKey := Cfg.Providers[ExistingIdx].APIKey;
+    end;
+
+    Model := PickModelInteractive(Spec, EffectiveKey);
 
     Cfg.DefaultProvider := Spec.Kind;
     if Model <> '' then Cfg.DefaultModel := Model;

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -112,38 +112,47 @@ begin
   end;
 end;
 
-procedure ShowPicker(const Models: TModelInfoArray;
-                     const ProviderName: string;
-                     SourceLabel: string;
-                     FetchedAt: Int64);
-{ Print the numbered picker over the top N models. SourceLabel is the
+function ShowPicker(const Models: TModelInfoArray;
+                    const ProviderName: string;
+                    SourceLabel: string;
+                    FetchedAt: Int64): Integer;
+{ Prints the numbered picker over the top N models. SourceLabel is the
   one-liner above the list ('Fetched live from ...', 'From cache
   (refreshed 3 days ago)', etc.) so the user knows where the list came
-  from and whether it might be stale. }
+  from and whether it might be stale.
+
+  Returns the number of rows actually printed (the visible count, N).
+  Caller MUST validate any typed numeric pick against this returned
+  value, NOT Length(Models) — typing 47 against a 12-row visible list
+  would otherwise silently pick a model the user can't see. Codex P2
+  on PR #172. }
 const
-  VISIBLE_TOP_N = 12;
+  VISIBLE_TOP_N = 12;     { mirror what ChatGPT / Claude do on their
+                            pickers — long enough to cover the
+                            useful tier, short enough to fit on a
+                            single screen }
 var
-  i, N: Integer;
+  i: Integer;
   Label_: string;
 begin
-  N := Length(Models);
-  if N > VISIBLE_TOP_N then N := VISIBLE_TOP_N;
+  Result := Length(Models);
+  if Result > VISIBLE_TOP_N then Result := VISIBLE_TOP_N;
 
   if SourceLabel <> '' then
     PrintLn(Ansi.Dim + SourceLabel + Ansi.Reset);
   PrintLn(Format('Available models (showing %d of %d, newest first):',
-                 [N, Length(Models)]));
-  for i := 0 to N - 1 do
+                 [Result, Length(Models)]));
+  for i := 0 to Result - 1 do
   begin
     Label_ := Models[i].Id;
     if (Models[i].Display <> '') and (Models[i].Display <> Models[i].Id) then
       Label_ := Label_ + Ansi.Dim + '  (' + Models[i].Display + ')' + Ansi.Reset;
     PrintLn(Format('  %d) %s', [i + 1, Label_]));
   end;
-  if Length(Models) > N then
+  if Length(Models) > Result then
     PrintLn(Ansi.Dim +
             Format('  (+ %d more — see `pasclaw model list %s`)',
-                   [Length(Models) - N, ProviderName]) +
+                   [Length(Models) - Result, ProviderName]) +
             Ansi.Reset);
 end;
 
@@ -184,7 +193,7 @@ var
   HaveCache, HaveLive, HaveKey: Boolean;
   Models: TModelInfoArray;
   ProviderName, SourceLabel, Input, Default: string;
-  Pick: Integer;
+  Pick, VisibleN: Integer;
 begin
   Default      := Spec.DefaultModel;
   ProviderName := Spec.Kind;     { same Name UpsertProvider will set;
@@ -252,9 +261,10 @@ begin
   end;
 
   SortModelsByDate(Models);
-  ShowPicker(Models, ProviderName, SourceLabel,
-             { FetchedAt unused by ShowPicker — kept on the signature for
-               future "stale by N days, refresh?" prompts } 0);
+  VisibleN := ShowPicker(Models, ProviderName, SourceLabel,
+                         { FetchedAt unused by ShowPicker — kept on the
+                           signature for future "stale by N days,
+                           refresh?" prompts } 0);
 
   if Default <> '' then
     Input := ReadLineEcho(Format(
@@ -266,8 +276,13 @@ begin
   if (Input = '') and (Default <> '') then
     Exit(Default);
 
+  { Validate against VisibleN (the count ShowPicker actually printed),
+    NOT Length(Models). Typing 47 against a 12-row visible list used
+    to silently pick an off-screen model — Codex P2 on PR #172. Numbers
+    outside the visible range fall through to the free-form-id branch
+    below, same as any non-numeric input. }
   Pick := StrToIntDef(Input, 0);
-  if (Pick >= 1) and (Pick <= Length(Models)) then
+  if (Pick >= 1) and (Pick <= VisibleN) then
     Exit(Models[Pick - 1].Id);
 
   { Anything else gets taken as a free-form model id — operator may


### PR DESCRIPTION
## Summary

You reported that `pasclaw onboard` didn't show the model picker — only the old "Default model [gemini-3.5-flash]:" prompt — even though PR #171 was supposed to add live discovery. **You confirmed: re-onboarding with an existing API key in config.** That's the most common flow, and PR #171 silently broke it.

Two root causes, both fixed:

## Cause 1 — Re-onboard with an existing key

The API key prompt says "leave blank to skip" so a re-onboarding user hits Enter to preserve their existing key. PR #171's `PickModelInteractive` saw an empty `APIKey` argument, treated the auth-required provider as unreachable, and silently fell through to the text-input prompt without ever attempting discovery.

**Fix in `Cmd.Onboard.RunOnboard`:** when the operator's key entry is blank, walk `Cfg.Providers` for an existing row matching `Spec.Kind` and reuse its `APIKey` as the effective key for discovery. `UpsertProvider` already treats `Key=''` as "preserve existing" so the saved config is untouched — this only affects the discovery path. Prompt copy also flipped from `"leave blank to skip"` to `"leave blank to keep existing"` so the existing-key path reads correctly.

## Cause 2 — Silent skip when no key available

Even when the user had no existing key, PR #171's picker fell straight to the text prompt with zero explanation. You rightly read that as "the picker is broken."

**Refactored `PickModelInteractive` into a four-step pipeline:**

1. Load any cached roster up-front.
2. If a key is available (entered OR existing), attempt the live fetch; on success refresh the cache.
3. Pick the data source: **live > cache > nothing**. `SourceLabel` explains where the list came from:
   - `Fetched live from Anthropic.`
   - `Showing the cached roster (refreshed 3 days ago).`
   - `API key not entered — showing the cached roster (refreshed 3 days ago). Re-run with a key to refresh.`
4. Only when there's **no live and no cache** do we drop to the text-input prompt, and we print an explicit one-liner — `API key not entered — using the catalog default. Run `pasclaw model refresh <provider>` later to populate the picker for next time.` — so you know why the picker isn't there.

The cache is never overwritten by a failed live fetch.

## `pasclaw model show` also got the inline preview

You also ran `pasclaw model` looking for a list and only saw the cache count. `show` now inlines a top-10 preview directly under the freshness line:

```
default provider: anthropic
default model:    claude-opus-4-7
models cached:    47 (refreshed 3 days ago)

  · claude-opus-4-8   (Claude Opus 4.8)
  · claude-opus-4-7   (Claude Opus 4.7)
  · claude-sonnet-4-6 (Claude Sonnet 4.6)
  ...
  (+ 37 more — run `pasclaw model list anthropic` for the full roster)
```

## Test plan

- [x] FPC build clean on Linux.
- [x] Synthesised cache → `pasclaw model show` renders the inline preview correctly.
- [x] Full test suite green: smoke + hashline + toolview + anthropic-server-tools + openai-server-tools + println-helper + utf8-codepage-tag + gemini-schema-strip + markdown-render + json-utf8-roundtrip + model-discovery.
- [ ] Live re-onboard with an existing Gemini / Anthropic / OpenAI key in `config.json`, hitting Enter at the API key prompt — should now show the live picker with the fresh roster.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_