### PR TITLE
tool-rpc: qualify SysUtils.DeleteFile (dcc64 E2010 fix)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.RPC.pas
+++ b/src/pkg/tools/PasClaw.Tools.RPC.pas
@@ -215,7 +215,14 @@ end;
 
 procedure TToolRPCServer.DeleteInfoFile;
 begin
-  if FileExists(FInfoPath) then DeleteFile(FInfoPath);
+  { SysUtils-qualified on purpose. PR #207 added Winapi.Windows to
+    this unit's uses clause (for GetCurrentProcessId), and Delphi's
+    later-unit-wins resolution then bound the bare DeleteFile to
+    Winapi.Windows.DeleteFile(PWideChar) -- dcc64 E2010 on the
+    string argument. FPC was unaffected (no Winapi.Windows in its
+    branch of the uses clause) but the qualification is harmless
+    there. }
+  if FileExists(FInfoPath) then SysUtils.DeleteFile(FInfoPath);
 end;
 
 procedure TToolRPCServer.Start;


### PR DESCRIPTION
PR #207 added `Winapi.Windows` to `PasClaw.Tools.RPC`'s uses clause for `GetCurrentProcessId`. Delphi's later-unit-wins name resolution then bound the bare `DeleteFile` call in `DeleteInfoFile` to `Winapi.Windows.DeleteFile(PWideChar)`, so dcc64 errors with **E2010 Incompatible types: 'PWideChar' and 'string'** on the string argument.

## Fix

Qualify the call as `SysUtils.DeleteFile(FInfoPath)`. One-line change plus a comment explaining the shadowing so the next person who adds a Win32 API import to this unit knows the trap.

Swept the unit for other commonly-shadowed names (`CopyFile`, `MoveFile`, `CreateDirectory`, `RemoveDirectory`, `GetCurrentDirectory`) — this was the only collision.

FPC was unaffected (its branch of the uses clause never pulls `Winapi.Windows`); the qualification is harmless there.

## Verification

- `make clean && make` clean under FPC 3.2.2
- `tool_rpc_tests` passes (exercises the Stop path that calls `DeleteInfoFile`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_