### PR TITLE
Fix c2w browser image CMD (pasclaw not found — login shell reset PATH)

### DIFF
--- a/browser/build.sh
+++ b/browser/build.sh
@@ -69,7 +69,10 @@ BROWSER_IMAGE="${IMAGE}-browser"
 docker build -t "$BROWSER_IMAGE" -f - . <<DOCKERFILE
 FROM $IMAGE
 ENTRYPOINT []
-CMD ["/bin/sh", "-lc", "pasclaw onboard && exec pasclaw agent"]
+# Use a non-login shell + absolute paths: a login shell (sh -l) re-reads
+# /etc/profile and resets PATH, dropping /opt/pasclaw, so bare "pasclaw"
+# would be "not found".
+CMD ["/bin/sh", "-c", "/opt/pasclaw/pasclaw onboard && exec /opt/pasclaw/pasclaw agent"]
 DOCKERFILE
 
 echo "==> 3/7  c2w --to-js : emscripten wasm + js into $OUT/"


### PR DESCRIPTION
## Fix: c2w browser image command was "pasclaw not found"

Follow-up to #185. The derived browser image (`pasclaw:c2w-browser`, built by
`browser/build.sh`) set its command with a **login shell**:

```
CMD ["/bin/sh", "-lc", "pasclaw onboard && exec pasclaw agent"]
```

`sh -l` re-reads `/etc/profile`, which **resets `PATH`** to the system default
and drops `/opt/pasclaw` (where the binary lives). So the container's command
failed immediately with `/bin/sh: 1: pasclaw: not found` — onboarding/agent
never started (and in the browser the booted guest had no working command).

### Fix
Non-login `sh -c` + absolute paths, so it resolves regardless of `PATH`:

```
CMD ["/bin/sh", "-c", "/opt/pasclaw/pasclaw onboard && exec /opt/pasclaw/pasclaw agent"]
```

### Verified
Reproduced and confirmed in Docker against the existing `pasclaw:c2w` image:
- login shell → `PATH=/usr/local/bin:/usr/bin:/bin:…` → `pasclaw` NOTFOUND
- non-login → `PATH=/opt/pasclaw:…` → found
- the patched image now boots straight into **"Onboarding PasClaw"** instead of "not found".

Consumers must rebuild (`make browser`) so `c2w --to-js` re-bakes the corrected
command into the wasm; the emulator layers are Docker-cached so it's fast.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_