### PR TITLE
browser: revert .gz precompression (broke VM boot); harden coi-serviceworker

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -98,6 +98,21 @@ worker.
 - Token **streaming** may buffer through the fetch proxy; the final answer
   still arrives.
 
+## Troubleshooting
+
+- **VM: "Not a migration stream / load of migration failed: Invalid
+  argument".** The `.data` (or `.wasm`) is reaching the emulator corrupted —
+  almost always because it was served **pre-gzipped under its real name**.
+  Don't ship `*.data.gz`/`*.wasm.gz` that a server hands back for the plain
+  URL, and don't let a proxy gzip it *without* a `Content-Encoding: gzip`
+  header (the browser only auto-decompresses when that header is present).
+  Serve `.data`/`.wasm` as raw bytes; any compression must be transparent.
+- **`coi-serviceworker.js` errors after a redeploy.** Service workers are
+  cached hard — the browser keeps running the *old* one. Hard-reload, or
+  DevTools → Application → Service Workers → **Unregister**, then reload.
+  Behind a CDN, also **purge the cache** for `coi-serviceworker.js`. (Serving
+  the SW with a short/no-cache header avoids this.)
+
 ## Files here
 
 | File | Purpose |

--- a/browser/build.sh
+++ b/browser/build.sh
@@ -92,12 +92,12 @@ cp "$HT/index.html" "$OUT/"
 cp -R "$HT/dist" "$OUT/"
 mkdir -p "$OUT/vendor"; cp "$HT/vendor/xterm.css" "$OUT/vendor/" 2>/dev/null || true
 
-echo "==> 6/8  in-browser fetch() network stack (gzip'd next to the page)"
+echo "==> 6/7  in-browser fetch() network stack (gzip'd next to the page)"
 curl -fsSL -o "$WORK/np.wasm" \
   "https://github.com/container2wasm/container2wasm/releases/download/${C2W_VERSION}/c2w-net-proxy.wasm"
 gzip -c "$WORK/np.wasm" > "$OUT/c2w-net-proxy.wasm.gzip"
 
-echo "==> 7/8  cross-origin isolation shim + PasClaw UI chrome"
+echo "==> 7/7  cross-origin isolation shim + PasClaw UI chrome"
 cp browser/coi-serviceworker.js "$OUT/"
 if ! grep -q coi-serviceworker "$OUT/index.html"; then
   sed -i 's#<head>#<head><script src="coi-serviceworker.js"></script>#' "$OUT/index.html"
@@ -108,17 +108,6 @@ cp browser/web/pasclaw.css browser/web/pasclaw.js "$OUT/"
 if ! grep -q pasclaw.js "$OUT/index.html"; then
   sed -i 's#<head>#<head>\n  <link rel="stylesheet" href="pasclaw.css">\n  <script src="pasclaw.js"></script>#' "$OUT/index.html"
 fi
-
-echo "==> 8/8  precompressed .gz siblings for gzip_static / precompressed-static hosts"
-# emscripten loads the .wasm/.data by exact name, so keep the originals and emit
-# .gz siblings next to them. Servers with gzip_static (nginx) or precompressed
-# handling (Apache) then serve the .gz transparently under the original URL.
-# On Cloudflare this is largely redundant (the edge compresses already).
-# c2w-net-proxy.wasm.gzip is already compressed — skip it.
-find "$OUT" -maxdepth 2 -type f \( -name '*.wasm' -o -name '*.data' -o -name '*.js' \) \
-  ! -name '*.gz' ! -name '*.gzip' -print0 | while IFS= read -r -d '' f; do
-    gzip -kf "$f"
-done
 
 echo
 echo "Done -> $OUT/   (static, manually deployable)"

--- a/browser/coi-serviceworker.js
+++ b/browser/coi-serviceworker.js
@@ -37,15 +37,22 @@ if (typeof window === 'undefined') {
               res.status === 204 || res.status === 205 || res.status === 304) {
             return res;
           }
-          const headers = new Headers(res.headers);
-          headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
-          headers.set('Cross-Origin-Opener-Policy', 'same-origin');
-          headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
-          return new Response(res.body, {
-            status: res.status,
-            statusText: res.statusText,
-            headers,
-          });
+          try {
+            const headers = new Headers(res.headers);
+            headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+            headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+            headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+            return new Response(res.body, {
+              status: res.status,
+              statusText: res.statusText,
+              headers,
+            });
+          } catch (e) {
+            // Any unexpected body/status combo: never throw — fall back to
+            // the untouched response so the stream is never torn down.
+            console.warn('[coi] passthrough:', e);
+            return res;
+          }
         })
         // Never resolve respondWith with undefined (that throws "Failed to
         // convert value to 'Response'"); surface a network error instead.


### PR DESCRIPTION
## Reverts the `.gz` regression from #198 and hardens the service worker

### 1. Remove the `.gz` precompression step (the regression)
#198 added a step emitting `*.data.gz`/`*.wasm.gz` siblings. In practice the server/CDN then handed emscripten **compressed bytes for the plain `.data` URL**, so QEMU's snapshot loader saw garbage → **"Not a migration stream / load of migration failed: Invalid argument"** inside the VM.

Removed entirely. emscripten loads `.data`/`.wasm` by exact name and needs the **raw** bytes; transparent compression must come from `Content-Encoding` (which the browser auto-decompresses), not pre-gzipped files. gzip also never addressed the real issue (in-tab memory), and Cloudflare compresses on its own.

### 2. Harden `coi-serviceworker.js` (host-agnostic, not Cloudflare-specific)
The COOP/COEP shim is kept (local/header-less hosts need it). Wrapped the response rewrap in `try/catch` so it can **never** throw on an unexpected body/status combo — it falls back to the untouched response. Combined with the existing "skip non-GET" + null-body guards, it's now bulletproof on local servers, Apache, and behind a CDN alike.

> The live `coi-serviceworker.js:31` error you're seeing is a **stale cached service worker** — that line is the *old* file; `main` already has the fixed one. Clear it: hard-reload, or DevTools → Application → Service Workers → **Unregister**; and **purge the CDN cache** for `coi-serviceworker.js`.

### 3. README troubleshooting
Documents both: the migration-stream cause (don't serve `.data`/`.wasm` pre-gzipped) and clearing a stale SW.

### After merging
Rebuild (`make browser`) and redeploy a **clean** `site/` (no `.gz` files). Also delete any `*.data.gz`/`*.wasm.gz` already on your server and purge the CDN cache for them + `coi-serviceworker.js`.

Verified: `bash -n build.sh`, `node --check coi-serviceworker.js`.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_