### PR TITLE
execute_code: add empty initialization for dcc64 (E2029 fix)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -531,6 +531,14 @@ begin
   GRunners := nil;
 end;
 
+{ Empty initialization is intentional. Delphi dcc64 errors with
+  E2029 "Declaration expected but 'FINALIZATION' found" when a
+  unit has a bare finalization section -- the initialization
+  keyword is required as a header even when there's no startup
+  work. FPC mode delphi is more permissive and accepts the bare
+  finalization, which is why this only surfaced under dcc64. }
+initialization
+
 finalization
   FreeRunners;
 


### PR DESCRIPTION
PR #206 landed the `finalization` section in `PasClaw.Tools.ExecuteCode` without a preceding `initialization` keyword. FPC mode delphi is permissive and accepts bare `finalization`, so the FPC build passed. Delphi dcc64 is stricter and errors with **E2029 "Declaration expected but 'FINALIZATION' found"** — the `initialization` keyword is required as a header even when there's no startup work.

`PasClaw.Tools.RPC` already compiles under dcc64 because PR #206 included both keywords there. `ExecuteCode` only had `finalization`, so this surfaces now.

## Fix

Add an empty `initialization` block above the existing `finalization`.

```pascal
{ Empty initialization is intentional. Delphi dcc64 errors with
  E2029 "Declaration expected but 'FINALIZATION' found" when a
  unit has a bare finalization section -- the initialization
  keyword is required as a header even when there's no startup
  work. FPC mode delphi is more permissive and accepts the bare
  finalization, which is why this only surfaced under dcc64. }
initialization

finalization
  FreeRunners;
```

No runtime change on either compiler — FPC was already executing the `finalization` (and just ignored the missing `initialization`); Delphi will now execute the same `finalization` plus a no-op `initialization`.

The inline comment is there so the next contributor who adds a unit-finalization helper doesn't hit the same E2029.

## Verification

- `make clean && make` clean under FPC 3.2.2
- All 21 test programs pass (including `execute_code_tests` and `tool_rpc_tests`, which exercise both the registry-registration path that creates the runners and the singleton lifecycle the finalization tears down)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_