### PR TITLE
Shell.Filters: declare TStringArray locally for dcc64

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.Shell.Filters.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.Filters.pas
@@ -72,6 +72,16 @@ implementation
 uses
   Classes, StrUtils;
 
+{$IFNDEF FPC}
+type
+  { FPC's SysUtils declares TStringArray; Delphi's RTL doesn't,
+    so dcc64 errors on the SplitTokens return type and every
+    downstream LowerCase(Tokens[i]) call below. Declare it
+    locally for the Delphi build only -- same pattern PasClaw
+    uses in PasClaw.Tools.Registry. }
+  TStringArray = array of string;
+{$ENDIF}
+
 var
   GCalls:      Int64;
   GBytesSaved: Int64;


### PR DESCRIPTION
## Summary

PR #189 introduced `PasClaw.Tools.Shell.Filters` using `TStringArray` as the `SplitTokens` return type. FPC's `SysUtils` declares `TStringArray`; Delphi's RTL doesn't, so dcc64 errors out on the function signature and every downstream `LowerCase(Tokens[i])` call cascades into a wall of `E2008` / `E2250` noise:

```
PasClaw.Tools.Shell.Filters.pas(89):  E2003 Undeclared identifier: 'TStringArray'
PasClaw.Tools.Shell.Filters.pas(98):  E2008 Incompatible types
PasClaw.Tools.Shell.Filters.pas(133): E2008 Incompatible types
PasClaw.Tools.Shell.Filters.pas(156): E2007 Constant or type identifier expected
...
```

## Fix

Same shape PasClaw already uses in `PasClaw.Tools.Registry`: declare `TStringArray` locally under `{$IFNDEF FPC}` so the Delphi build has a definition without conflicting with FPC's `SysUtils` declaration.

```pascal
{$IFNDEF FPC}
type
  { FPC's SysUtils declares TStringArray; Delphi's RTL doesn't... }
  TStringArray = array of string;
{$ENDIF}
```

One block, top of the implementation section. No functional changes.

## Test plan

- [x] `make` rebuilds cleanly (FPC, mode delphi)
- [x] `make test` — all 15 suites green, including `shell_filters_tests`
- [ ] dcc64 / Delphi build of `PasClaw.dproj` — confirm all the cascading errors are gone


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_