### PR TITLE
execute_code: drop FPC-only GetTickCount64 (dcc64 E2003 fix)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -102,6 +102,12 @@ function Tool_ExecuteCode(const ArgsJSON: string; out ErrMsg: string): string;
 implementation
 
 uses
+  DateUtils,    { MilliSecondsBetween / EncodeDate -- the FPC+Delphi-portable
+                  way to get a millisecond timestamp. GetTickCount64 is FPC
+                  RTL only; Delphi dcc64 errors with E2003 unless we pull
+                  in System.SysUtils.GetTickCount64 explicitly, which is
+                  itself a Windows-only wrapper. MilliSecondsBetween skips
+                  the platform mess. }
   PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Config,
@@ -275,12 +281,16 @@ begin
       ErrMsg := 'execute_code: failed to create temp dir ' + Dir;
       Exit;
     end;
-  { GetTickCount64 + Random gives enough uniqueness for a
-    single-process tool that runs sequentially. No locking needed
-    because the registry serialises tool dispatch. }
+  { MilliSecondsBetween(Now, 1970-01-01) + Random gives enough
+    uniqueness for a single-process tool that runs sequentially.
+    No locking needed because the registry serialises tool
+    dispatch. Same pattern as PasClaw.Skills.GitHub.UniqueSuffix;
+    avoids the FPC-only GetTickCount64 that Delphi dcc64 refuses
+    to resolve. }
   Path := JoinPath(Dir,
                    Format('exec-%d-%d%s',
-                          [Int64(GetTickCount64), Random(1000000),
+                          [Int64(MilliSecondsBetween(Now, EncodeDate(1970, 1, 1))),
+                           Random(1000000),
                            ScriptExtension(Lang)]));
   Sl := TStringList.Create;
   try


### PR DESCRIPTION
PR #199 landed `Tool_ExecuteCode` with `GetTickCount64` in the temp-file naming line. That call is FPC RTL only — dcc64 errors with **E2003 Undeclared identifier: 'GetTickCount64'** unless you explicitly pull in `System.SysUtils.GetTickCount64`, which is itself a Windows-only wrapper. The Delphi build was broken from PR #199's first commit.

## Fix

Switch the timestamp source to `MilliSecondsBetween(Now, EncodeDate(1970, 1, 1))` — the same FPC+Delphi-portable pattern already used by `PasClaw.Skills.GitHub.UniqueSuffix`. That helper's existing comment even calls out the reason: GetTickCount is Windows-only and the FPC/Delphi epoch helpers don't agree. No need to invent a new pattern.

`DateUtils` added to the implementation uses clause.

## Uniqueness contract is unchanged

Both `GetTickCount64` and `MilliSecondsBetween(...epoch...)` produce a millisecond-granularity integer; the `Random(1000000)` suffix covers the (vanishingly small) collision window of two `execute_code` calls landing in the same millisecond. The tool registry serialises dispatch anyway, so even back-to-back calls won't race.

## Verification

- `make clean && make` — clean under FPC 3.2.2.
- All 15 test programs still pass (including `execute_code_tests` which exercises the temp-file path end-to-end).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_