### PR TITLE
dproj: fix XML comment containing `--` (won't open in Delphi)

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -87,7 +87,7 @@
           so users don't need libeay32.dll / ssleay32.dll alongside the
           exe. Defined in the Base group so every Platform × Config
           inherits it. To switch back to Indy for cross-checking,
-          delete this DCC_Define line -- FPC ignores PASCLAW_NETHTTP
+          delete this DCC_Define line; FPC ignores PASCLAW_NETHTTP
           regardless (TNetHTTPClient doesn't exist there).
         -->
         <DCC_Define>PASCLAW_NETHTTP;$(DCC_Define)</DCC_Define>
@@ -274,7 +274,7 @@
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.Index.pas"/>
         <DCCReference Include="..\pkg\memory\PasClaw.Memory.Vector.pas"/>
 
-        <!-- pkg/memory/localvector -- in-tree port of FMXExpress/localvector
+        <!-- pkg/memory/localvector: in-tree port of FMXExpress/localvector
              (MIT, src/pkg/memory/localvector/LICENSE). Used by
              PasClaw.Memory.Vector for the hybrid FTS5 + sqlite-vec
              backend; provisioning surface lives in


### PR DESCRIPTION
## Summary

The em-dash sweep in PR #193 (`—` → `--` to fix Windows console mojibake) also rewrote two em-dashes inside XML comments in `PasClaw.dproj`:

```xml
<!-- ... delete this DCC_Define line -- FPC ignores ... -->
<!-- pkg/memory/localvector -- in-tree port of FMXExpress/localvector
     ... -->
```

Per the [XML 1.0 spec § 2.5](https://www.w3.org/TR/xml/#sec-comments):

> For compatibility, the string `--` (double-hyphen) MUST NOT occur within comments.

Delphi's MSBuild XML parser enforces this and refuses to load the project — "won't open in delphi" is exactly that loader bail.

## Fix

Replaced the two offending `--` separators with characters that read identically but parse legally:

| Before | After |
|---|---|
| `... line -- FPC ignores ...` | `... line; FPC ignores ...` |
| `pkg/memory/localvector -- in-tree port ...` | `pkg/memory/localvector: in-tree port ...` |

## Verification

```python
# Across every .dproj in the repo, look for -- inside <!-- ... --> bodies
for m in re.finditer(r'<!--(.*?)-->', s, re.DOTALL):
    if '--' in m.group(1): print('invalid')
```

Returned zero matches after the fix. FPC `make` build still clean (dproj is Delphi-only).

## Test plan

- [x] FPC `make` rebuilds cleanly
- [x] Python sweep confirms no `--` runs in any XML comment body across all `.dproj` files
- [ ] Open `src/pasclaw/PasClaw.dproj` in Delphi — confirm it loads without the XML parse error


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_