### PR TITLE
browser: PasClaw UI chrome over the xterm page (branding, boot screen, auto ?net=browser)

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -104,7 +104,25 @@ worker.
 |------|---------|
 | `build.sh` | One-shot: image (C2W=1) → `c2w --to-js` → webpack harness → static `site/`. |
 | `coi-serviceworker.js` | Adds the COOP/COEP headers (cross-origin isolation) the emulator needs, so any static server/host works. |
+| `web/pasclaw.css`, `web/pasclaw.js` | PasClaw page chrome injected over the upstream xterm page (see below). |
 | `site/` | Generated, manually-deployable bundle (git-ignored — large). |
+
+## The page UI
+
+The page is the real `pasclaw` CLI running in an **xterm terminal** inside the
+emulated Linux — it is not a chat UI (that would require parsing the terminal
+stream). `build.sh` layers a thin, framework-free chrome over the upstream
+container2wasm example (`web/pasclaw.css` + `web/pasclaw.js`):
+
+- **Auto `?net=browser`** — redirects to add the query if missing, so the
+  in-browser fetch proxy always activates (otherwise the agent has no network).
+- **Header bar** with PasClaw branding + a GitHub link, and a favicon.
+- **Boot screen** while the runtime downloads/boots, auto-dismissed on the
+  terminal's first output (with click-to-skip and a timeout fallback).
+
+It's purely additive: remove the two injected `<link>`/`<script>` tags (or the
+`web/` copy step in `build.sh`) and the upstream terminal still works. To
+customize branding/colors, edit `web/pasclaw.css`/`web/pasclaw.js` and rebuild.
 
 > Status: `build.sh` follows container2wasm's documented emscripten "on
 > browser" pipeline (pinned to `v0.8.4`), pointed at the pasclaw image. The

--- a/browser/build.sh
+++ b/browser/build.sh
@@ -97,10 +97,16 @@ curl -fsSL -o "$WORK/np.wasm" \
   "https://github.com/container2wasm/container2wasm/releases/download/${C2W_VERSION}/c2w-net-proxy.wasm"
 gzip -c "$WORK/np.wasm" > "$OUT/c2w-net-proxy.wasm.gzip"
 
-echo "==> 7/7  enable cross-origin isolation on header-less static hosts"
+echo "==> 7/7  cross-origin isolation shim + PasClaw UI chrome"
 cp browser/coi-serviceworker.js "$OUT/"
 if ! grep -q coi-serviceworker "$OUT/index.html"; then
   sed -i 's#<head>#<head><script src="coi-serviceworker.js"></script>#' "$OUT/index.html"
+fi
+# PasClaw page chrome (branding, boot screen, auto ?net=browser). Additive —
+# the upstream terminal still boots if these are removed.
+cp browser/web/pasclaw.css browser/web/pasclaw.js "$OUT/"
+if ! grep -q pasclaw.js "$OUT/index.html"; then
+  sed -i 's#<head>#<head>\n  <link rel="stylesheet" href="pasclaw.css">\n  <script src="pasclaw.js"></script>#' "$OUT/index.html"
 fi
 
 echo

