### PR TITLE
tool-rpc: cross-compiler PID lookup (dcc64 E2003 fix)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.RPC.pas
+++ b/src/pkg/tools/PasClaw.Tools.RPC.pas
@@ -129,10 +129,28 @@ uses
   PasClaw.Utils,
   PasClaw.Logger,
   PasClaw.JSON,
-  PasClaw.Crypto.Random;
+  PasClaw.Crypto.Random
+  {$IFNDEF FPC}{$IFDEF MSWINDOWS}, Winapi.Windows{$ENDIF}
+                {$IFDEF POSIX}, Posix.Unistd{$ENDIF}{$ENDIF};
 
 const
   EnvInfoVar = 'PASCLAW_TOOL_RPC_INFO';
+
+function CurrentProcessID: Int64;
+{ Cross-compiler PID lookup. FPC ships SysUtils.GetProcessID;
+  Delphi dcc64 doesn't (E2003 on that name) and routes through
+  the platform RTL instead -- Winapi.Windows.GetCurrentProcessId
+  on Windows, Posix.Unistd.getpid on POSIX. Wrapped so the two
+  callers below don't have to repeat the IFDEF dance. }
+begin
+  {$IFDEF FPC}
+  Result := GetProcessID;
+  {$ELSE}{$IFDEF MSWINDOWS}
+  Result := GetCurrentProcessId;
+  {$ELSE}
+  Result := getpid;
+  {$ENDIF}{$ENDIF}
+end;
 
 function RandomHexToken(NBytes: Integer): string;
 var
@@ -158,7 +176,7 @@ function MakePerCallInfoPath: string;
 begin
   Result := JoinPath(JoinPath(GetHome, 'run'),
                      Format('tool-rpc-%d-%s.json',
-                            [GetProcessID, RandomHexToken(4)]));
+                            [CurrentProcessID, RandomHexToken(4)]));
 end;
 
 constructor TToolRPCServer.Create(Registry: TToolRegistry; const InfoPath: string);
@@ -188,7 +206,7 @@ begin
   Sl := TStringList.Create;
   try
     Sl.Add(Format('{"port":%d,"token":"%s","pid":%d}',
-                  [FPort, FToken, GetProcessID]));
+                  [FPort, FToken, CurrentProcessID]));
     Sl.SaveToFile(FInfoPath);
   finally
     Sl.Free;


### PR DESCRIPTION
PR #206 landed `PasClaw.Tools.RPC` with two `GetProcessID` call sites. That name lives in FPC's `SysUtils` but **isn't part of Delphi's RTL** — dcc64 errors with **E2003 Undeclared identifier: 'GetProcessID'**. Delphi build broken from the merge.

## Fix

Wrap behind a `CurrentProcessID` helper:

| Compiler / target | Source |
|---|---|
| FPC | `SysUtils.GetProcessID` (unchanged) |
| Delphi Windows | `Winapi.Windows.GetCurrentProcessId` |
| Delphi POSIX | `Posix.Unistd.getpid` |

The `uses` clause conditionally pulls in `Winapi.Windows` or `Posix.Unistd` only on the Delphi side; the FPC build sees no new imports.

Two call sites updated (`MakePerCallInfoPath` and `WriteInfoFile`). Both now go through the helper. Wire shape and PID values are byte-identical at runtime under FPC.

## Verification

- `make clean && make` — clean under FPC 3.2.2.
- All 20 test programs pass, including `tool_rpc_tests` which exercises the per-call info-file naming path that depends on the PID.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_