### PR TITLE
Cleanup: round-four dcc64 (E2008 working-state assign + W1050 hashline)

### DIFF
--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -645,7 +645,11 @@ begin
         Match := HL_PAYLOAD_REPLACE;
       if Match = '' then Continue;
       j := p - 1;
-      while (j >= 1) and (L[j] in ['0'..'9']) do Dec(j);
+      { CharInSet vs bare `in [...]` silences dcc64 W1050: on the
+        modern Delphi compiler L[j] is WideChar and the byte-char
+        set literal narrows implicitly. Same fix shape as PR #177
+        applied to Channels.Email. }
+      while (j >= 1) and CharInSet(L[j], ['0'..'9']) do Dec(j);
       if (j = 0) or ((j >= 1) and (L[j] = '-')) then
       begin
         ErrMsg := Format('line %d: unsupported inline payload token near "%s"; use canonical grammar with anchor on its own line and payload lines beginning with %s/%s/%s',

--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -68,8 +68,16 @@ type
      Persisted under the 'working_state' object inside session
      JSON. Empty defaults: no fields emitted unless populated, so
      pre-existing session files round-trip without bloat. *)
+  { Named alias so PushEditedFile (and any future caller that
+    builds the array fresh) can assign back into the record's
+    field without dcc64 raising E2008 "Incompatible types" on the
+    anonymous `array of string` vs the field's anonymous type.
+    Same pattern PasClaw uses elsewhere for TLLMProviderArray /
+    TSubagentSpecArray / TStringArray. }
+  TEditedFilesArray = array of string;
+
   TWorkingState = record
-    EditedFiles: array of string;
+    EditedFiles: TEditedFilesArray;
     LastShell:   string;
     LastError:   string;
     Updated:     Int64;
@@ -440,7 +448,9 @@ procedure PushEditedFile(var W: TWorkingState; const Path: string);
   first so the formatted block reads chronologically backward. }
 var
   i: Integer;
-  Tmp: array of string;
+  Tmp: TEditedFilesArray;     { named-type alias so the W.EditedFiles
+                                assignment below doesn't trip dcc64's
+                                strict-array E2008. }
 begin
   if Path = '' then Exit;
   SetLength(Tmp, 1);


### PR DESCRIPTION
## Summary

Two diagnostics, both from PR #180's new code path. The **E2008** is a real compile blocker; the **W1050** is the same WideChar-narrowing pattern I fixed for `Channels.Email` in PR #177.

### E2008 — strict-array mismatch in working-state assign

`PushEditedFile` in `PasClaw.Session.Store.pas` builds a fresh local `Tmp: array of string` then assigns it back to `W.EditedFiles` (also `array of string`, inline on the `TWorkingState` record). dcc64 sees the two declarations as **distinct anonymous types** and refuses the assignment. FPC is permissive about this; dcc64 is not — exact pattern PasClaw has hit before with `TLLMProviderArray` (PR #104), `TSubagentSpecArray`, and `TStringArray`.

Fix: introduce `TEditedFilesArray = array of string` as a named alias next to `TWorkingState`. Type both the record field and the `Tmp` local against it. One named type, dcc64 accepts the assignment.

### W1050 — WideChar narrowed to byte in set expression

`PasClaw.Hashline.pas:648` had `L[j] in ['0'..'9']`. On dcc64 `L[j]` is `WideChar` and the byte-char set literal narrows implicitly. Replaced with `CharInSet(L[j], ['0'..'9'])` — same one-line fix shape as PR #177 applied to `Channels.Email`.

## Test plan

- [x] `make` rebuilds cleanly (FPC, mode delphi)
- [x] `make test` — all 12 suites green (including `working_state_tests` which exercises the PushEditedFile path the E2008 was on)
- [ ] dcc64 / Delphi build of `PasClaw.dproj` — confirm both diagnostics are gone

Each fix is mechanical; no behavioral changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_