### PR TITLE
TUI: stop sort-drift on navigation + load newest session on launch

### DIFF
--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -941,9 +941,23 @@ procedure TTUI.SelectSession(Id: string);
   the truncate. Pure navigation has nothing to save, but the call
   unconditionally bumped Meta.UpdatedAt via Touch -- so leaving
   session A to peek at session B re-promoted A to the top of the
-  newest-first list. Codex / user-reported "sort drift" on PR
-  #182's sort change. }
+  newest-first list. User-reported sort drift after PR #182.
+
+  Exception: when a tool loop is in flight against the outgoing
+  session, StartTurn has appended the user's prompt to in-memory
+  FSession.Messages but the loop hasn't returned yet so the
+  prompt isn't on disk. PollLoopWorker's eventual
+  ApplyLoopResultTo / AppendErrorTo reloads the session from disk
+  by id -- so without a save here, a timeout / failure on a turn
+  the user has already navigated away from would land only the
+  error text in the saved transcript with no record of the
+  prompt that triggered it. Persist that specific case (it bumps
+  UpdatedAt, which is correct -- there IS new content). Codex P2
+  on PR #184. }
 begin
+  if (FSession <> nil) and (FLoopThread <> nil) and
+     (FLoopSessionId = FSession.Meta.Id) then
+    PersistSession;
   FSession.Free;
   if Id = '' then Id := NewSessionId;
   FSession := TSession.Create(Id);
@@ -1588,6 +1602,16 @@ begin
   Body := Msg.Content;
   if RenderMd and (Msg.Role = mrAssistant) and (Trim(Body) <> '') then
     Body := RenderMarkdown(Body);
+  { Tabs cause the chat pane to overflow: VisibleLength counts a
+    tab as one column, but the terminal expands it to the next
+    8-column tab stop (1-7 extra columns depending on position).
+    Long markdown code blocks routinely include tab-indented
+    content from the model. Expanding to 4 spaces ahead of the
+    wrap pass keeps the visible-width math honest at the cost of
+    a slightly wider code block; for content that's already
+    space-indented this is a no-op. User-reported "1-2 chars
+    bleed onto the next line" on PR #184. }
+  Body := StringReplace(Body, #9, '    ', [rfReplaceAll]);
   if Trim(Body) = '' then
   begin
     if Length(Msg.ToolCalls) > 0 then

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -931,10 +931,19 @@ begin
 end;
 
 procedure TTUI.SelectSession(Id: string);
+{ Navigation only: free the in-memory session object and load a
+  different one off disk. Used to PersistSession on the outgoing
+  session here -- the rationale was "flush anything pending before
+  the swap" -- but in practice every meaningful state change on
+  the outgoing session has ALREADY been persisted by the time we
+  get here: PollLoopWorker's ApplyLoopResultTo saves after each
+  turn, ApplyModelSelection saves after /model, /clear saves on
+  the truncate. Pure navigation has nothing to save, but the call
+  unconditionally bumped Meta.UpdatedAt via Touch -- so leaving
+  session A to peek at session B re-promoted A to the top of the
+  newest-first list. Codex / user-reported "sort drift" on PR
+  #182's sort change. }
 begin
-  { Persist anything pending on the current session before swapping. }
-  if (FSession <> nil) and (Length(FSession.Messages) > 0) then
-    PersistSession;
   FSession.Free;
   if Id = '' then Id := NewSessionId;
   FSession := TSession.Create(Id);
@@ -1952,8 +1961,22 @@ begin
   FLastResizeW := -1; FLastResizeH := -1;
 
   { Always allocate a session (PR #117 default-persist semantics).
-    SessionId from --session is honoured: empty = fresh id; existing
-    on disk = resume; missing on disk = pre-seed at that id. }
+    SessionId resolution:
+      - non-empty (from --session): honour as-is; missing on disk
+        pre-seeds at that id, existing on disk resumes.
+      - empty AND there's an existing session on disk: resume the
+        newest by UpdatedAt -- so `pasclaw tui` with no args picks
+        up where the operator left off and the left-pane highlight
+        agrees with the loaded chat. Press N to start a fresh
+        session instead.
+      - empty AND no sessions on disk: allocate a fresh id (the
+        original PR #117 behavior). }
+  if SessionId = '' then
+  begin
+    FSessions := ListSessions;            { newest-first }
+    if Length(FSessions) > 0 then
+      SessionId := FSessions[0].Id;
+  end;
   FSession := TSession.Create(SessionId);
   RefreshSessions;
 


### PR DESCRIPTION
## Summary

Two user-reported regressions against PR #182's newest-first session sort. Both live in the TUI session start/navigate path.

### Bug A — sort drifts when picking older sessions

**Symptom**: open `pasclaw tui`, peek at an older session from the left pane, come back — and the order has reshuffled. The session you just **left** is now at the top.

**Root cause**: `SelectSession` called `PersistSession` on the outgoing session "to flush anything pending before the swap." By the time we reach `SelectSession`, every meaningful state change is already on disk — `PollLoopWorker.ApplyLoopResultTo` saves after each turn, `ApplyModelSelection` saves after `/model`, etc. Pure navigation had nothing to save — but `PersistSession`'s unconditional `FSession.Touch` bumped `Meta.UpdatedAt` anyway, so the next `RefreshSessions` re-sorted the just-departed session to the top.

**Fix**: drop the Persist call in `SelectSession`. Added a comment listing what's already persisted at each entry point so a future maintainer doesn't re-add it on the theory it might miss something.

### Bug B — TUI launches with empty chat, mismatched highlight

**Symptom**: `pasclaw tui` with no args shows the newest session highlighted in the left pane, but the chat pane is empty.

**Root cause**: when `SessionId` is empty, `TSession.Create('')` auto-allocates a brand-new session id and returns an in-memory blank — `FSession.Meta.Id` doesn't match any persisted session. `RefreshSessions` then can't find it in `FSessions` and falls back to `FSelSessIdx := 0`, which highlights the newest persisted session. So the highlight and the rendered chat diverge.

**Fix**: in `TTUI.Run`, resolve `SessionId` before creating the session:
- non-empty (`--session id`): honor as-is (existing behavior — pre-seed if missing, resume if present).
- empty + sessions on disk: resume the newest by `UpdatedAt` — `pasclaw tui` picks up where you left off, highlight matches chat.
- empty + no sessions on disk: fresh id (original PR #117 default-persist behavior).

`N` still spawns a fresh session via `StartNewSession → SelectSession('')` — that path is unchanged.

## Test plan

- [x] `make` rebuilds cleanly
- [x] `make test` — all 13 suites green
- [ ] Manual: `pasclaw tui` against a workspace with several sessions — confirm the newest session loads in the chat pane, with its row highlighted in the left pane.
- [ ] Manual: navigate to an older session with arrow keys + Enter, then arrow back to the top — confirm the order is stable (the session you left isn't re-promoted).
- [ ] Manual: press N to start a fresh session — confirm a new blank session opens, persists on the first user turn.
- [ ] Manual: `pasclaw tui --session <existing-id>` — confirm the explicit id still wins.
- [ ] Manual: `pasclaw tui` against an empty workspace (no `sessions/*.json`) — confirm a fresh session is allocated, persists on first turn.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_