### PR TITLE
Fix Gemini 415 on FPC: valid Content-Type, drop invalid Content-Encoding: utf-8

### DIFF
--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -652,7 +652,7 @@ begin
     SaveConfig(Cfg);
     PrintLn;
     PrintLn(Ansi.Green + '✓' + Ansi.Reset + ' wrote ' + CfgPath);
-    PrintLn('Next: ' + Ansi.Bold + 'pasclaw agent "hello"' + Ansi.Reset);
+    PrintLn('Next: ' + Ansi.Bold + 'pasclaw agent -m "hello"' + Ansi.Reset);
     Result := 0;
   finally
     Cfg.Free;

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -812,8 +812,7 @@ begin
     JSON values (user names, system prompts, content blocks). }
   Req  := TStringStream.Create(JSON, TEncoding.UTF8);
   try
-    Http.Request.ContentType    := 'application/json';
-    Http.Request.ContentEncoding := 'utf-8';
+    Http.Request.ContentType    := 'application/json; charset=utf-8';
     Http.Request.Accept         := 'application/json';
     ApplyHeaders(Http, Headers);
     Result := DoRequest(Http, URL, Req, True);
@@ -843,8 +842,7 @@ begin
   Req  := TStringStream.Create(JSON, TEncoding.UTF8);
   Resp := TStringStream.Create('', TEncoding.UTF8);
   try
-    Http.Request.ContentType    := 'application/json';
-    Http.Request.ContentEncoding := 'utf-8';
+    Http.Request.ContentType    := 'application/json; charset=utf-8';
     Http.Request.Accept         := 'application/json';
     ApplyHeaders(Http, Headers);
     Result.StatusCode := 0;
@@ -1002,8 +1000,7 @@ begin
   Req := TStringStream.Create(Body, TEncoding.UTF8);
   try
     if UserAgent <> '' then Http.Request.UserAgent := UserAgent;
-    Http.Request.ContentType     := ContentType;
-    Http.Request.ContentEncoding := 'utf-8';
+    Http.Request.ContentType     := ContentType + '; charset=utf-8';
     if Accept <> '' then Http.Request.Accept := Accept
     else                 Http.Request.Accept := '*/*';
     ApplyHeaders(Http, Headers);
@@ -1041,8 +1038,7 @@ begin
   Req := TStringStream.Create(JSON, TEncoding.UTF8);
   try
     if UserAgent <> '' then Http.Request.UserAgent := UserAgent;
-    Http.Request.ContentType     := 'application/json';
-    Http.Request.ContentEncoding := 'utf-8';
+    Http.Request.ContentType     := 'application/json; charset=utf-8';
     if Accept <> '' then Http.Request.Accept := Accept
     else                 Http.Request.Accept := 'application/json';
     ApplyHeaders(Http, Headers);


### PR DESCRIPTION
## Gemini POSTs fail with HTTP 415 on FPC builds

The FPC/Indy request path set:

```pascal
Http.Request.ContentType    := 'application/json';
Http.Request.ContentEncoding := 'utf-8';   // ← invalid
```

`Content-Encoding` is only for transfer codings (`gzip`/`deflate`/`br`/`identity`) — `utf-8` is not one. Anthropic and OpenAI ignore the bogus header, but **Gemini strictly rejects the unknown content-coding with `415 Unsupported Media Type`**, so `gemini/*` chat POSTs (`generateContent`) fail:

```
assistant (gemini/gemini-3.5-flash):
gemini error: status=415 msg=HTTP/1.0 415 Unsupported Media Type
```

(The model-list `GET` has no body/Content-Type, which is why discovery worked but chat didn't.) The Delphi/`TNetHTTPClient` path already does this correctly (`application/json; charset=utf-8`, no `Content-Encoding`); only the FPC path was wrong.

## Fix

All four Indy request sites (`PostJSON`, `PutJSON`, `PostRaw`, `PostJSONToStream`) now put the charset in `Content-Type` and drop `Content-Encoding`:
- `application/json; charset=utf-8`
- `ContentType + '; charset=utf-8'` for `PostRaw`

## Notes

- Affects **native FPC + Gemini** too, not just the browser — it was surfaced via the container2wasm in-browser build (#185), where Gemini was the first provider exercised through the fetch proxy.
- Anthropic/OpenAI behaviour is unchanged (the charset is standard; the removed header was invalid anyway).

## Verified
Clean rebuild under FPC 3.2.2, both default and `C2W=1`, no new warnings.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_