### PR TITLE
Gateway: server-side call_id → thoughtSignature cache for /v1/responses

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1777,6 +1777,66 @@ begin
     Result := Result + Alphabet[1 + Random(Length(Alphabet))];
 end;
 
+{ ============= provider-signature cache (Gemini 3 thoughtSignature) =============
+
+  PR #154 added a `provider_signature` extension field on /v1/responses
+  function_call output items so PasClaw could round-trip Gemini 3+'s
+  thoughtSignature across turns. That works for a PasClaw-aware client.
+  Codex CLI (and any stock OpenAI-Responses client) JSON-validates input
+  items and drops unknown fields -- so the signature is gone by the next
+  turn, and Gemini 3 returns:
+
+      400 Function call is missing a thought_signature in functionCall parts.
+
+  Belt-and-suspenders: also keep a process-wide call_id -> signature map.
+  Whenever PasClaw emits a function_call output item with a non-empty
+  signature, remember it. When an incoming function_call input item lacks
+  one but echoes a call_id we recognise, restore it before the request
+  goes back to the provider.
+
+  Bounded to PROVIDER_SIGNATURE_CACHE_MAX entries (default 1024) -- a
+  long-lived /v1/responses session has maybe dozens of tool calls; 1024
+  covers ~50 active conversations comfortably. Eviction is FIFO via
+  TStringList ordering; we delete the oldest when capacity hits.
+  Per-process, in-memory only -- restart drops the cache (consistent
+  with the rest of /v1/responses, which has no durable session). }
+const
+  PROVIDER_SIGNATURE_CACHE_MAX = 1024;
+
+var
+  GProviderSignatureCacheLock: TCriticalSection;
+  GProviderSignatureCache:     TStringList;
+
+procedure RememberProviderSignature(const CallId, Signature: string);
+begin
+  if (CallId = '') or (Signature = '') then Exit;
+  GProviderSignatureCacheLock.Enter;
+  try
+    if GProviderSignatureCache.IndexOfName(CallId) >= 0 then Exit;
+    if GProviderSignatureCache.Count >= PROVIDER_SIGNATURE_CACHE_MAX then
+      GProviderSignatureCache.Delete(0);    { FIFO eviction }
+    GProviderSignatureCache.Add(CallId + '=' + Signature);
+  finally
+    GProviderSignatureCacheLock.Leave;
+  end;
+end;
+
+function LookupProviderSignature(const CallId: string): string;
+var
+  Idx: Integer;
+begin
+  Result := '';
+  if CallId = '' then Exit;
+  GProviderSignatureCacheLock.Enter;
+  try
+    Idx := GProviderSignatureCache.IndexOfName(CallId);
+    if Idx >= 0 then
+      Result := GProviderSignatureCache.ValueFromIndex[Idx];
+  finally
+    GProviderSignatureCacheLock.Leave;
+  end;
+end;
+
 function FunctionCallItemJSON(const ItemId, CallId, Name, ArgsJSON, Status,
                               Signature: string): string;
 { One ResponseOutputItem of type function_call, serialized to a JSON
@@ -1816,7 +1876,17 @@ begin
     Obj.PutStr('name',      Name);
     Obj.PutStr('arguments', ArgsJSON);
     if Signature <> '' then
+    begin
       Obj.PutStr('provider_signature', Signature);
+      { Belt-and-suspenders: stock OpenAI-Responses clients (Codex
+        CLI, etc.) JSON-validate input items and drop unknown
+        fields, so the signature gets lost by the next turn and
+        Gemini 3 rejects with "missing thought_signature".
+        Cache (call_id -> signature) here so the input-parser path
+        can restore it from server memory even when the client
+        didn't echo it back. }
+      RememberProviderSignature(CallId, Signature);
+    end;
     Result := Obj.ToJSON;
   finally
     Obj.Free;
@@ -2644,6 +2714,7 @@ var
   ParamsObj: TJsonObject;
   ParamsRaw, ToolKind, ToolDisplayName: string;
   EmptyToolCalls: array of TToolCall;
+  FcCallIdVal, FcSignatureVal: string;
 
   procedure AppendMessage(Role: TMsgRole; const Content: string);
   begin
@@ -2857,12 +2928,28 @@ begin
           begin
             { Previous-turn tool call coming back in the input stream.
               Synthesize an assistant message carrying the matching
-              TToolCall -- see AppendAssistantToolCall comment. }
+              TToolCall -- see AppendAssistantToolCall comment.
+
+              Signature resolution order:
+                1. provider_signature field on the input item (the
+                   PasClaw-aware client path -- Codex with the PR #154
+                   extension echoed it back).
+                2. Server-side cache by call_id (the stock-client path
+                   -- Codex CLI etc. strip unknown fields, so we
+                   restore from memory).
+              Either path yields a non-empty signature when the original
+              tool call carried one, so Gemini 3's "missing
+              thought_signature" 400 stops triggering when an
+              OpenAI-Responses client doesn't preserve our extension. }
+            FcCallIdVal    := InputObj.GetStr('call_id', InputObj.GetStr('id', ''));
+            FcSignatureVal := InputObj.GetStr('provider_signature', '');
+            if FcSignatureVal = '' then
+              FcSignatureVal := LookupProviderSignature(FcCallIdVal);
             AppendAssistantToolCall(
-              InputObj.GetStr('call_id', InputObj.GetStr('id', '')),
+              FcCallIdVal,
               InputObj.GetStr('name',      ''),
               InputObj.GetStr('arguments', '{}'),
-              InputObj.GetStr('provider_signature', ''));
+              FcSignatureVal);
           end
           else if ItemType = 'function_call_output' then
           begin
@@ -3190,5 +3277,22 @@ begin
     Root.Free;
   end;
 end;
+
+initialization
+  GProviderSignatureCacheLock := TCriticalSection.Create;
+  GProviderSignatureCache     := TStringList.Create;
+  { Unsorted on purpose: insertion order doubles as FIFO so the
+    eviction in RememberProviderSignature (Delete(0)) actually drops
+    the OLDEST entry. A sorted+dupIgnore TStringList would order by
+    call_id alphabetically and Delete(0) would evict whichever
+    conversation happened to draw the lowest call_id, breaking
+    active turns unpredictably. IndexOfName scans linearly but
+    PROVIDER_SIGNATURE_CACHE_MAX is small (1024) and we only hit
+    this on tool-call boundaries -- O(n) lookups are sub-millisecond
+    and rare. }
+
+finalization
+  GProviderSignatureCache.Free;
+  GProviderSignatureCacheLock.Free;
 
 end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1808,11 +1808,28 @@ var
   GProviderSignatureCache:     TStringList;
 
 procedure RememberProviderSignature(const CallId, Signature: string);
+var
+  Idx: Integer;
 begin
   if (CallId = '') or (Signature = '') then Exit;
   GProviderSignatureCacheLock.Enter;
   try
-    if GProviderSignatureCache.IndexOfName(CallId) >= 0 then Exit;
+    { Codex P1 on PR #194: when the call_id is already present we
+      MUST overwrite, not skip. Gemini synthesises ids like
+      `gemini_call_<name>_<index>` when the original assistant
+      turn didn't carry one (PasClaw.Providers.Gemini), so two
+      conversations that both call the same tool first end up
+      with identical call_ids. Early-exiting would keep the
+      FIRST conversation's signature forever and serve it back
+      to the SECOND conversation -- the next turn there replays
+      a stale thought_signature and Gemini rejects it.
+
+      Delete-then-Add (vs. updating in place via Values[]) is
+      deliberate: it ALSO refreshes the FIFO eviction position,
+      so a tool call that just got reused isn't the next to be
+      evicted when the cap is reached. }
+    Idx := GProviderSignatureCache.IndexOfName(CallId);
+    if Idx >= 0 then GProviderSignatureCache.Delete(Idx);
     if GProviderSignatureCache.Count >= PROVIDER_SIGNATURE_CACHE_MAX then
       GProviderSignatureCache.Delete(0);    { FIFO eviction }
     GProviderSignatureCache.Add(CallId + '=' + Signature);


### PR DESCRIPTION
## Summary

Your 400 from Gemini:

```
"code": 400,
"message": "Function call is missing a thought_signature in functionCall parts.
            ... function call default_api:mcp__Kai__getProjectInfo, position 4."
```

Gemini 3+ tags each `functionCall` part it returns with a `thoughtSignature` and requires that exact value to be echoed back on subsequent turns. PR #154 wired this up end-to-end inside PasClaw via `TToolCall.ProviderSignature`, and the `/v1/responses` endpoint already emits the value on output items as a `provider_signature` extension field — but stock OpenAI-Responses clients (Codex CLI, anything that JSON-validates input items) drop unknown fields, so the signature is gone by the next turn.

## Fix — server-side cache

Belt-and-suspenders: keep a process-wide `call_id → signature` map. Two helpers:

| Function | Called from | Effect |
|---|---|---|
| `RememberProviderSignature(CallId, Signature)` | `FunctionCallItemJSON`, whenever we emit a `function_call` output item with a non-empty signature | Record the mapping |
| `LookupProviderSignature(CallId)` | `HandleResponses`'s `function_call` input parser, when `provider_signature` is empty | Restore from server memory |

Two-source resolution in the input parser:
1. The `provider_signature` field on the input item (PasClaw-aware client — Codex with the PR #154 extension echoed it back).
2. Server-side cache by `call_id` (stock client — Codex CLI etc. strip unknown fields, so we restore from memory).

Either path yields a non-empty signature when Gemini's original tool call carried one, so the "missing thought_signature" 400 stops triggering regardless of what the client preserves.

## Eviction (the tricky part)

Bounded to `PROVIDER_SIGNATURE_CACHE_MAX = 1024` — a long-lived conversation has maybe dozens of tool calls, so ~50 active conversations comfortable.

Eviction is **real FIFO**: the `TStringList` is intentionally **unsorted** so `Delete(0)` removes the oldest insertion. A `Sorted := True; Duplicates := dupIgnore` list would order by `call_id` alphabetically and `Delete(0)` would drop whichever conversation happened to draw the smallest `call_id`, breaking active turns unpredictably. `IndexOfName` is linear on unsorted lists but the cache is small and we only touch it on tool-call boundaries — sub-millisecond and rare.

## Lifecycle

- Per-process, in-memory only (`TCriticalSection`-protected). Restart drops the cache, consistent with the rest of `/v1/responses` having no durable session.
- The crit section guards against concurrent `HandleResponses` invocations on the Indy thread pool.

## Test plan

- [x] `make` rebuilds cleanly
- [x] `make test` — all 15 suites green
- [ ] Manual: drive Codex CLI through a multi-turn conversation that hits an MCP tool (the case in your bug report — `mcp__Kai__getProjectInfo`) on a Gemini 3 provider. Confirm:
  - first turn: tool call lands, response continues
  - second turn: no 400, the tool call from turn 1 round-trips with its signature intact via the server cache
- [ ] Manual: long conversation that overflows 1024 cached call_ids. Confirm older signatures get evicted (no memory leak) but recent turns keep working.

Doesn't touch the existing PR #154 extension-field path — that still wins when present, server-cache is the fallback.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_