### PR TITLE
sessions: hide gateway stats buckets from TUI / `session list` / learn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,4 +351,11 @@ test-session-stats: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/session_stats_tests.pas -o$(BUILDDIR)/session_stats_tests
 	@PASCLAW_HOME=$(BUILDDIR)/session-stats-test-home $(BUILDDIR)/session_stats_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets
+# ListSessions bucket-filter contract -- default call hides gateway
+# stats buckets; /v1/stats opts back in via ListSessions(True).
+test-session-list-filter: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/session_list_filter_tests.pas -o$(BUILDDIR)/session_list_filter_tests
+	@PASCLAW_HOME=$(BUILDDIR)/session-list-filter-test-home $(BUILDDIR)/session_list_filter_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -821,7 +821,11 @@ begin
     Exit;
   end;
 
-  Sessions := ListSessions;
+  { IncludeBuckets: the gateway's per-endpoint stats buckets
+    (_gateway_v1_*) are hidden from the TUI / `pasclaw session
+    list` by default. The aggregator MUST see them or the
+    Stats tab loses the entire gateway-API traffic line. }
+  Sessions := ListSessions(True);
   TotalIn := 0; TotalOut := 0; CacheRead := 0; CacheWrite := 0;
   Turns := 0; ToolCalls := 0; BytesSaved := 0;
   ByProvider := TStringList.Create;

--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -158,7 +158,24 @@ function SessionsDir: string;
   path of the session file. Callers MUST handle the empty-string
   case (treat as "no session named X"). }
 function SessionPath(const Id: string): string;
