### PR TITLE
Cleanup: round-two dcc64 hints (RenameFile inlines, deprecated Info.Time, dead writes)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -194,7 +194,11 @@ var
   ArgArr: TArray<string>;
   Cfg: TConfig;
 begin
-  Result := 0;
+  { Result := 0 removed — dead write per dcc64 H2077. Every exit
+    path assigns Result before returning: Exit(0) for the help
+    branch, Result := DispatchCommand(...) for the dispatch
+    branch (which itself always assigns Result, including the
+    unknown-command else clause). }
   Args := CollectArgs;
   try
     StripGlobalFlags(Args);

--- a/src/pkg/agent/PasClaw.Agent.Steering.pas
+++ b/src/pkg/agent/PasClaw.Agent.Steering.pas
@@ -76,6 +76,11 @@ implementation
 
 uses
   Classes, DateUtils,
+  {$IFDEF MSWINDOWS}
+  { Lets dcc64 inline SysUtils.RenameFile (used by the .drain
+    handoff in Drain) instead of falling back and emitting H2443. }
+  {$IFDEF FPC}Windows,{$ELSE}Winapi.Windows,{$ENDIF}
+  {$ENDIF}
   PasClaw.Utils,
   PasClaw.Config,
   PasClaw.Session.Store,
@@ -133,7 +138,11 @@ begin
       directory itself gives us its mtime via SR.Time. }
     if FindFirst(LockDir, faDirectory, Info) = 0 then
     try
-      Age := DateTimeToUnix(Now, False) - DateTimeToUnix(FileDateToDateTime(Info.Time), False);
+      { Info.TimeStamp is the modern TDateTime field — the legacy
+        Info.Time + FileDateToDateTime pair is deprecated on dcc64
+        (W1000) and flagged platform-specific (W1002). TimeStamp
+        has shipped on both FPC 3.0+ and Delphi for years. }
+      Age := DateTimeToUnix(Now, False) - DateTimeToUnix(Info.TimeStamp, False);
       if Age > STALE_LOCK_SECS then
       begin
         LogWarn('steering: reclaiming stale lock %s (age=%ds)', [LockDir, Age]);

--- a/src/pkg/cron/PasClaw.Cron.State.pas
+++ b/src/pkg/cron/PasClaw.Cron.State.pas
@@ -55,6 +55,12 @@ implementation
 
 uses
   DateUtils,
+  {$IFDEF MSWINDOWS}
+  { Lets dcc64 inline SysUtils.RenameFile — 4 RenameFile calls in
+    this unit's Load + Save paths all triggered H2443 without this.
+    Same pattern as PasClaw.Session.Store / PasClaw.Agent.Steering. }
+  {$IFDEF FPC}Windows,{$ELSE}Winapi.Windows,{$ENDIF}
+  {$ENDIF}
   PasClaw.JSON,
   PasClaw.Config,
   PasClaw.Utils,

--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -110,6 +110,12 @@ implementation
 
 uses
   DateUtils,
+  {$IFDEF MSWINDOWS}
+  { Lets dcc64 inline SysUtils.RenameFile (used by Save's atomic
+    write) — without this it falls back to a regular call and emits
+    H2443. Mirrors the pattern used in PasClaw.CliUI / PasClaw.Crypto.Random. }
+  {$IFDEF FPC}Windows,{$ELSE}Winapi.Windows,{$ENDIF}
+  {$ENDIF}
   PasClaw.Config,
   PasClaw.Utils,
   PasClaw.Logger;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -163,11 +163,18 @@ type
     procedure Flash(const Msg: string);
     function CurrentSpinnerChar: Char;
     {$ENDIF}
+    {$IFDEF FPC}
+    { Legacy line-based REPL surface, used by the FPC build only.
+      The Delphi build's positioned TUI handles slash commands
+      inline inside SubmitInput, so these methods would never be
+      called — declaring them on the Delphi side just triggered
+      H2219 "unused private symbol". }
     procedure DrawHeader;
     procedure ShowHelp;
     procedure ShowTools;
     procedure HandleSlashCommand(const Cmd: string);
     procedure HandleUserInput(const Text: string);
+    {$ENDIF}
   public
     (* Operator's prompt-cache settings. Defaults to default-on (matches
        DefaultChatOptions). Cmd_TUI_Run copies Cfg.PromptCache into this
@@ -840,7 +847,9 @@ begin
     Label_ := '   (none yet)';
     while Length(Label_) < BoxW - 2 do Label_ := Label_ + ' ';
     WriteAnsiText(ConsoleTheme.Text, Side + Label_ + Side);
-    Inc(Row);
+    { Row no longer read after this — bottom border is positioned
+      via BoxY + BoxH - 1 below. Dropping the trailing Inc to
+      silence dcc64 H2077. }
   end
   else
   begin