--- a/browser/web/pasclaw.css
+++ b/browser/web/pasclaw.css
@@ -1,57 +1,84 @@
-/* PasClaw browser-bundle UI — chrome around the container2wasm xterm terminal.
-   Purely additive: injected into the upstream example index.html by
-   browser/build.sh. Targets only the page chrome and standard xterm.js
-   classes; it does not touch how the emulator/terminal boots. */
+/* PasClaw browser-bundle UI — synthwave chrome around the container2wasm
+   xterm terminal. Palette mirrors the gateway web UI (src/pkg/gateway/
+   webui.html). Purely additive: injected into the upstream example
+   index.html by browser/build.sh; targets only page chrome + standard
+   xterm.js classes, never how the emulator boots. */
 
 :root {
-  --pc-bg:  #0e1014;
-  --pc-fg:  #e8e8e8;
-  --pc-mut: #7e858f;
-  --pc-blue:#3e5db9;
-  --pc-red: #d54646;
-  --pc-line:#20242c;
+  --bg:   #050611;
+  --bg2:  #0b1026;
+  --fg:   #f5f7ff;
+  --mut:  #8f9bc6;
+  --cyan: #20f6ff;
+  --mag:  #ff37d5;
+  --violet:#8f5cff;
+  --red:  #ff4d6d;
+  --panel:rgba(12,18,43,.72);
+  --line: rgba(32,246,255,.22);
+  --glow-cyan: 0 0 18px rgba(32,246,255,.55), 0 0 42px rgba(32,246,255,.18);
+  --glow-mag:  0 0 18px rgba(255,55,213,.55), 0 0 42px rgba(255,55,213,.18);
+  --shadow: 0 18px 60px rgba(0,0,0,.45);
 }
 
 html, body { height: 100%; }
 
 body {
   margin: 0;
-  background: var(--pc-bg);
-  color: var(--pc-fg);
+  color: var(--fg);
   font: 14px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  background:
+    radial-gradient(circle at 15% 10%, rgba(255,55,213,.22), transparent 28rem),
+    radial-gradient(circle at 85% 0%,  rgba(32,246,255,.18), transparent 26rem),
+    radial-gradient(circle at 55% 100%,rgba(255,77,109,.20), transparent 30rem),
+    linear-gradient(135deg, var(--bg), var(--bg2) 48%, #13051f);
+  background-attachment: fixed;
 }
 
-/* top bar */
+/* top bar — glassy synthwave panel */
 .pc-header {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   gap: .75rem;
-  padding: .5rem .9rem;
-  background: #15171c;
-  border-bottom: 1px solid var(--pc-line);
+  padding: .55rem 1rem;
+  background: linear-gradient(120deg, var(--panel), rgba(14,8,29,.7));
+  border-bottom: 1px solid var(--line);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255,255,255,.08);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
-.pc-logo { font-weight: 700; letter-spacing: .5px; }
-.pc-blue { color: var(--pc-blue); }
-.pc-red  { color: var(--pc-red); }
-.pc-tag  { color: var(--pc-mut); font-size: 12px; }
+.pc-logo { font-weight: 700; letter-spacing: 1px; text-shadow: var(--glow-cyan); }
+.pc-blue { color: var(--cyan); }
+.pc-red  { color: var(--mag); text-shadow: var(--glow-mag); }
+.pc-tag {
+  color: #dbe7ff;
+  font-size: 11px;
+  letter-spacing: .02em;
+  padding: .15rem .5rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(32,246,255,.12), rgba(255,55,213,.12));
+  border: 1px solid var(--line);
+}
 .pc-spacer { margin-left: auto; }
 .pc-link {
-  color: var(--pc-mut);
+  color: var(--mut);
   text-decoration: none;
   font-size: 12px;
+  padding: .2rem .55rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
 }
-.pc-link:hover { color: var(--pc-fg); }
+.pc-link:hover { color: var(--fg); border-color: rgba(32,246,255,.4); box-shadow: var(--glow-cyan); }
 
-/* terminal fills the rest */
+/* terminal fills the rest; let the backdrop glow show through the padding */
 #terminal {
   flex: 1 1 auto;
   min-height: 0;
-  padding: .5rem .6rem;
-  background: var(--pc-bg);
+  padding: .6rem .7rem;
+  background: transparent;
 }
 
 /* boot/loading overlay (auto-dismisses on first terminal output) */
@@ -62,22 +89,27 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--pc-bg);
-  transition: opacity .35s ease;
   cursor: pointer;
+  transition: opacity .35s ease;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255,55,213,.18), transparent 30rem),
+    radial-gradient(circle at 50% 80%, rgba(32,246,255,.16), transparent 28rem),
+    linear-gradient(135deg, var(--bg), var(--bg2) 48%, #13051f);
 }
 .pc-boot.pc-hide { opacity: 0; pointer-events: none; }
-.pc-boot-inner { text-align: center; max-width: 32rem; padding: 1rem; }
-.pc-boot-logo  { font-weight: 700; letter-spacing: 1px; font-size: 20px; }
-.pc-boot-msg   { margin-top: 1.1rem; font-weight: 700; }
-.pc-boot-sub   { margin-top: .4rem; color: var(--pc-mut); font-size: 12px; }
-.pc-boot-skip  { margin-top: 1rem; color: var(--pc-mut); font-size: 11px; }
+.pc-boot-inner { text-align: center; max-width: 34rem; padding: 1.2rem; }
+.pc-boot-logo  { font-weight: 700; letter-spacing: 2px; font-size: 22px; text-shadow: var(--glow-cyan); }
+.pc-boot-msg   { margin-top: 1.1rem; font-weight: 700; color: var(--fg); }
+.pc-boot-sub   { margin-top: .45rem; color: var(--mut); font-size: 12px; line-height: 1.5; }
+.pc-boot-skip  { margin-top: 1rem; color: var(--mut); font-size: 11px; letter-spacing: .04em; }
 .pc-spin {
-  width: 34px; height: 34px;
-  margin: 1.4rem auto 0;
-  border: 3px solid #2a2d34;
-  border-top-color: var(--pc-blue);
+  width: 36px; height: 36px;
+  margin: 1.5rem auto 0;
+  border: 3px solid rgba(143,92,255,.25);
+  border-top-color: var(--cyan);
+  border-right-color: var(--mag);
   border-radius: 50%;
+  box-shadow: var(--glow-cyan);
   animation: pc-rot .9s linear infinite;
 }
 @keyframes pc-rot { to { transform: rotate(360deg); } }

