### PR TITLE
browser: fix coi-serviceworker errors (Cloudflare) + emit precompressed .gz assets

### DIFF
--- a/browser/build.sh
+++ b/browser/build.sh
@@ -92,12 +92,12 @@ cp "$HT/index.html" "$OUT/"
 cp -R "$HT/dist" "$OUT/"
 mkdir -p "$OUT/vendor"; cp "$HT/vendor/xterm.css" "$OUT/vendor/" 2>/dev/null || true
 
-echo "==> 6/7  in-browser fetch() network stack (gzip'd next to the page)"
+echo "==> 6/8  in-browser fetch() network stack (gzip'd next to the page)"
 curl -fsSL -o "$WORK/np.wasm" \
   "https://github.com/container2wasm/container2wasm/releases/download/${C2W_VERSION}/c2w-net-proxy.wasm"
 gzip -c "$WORK/np.wasm" > "$OUT/c2w-net-proxy.wasm.gzip"
 
-echo "==> 7/7  cross-origin isolation shim + PasClaw UI chrome"
+echo "==> 7/8  cross-origin isolation shim + PasClaw UI chrome"
 cp browser/coi-serviceworker.js "$OUT/"
 if ! grep -q coi-serviceworker "$OUT/index.html"; then
   sed -i 's#<head>#<head><script src="coi-serviceworker.js"></script>#' "$OUT/index.html"
@@ -108,6 +108,17 @@ cp browser/web/pasclaw.css browser/web/pasclaw.js "$OUT/"
 if ! grep -q pasclaw.js "$OUT/index.html"; then
   sed -i 's#<head>#<head>\n  <link rel="stylesheet" href="pasclaw.css">\n  <script src="pasclaw.js"></script>#' "$OUT/index.html"
 fi
+
+echo "==> 8/8  precompressed .gz siblings for gzip_static / precompressed-static hosts"
+# emscripten loads the .wasm/.data by exact name, so keep the originals and emit
+# .gz siblings next to them. Servers with gzip_static (nginx) or precompressed
+# handling (Apache) then serve the .gz transparently under the original URL.
+# On Cloudflare this is largely redundant (the edge compresses already).
+# c2w-net-proxy.wasm.gzip is already compressed — skip it.
+find "$OUT" -maxdepth 2 -type f \( -name '*.wasm' -o -name '*.data' -o -name '*.js' \) \
+  ! -name '*.gz' ! -name '*.gzip' -print0 | while IFS= read -r -d '' f; do
+    gzip -kf "$f"
+done
 
 echo
 echo "Done -> $OUT/   (static, manually deployable)"

--- a/browser/coi-serviceworker.js
+++ b/browser/coi-serviceworker.js
@@ -20,21 +20,36 @@ if (typeof window === 'undefined') {
   self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));
   self.addEventListener('fetch', (event) => {
     const req = event.request;
+    // Only GETs need the isolation headers. Leave POSTs and other methods
+    // (e.g. Cloudflare's /cdn-cgi/rum analytics beacon) completely alone —
+    // their responses often have null-body statuses that can't be rewrapped.
+    if (req.method !== 'GET') return;
     if (req.cache === 'only-if-cached' && req.mode !== 'same-origin') return;
     event.respondWith(
       fetch(req)
         .then((res) => {
-          if (res.status === 0) return res; // opaque — leave as-is
+          // Don't rebuild responses that legally can't carry a body
+          // (1xx / 204 / 205 / 304) or opaque/redirect (status 0) —
+          // constructing a new Response with a body for those throws
+          // "Response with null body status cannot have body".
+          if (res.status === 0 || res.type === 'opaqueredirect' ||
+              res.status === 101 || res.status === 103 ||
+              res.status === 204 || res.status === 205 || res.status === 304) {
+            return res;
+          }
           const headers = new Headers(res.headers);
           headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
           headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+          headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
           return new Response(res.body, {
             status: res.status,
             statusText: res.statusText,
             headers,
           });
         })
-        .catch((e) => console.error(e))
+        // Never resolve respondWith with undefined (that throws "Failed to
+        // convert value to 'Response'"); surface a network error instead.
+        .catch((e) => { console.error('[coi]', e); return Response.error(); })
     );
   });
 } else {


### PR DESCRIPTION
## 1. Fix `coi-serviceworker.js` runtime errors (seen behind Cloudflare)

The COOP/COEP shim intercepted **every** request and threw on two cases:
- A Cloudflare analytics **POST** beacon (`/cdn-cgi/rum`) whose null-body-status response can't be re-wrapped → `TypeError: Response with null body status cannot have body`.
- The `.catch` returned `undefined`, so `respondWith` got a non-Response → `Failed to convert value to 'Response'`.

Fix:
- **Skip non-GET requests** entirely (POST beacons pass through untouched).
- **Pass through** null-body / redirect statuses (0, 101, 103, 204, 205, 304, `opaqueredirect`) without rebuilding them.
- Add `Cross-Origin-Resource-Policy: cross-origin` to rewrapped responses.
- On fetch failure return `Response.error()` instead of `undefined`.

> Note for the Cloudflare deploy: you can skip the SW altogether — set `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` at the edge (Transform Rules → Modify Response Header) and drop `coi-serviceworker.js` from the page. No SW = nothing intercepts the RUM beacon.

## 2. `build.sh`: emit precompressed `.gz` siblings

New final step gzips the big static assets (`.wasm` / `.data` / `.js`) into `.gz` siblings (originals kept, since emscripten fetches them by exact name; the already-compressed `c2w-net-proxy.wasm.gzip` is skipped). Hosts with `gzip_static` (nginx) or precompressed handling (Apache) then serve the `.gz` transparently under the original URL.

Why not rename like `c2w-net-proxy.wasm.gzip`? That file works renamed only because the harness manually gunzips it; `.wasm`/`.data` are loaded by emscripten by exact name, so the originals must remain. On **Cloudflare this is largely redundant** (the edge compresses already) — it's for plain origins.

## Verified
`bash -n build.sh` and `node --check coi-serviceworker.js` pass. (The full `c2w --to-js` browser build needs registry access + no TLS interception, so it isn't run in CI.)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_