@@ -861,7 +870,7 @@ begin
                        [Length(FStatsToolCallNames) - ToolRows]);
       while Length(Label_) < BoxW - 2 do Label_ := Label_ + ' ';
       WriteAnsiText(ConsoleTheme.Text, Side + Label_ + Side);
-      Inc(Row);
+      { Same reason: Row not read after — see comment above. }
     end;
   end;
 
@@ -1927,17 +1936,13 @@ begin
   end;
 end;
 
-{ The slash-command + Help/Tools surface from the old REPL stays
-  available — but it's invoked from inside the input buffer now
-  (typing "/help" + Enter) so users don't have to learn a new
-  dispatch model. Empty stubs here keep the FPC-shared interface
-  happy without re-implementing the legacy box renderer. }
-
-procedure TTUI.DrawHeader;     begin end;
-procedure TTUI.ShowHelp;       begin end;
-procedure TTUI.ShowTools;      begin end;
-procedure TTUI.HandleSlashCommand(const Cmd: string); begin end;
-procedure TTUI.HandleUserInput(const Text: string);   begin end;
+{ Slash commands / help / tools are handled inline by SubmitInput
+  in the Delphi positioned-TUI path above (see /help, /theme,
+  /model, /stats dispatching there). The legacy REPL-style methods
+  (DrawHeader / ShowHelp / ShowTools / HandleSlashCommand /
+  HandleUserInput) live in the FPC branch below — their
+  declarations are also gated on FPC in the class section so dcc64
+  doesn't emit H2219 for unused private symbols. }
 
 {$ELSE}
 { ============================= FPC (line-based) ============================ }


### PR DESCRIPTION
## Summary

Round-two batch of dcc64 cleanups. Same shape as PR #177 — no behavior changes, just silencing diagnostics one mechanical fix at a time.

### H2443 — `RenameFile` inline can't expand without `Winapi.Windows`

`SysUtils.RenameFile` on modern Delphi is declared inline and its body references `Winapi.Windows.MoveFileEx`. Without that unit in the caller's `uses`, dcc64 falls back to a non-inlined call and emits H2443. Added the standard cross-compiler gate to each unit's implementation `uses`:

```pascal
{$IFDEF MSWINDOWS}
{$IFDEF FPC}Windows,{$ELSE}Winapi.Windows,{$ENDIF}
{$ENDIF}
```

This is the exact pattern PasClaw already uses in `PasClaw.CliUI`, `PasClaw.Crypto.Random`, `LocalVector.Sqlite3`, etc. Affected files:

- `PasClaw.Session.Store.pas` (line 343 — atomic session save)
- `PasClaw.Agent.Steering.pas` (line 281 — drain handoff)
- `PasClaw.Cron.State.pas` (4 sites at lines 103/194/202/206 — atomic state save with `.bak` rollback)

### W1000 / W1002 — deprecated `TSearchRec.Time`

`PasClaw.Agent.Steering.pas:136` calls `FileDateToDateTime(Info.Time)` to convert a `FindFirst` result's mtime. `TSearchRec.Time` is the legacy DOS-format Integer field marked deprecated + platform-specific on dcc64. Swapped for `Info.TimeStamp` — already a `TDateTime`, no conversion needed. Available on FPC 3.0+ and every Delphi release that emits the warning, so both compilers stay happy.

### H2077 — dead writes

- `PasClaw.TUI.pas:843, 864` — two `Inc(Row);` calls at the tail of `DrawStatsOverlay` branches. Row isn't read after the branch converges (the bottom border uses `BoxY + BoxH - 1`). Dropped both.
- `PasClaw.Cmd.Root.pas:197` — `Result := 0;` in `RunRootCommand`. Every exit path assigns Result before returning: `Exit(0)` for the help branch, `Result := DispatchCommand(...)` for the main branch (and `DispatchCommand` itself assigns Result on every code path, including the unknown-command else). The leading `Result := 0` is unreachable from any read.

### H2219 — unused private symbols (FPC stubs in the Delphi build)

`PasClaw.TUI.pas:166-170` declared `DrawHeader / ShowHelp / ShowTools / HandleSlashCommand / HandleUserInput` unconditionally on the class, but they're the legacy REPL surface used only by the FPC line-based TUI. The Delphi positioned-TUI handles slash commands inline inside `SubmitInput`, so dcc64 saw five private methods with empty stub bodies and nobody calling them. Wrapped both the declarations and the stub implementations in `{$IFDEF FPC}`. The FPC build path is unchanged; the Delphi class no longer carries dead surface.

## Test plan

- [x] `make` rebuilds cleanly (FPC, mode delphi)
- [x] `make test` — all 11 suites green (smoke, hashline, toolview, server-tools, printer, utf8, schema-strip, markdown, json-utf8, model_discovery, output_cache)
- [ ] dcc64 / Delphi build of `PasClaw.dproj` — confirm all 14 diagnostics gone (6× H2443, 1× W1000, 1× W1002, 3× H2077, 5× H2219)

Each fix is mechanical and self-contained; no behavioral changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_