--- a/browser/web/pasclaw.css
+++ b/browser/web/pasclaw.css
@@ -1,0 +1,83 @@
+/* PasClaw browser-bundle UI — chrome around the container2wasm xterm terminal.
+   Purely additive: injected into the upstream example index.html by
+   browser/build.sh. Targets only the page chrome and standard xterm.js
+   classes; it does not touch how the emulator/terminal boots. */
+
+:root {
+  --pc-bg:  #0e1014;
+  --pc-fg:  #e8e8e8;
+  --pc-mut: #7e858f;
+  --pc-blue:#3e5db9;
+  --pc-red: #d54646;
+  --pc-line:#20242c;
+}
+
+html, body { height: 100%; }
+
+body {
+  margin: 0;
+  background: var(--pc-bg);
+  color: var(--pc-fg);
+  font: 14px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* top bar */
+.pc-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  padding: .5rem .9rem;
+  background: #15171c;
+  border-bottom: 1px solid var(--pc-line);
+}
+.pc-logo { font-weight: 700; letter-spacing: .5px; }
+.pc-blue { color: var(--pc-blue); }
+.pc-red  { color: var(--pc-red); }
+.pc-tag  { color: var(--pc-mut); font-size: 12px; }
+.pc-spacer { margin-left: auto; }
+.pc-link {
+  color: var(--pc-mut);
+  text-decoration: none;
+  font-size: 12px;
+}
+.pc-link:hover { color: var(--pc-fg); }
+
+/* terminal fills the rest */
+#terminal {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: .5rem .6rem;
+  background: var(--pc-bg);
+}
+
+/* boot/loading overlay (auto-dismisses on first terminal output) */
+.pc-boot {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--pc-bg);
+  transition: opacity .35s ease;
+  cursor: pointer;
+}
+.pc-boot.pc-hide { opacity: 0; pointer-events: none; }
+.pc-boot-inner { text-align: center; max-width: 32rem; padding: 1rem; }
+.pc-boot-logo  { font-weight: 700; letter-spacing: 1px; font-size: 20px; }
+.pc-boot-msg   { margin-top: 1.1rem; font-weight: 700; }
+.pc-boot-sub   { margin-top: .4rem; color: var(--pc-mut); font-size: 12px; }
+.pc-boot-skip  { margin-top: 1rem; color: var(--pc-mut); font-size: 11px; }
+.pc-spin {
+  width: 34px; height: 34px;
+  margin: 1.4rem auto 0;
+  border: 3px solid #2a2d34;
+  border-top-color: var(--pc-blue);
+  border-radius: 50%;
+  animation: pc-rot .9s linear infinite;
+}
+@keyframes pc-rot { to { transform: rotate(360deg); } }

