### PR TITLE
Cleanup: dcc64 hints + the E2003 from the /stats overlay PR

### DIFF
--- a/src/cmd/PasClaw.Cmd.Skills.pas
+++ b/src/cmd/PasClaw.Cmd.Skills.pas
@@ -361,7 +361,10 @@ begin
   end;
 
   PrintLn(Ansi.Dim + '  not on pasclaw.dev — trying ClawHub …' + Ansi.Reset);
-  ClawNotFound := False;
+  { Pre-call `ClawNotFound := False` removed — dead write per dcc64
+    H2077. The only read is at the `if not ClawNotFound` below, and
+    we unconditionally reassign on line `ClawNotFound := SameText(...)`
+    before that read. }
   if InstallFromClawHub(Slug, Version, DestRoot, Installed, ErrMsg) then
   begin
     PrintLn(Ansi.Green + '✓ ' + Ansi.Reset + 'installed as ' +

--- a/src/pkg/channels/PasClaw.Channels.Email.pas
+++ b/src/pkg/channels/PasClaw.Channels.Email.pas
@@ -164,8 +164,10 @@ begin
   Result := 30;
   T := Trim(S);
   if T = '' then Exit;
-  { Strip trailing s/m/h }
-  if (Length(T) > 1) and (T[Length(T)] in ['s', 'm', 'h', 'S', 'M', 'H']) then
+  { Strip trailing s/m/h. CharInSet (vs `in [...]`) silences dcc64
+    W1050: on the modern compiler Char is WideChar and a bare set
+    membership test against byte-char literals narrows implicitly. }
+  if (Length(T) > 1) and CharInSet(T[Length(T)], ['s', 'm', 'h', 'S', 'M', 'H']) then
   begin
     case T[Length(T)] of
       's', 'S': N := 1;

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -374,7 +374,9 @@ begin
   AResponse.ContentText := '{}';
   AResponse.ContentType := 'application/json';
 
-  Root := nil;
+  { Pre-try `Root := nil` removed — dead write per dcc64 H2077. The
+    except branch always Exits, so Root is either assigned by Parse
+    on the success path or we never reach the post-try-except code. }
   try
     Root := TJsonObject.Parse(Body);
   except

--- a/src/pkg/channels/PasClaw.Channels.Matrix.pas
+++ b/src/pkg/channels/PasClaw.Channels.Matrix.pas
@@ -424,7 +424,9 @@ var
   RoomIds: TStringList;
   RoomId: string;
 begin
-  Root := nil;
+  { Pre-try `Root := nil` removed — dead write per dcc64 H2077. The
+    except branch always Exits, so Root is either assigned by Parse
+    on the success path or we never reach the post-try-except code. }
   try
     Root := TJsonObject.Parse(RawJSON);
   except

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -381,7 +381,9 @@ begin
   AResponse.ContentText := '{}';
   AResponse.ContentType := 'application/json';
 
-  Root := nil;
+  { Pre-try `Root := nil` removed — dead write per dcc64 H2077. The
+    except branch always Exits, so Root is either assigned by Parse
+    on the success path or we never reach the post-try-except code. }
   try
     Root := TJsonObject.Parse(Body);
   except

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -102,7 +102,10 @@ type
                               out AResponseStarted: Boolean);
     procedure HandleModels(AResp: TIdHTTPResponseInfo);
     procedure WriteJSON(AResp: TIdHTTPResponseInfo; Code: Integer; const Body: string);
-    procedure WriteSSE(AResp: TIdHTTPResponseInfo; const Body: string);
+    { TGatewayServer.WriteSSE removed — never called. The streaming
+      response paths build their SSE frames via TSSEStreamer +
+      TLogStreamWriter (which has its own WriteSSE on a different
+      class). Codex dcc64 H2219 cleanup. }
   public
     constructor Create(Cfg: TConfig; Provider: ILLMProvider; Registry: TToolRegistry);
     destructor  Destroy; override;
@@ -275,15 +278,8 @@ begin
   WriteBodyStream(AResp, Body);
 end;
 
