### PR TITLE
TUI: explicit PasClaw.Utils import for the ANSI-aware width helpers

### DIFF
--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -214,6 +214,14 @@ uses
   SyncObjs,
   DateUtils,
   PasClaw.CliUI,
+  PasClaw.Utils,                   { VisibleLength + PadVisibleRight +
+                                     TruncateVisible -- the ANSI-aware
+                                     width helpers RenderMsgLines and
+                                     DrawChatPane use. FPC happened to
+                                     resolve them through a transitive
+                                     import chain (CliUI's impl uses
+                                     Utils); dcc64 doesn't, so the
+                                     import has to be explicit here. }
   PasClaw.Logger,
   { PasClaw.Tools.ToolLoop now lives in the interface uses (above) so
     dcc64 can see TToolLoopResult from the TTUI class declaration. }


### PR DESCRIPTION
## Summary

One-line follow-up to PR #182. The Codex P2 fix added calls to `VisibleLength`, `TruncateVisible`, and `PadVisibleRight` inside `RenderMsgLines` and `DrawChatPane` but never added `PasClaw.Utils` to the TUI's implementation `uses`. FPC happened to resolve the symbols via a transitive impl-uses chain (`PasClaw.CliUI`'s implementation uses `PasClaw.Utils`) — mode delphi tolerates that lookup; dcc64 doesn't.

```
[dcc64 Error] PasClaw.TUI.pas(1597): E2003 Undeclared identifier: 'VisibleLength'
[dcc64 Error] PasClaw.TUI.pas(1611): E2003 Undeclared identifier: 'TruncateVisible'
[dcc64 Error] PasClaw.TUI.pas(1685): E2003 Undeclared identifier: 'VisibleLength'
[dcc64 Error] PasClaw.TUI.pas(1686): E2003 Undeclared identifier: 'TruncateVisible'
[dcc64 Error] PasClaw.TUI.pas(1687): E2003 Undeclared identifier: 'PadVisibleRight'
```

Fix: add `PasClaw.Utils` to the TUI's implementation `uses` block, right next to `PasClaw.CliUI`. No behavior change — FPC build was already pulling these symbols in via the transitive chain.

## Test plan

- [x] `make` rebuilds cleanly (FPC, mode delphi)
- [x] `make test` — all 13 suites green
- [ ] dcc64 / Delphi build of `PasClaw.dproj` — confirm all five E2003 errors are gone


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_