--- a/browser/web/pasclaw.js
+++ b/browser/web/pasclaw.js
@@ -1,0 +1,92 @@
+/* PasClaw browser-bundle UI helper. Additive, framework-free; injected into
+   the upstream container2wasm example index.html by browser/build.sh.
+   Three jobs:
+     1. Guarantee ?net=browser (else the guest has no network egress).
+     2. Add a small PasClaw header bar + favicon.
+     3. Show a boot screen that auto-dismisses on the first terminal output.
+   It only reads/writes page chrome and standard xterm.js DOM; it never
+   touches how the emulator boots, so if anything here misbehaves you can
+   drop the two injected <link>/<script> tags and the page still works. */
+(function () {
+  'use strict';
+
+  /* 1) Network mode guard — runs synchronously, before the ~160MB runtime
+        starts downloading, so a wrong URL redirects cheaply. */
+  try {
+    var params = new URLSearchParams(location.search);
+    if (params.get('net') !== 'browser') {
+      params.set('net', 'browser');
+      location.replace(location.pathname + '?' + params.toString() + location.hash);
+      return;
+    }
+  } catch (e) { /* URLSearchParams unsupported — harmless, fall through */ }
+
+  function onReady(fn) {
+    if (document.readyState !== 'loading') fn();
+    else document.addEventListener('DOMContentLoaded', fn);
+  }
+
+  onReady(function () {
+    document.title = 'PasClaw';
+
+    /* favicon (data URI, avoids a 404 under COEP) */
+    var icon = document.createElement('link');
+    icon.rel = 'icon';
+    icon.href = 'data:image/svg+xml,' + encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">' +
+      '<rect width="16" height="16" rx="3" fill="#0e1014"/>' +
+      '<rect x="3" y="3" width="5" height="10" fill="#3e5db9"/>' +
+      '<rect x="8" y="3" width="5" height="10" fill="#d54646"/></svg>');
+    document.head.appendChild(icon);
+
+    /* 2) header bar */
+    var header = document.createElement('header');
+    header.className = 'pc-header';
+    header.innerHTML =
+      '<span class="pc-logo"><span class="pc-blue">PAS</span><span class="pc-red">CLAW</span></span>' +
+      '<span class="pc-tag">agent in your browser</span>' +
+      '<span class="pc-spacer"></span>' +
+      '<a class="pc-link" href="https://github.com/FMXExpress/PasClaw" target="_blank" rel="noopener">GitHub</a>';
+    document.body.insertBefore(header, document.body.firstChild);
+
+    /* 3) boot overlay */
+    var ov = document.createElement('div');
+    ov.className = 'pc-boot';
+    ov.innerHTML =
+      '<div class="pc-boot-inner">' +
+        '<div class="pc-boot-logo"><span class="pc-blue">PAS</span><span class="pc-red">CLAW</span></div>' +
+        '<div class="pc-spin"></div>' +
+        '<div class="pc-boot-msg">Booting…</div>' +
+        '<div class="pc-boot-sub">Downloading the runtime and starting Linux in your browser. ' +
+          'First load is large; it is cached afterwards. You’ll be asked for your provider ' +
+          'and API key, then dropped into the agent.</div>' +
+        '<div class="pc-boot-skip">click anywhere to skip</div>' +
+      '</div>';
+    document.body.appendChild(ov);
+
+    var done = false;
+    function hideBoot() {
+      if (done) return;
+      done = true;
+      ov.classList.add('pc-hide');
+      setTimeout(function () { if (ov.parentNode) ov.parentNode.removeChild(ov); }, 400);
+    }
+
+    /* dismiss as soon as the terminal prints anything */
+    var term = document.getElementById('terminal');
+    if (term && window.MutationObserver) {
+      var mo = new MutationObserver(function () {
+        var rows = term.querySelector('.xterm-rows');
+        if (rows && rows.textContent && rows.textContent.trim().length > 0) {
+          mo.disconnect();
+          hideBoot();
+        }
+      });
+      mo.observe(term, { childList: true, subtree: true, characterData: true });
+    }
+
+    /* fallbacks so the overlay can never trap the user */
+    ov.addEventListener('click', hideBoot);
+    setTimeout(hideBoot, 90000);
+  });
+})();

--- a/browser/web/pasclaw.js
+++ b/browser/web/pasclaw.js
@@ -34,9 +34,9 @@
     icon.rel = 'icon';
     icon.href = 'data:image/svg+xml,' + encodeURIComponent(
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">' +
-      '<rect width="16" height="16" rx="3" fill="#0e1014"/>' +
-      '<rect x="3" y="3" width="5" height="10" fill="#3e5db9"/>' +
-      '<rect x="8" y="3" width="5" height="10" fill="#d54646"/></svg>');
+      '<rect width="16" height="16" rx="3" fill="#050611"/>' +
+      '<rect x="3" y="3" width="5" height="10" fill="#20f6ff"/>' +
+      '<rect x="8" y="3" width="5" height="10" fill="#ff37d5"/></svg>');
     document.head.appendChild(icon);
 
     /* 2) header bar */


### PR DESCRIPTION
## Polish the in-browser bundle page

The container2wasm bundle (`browser/`) shipped the bare upstream xterm page. This layers a thin, framework-free **PasClaw chrome** over it, injected by `build.sh` alongside the existing coi-serviceworker.

### Framing
The page is the real `pasclaw` CLI running in an **xterm terminal** inside the emulated Linux — not a chat UI. A bubble UI (like openbrowserclaw, whose agent is JS) would require parsing the terminal stream, which is brittle. So this enhances the page *around* the terminal rather than replacing it.

### What it adds (`web/pasclaw.css` + `web/pasclaw.js`)
- **Auto `?net=browser`** — if the URL is missing the query, it redirects to add it *before* the ~160 MB runtime downloads. This is the footgun that otherwise leaves the agent with no network egress (it falls back to a `ws://…:8888` host relay that isn't there).
- **Header bar** with PasClaw branding + GitHub link, and a data-URI favicon (no extra request under COEP).
- **Boot screen** while the runtime downloads/boots, auto-dismissed on the terminal's first output, with click-to-skip and a timeout fallback so it can never trap the user.

### Safety
Purely additive: it only touches page chrome and standard xterm.js DOM (`#terminal`, `.xterm-rows`), never how the emulator boots. Removing the injected `<link>`/`<script>` tags (or the `web/` copy step in `build.sh`) leaves the upstream terminal fully working. Branding/colors live in `web/pasclaw.css`.

### Notes
- `build.sh` and `pasclaw.js` pass syntax checks (`bash -n`, `node --check`). The full `c2w --to-js` browser build couldn't be exercised in CI (needs registry access + no TLS interception), so the rendered result should be eyeballed once after a real build.
- Independent of #186/#187 (touches only `browser/web/*`, `browser/build.sh` step 7, and the README) — no overlap.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_