-procedure TGatewayServer.WriteSSE(AResp: TIdHTTPResponseInfo; const Body: string);
-begin
-  AResp.ResponseNo := 200;
-  AResp.ContentType := 'text/event-stream; charset=utf-8';
-  AResp.CharSet     := 'utf-8';
-  AResp.CustomHeaders.AddValue('Cache-Control', 'no-cache');
-  AResp.CustomHeaders.AddValue('X-Accel-Buffering', 'no');
-  WriteBodyStream(AResp, Body);
-end;
+{ TGatewayServer.WriteSSE removed — dead method, see class
+  declaration. dcc64 H2219 cleanup. }
 
 procedure TGatewayServer.OnCommandGet(AContext: TIdContext;
                                      ARequest: TIdHTTPRequestInfo;
@@ -543,7 +539,6 @@ procedure TGatewayServer.HandleMemoryRead(const Doc: string;
 var
   Name, Path, Body: string;
   Root: TJsonObject;
-  i: Integer;
 begin
   Name := Copy(Doc, Length('/v1/memory/') + 1, MaxInt);
   { Refuse any path-traversal — only bare filenames inside the
@@ -577,7 +572,6 @@ begin
   finally
     Root.Free;
   end;
-  if i = 0 then;   { silence unused-var warning }
 end;
 
 procedure TGatewayServer.HandleConfig(AResp: TIdHTTPResponseInfo);
@@ -1673,7 +1667,9 @@ begin
           begin
             try
               Streamer.WriteError('internal error: ' + SanitizeStreamError(E.Message));
-              StreamClosed := Streamer.Closed;
+              { Previously assigned StreamClosed := Streamer.Closed here;
+                dropped — `raise;` below unwinds the stack so the value
+                is never read. dcc64 H2077 cleanup. }
             except
               if (AContext <> nil) and (AContext.Connection <> nil) then
                 AContext.Connection.Disconnect;

--- a/src/pkg/mcp/PasClaw.MCP.Hub.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Hub.pas
@@ -370,7 +370,10 @@ var
   Entry: TMCPCatalogEntry;
   ProjectErr: string;
 begin
-  Result := False;
+  { Result := False removed — dead write per dcc64 H2077. The two
+    success exits (hub fetch produced entries; builtin fallback) both
+    explicitly set Result := True before returning. No code path
+    leaves the function without one of those assignments. }
   Source := '';
   HubSkipped := 0;
   HubErr := '';

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -46,6 +46,10 @@ uses
                                      from the interface section's uses, not
                                      just the implementation's. FPC was
                                      permissive about this; dcc64 is not. }
+  PasClaw.Tools.ToolLoop,          { TToolLoopResult — referenced by the
+                                     AccumulateLoopStats method declaration
+                                     in the TTUI class; same dcc64
+                                     visibility rule as the line above. }
   PasClaw.Tools.Registry,
   PasClaw.Session.Store;
 
@@ -204,7 +208,8 @@ uses
   DateUtils,
   PasClaw.CliUI,
   PasClaw.Logger,
-  PasClaw.Tools.ToolLoop,
+  { PasClaw.Tools.ToolLoop now lives in the interface uses (above) so
+    dcc64 can see TToolLoopResult from the TTUI class declaration. }
   PasClaw.Tools.OutputCache,       { GetOutputCacheStats — surfaced
                                      in /stats overlay }
   PasClaw.Agent.Steering,


### PR DESCRIPTION
## Summary

Batch fix of the dcc64 diagnostics you posted — one real compile error from PR #176 plus a handful of dead writes / unused declarations / a Char-set narrowing that FPC's mode delphi tolerates but dcc64 flags.

### Compile error (real)

- **`PasClaw.TUI.pas(144)` E2003 Undeclared identifier: 'TToolLoopResult'** — `AccumulateLoopStats(const Loop: TToolLoopResult)` is declared in the `TTUI` interface section, so dcc64 needs `PasClaw.Tools.ToolLoop` visible from the interface uses, not just the implementation. Same fix shape as PR #174's `TModelInfoArray` move. Moved the unit up to the interface uses; left a one-line marker in the impl uses.

### Dead writes (H2077)

All six were `Init := X; ...; Init := Y;` where the `...` block never reads `X`:

- `PasClaw.Channels.LINE.pas:377` — `Root := nil` ahead of `Root := TJsonObject.Parse(Body)`; the except branch `Exit`s, so the nil is unreachable from any read.
- `PasClaw.Channels.WhatsApp.pas:384` — same shape.
- `PasClaw.Channels.Matrix.pas:427` — same shape.
- `PasClaw.MCP.Hub.pas:373` — `Result := False` at the top of `ResolveMCPCatalog`; both function exits set `Result := True`.
- `PasClaw.Cmd.Skills.pas:364` — `ClawNotFound := False` immediately overwritten by `SameText(...)` before any read.
- `PasClaw.Gateway.Server.pas:1676` — `StreamClosed := Streamer.Closed` inside an exception handler that re-`raise`s; the value can't be read after the unwind.

### Unused symbol (H2219)

- `PasClaw.Gateway.Server.pas:105` — private `TGatewayServer.WriteSSE` method. Streaming paths use `TSSEStreamer` + `TLogStreamWriter.WriteSSE` (a different class). The `TGatewayServer` copy was never wired up. Removed both declaration and implementation.

### Maybe-uninitialized var (W1036)

- `PasClaw.Gateway.Server.pas:580` — `HandleMemoryRead` declared a stray `i: Integer;` and ended with `if i = 0 then;` as an FPC "silence unused var" hack. dcc64 reads it as an uninitialized var read. Removed both the declaration and the hack.

### WideChar narrowed in set expression (W1050)

- `PasClaw.Channels.Email.pas:168` — `T[Length(T)] in ['s', 'm', 'h', 'S', 'M', 'H']`. On dcc64, `T[i]` is `WideChar` and the bare set literal is byte chars — implicit narrowing. Replaced with `CharInSet(T[Length(T)], [...])` from `SysUtils`, which handles the conversion safely.

## Test plan

- [x] `make` clean rebuild succeeds (FPC, mode delphi) — `make test` runs all 11 suites green.
- [ ] dcc64 / Delphi build of `PasClaw.dproj` — confirm all 10 diagnostics (1 E2003 + 6 H2077 + 1 H2219 + 1 W1036 + 1 W1050) are gone.

Each fix is mechanical and self-contained; no behavioral changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_