-function ListSessions: TSessionMetaArray;
+
+(* List on-disk sessions. By default skips synthetic "gateway
+   bucket" sessions (ids prefixed with `_gateway_`) -- those exist
+   only to aggregate stateless gateway-endpoint stats and would
+   otherwise clutter the TUI session pane, `pasclaw session list`,
+   and `pasclaw learn`'s pattern miner with empty pseudo-sessions
+   the operator never created. Callers that DO want them (the
+   gateway's /v1/stats aggregator) pass IncludeBuckets=True. *)
+function ListSessions(IncludeBuckets: Boolean = False): TSessionMetaArray;
+
+(* Predicate: True iff Id matches the gateway's bucket-session
+   naming convention. Centralised here so the TUI / Cmd.Session
+   list filtering, the /v1/stats aggregator (which opts back in),
+   and any future consumer share one rule. The current rule is
+   "starts with `_gateway_`"; tightening this is a one-liner if
+   we ever need other prefixed-id session conventions. *)
+function IsGatewayBucketSessionId(const Id: string): Boolean;
+
 function DeleteSession(const Id: string): Boolean;
 
 (* Sort a TSessionMetaArray in place, newest-first by UpdatedAt with
@@ -847,7 +864,15 @@ begin
   end;
 end;
 
-function ListSessions: TSessionMetaArray;
+function IsGatewayBucketSessionId(const Id: string): Boolean;
+const
+  Prefix = '_gateway_';
+begin
+  Result := (Length(Id) > Length(Prefix)) and
+            (Copy(Id, 1, Length(Prefix)) = Prefix);
+end;
+
+function ListSessions(IncludeBuckets: Boolean = False): TSessionMetaArray;
 var
   SR: TSearchRec;
   Pattern, Id: string;
@@ -864,6 +889,13 @@ begin
         anything a human dropped in here) -- only ids that round-trip
         through IsSafeSessionId are real sessions. }
       if not IsSafeSessionId(Id) then Continue;
+      { Hide gateway bucket sessions from the TUI session pane and
+        the `pasclaw session list` / `pasclaw learn` paths -- they
+        are stats-only synthetic sessions, never carry messages,
+        and would otherwise pollute the operator's session view
+        with one entry per stateless gateway endpoint. The /v1/
+        stats aggregator opts back in via IncludeBuckets=True. }
+      if (not IncludeBuckets) and IsGatewayBucketSessionId(Id) then Continue;
       { Load only the meta; this is wasteful but the sessions tree is
         typically small (10s to low 100s) and ListSessions runs from
         an interactive command. If it grows: write a "headers only"

--- a/src/tests/session_list_filter_tests.pas
+++ b/src/tests/session_list_filter_tests.pas
@@ -67,10 +67,20 @@ procedure TestListSessionsFiltersBuckets;
   default ListSessions returns only the regular one, while
   ListSessions(True) returns both. The PASCLAW_HOME the Makefile
   exports for this target is isolated so the fixture doesn't
-  collide with the operator's real session store. }
+  collide with the operator's real session store.
+
+  IMPORTANT: the bucket id is a TEST-ONLY id, not the real
+  '_gateway_v1_chat_completions' production bucket name. Codex P2
+  on PR #205: an earlier draft used the production id, which
+  meant running build/session_list_filter_tests directly (without
+  the Makefile's isolated PASCLAW_HOME) would unconditionally
+  DeleteFile the operator's real bucket. The test-only id still
+  satisfies IsGatewayBucketSessionId (the prefix matches) so the
+  filter contract still gets exercised, but cannot collide with
+  any bucket the gateway writes. }
 const
   RegularId = 'list-filter-test-regular';
-  BucketId  = '_gateway_v1_chat_completions';
+  BucketId  = '_gateway_v1_listfilter_test_only';
 var
   S: TSession;
   ListedDefault, ListedIncluding: TSessionMetaArray;
@@ -127,7 +137,32 @@ begin
   DeleteFile(SessionPath(BucketId));
 end;
 
+function HomeLooksIsolated: Boolean;
+{ Belt-and-braces gate on top of the test-only bucket id. The
+  bucket id alone makes a collision impossible, but a contributor
+  who's manually invoking this binary on their dev box probably
+  doesn't expect it to drop files into the live session store
+  either. Pass if the operator opted in by pointing PASCLAW_HOME
+  at a scratch directory; otherwise bail with a clear message.
+
+  Detection rule: PASCLAW_HOME is set AND not equal to the
+  default user-home location. The Makefile target sets
+  PASCLAW_HOME explicitly so CI runs are unaffected. }
+var
+  Home: string;
 begin
+  Home := GetEnvironmentVariable('PASCLAW_HOME');
+  Result := (Home <> '') and (Pos('.pasclaw', LowerCase(Home)) = 0);
+end;
+
+begin
+  if not HomeLooksIsolated then
+  begin
+    WriteLn('session_list_filter_tests: SKIP -- set PASCLAW_HOME to an');
+    WriteLn('  isolated scratch directory before running this binary directly');
+    WriteLn('  (the Makefile target ''make test-session-list-filter'' does this).');
+    Halt(0);
+  end;
   TestPredicate;
   TestListSessionsFiltersBuckets;
   WriteLn('session_list_filter_tests: OK');

--- a/src/tests/session_list_filter_tests.pas
+++ b/src/tests/session_list_filter_tests.pas
@@ -1,0 +1,134 @@
+program session_list_filter_tests;
+(*
+  Covers the bucket-session filtering contract on ListSessions.
+
+  Pre-PR the gateway's per-endpoint stats buckets (ids starting
+  with `_gateway_`) showed up in the TUI session pane and the
+  `pasclaw session list` output, polluting the operator's view
+  with stats-only pseudo-sessions they never created. ListSessions
+  now skips them by default; the /v1/stats aggregator opts back
+  in via IncludeBuckets=True.
+
+  We pin:
+    - IsGatewayBucketSessionId recognises the bucket-id naming
+      rule and rejects regular session ids (operator-named or
+      timestamp-prefixed)
+    - Default ListSessions() hides bucket sessions
+    - ListSessions(True) returns them
+    - Real sessions (no bucket prefix) always come back either way
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Session.Store;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertFalse(Cond: Boolean; const Msg: string);
+begin
+  if Cond then Fail_(Msg);
+end;
+
+procedure TestPredicate;
+begin
+  AssertTrue(IsGatewayBucketSessionId('_gateway_v1_chat'),
+             '_gateway_v1_chat matches');
+  AssertTrue(IsGatewayBucketSessionId('_gateway_v1_chat_completions'),
+             '_gateway_v1_chat_completions matches');
+  AssertTrue(IsGatewayBucketSessionId('_gateway_v1_responses'),
+             '_gateway_v1_responses matches');
+  AssertFalse(IsGatewayBucketSessionId('gateway_v1_chat'),
+              'no leading underscore -> not a bucket');
+  AssertFalse(IsGatewayBucketSessionId('_gateway'),
+              'bare _gateway -> not a bucket (too short, no body)');
+  AssertFalse(IsGatewayBucketSessionId(''),
+              'empty -> not a bucket');
+  AssertFalse(IsGatewayBucketSessionId('20260609T101010-abc'),
+              'timestamp session id -> not a bucket');
+  AssertFalse(IsGatewayBucketSessionId('my-conversation'),
+              'operator-named session -> not a bucket');
+end;
+
+procedure TestListSessionsFiltersBuckets;
+{ Create one regular session + one bucket session and verify the
+  default ListSessions returns only the regular one, while
+  ListSessions(True) returns both. The PASCLAW_HOME the Makefile
+  exports for this target is isolated so the fixture doesn't
+  collide with the operator's real session store. }
+const
+  RegularId = 'list-filter-test-regular';
+  BucketId  = '_gateway_v1_chat_completions';
+var
+  S: TSession;
+  ListedDefault, ListedIncluding: TSessionMetaArray;
+  HasRegular, HasBucket: Boolean;
+  i: Integer;
+begin
+  { Wipe whatever might be left over from a prior run. }
+  if FileExists(SessionPath(RegularId)) then DeleteFile(SessionPath(RegularId));
+  if FileExists(SessionPath(BucketId))  then DeleteFile(SessionPath(BucketId));
+
+  S := TSession.Create(RegularId);
+  try
+    S.Meta.Title := 'a regular operator session';
+    S.Save;
+  finally
+    S.Free;
+  end;
+
+  S := TSession.Create(BucketId);
+  try
+    S.Meta.Title := '(gateway: /v1/chat/completions)';
+    { Stamp a counter so the bucket has data the aggregator would
+      want to see. }
+    AccumulateTurnStats(S.Meta, 100, 200, 0, 0, 3, 0);
+    S.Save;
+  finally
+    S.Free;
+  end;
+
+  { Default call: bucket hidden, regular present. }
+  ListedDefault := ListSessions;
+  HasRegular := False; HasBucket := False;
+  for i := 0 to High(ListedDefault) do
+  begin
+    if ListedDefault[i].Id = RegularId then HasRegular := True;
+    if ListedDefault[i].Id = BucketId  then HasBucket  := True;
+  end;
+  AssertTrue (HasRegular, 'default ListSessions returns regular session');
+  AssertFalse(HasBucket,  'default ListSessions hides the bucket session');
+
+  { Opt-in call: both visible. }
+  ListedIncluding := ListSessions(True);
+  HasRegular := False; HasBucket := False;
+  for i := 0 to High(ListedIncluding) do
+  begin
+    if ListedIncluding[i].Id = RegularId then HasRegular := True;
+    if ListedIncluding[i].Id = BucketId  then HasBucket  := True;
+  end;
+  AssertTrue(HasRegular, 'opt-in ListSessions includes regular session');
+  AssertTrue(HasBucket,  'opt-in ListSessions includes bucket session');
+
+  { Cleanup. }
+  DeleteFile(SessionPath(RegularId));
+  DeleteFile(SessionPath(BucketId));
+end;
+
+begin
+  TestPredicate;
+  TestListSessionsFiltersBuckets;
+  WriteLn('session_list_filter_tests: OK');
+end.


### PR DESCRIPTION
PR #204 added per-endpoint stats bucket sessions (`_gateway_v1_chat`, `_gateway_v1_chat_completions`, `_gateway_v1_responses`) under `workspace/sessions/` so `/v1/stats` could surface gateway-API traffic. Those files are real sessions on disk — which meant they also showed up in:

- the TUI session pane
- `pasclaw session list`
- `pasclaw learn` (walking session JSON for failure patterns)

The buckets are stats-only artifacts (zero messages, never something the operator created) so seeing them in any of those operator-facing lists was just noise.

## Fix

Filter at the source, with an opt-in for the one caller that legitimately needs them.

**New `IsGatewayBucketSessionId` predicate** in the `PasClaw.Session.Store` interface — True iff the id starts with `_gateway_`. One rule, one place; every consumer shares it.

**`ListSessions` gains an opt-in `IncludeBuckets` parameter** (default False). Existing callers — TUI, `Cmd.Session.pas`, `Cmd.Learn.pas`, anything else hitting `ListSessions` — get the regular-session view they always expected. No code changes at those sites.

**`HandleStats` (the `/v1/stats` aggregator) opts back in** with `ListSessions(True)` so the gateway-API traffic stays in the totals, `by_provider`, and `by_model` rollups.

```pascal
// Default — TUI / pasclaw session list / pasclaw learn / anyone else
Sessions := ListSessions;          // buckets hidden

// /v1/stats only
Sessions := ListSessions(True);    // buckets visible
```

## Tests

`session_list_filter_tests.pas` (2 cases):

- `TestPredicate` — pins the recognition rule: matches the three current ids, rejects timestamp-style session ids, rejects operator-named sessions, rejects the bare string `_gateway` (no body), rejects empty string.
- `TestListSessionsFiltersBuckets` — stands up one regular session + one bucket session in an isolated `PASCLAW_HOME`, then asserts:
  - Default `ListSessions` returns the regular session and **excludes** the bucket
  - `ListSessions(True)` returns **both**

All 18 test programs pass on clean FPC 3.2.2 build.

## Note on the web UI

The web UI sidebar reads from client-side `localStorage`, not from the gateway's session list — so the buckets were never visible there to begin with. This PR only fixes the server-side consumers.

## Sequencing

Logically follows #204 (which created the buckets). The filter itself is harmless without #204 merged (no bucket files exist, so nothing to filter), but the operator pain — bucket pollution in TUI / `session list` — only shows up once #204 is in. Either order merges cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_