### PR TITLE
gateway: stream-reliability layer (empty-turn retry, idle-timeout, tool-call repair)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ UNIT_DIRS = \
 	src/pkg/config \
 	src/pkg/json \
 	src/pkg/providers \
+	src/pkg/stream \
 	src/pkg/tokenizer \
 	src/pkg/tools \
 	src/pkg/mcp \
@@ -153,7 +154,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -376,9 +377,17 @@ test-subagent-bg: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/subagent_bg_tests.pas -o$(BUILDDIR)/subagent_bg_tests
 	@$(BUILDDIR)/subagent_bg_tests
 
+# Stream reliability: empty-turn retry, idle-timeout, tool-call repair.
+# Uses a scripted fake provider; one test sleeps a few seconds to verify
+# the idle-timeout watcher.
+test-stream-reliability: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/stream_reliability_tests.pas -o$(BUILDDIR)/stream_reliability_tests
+	@$(BUILDDIR)/stream_reliability_tests
+
 test-session-search: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/session_search_tests.pas -o$(BUILDDIR)/session_search_tests
 	@PASCLAW_HOME=$(BUILDDIR)/session-search-test-home $(BUILDDIR)/session_search_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -301,6 +301,11 @@ begin
     `tool_output_get` tool is registered alongside the other core
     tools in RegisterFSTools' caller (Cmd.Agent / Cmd.TUI). }
   Result.ToolOutputCap := Cfg.ToolOutputCap;
+  { Stream-reliability: same default-shape pattern -- forwarded as
+    a struct copy so the loop's primary Provider.Chat call goes
+    through ChatWithEmptyRetry. Loop-side fallback walk is
+    unaffected; this only catches the empty-turn brownout shape. }
+  Result.StreamReliability := Cfg.StreamReliability;
 end;
 
 { One-line per-turn token summary. Cache fields only appear when

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -44,6 +44,7 @@ uses
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Cron.Scheduler,
+  PasClaw.Stream.Reliability,
   PasClaw.Gateway.Server,
   PasClaw.Channels.Telegram,
   PasClaw.Channels.LINE,
@@ -164,6 +165,11 @@ begin
   ConfigureSandbox(Cfg.Sandbox, '');
   try
     Args := ParseGw(Argv, Cfg);
+
+    { Stream-reliability env-var overrides -- see Cmd.Serve for the
+      same shape. Env wins over config; defaults from TConfig.Create
+      win otherwise. }
+    Cfg.StreamReliability := LoadStreamReliabilityFromEnv(Cfg.StreamReliability);
 
     Provider := nil;
     if Cfg.DefaultProvider <> '' then

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -56,6 +56,7 @@ uses
   PasClaw.Tools.Sandbox,
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
+  PasClaw.Stream.Reliability,
   PasClaw.Gateway.Server;
 
 type
@@ -112,6 +113,13 @@ begin
   ConfigureSandbox(Cfg.Sandbox, '');
   try
     Args := ParseServe(Argv, Cfg);
+
+    { Stream-reliability env-var overrides. Lets operators tune
+      UC_EMPTY_RETRY_ATTEMPTS / UC_EMPTY_RETRY_BACKOFF_MS /
+      UC_STREAM_IDLE_TIMEOUT_SEC / UC_TOOL_CALL_REPAIR per-run
+      without rewriting config.json. Env wins over config; defaults
+      from TConfig.Create win otherwise. }
+    Cfg.StreamReliability := LoadStreamReliabilityFromEnv(Cfg.StreamReliability);
 
     if Args.Debug then
     begin

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -709,6 +709,7 @@ begin
   Cfg.OnText        := ForwardText;
   Cfg.OnToolCall    := ForwardToolCall;
   Cfg.OnToolResult  := ForwardToolResult;
+  Cfg.StreamReliability := FConfig.StreamReliability;
 
   try
     Result := RunToolLoop(Cfg, Msgs, Loop);

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -12,7 +12,8 @@ interface
 
 uses
   SysUtils, Classes,
-  PasClaw.Providers.Types;
+  PasClaw.Providers.Types,
+  PasClaw.Stream.Reliability;
 
 const
   (* Single source of truth for the product version is VersionFallback below;
@@ -229,6 +230,16 @@ type
     TTL:     string;
   end;
 
+  (* TStreamReliabilityConfig is declared in PasClaw.Stream.Reliability
+     -- this unit re-exports nothing, just folds the record into
+     TConfig as the persisted operator-facing shape. See the
+     unit comment in PasClaw.Stream.Reliability for the four
+     knobs and their semantics. Operators tune via config.json
+     under "stream_reliability": {...} OR via the well-known
+     env vars (UC_EMPTY_RETRY_ATTEMPTS, UC_EMPTY_RETRY_BACKOFF_MS,
+     UC_STREAM_IDLE_TIMEOUT_SEC, UC_TOOL_CALL_REPAIR); env wins
+     over config.json. *)
+
   (* Anthropic-only: register Anthropic's server-side web tools
      (web_search_20260209 / web_fetch_20260209) in the request's
      tools array. Claude runs the queries / fetches on Anthropic's
@@ -402,6 +413,7 @@ type
     AnthropicServerTools: TAnthropicServerToolsConfig;
     OpenAIServerTools:    TOpenAIServerToolsConfig;
     GeminiServerTools:    TGeminiServerToolsConfig;
+    StreamReliability:    TStreamReliabilityConfig;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -490,6 +502,15 @@ begin
     (gemini-3.5-flash) accepts the field. See the type comment for
     the model-compat caveat. }
   GeminiServerTools.GoogleSearch        := True;
+  { Stream reliability defaults match the UltraCode-Shim shipping
+    config -- conservative enough that operators on healthy
+    backends never notice, aggressive enough to recover the
+    common brownout cases (Together / OpenRouter route hiccups,
+    DeepSeek thinking-token overflow). }
+  StreamReliability.EmptyRetryAttempts    := 2;
+  StreamReliability.EmptyRetryBackoffMs   := 750;
+  StreamReliability.StreamIdleTimeoutMs   := 150 * 1000;
+  StreamReliability.ToolCallRepairEnabled := True;
 end;
 
 function ProviderToJSON(const P: TProviderConfig): TJsonObject;
@@ -687,6 +708,23 @@ begin
     Tmp := TJsonObject.Create;
     Tmp.PutBool('google_search', GeminiServerTools.GoogleSearch);
     Root.PutObject('gemini_server_tools', Tmp);
+
+    { Emit stream_reliability only when at least one knob differs
+      from the defaults -- keeps stock configs tidy. The reader
+      below initialises each field from the live default before
+      overlaying JSON values so missing keys round-trip cleanly. }
+    if (StreamReliability.EmptyRetryAttempts    <> 2)         or
+       (StreamReliability.EmptyRetryBackoffMs   <> 750)       or
+       (StreamReliability.StreamIdleTimeoutMs   <> 150 * 1000) or
+       (not StreamReliability.ToolCallRepairEnabled)          then
+    begin
+      Tmp := TJsonObject.Create;
+      Tmp.PutInt ('empty_retry_attempts',     StreamReliability.EmptyRetryAttempts);
+      Tmp.PutInt ('empty_retry_backoff_ms',   StreamReliability.EmptyRetryBackoffMs);
+      Tmp.PutInt ('stream_idle_timeout_ms',   StreamReliability.StreamIdleTimeoutMs);
+      Tmp.PutBool('tool_call_repair_enabled', StreamReliability.ToolCallRepairEnabled);
+      Root.PutObject('stream_reliability', Tmp);
+    end;
 
     Arr := TJsonArray.Create;
     for i := 0 to High(Providers) do
@@ -886,6 +924,21 @@ begin
     try
       GeminiServerTools.GoogleSearch :=
         Obj.GetBool('google_search', GeminiServerTools.GoogleSearch);
+    finally
+      Obj.Free;
+    end;
+
+    Obj := Root.ChildObject('stream_reliability');
+    if Obj <> nil then
+    try
+      StreamReliability.EmptyRetryAttempts :=
+        Integer(Obj.GetInt('empty_retry_attempts',  StreamReliability.EmptyRetryAttempts));
+      StreamReliability.EmptyRetryBackoffMs :=
+        Integer(Obj.GetInt('empty_retry_backoff_ms', StreamReliability.EmptyRetryBackoffMs));
+      StreamReliability.StreamIdleTimeoutMs :=
+        Integer(Obj.GetInt('stream_idle_timeout_ms', StreamReliability.StreamIdleTimeoutMs));
+      StreamReliability.ToolCallRepairEnabled :=
+        Obj.GetBool('tool_call_repair_enabled',     StreamReliability.ToolCallRepairEnabled);
     finally
       Obj.Free;
     end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -155,6 +155,7 @@ uses
   PasClaw.Tools.Sandbox,
   PasClaw.Providers.Factory,
   PasClaw.Tools.ToolLoop,
+  PasClaw.Stream.Reliability,
   PasClaw.Agent.Compact,
   PasClaw.Agent.Prompt,
   PasClaw.Identity,
@@ -1213,7 +1214,7 @@ var
   Body, Prompt: string;
   Bytes: TBytes;
   Req, RespJ: TJsonObject;
-  Msgs: array of TMessage;
+  Msgs: TMessageArray;
   Loop: TToolLoopResult;
   LoopCfg: TToolLoopConfig;
 begin
@@ -1282,6 +1283,7 @@ begin
   LoopCfg.CompactEnabled := True;
   LoopCfg.CompactOpts    := DefaultCompactOptions;
   LoopCfg.ToolOutputCap := FCfg.ToolOutputCap;
+  LoopCfg.StreamReliability := FCfg.StreamReliability;
 
   if not RunToolLoop(LoopCfg, Msgs, Loop) then
   begin
@@ -1705,7 +1707,7 @@ var
   Bytes: TBytes;
   Req, MsgObj: TJsonObject;
   MsgArr: TJsonArray;
-  Msgs: array of TMessage;
+  Msgs: TMessageArray;
   i: Integer;
   WantsStream: Boolean;
   Loop: TToolLoopResult;
@@ -1838,6 +1840,18 @@ begin
     LoopCfg.CompactEnabled := True;
     LoopCfg.CompactOpts    := DefaultCompactOptions;
     LoopCfg.ToolOutputCap := FCfg.ToolOutputCap;
+    LoopCfg.StreamReliability := FCfg.StreamReliability;
+
+    { Tool-call repair: synthesize stub tool_result messages for any
+      assistant tool_call.Id in the incoming history that lacks a
+      paired mrTool. Strict OpenAI-compat backends (DeepSeek,
+      MiniMax-class) reject the request with HTTP 400 when these
+      orphans reach them. The repair runs once at the gateway
+      boundary before the tool loop -- subsequent loop-managed
+      tool_call/tool_result pairs are appended in lock-step so
+      cannot orphan. }
+    if FCfg.StreamReliability.ToolCallRepairEnabled then
+      RepairOrphanedToolCalls(Msgs);
 
     CompId := GenChatCompletionId;
 
@@ -2740,6 +2754,7 @@ procedure StreamResponsesViaProvider(AContext: TIdContext;
                                       const Opts: TChatOptions;
                                       const ToolsRawJSON: string;
                                       DebugIO: Boolean;
+                                      const Reliability: TStreamReliabilityConfig;
                                       out OutUsage: TUsageInfo;
                                       out OutToolCallCount: Integer);
 (* Real partial-streaming variant of EmitResponsesStream for the
@@ -2850,7 +2865,16 @@ begin
       StreamErr := '';
       Failed    := False;
       try
-        Resp := Provider.ChatStream(Msgs, ToolDefs, Model, Opts, State.OnChunk);
+        { ChatStreamWithReliability wraps Provider.ChatStream with an
+          idle-timeout watcher (returns synthetic empty response with
+          FinishReason='timeout' if no chunks arrive within the
+          configured window) and empty-turn retry (only when the
+          stream emitted zero chunks AND landed on the empty shape).
+          With both knobs zero the wrapper degrades to a direct
+          Provider.ChatStream call. }
+        Resp := ChatStreamWithReliability(Provider, Msgs, ToolDefs,
+                                           Model, Opts, State.OnChunk,
+                                           Reliability);
       except
         on E: Exception do
         begin
@@ -2874,6 +2898,16 @@ begin
           else
             StreamErr := 'provider returned finish_reason=error';
         end;
+      end;
+      { Idle-timeout from the reliability wrapper surfaces as
+        FinishReason='timeout'. Map to the response.failed code
+        path so the client gets a clean 502-style error instead of
+        a half-streamed response that silently never finishes. }
+      if (not Failed) and (Resp.FinishReason = 'timeout') then
+      begin
+        Failed := True;
+        if StreamErr = '' then
+          StreamErr := 'upstream stream idle-timeout';
       end;
 
       { Surface the totals to the caller's out-params. Whether the
@@ -3019,7 +3053,7 @@ var
   Bytes: TBytes;
   Req, InputObj, ReplyObj, ErrObj, ToolObj: TJsonObject;
   InputArr, ToolsArrIn: TJsonArray;
-  Msgs: array of TMessage;
+  Msgs: TMessageArray;
   i, MsgCount, j: Integer;
   WantsStream, HasFunctionTools: Boolean;
   Loop: TToolLoopResult;
@@ -3397,7 +3431,15 @@ begin
         we DON'T run PasClaw's internal tool loop -- that would have
         the model's tool calls vanish into our server-side handlers
         instead of reaching the client. One Chat() round-trip, hand
-        back text and any tool_calls verbatim. }
+        back text and any tool_calls verbatim.
+
+        Tool-call repair fires here too: the client may have aborted
+        a parallel tool mid-flight, leaving an assistant turn whose
+        tool_call.Id has no matched tool_result in the follow-up.
+        Strict OpenAI-compat backends 400 in that shape; the
+        synthesized stub keeps the request valid. }
+      if FCfg.StreamReliability.ToolCallRepairEnabled then
+        RepairOrphanedToolCalls(Msgs);
       PassthroughOpts := DefaultChatOptions;
       ApplyPromptCacheConfig(PassthroughOpts, FCfg.PromptCache);
       { Skip BuildSystemPrompt -- Codex sends its own developer
@@ -3439,6 +3481,7 @@ begin
         StreamResponsesViaProvider(AContext, AResp, AResponseStarted,
                                     FProvider, RespId, ReqModel, Msgs, ToolDefs,
                                     PassthroughOpts, ToolsRawJSON, FDebugIO,
+                                    FCfg.StreamReliability,
                                     OutUsage, StreamToolCallCount);
         { Stats accumulation for the streaming passthrough path.
           Mirrors the non-streaming branch below: count tokens
@@ -3455,7 +3498,15 @@ begin
       end;
 
       try
-        PassthroughResp := FProvider.Chat(Msgs, ToolDefs, ReqModel, PassthroughOpts);
+        { Empty-turn retry on the passthrough path -- same
+          semantics as the tool-loop site, just delivered through
+          ChatWithEmptyRetry. The passthrough has no fallback
+          chain, so retries against the primary provider are the
+          only recovery before the response goes back to the
+          client. }
+        PassthroughResp := ChatWithEmptyRetry(FProvider, Msgs, ToolDefs,
+                                               ReqModel, PassthroughOpts,
+                                               FCfg.StreamReliability);
       except
         on E: Exception do
         begin
@@ -3529,6 +3580,10 @@ begin
       LoopCfg.OnToolCall    := nil;
       LoopCfg.OnToolResult  := nil;
       LoopCfg.ToolOutputCap := FCfg.ToolOutputCap;
+      LoopCfg.StreamReliability := FCfg.StreamReliability;
+
+      if FCfg.StreamReliability.ToolCallRepairEnabled then
+        RepairOrphanedToolCalls(Msgs);
 
       if not RunToolLoop(LoopCfg, Msgs, Loop) then
       begin

--- a/src/pkg/stream/PasClaw.Stream.Reliability.pas
+++ b/src/pkg/stream/PasClaw.Stream.Reliability.pas
@@ -334,33 +334,39 @@ begin
 end;
 
 procedure TStreamJob.InternalOnChunk(const C: TStreamChunk);
-var
-  FireUser: Boolean;
-  Cb: TStreamCallback;
 begin
+  { Hold the lock across the user callback so Cancel cannot return
+    until any in-progress OnChunk has finished. Without that
+    guarantee the wrapper can return its synthetic timeout response,
+    the gateway tears down its TResponsesStreamState, and a stale
+    chunk arriving milliseconds later from the still-running worker
+    calls back into freed memory. Holding the lock around the call
+    serialises Cancel with in-progress OnChunks; combined with the
+    FCancelled flag (which gates entry on the next chunk) it
+    guarantees that once Cancel returns, no further user callback
+    can fire from this job. The lock is brief on the writer side
+    (Cancel / Detach just flip Booleans) so the worker-blocked-on-
+    Cancel window is bounded by the OnChunk write -- typically a
+    single socket write, well under the idle-timeout poll cadence. }
   FLock.Enter;
   try
     FLastChunkAt := Now;
     Inc(FChunkCount);
-    FireUser := (not FCancelled) and Assigned(FUserOnChunk);
-    Cb := FUserOnChunk;
-  finally
-    FLock.Leave;
-  end;
-  if FireUser then
-  begin
+    if FCancelled or (not Assigned(FUserOnChunk)) then Exit;
     { User OnChunk may write to a torn-down connection; swallow any
       exception so the worker can still drain the provider stream
       cleanly. Without this the provider would see its own callback
       raise, often classify it as a hard error, and we'd lose the
       finish_reason on the final response. }
     try
-      Cb(C);
+      FUserOnChunk(C);
     except
       on E: Exception do
         LogDebug('stream-reliability: user OnChunk raised %s: %s',
                  [E.ClassName, E.Message]);
     end;
+  finally
+    FLock.Leave;
   end;
 end;
 

--- a/src/pkg/stream/PasClaw.Stream.Reliability.pas
+++ b/src/pkg/stream/PasClaw.Stream.Reliability.pas
@@ -1,0 +1,614 @@
+{
+  PasClaw.Stream.Reliability - production-grade polish for the serve /
+  gateway OpenAI-compat surface. Mirrors the UltraCode-Shim layer:
+
+    1. Empty-turn auto-retry. Some upstream models / proxies (notably
+       on the OpenAI-compat side: certain Together / OpenRouter route
+       hiccups, MoonShot K2 brownouts, DeepSeek R1 thinking-token
+       overflow) hand back a perfectly-shaped response whose
+       Content is empty AND ToolCalls is empty AND FinishReason is
+       "stop". The model said nothing. The provider returned 200.
+       The end user sees the agent fall silent mid-turn. Auto-retry
+       up to N times with exponential backoff catches the transient
+       cases and stops short of pounding on a true silent backend.
+
+    2. Idle-timeout kill for hung streams. ChatStream calls that
+       stop emitting chunks for longer than IdleTimeoutMs are
+       declared dead: the wrapper returns a synthetic empty
+       response with FinishReason='timeout' to the caller while a
+       background thread continues to drain the provider until its
+       own Indy ReadTimeout retires the socket. Without this an
+       upstream that opens the stream then never writes will wedge
+       the gateway worker until the Indy connect/read timeout
+       (typically tens of seconds, sometimes more on chained
+       proxies).
+
+    3. Tool-call repair. Strict OpenAI-compat backends -- DeepSeek,
+       MiniMax-class endpoints, anything tightly validating the
+       tool_call / tool_result pairing -- return HTTP 400 when an
+       assistant turn carries N tool_calls but the follow-up
+       messages contain fewer matched tool_result entries.
+       Real-world cause: parallel tool dispatch where the client
+       cancelled one of the calls, or a previous turn aborted
+       between tool_use and tool_result. RepairOrphanedToolCalls
+       walks the message history, finds every assistant
+       tool_call.Id that lacks a paired mrTool entry following it,
+       and synthesizes a stub mrTool result so the next request
+       validates.
+
+  All three knobs come from TConfig.StreamReliability; default values
+  match the UltraCode-Shim shipping config (2 attempts, 750ms base
+  backoff, 150s idle timeout). Operators tune via config.json or via
+  the well-known env vars UC_EMPTY_RETRY_ATTEMPTS,
+  UC_EMPTY_RETRY_BACKOFF_MS, UC_STREAM_IDLE_TIMEOUT_SEC.
+}
+unit PasClaw.Stream.Reliability;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf;
+
+type
+  TStreamReliabilityConfig = record
+    { Max attempts when the provider returns an empty turn
+      (Content='' AND ToolCalls=[] AND FinishReason='stop'). 0
+      disables retry (single attempt, surface the empty response
+      verbatim). Default 2. }
+    EmptyRetryAttempts:    Integer;
+    { Base backoff in milliseconds between retry attempts. Doubles
+      each subsequent attempt (capped). Default 750. }
+    EmptyRetryBackoffMs:   Integer;
+    { Max idle window in milliseconds for ChatStream. If no chunk
+      arrives within this window the stream is declared timed out
+      and a synthetic empty response is returned. 0 disables the
+      watcher entirely. Default 150_000 (150s). }
+    StreamIdleTimeoutMs:   Integer;
+    { When True, RepairOrphanedToolCalls runs at the gateway
+      boundary to synthesize stub tool_result messages for
+      assistant tool_call ids that have no matched tool_result.
+      Default True. }
+    ToolCallRepairEnabled: Boolean;
+  end;
+
+function DefaultStreamReliabilityConfig: TStreamReliabilityConfig;
+
+{ Override defaults with env-var values when set. Recognised vars:
+    UC_EMPTY_RETRY_ATTEMPTS     -- integer
+    UC_EMPTY_RETRY_BACKOFF_MS   -- integer (milliseconds)
+    UC_STREAM_IDLE_TIMEOUT_SEC  -- integer (seconds)
+    UC_TOOL_CALL_REPAIR         -- 0/1/false/true
+  Unset / malformed values fall through to the supplied Defaults. }
+function LoadStreamReliabilityFromEnv(
+  const Defaults: TStreamReliabilityConfig): TStreamReliabilityConfig;
+
+{ The empty-turn shape: provider returned 2xx with no text, no tool
+  calls, and a non-error finish_reason. This is the surface symptom
+  of an upstream brownout. }
+function IsEmptyTurn(const R: TLLMResponse): Boolean;
+
+{ Drop-in wrapper around Provider.Chat that retries empty turns.
+  All other failure modes (HTTP errors, exceptions) are passed
+  through verbatim -- the tool-loop's fallback walk and OnError
+  hooks handle those. Empty-turn retries do NOT attempt fallbacks;
+  the primary provider gets every retry attempt. }
+function ChatWithEmptyRetry(Provider: ILLMProvider;
+                            const Messages: array of TMessage;
+                            const Tools:    array of TToolDefinition;
+                            const Model:    string;
+                            const Options:  TChatOptions;
+                            const Cfg:      TStreamReliabilityConfig): TLLMResponse;
+
+{ Drop-in wrapper around Provider.ChatStream with idle-timeout and
+  empty-turn retry. The wrapper runs ChatStream on a worker thread
+  and watches the OnChunk timestamp from the calling thread; if no
+  chunk arrives within Cfg.StreamIdleTimeoutMs the wrapper returns
+  a synthetic empty response with FinishReason='timeout'.
+
+  Worker-thread cleanup: when the watcher fires the wrapper sets a
+  cancellation flag on the job. Any further chunks the worker
+  receives are dropped on the floor (the user's OnChunk is not
+  invoked). The worker continues until Provider.ChatStream returns
+  -- typically when the underlying Indy ReadTimeout retires the
+  socket -- at which point the job frees itself. No leaked sockets,
+  no leaked threads.
+
+  Empty-turn retry semantics for streams: only fires when the
+  stream completed with ZERO chunks AND an empty TLLMResponse. If
+  any chunks reached the user callback, we cannot retry without
+  duplicate output downstream; the empty response (if any) is
+  surfaced as-is. }
+function ChatStreamWithReliability(Provider: ILLMProvider;
+                                    const Messages: array of TMessage;
+                                    const Tools:    array of TToolDefinition;
+                                    const Model:    string;
+                                    const Options:  TChatOptions;
+                                    OnChunk: TStreamCallback;
+                                    const Cfg: TStreamReliabilityConfig): TLLMResponse;
+
+{ Walk Msgs and synthesize stub mrTool messages for every assistant
+  tool_call.Id that has no matched mrTool with ToolCallId equal to
+  it. Stubs are inserted immediately after the assistant turn that
+  emitted the orphaned call.
+
+  Returns the number of stubs that were synthesized; callers can
+  log a warning when > 0 so operators see when their client is
+  shipping malformed histories. }
+function RepairOrphanedToolCalls(var Msgs: TMessageArray): Integer;
+
+implementation
+
+uses
+  DateUtils,
+  PasClaw.Logger;
+
+function DefaultStreamReliabilityConfig: TStreamReliabilityConfig;
+begin
+  Result.EmptyRetryAttempts    := 2;
+  Result.EmptyRetryBackoffMs   := 750;
+  Result.StreamIdleTimeoutMs   := 150 * 1000;
+  Result.ToolCallRepairEnabled := True;
+end;
+
+function ParseIntEnv(const Name: string; Default_: Integer): Integer;
+var
+  S: string;
+  V: Integer;
+begin
+  Result := Default_;
+  S := GetEnvironmentVariable(Name);
+  if S = '' then Exit;
+  if TryStrToInt(Trim(S), V) and (V >= 0) then Result := V;
+end;
+
+function ParseBoolEnv(const Name: string; Default_: Boolean): Boolean;
+var
+  S: string;
+begin
+  Result := Default_;
+  S := LowerCase(Trim(GetEnvironmentVariable(Name)));
+  if S = '' then Exit;
+  if (S = '1') or (S = 'true')  or (S = 'yes') or (S = 'on')  then Result := True
+  else if (S = '0') or (S = 'false') or (S = 'no')  or (S = 'off') then Result := False;
+end;
+
+function LoadStreamReliabilityFromEnv(
+  const Defaults: TStreamReliabilityConfig): TStreamReliabilityConfig;
+var
+  IdleSec: Integer;
+begin
+  Result := Defaults;
+  Result.EmptyRetryAttempts  := ParseIntEnv('UC_EMPTY_RETRY_ATTEMPTS',
+                                            Defaults.EmptyRetryAttempts);
+  Result.EmptyRetryBackoffMs := ParseIntEnv('UC_EMPTY_RETRY_BACKOFF_MS',
+                                            Defaults.EmptyRetryBackoffMs);
+  IdleSec := ParseIntEnv('UC_STREAM_IDLE_TIMEOUT_SEC',
+                         Defaults.StreamIdleTimeoutMs div 1000);
+  Result.StreamIdleTimeoutMs := IdleSec * 1000;
+  Result.ToolCallRepairEnabled := ParseBoolEnv('UC_TOOL_CALL_REPAIR',
+                                                Defaults.ToolCallRepairEnabled);
+end;
+
+function IsEmptyTurn(const R: TLLMResponse): Boolean;
+begin
+  Result := (R.Content = '')
+        and (Length(R.ToolCalls) = 0)
+        and ((R.FinishReason = 'stop') or (R.FinishReason = '') or
+             (R.FinishReason = 'end_turn'));
+end;
+
+function ChatWithEmptyRetry(Provider: ILLMProvider;
+                            const Messages: array of TMessage;
+                            const Tools:    array of TToolDefinition;
+                            const Model:    string;
+                            const Options:  TChatOptions;
+                            const Cfg:      TStreamReliabilityConfig): TLLMResponse;
+var
+  Attempt: Integer;
+  Backoff: Integer;
+begin
+  if Provider = nil then
+  begin
+    Result := Default(TLLMResponse);
+    Result.StatusCode := -1;
+    Exit;
+  end;
+
+  Result := Provider.Chat(Messages, Tools, Model, Options);
+  if Cfg.EmptyRetryAttempts <= 0 then Exit;
+
+  { Only retry the empty-turn shape. Any non-2xx, non-empty, or
+    tool-call response is the caller's to handle. }
+  Attempt := 0;
+  Backoff := Cfg.EmptyRetryBackoffMs;
+  if Backoff < 50 then Backoff := 50;
+  while (Attempt < Cfg.EmptyRetryAttempts) and
+        (Result.StatusCode >= 200) and (Result.StatusCode < 300) and
+        IsEmptyTurn(Result) do
+  begin
+    Inc(Attempt);
+    LogWarn('stream-reliability: empty turn from %s/%s, retry %d/%d after %dms',
+            [Provider.GetName, Model, Attempt, Cfg.EmptyRetryAttempts, Backoff]);
+    Sleep(Backoff);
+    Result := Provider.Chat(Messages, Tools, Model, Options);
+    Backoff := Backoff * 2;
+    if Backoff > 16000 then Backoff := 16000;
+  end;
+end;
+
+type
+  TStreamJob = class(TThread)
+  private
+    FProvider:    ILLMProvider;
+    FMessages:    TMessageArray;
+    FTools:       TToolDefinitionArray;
+    FModel:       string;
+    FOptions:     TChatOptions;
+    FUserOnChunk: TStreamCallback;
+    FLock:        TCriticalSection;
+    FLastChunkAt: TDateTime;
+    FChunkCount:  Integer;
+    FCancelled:   Boolean;
+    FResp:        TLLMResponse;
+    FExceptionMsg: string;
+    procedure InternalOnChunk(const C: TStreamChunk);
+  protected
+    procedure Execute; override;
+  public
+    Done: TEvent;
+    constructor Create(AProvider: ILLMProvider;
+                       const AMessages: array of TMessage;
+                       const ATools: array of TToolDefinition;
+                       const AModel: string;
+                       const AOptions: TChatOptions;
+                       AUserOnChunk: TStreamCallback);
+    destructor Destroy; override;
+    procedure Cancel;
+    procedure Detach;
+    function  GetLastChunkAt: TDateTime;
+    function  GetChunkCount: Integer;
+    function  GetResp: TLLMResponse;
+    function  GetExceptionMsg: string;
+  end;
+
+constructor TStreamJob.Create(AProvider: ILLMProvider;
+                              const AMessages: array of TMessage;
+                              const ATools: array of TToolDefinition;
+                              const AModel: string;
+                              const AOptions: TChatOptions;
+                              AUserOnChunk: TStreamCallback);
+var
+  i: Integer;
+begin
+  inherited Create(True);  { suspended; caller Start's after construction }
+  { FreeOnTerminate stays False on the happy path so the wrapper can
+    safely read FResp + Free the job after Done signals. The timeout
+    branch flips it to True before walking away (Detach), turning the
+    job into a self-cleaning orphan that finishes draining the
+    provider stream in the background. }
+  FreeOnTerminate := False;
+  FProvider    := AProvider;
+  FModel       := AModel;
+  FOptions     := AOptions;
+  FUserOnChunk := AUserOnChunk;
+  SetLength(FMessages, Length(AMessages));
+  for i := 0 to High(AMessages) do FMessages[i] := AMessages[i];
+  SetLength(FTools, Length(ATools));
+  for i := 0 to High(ATools) do FTools[i] := ATools[i];
+  FLock        := TCriticalSection.Create;
+  FLastChunkAt := Now;
+  FChunkCount  := 0;
+  FCancelled   := False;
+  Done         := TEvent.Create(nil, True, False, '');
+end;
+
+destructor TStreamJob.Destroy;
+begin
+  FLock.Free;
+  Done.Free;
+  inherited;
+end;
+
+procedure TStreamJob.Cancel;
+begin
+  FLock.Enter;
+  try
+    FCancelled := True;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+procedure TStreamJob.Detach;
+{ Hand ownership of the job to the runtime: from here the worker
+  will self-free when its Execute returns. The wrapper invokes this
+  right before walking away on the timeout path so the still-running
+  worker doesn't leak. Caller must not touch the job after Detach. }
+begin
+  FreeOnTerminate := True;
+end;
+
+procedure TStreamJob.InternalOnChunk(const C: TStreamChunk);
+var
+  FireUser: Boolean;
+  Cb: TStreamCallback;
+begin
+  FLock.Enter;
+  try
+    FLastChunkAt := Now;
+    Inc(FChunkCount);
+    FireUser := (not FCancelled) and Assigned(FUserOnChunk);
+    Cb := FUserOnChunk;
+  finally
+    FLock.Leave;
+  end;
+  if FireUser then
+  begin
+    { User OnChunk may write to a torn-down connection; swallow any
+      exception so the worker can still drain the provider stream
+      cleanly. Without this the provider would see its own callback
+      raise, often classify it as a hard error, and we'd lose the
+      finish_reason on the final response. }
+    try
+      Cb(C);
+    except
+      on E: Exception do
+        LogDebug('stream-reliability: user OnChunk raised %s: %s',
+                 [E.ClassName, E.Message]);
+    end;
+  end;
+end;
+
+procedure TStreamJob.Execute;
+begin
+  try
+    FResp := FProvider.ChatStream(FMessages, FTools, FModel, FOptions,
+                                   InternalOnChunk);
+  except
+    on E: Exception do
+    begin
+      FExceptionMsg := E.ClassName + ': ' + E.Message;
+      FResp := Default(TLLMResponse);
+      FResp.StatusCode := -1;
+    end;
+  end;
+  Done.SetEvent;
+end;
+
+function TStreamJob.GetLastChunkAt: TDateTime;
+begin
+  FLock.Enter;
+  try
+    Result := FLastChunkAt;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+function TStreamJob.GetChunkCount: Integer;
+begin
+  FLock.Enter;
+  try
+    Result := FChunkCount;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+function TStreamJob.GetResp: TLLMResponse;
+begin
+  Result := FResp;
+end;
+
+function TStreamJob.GetExceptionMsg: string;
+begin
+  Result := FExceptionMsg;
+end;
+
+function RunOneStream(Provider: ILLMProvider;
+                      const Messages: array of TMessage;
+                      const Tools:    array of TToolDefinition;
+                      const Model:    string;
+                      const Options:  TChatOptions;
+                      OnChunk: TStreamCallback;
+                      IdleTimeoutMs: Integer;
+                      out ChunkCount: Integer;
+                      out TimedOut: Boolean): TLLMResponse;
+const
+  PollMs = 500;
+var
+  Job: TStreamJob;
+  IdleMs: Integer;
+  WaitRes: TWaitResult;
+begin
+  TimedOut   := False;
+  ChunkCount := 0;
+  if IdleTimeoutMs <= 0 then
+  begin
+    { Watcher disabled -- pass through directly. Avoids the worker-
+      thread overhead for callers that don't want kill semantics. }
+    Result := Provider.ChatStream(Messages, Tools, Model, Options, OnChunk);
+    Exit;
+  end;
+
+  Job := TStreamJob.Create(Provider, Messages, Tools, Model, Options, OnChunk);
+  Job.Start;
+  try
+    while True do
+    begin
+      WaitRes := Job.Done.WaitFor(PollMs);
+      if WaitRes = wrSignaled then
+      begin
+        Result     := Job.GetResp;
+        ChunkCount := Job.GetChunkCount;
+        if Job.GetExceptionMsg <> '' then
+          LogWarn('stream-reliability: ChatStream raised: %s',
+                  [Job.GetExceptionMsg]);
+        { Worker has signalled Done as its last act in Execute --
+          waiting on the OS thread handle here ensures Execute has
+          fully unwound before we free the object. Without the
+          WaitFor the worker can still be in its post-Execute
+          cleanup when we Free below, producing an AV. }
+        Job.WaitFor;
+        Job.Free;
+        Job := nil;
+        Exit;
+      end;
+      IdleMs := MilliSecondsBetween(Now, Job.GetLastChunkAt);
+      if IdleMs >= IdleTimeoutMs then
+      begin
+        Job.Cancel;
+        ChunkCount := Job.GetChunkCount;
+        TimedOut   := True;
+        LogWarn('stream-reliability: ChatStream idle >%dms (chunks=%d) -- declaring timeout, draining in background',
+                [IdleMs, ChunkCount]);
+        Result := Default(TLLMResponse);
+        Result.FinishReason := 'timeout';
+        Result.StatusCode   := -1;
+        { Detach hands the job to FreeOnTerminate cleanup: it stays
+          alive draining the provider stream until Indy's ReadTimeout
+          retires the socket, then self-frees. No leaked sockets,
+          no leaked threads. }
+        Job.Detach;
+        Job := nil;
+        Exit;
+      end;
+    end;
+  except
+    { On unexpected wrapper-side exception, cancel + detach the job
+      so the orphaned worker stops calling back into the (possibly
+      freed) user OnChunk, and re-raise. Job self-frees when its
+      Execute returns. }
+    if Job <> nil then
+    begin
+      Job.Cancel;
+      Job.Detach;
+    end;
+    raise;
+  end;
+end;
+
+function ChatStreamWithReliability(Provider: ILLMProvider;
+                                    const Messages: array of TMessage;
+                                    const Tools:    array of TToolDefinition;
+                                    const Model:    string;
+                                    const Options:  TChatOptions;
+                                    OnChunk: TStreamCallback;
+                                    const Cfg: TStreamReliabilityConfig): TLLMResponse;
+var
+  Attempt, Backoff, ChunkCount: Integer;
+  TimedOut: Boolean;
+begin
+  if Provider = nil then
+  begin
+    Result := Default(TLLMResponse);
+    Result.StatusCode := -1;
+    Exit;
+  end;
+
+  Result := RunOneStream(Provider, Messages, Tools, Model, Options,
+                          OnChunk, Cfg.StreamIdleTimeoutMs,
+                          ChunkCount, TimedOut);
+
+  if (Cfg.EmptyRetryAttempts <= 0) or TimedOut then Exit;
+
+  { Empty-turn retry only fires when the stream produced no chunks
+    AND landed on the empty shape. If chunks reached the user
+    callback, retrying would duplicate output downstream -- skip. }
+  Attempt := 0;
+  Backoff := Cfg.EmptyRetryBackoffMs;
+  if Backoff < 50 then Backoff := 50;
+  while (Attempt < Cfg.EmptyRetryAttempts) and
+        (ChunkCount = 0) and
+        (Result.StatusCode >= 200) and (Result.StatusCode < 300) and
+        IsEmptyTurn(Result) do
+  begin
+    Inc(Attempt);
+    LogWarn('stream-reliability: empty stream from %s/%s, retry %d/%d after %dms',
+            [Provider.GetName, Model, Attempt, Cfg.EmptyRetryAttempts, Backoff]);
+    Sleep(Backoff);
+    Result := RunOneStream(Provider, Messages, Tools, Model, Options,
+                            OnChunk, Cfg.StreamIdleTimeoutMs,
+                            ChunkCount, TimedOut);
+    if TimedOut then Exit;
+    Backoff := Backoff * 2;
+    if Backoff > 16000 then Backoff := 16000;
+  end;
+end;
+
+function HasMatchingToolResult(const Msgs: TMessageArray;
+                                StartAfter: Integer;
+                                const ToolCallId: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  if ToolCallId = '' then Exit;
+  for i := StartAfter + 1 to High(Msgs) do
+    if (Msgs[i].Role = mrTool) and (Msgs[i].ToolCallId = ToolCallId) then
+      Exit(True);
+end;
+
+function InsertStubAt(var Msgs: TMessageArray; InsertAt: Integer;
+                      const ToolCallId, FuncName: string): Integer;
+{ Insert a stub mrTool message at InsertAt. Returns 1 (one stub
+  added) so the caller can roll up the count. The insertion shifts
+  every subsequent index by one; callers walking the array re-read
+  Length(Msgs) and adjust their loop variables accordingly. }
+var
+  i: Integer;
+  Stub: TMessage;
+begin
+  Stub := Default(TMessage);
+  Stub.Role       := mrTool;
+  Stub.ToolCallId := ToolCallId;
+  Stub.Name       := FuncName;
+  Stub.Content    := '[tool result missing -- repaired by gateway]';
+  SetLength(Msgs, Length(Msgs) + 1);
+  for i := High(Msgs) downto InsertAt + 1 do
+    Msgs[i] := Msgs[i - 1];
+  Msgs[InsertAt] := Stub;
+  Result := 1;
+end;
+
+function RepairOrphanedToolCalls(var Msgs: TMessageArray): Integer;
+var
+  i, j, InsertAt: Integer;
+  Asst: TMessage;
+  Tc: TToolCall;
+begin
+  Result := 0;
+  i := 0;
+  while i <= High(Msgs) do
+  begin
+    if Msgs[i].Role = mrAssistant then
+    begin
+      Asst := Msgs[i];
+      InsertAt := i + 1;
+      for j := 0 to High(Asst.ToolCalls) do
+      begin
+        Tc := Asst.ToolCalls[j];
+        if Tc.Id = '' then Continue;
+        if not HasMatchingToolResult(Msgs, i, Tc.Id) then
+        begin
+          Inc(Result, InsertStubAt(Msgs, InsertAt, Tc.Id, Tc.Func.Name));
+          Inc(InsertAt);
+        end;
+      end;
+      { Advance past the assistant + any stubs we just inserted. }
+      i := InsertAt;
+    end
+    else
+      Inc(i);
+  end;
+  if Result > 0 then
+    LogWarn('stream-reliability: tool-call repair synthesized %d stub result(s)',
+            [Result]);
+end;
+
+end.

--- a/src/pkg/stream/PasClaw.Stream.Reliability.pas
+++ b/src/pkg/stream/PasClaw.Stream.Reliability.pas
@@ -334,6 +334,8 @@ begin
 end;
 
 procedure TStreamJob.InternalOnChunk(const C: TStreamChunk);
+var
+  DeliveredContent: Boolean;
 begin
   { Hold the lock across the user callback so Cancel cannot return
     until any in-progress OnChunk has finished. Without that
@@ -348,10 +350,21 @@ begin
     (Cancel / Detach just flip Booleans) so the worker-blocked-on-
     Cancel window is bounded by the OnChunk write -- typically a
     single socket write, well under the idle-timeout poll cadence. }
+  { Bump FChunkCount only when the chunk actually delivered
+    user-visible content. Empty text deltas and protocol-only
+    events ('usage', 'done', terminal end-of-stream markers some
+    providers emit) would otherwise pin ChunkCount > 0 and
+    suppress the empty-turn retry on a stream that produced no
+    output -- exactly the case the retry exists to recover from.
+    Codex P2 finding on PR #213. FLastChunkAt still updates on
+    every chunk because any activity counts as "not idle" for
+    the timeout watcher. }
+  DeliveredContent := ((C.Kind = 'text') and (C.Text <> '')) or
+                      (C.Kind = 'tool_call');
   FLock.Enter;
   try
     FLastChunkAt := Now;
-    Inc(FChunkCount);
+    if DeliveredContent then Inc(FChunkCount);
     if FCancelled or (not Assigned(FUserOnChunk)) then Exit;
     { User OnChunk may write to a torn-down connection; swallow any
       exception so the worker can still drain the provider stream
@@ -380,7 +393,18 @@ begin
     begin
       FExceptionMsg := E.ClassName + ': ' + E.Message;
       FResp := Default(TLLMResponse);
-      FResp.StatusCode := -1;
+      FResp.StatusCode   := -1;
+      { Mark the response as a hard failure so callers that
+        switch on FinishReason (StreamResponsesViaProvider checks
+        for 'error' / 'timeout' to drive its response.failed
+        path) propagate the exception instead of reporting a
+        successful empty completion. Codex P2 finding on PR #213:
+        the previous shape -- StatusCode=-1 with FinishReason=''
+        -- looked identical to "200 OK, model said nothing", and
+        the gateway happily closed the SSE stream with
+        response.completed. }
+      FResp.FinishReason := 'error';
+      FResp.Content      := FExceptionMsg;
     end;
   end;
   Done.SetEvent;

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -24,7 +24,8 @@ uses
   PasClaw.Agent.Compact,
   PasClaw.Agent.Hooks,
   PasClaw.Agent.Steering,
-  PasClaw.Identity;
+  PasClaw.Identity,
+  PasClaw.Stream.Reliability;
 
 type
   TToolLoopConfig = record
@@ -117,6 +118,18 @@ type
        set this to ~8192 and register the OutputCache tool on the
        same registry. *)
     ToolOutputCap:  Integer;
+    (* Stream-reliability knobs. When EmptyRetryAttempts > 0 the
+       loop's primary Provider.Chat goes through ChatWithEmptyRetry,
+       which retries empty-turn responses (Content='' + no tool
+       calls + finish_reason='stop') up to N times with exponential
+       backoff. Fallback-walk semantics are unchanged -- the retry
+       fires on the primary provider only, BEFORE the fallback walk
+       sees the response. Zero attempts (default record value)
+       means single-shot behaviour, same as pre-PR. The other
+       fields (StreamIdleTimeoutMs, ToolCallRepairEnabled) don't
+       apply to the synchronous tool loop -- they're surfaced by
+       gateway / channel paths that drive ChatStream directly. *)
+    StreamReliability: TStreamReliabilityConfig;
   end;
 
   TToolLoopResult = record
@@ -733,7 +746,16 @@ begin
       diagnostic still get it via OnError. (Codex P2 on PR #114.) }
     LastProviderErrText := '';
     try
-      Resp := Cfg.Provider.Chat(Hist, Tools, Cfg.Model, LiveOptions);
+      { Empty-turn auto-retry. When StreamReliability.EmptyRetryAttempts
+        is 0 (default record zero, the legacy shape) ChatWithEmptyRetry
+        is a one-shot call -- identical to the pre-PR behaviour.
+        Callers (Cmd.Agent BuildLoopConfig, gateway HandleChat, etc.)
+        populate StreamReliability from Cfg.StreamReliability to
+        opt this loop into the retry path. The fallback walk below
+        still runs unchanged on retryable HTTP failures; empty-turn
+        is a separate, pre-fallback recovery. }
+      Resp := ChatWithEmptyRetry(Cfg.Provider, Hist, Tools, Cfg.Model,
+                                  LiveOptions, Cfg.StreamReliability);
     except
       on E: Exception do
       begin

--- a/src/tests/stream_reliability_tests.pas
+++ b/src/tests/stream_reliability_tests.pas
@@ -1,0 +1,565 @@
+program stream_reliability_tests;
+(*
+  Covers PasClaw.Stream.Reliability -- the empty-turn auto-retry,
+  ChatStream idle-timeout wrapper, and orphaned-tool-call repair
+  that ship with the UltraCode-Shim gateway polish.
+
+  We pin contracts that don't require a real LLM:
+
+    - IsEmptyTurn identifies the three-piece empty shape and
+      rejects every legitimate response shape that differs.
+    - ChatWithEmptyRetry returns the FIRST non-empty response
+      after one or more empty responses (happy retry path).
+    - ChatWithEmptyRetry stops at EmptyRetryAttempts and surfaces
+      the last empty response when the provider stays silent
+      (exhaustion path; we cap the loop, don't pound forever).
+    - ChatWithEmptyRetry with EmptyRetryAttempts=0 is single-shot.
+    - ChatStreamWithReliability times out a hung provider (no
+      chunks within IdleTimeoutMs) and returns a synthetic
+      timeout response without leaking the worker.
+    - ChatStreamWithReliability passes through the happy stream
+      verbatim when no timeout fires.
+    - RepairOrphanedToolCalls synthesizes stubs for tool_call ids
+      that lack matching tool_results, leaves matched pairs alone,
+      and reports the synthesized count.
+
+  Strategy: substitute a FAKE ILLMProvider with scripted behaviour
+  per test (return-N-empties-then-content; sleep-for-N-seconds; ...)
+  so the test doesn't need a real model and isn't flaky.
+
+  Threading note: ChatStreamWithReliability owns a worker thread.
+  The two stream tests below use a fake provider whose ChatStream
+  sleeps a deterministic amount before returning -- short for the
+  passthrough test, long for the timeout test -- so we can verify
+  both the success path and the watcher kill path without flakiness.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Types,
+  PasClaw.Stream.Reliability;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertFalse(Cond: Boolean; const Msg: string);
+begin
+  if Cond then Fail_(Msg);
+end;
+
+procedure AssertEqInt(const Got, Want: Integer; const Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Format('%s (got %d, want %d)', [Msg, Got, Want]));
+end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Copy(Got, 1, 200) + '", want "' +
+          Copy(Want, 1, 200) + '")');
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' +
+          Copy(Haystack, 1, 200) + '")');
+end;
+
+type
+  { Scripted ILLMProvider. Each call to Chat or ChatStream returns
+    the next entry from Script (cycling at end). When Script is
+    empty, returns a real-looking response with Content='OK'. }
+  TScriptedProvider = class(TInterfacedObject, ILLMProvider)
+  private
+    FScript:      array of TLLMResponse;
+    FCallCount:   Integer;
+    FSleepBefore: Integer;  { ms per Chat / ChatStream call }
+    FChunkText:   string;   { if non-empty, ChatStream emits this as one chunk
+                              before returning the scripted response }
+  public
+    constructor Create;
+    function ChatCallCount: Integer;
+    procedure SetSleepBeforeMs(MS: Integer);
+    procedure SetChunkText(const Text: string);
+    procedure AddScriptedEmpty;
+    procedure AddScriptedContent(const Body: string);
+    function Chat(const Messages: array of TMessage;
+                  const Tools:    array of TToolDefinition;
+                  const Model:    string;
+                  const Options:  TChatOptions): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+  end;
+
+constructor TScriptedProvider.Create;
+begin
+  inherited;
+  SetLength(FScript, 0);
+  FCallCount   := 0;
+  FSleepBefore := 0;
+  FChunkText   := '';
+end;
+
+function TScriptedProvider.ChatCallCount: Integer; begin Result := FCallCount; end;
+
+procedure TScriptedProvider.SetSleepBeforeMs(MS: Integer);
+begin FSleepBefore := MS; end;
+
+procedure TScriptedProvider.SetChunkText(const Text: string);
+begin FChunkText := Text; end;
+
+procedure TScriptedProvider.AddScriptedEmpty;
+var
+  R: TLLMResponse;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode   := 200;
+  R.FinishReason := 'stop';
+  R.Content      := '';
+  SetLength(R.ToolCalls, 0);
+  SetLength(FScript, Length(FScript) + 1);
+  FScript[High(FScript)] := R;
+end;
+
+procedure TScriptedProvider.AddScriptedContent(const Body: string);
+var
+  R: TLLMResponse;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode   := 200;
+  R.FinishReason := 'stop';
+  R.Content      := Body;
+  SetLength(R.ToolCalls, 0);
+  SetLength(FScript, Length(FScript) + 1);
+  FScript[High(FScript)] := R;
+end;
+
+function TScriptedProvider.Chat(const Messages: array of TMessage;
+                                 const Tools:    array of TToolDefinition;
+                                 const Model:    string;
+                                 const Options:  TChatOptions): TLLMResponse;
+var
+  Idx: Integer;
+begin
+  if FSleepBefore > 0 then Sleep(FSleepBefore);
+  Inc(FCallCount);
+  if Length(FScript) = 0 then
+  begin
+    Result := Default(TLLMResponse);
+    Result.StatusCode := 200;
+    Result.FinishReason := 'stop';
+    Result.Content := 'OK';
+    Exit;
+  end;
+  Idx := (FCallCount - 1);
+  if Idx > High(FScript) then Idx := High(FScript);  { cycle on last }
+  Result := FScript[Idx];
+end;
+
+function TScriptedProvider.ChatStream(const Messages: array of TMessage;
+                                       const Tools:    array of TToolDefinition;
+                                       const Model:    string;
+                                       const Options:  TChatOptions;
+                                       OnChunk: TStreamCallback): TLLMResponse;
+var
+  Chunk: TStreamChunk;
+begin
+  if FSleepBefore > 0 then Sleep(FSleepBefore);
+  Inc(FCallCount);
+  if (FChunkText <> '') and Assigned(OnChunk) then
+  begin
+    Chunk := Default(TStreamChunk);
+    Chunk.Kind := 'text';
+    Chunk.Text := FChunkText;
+    OnChunk(Chunk);
+  end;
+  if Length(FScript) = 0 then
+  begin
+    Result := Default(TLLMResponse);
+    Result.StatusCode := 200;
+    Result.FinishReason := 'stop';
+    Result.Content := FChunkText;  { mirror the chunk content for parity }
+    Exit;
+  end;
+  Result := FScript[(FCallCount - 1) mod Length(FScript)];
+end;
+
+function TScriptedProvider.GetDefaultModel: string; begin Result := 'scripted'; end;
+function TScriptedProvider.GetName: string;         begin Result := 'scripted'; end;
+function TScriptedProvider.SupportsThinking: Boolean;     begin Result := False; end;
+function TScriptedProvider.SupportsNativeSearch: Boolean; begin Result := False; end;
+function TScriptedProvider.SupportsStreaming: Boolean;    begin Result := True;  end;
+
+procedure TestIsEmptyTurn;
+var
+  R: TLLMResponse;
+  Tc: TToolCall;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode := 200;
+  R.FinishReason := 'stop';
+  AssertTrue(IsEmptyTurn(R), 'empty + stop is empty turn');
+
+  R.FinishReason := '';
+  AssertTrue(IsEmptyTurn(R), 'empty finish_reason still empty turn');
+
+  R.FinishReason := 'end_turn';
+  AssertTrue(IsEmptyTurn(R), 'Anthropic end_turn shape recognised');
+
+  R.Content := 'hi';
+  R.FinishReason := 'stop';
+  AssertFalse(IsEmptyTurn(R), 'non-empty content not empty turn');
+
+  R.Content := '';
+  R.FinishReason := 'tool_use';
+  AssertFalse(IsEmptyTurn(R), 'tool_use finish not empty turn');
+
+  R.FinishReason := 'stop';
+  Tc := Default(TToolCall);
+  Tc.Id := 'tc1';
+  SetLength(R.ToolCalls, 1);
+  R.ToolCalls[0] := Tc;
+  AssertFalse(IsEmptyTurn(R), 'has tool calls not empty turn');
+end;
+
+procedure TestChatWithEmptyRetryHappyPath;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;  { hold a reference }
+  P.AddScriptedEmpty;
+  P.AddScriptedEmpty;
+  P.AddScriptedContent('hello there');
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.EmptyRetryAttempts  := 3;
+  Cfg.EmptyRetryBackoffMs := 50;  { keep test fast }
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+  SetLength(Tools, 0);
+
+  R := ChatWithEmptyRetry(Pi, Msgs, Tools, 'fake', DefaultChatOptions, Cfg);
+
+  AssertEqStr(R.Content, 'hello there', 'retried until non-empty response');
+  AssertEqInt(P.ChatCallCount, 3, 'three calls (2 empty + 1 success)');
+end;
+
+procedure TestChatWithEmptyRetryExhaustion;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  P.AddScriptedEmpty;  { every call returns the same empty (cycles) }
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.EmptyRetryAttempts  := 2;
+  Cfg.EmptyRetryBackoffMs := 50;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+  SetLength(Tools, 0);
+
+  R := ChatWithEmptyRetry(Pi, Msgs, Tools, 'fake', DefaultChatOptions, Cfg);
+
+  AssertEqStr(R.Content, '', 'still empty after exhausting retries');
+  AssertEqInt(P.ChatCallCount, 3, 'one initial + two retries = three calls');
+end;
+
+procedure TestChatWithEmptyRetryDisabled;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  P.AddScriptedEmpty;
+  P.AddScriptedContent('would-have-retried');
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.EmptyRetryAttempts := 0;  { disabled }
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+  SetLength(Tools, 0);
+
+  R := ChatWithEmptyRetry(Pi, Msgs, Tools, 'fake', DefaultChatOptions, Cfg);
+
+  AssertEqStr(R.Content, '', 'no retry when attempts=0');
+  AssertEqInt(P.ChatCallCount, 1, 'single call when retries disabled');
+end;
+
+type
+  TStreamCollector = class
+  public
+    Chunks: TStringList;
+    constructor Create;
+    destructor Destroy; override;
+    procedure OnChunk(const C: TStreamChunk);
+  end;
+
+constructor TStreamCollector.Create;
+begin
+  inherited;
+  Chunks := TStringList.Create;
+end;
+
+destructor TStreamCollector.Destroy;
+begin
+  Chunks.Free;
+  inherited;
+end;
+
+procedure TStreamCollector.OnChunk(const C: TStreamChunk);
+begin
+  if C.Kind = 'text' then Chunks.Add(C.Text);
+end;
+
+procedure TestChatStreamHappyPath;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+  Collector: TStreamCollector;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  P.SetChunkText('hello world');
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.StreamIdleTimeoutMs := 5000;
+  Cfg.EmptyRetryAttempts  := 0;  { not testing retry here }
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+
+  Collector := TStreamCollector.Create;
+  try
+    SetLength(Tools, 0);
+    R := ChatStreamWithReliability(Pi, Msgs, Tools, 'fake',
+                                    DefaultChatOptions, Collector.OnChunk, Cfg);
+    AssertEqStr(R.Content, 'hello world', 'response carries the chunk content');
+    AssertEqInt(Collector.Chunks.Count, 1, 'one chunk delivered to user');
+    AssertEqStr(Collector.Chunks[0], 'hello world', 'chunk text matched');
+  finally
+    Collector.Free;
+  end;
+end;
+
+procedure TestChatStreamIdleTimeout;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+  Collector: TStreamCollector;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  { Provider sleeps for 4 seconds before returning; timeout fires at 1s. }
+  P.SetSleepBeforeMs(4000);
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.StreamIdleTimeoutMs := 1000;
+  Cfg.EmptyRetryAttempts  := 0;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+
+  Collector := TStreamCollector.Create;
+  try
+    SetLength(Tools, 0);
+    R := ChatStreamWithReliability(Pi, Msgs, Tools, 'fake',
+                                    DefaultChatOptions, Collector.OnChunk, Cfg);
+    AssertEqStr(R.FinishReason, 'timeout', 'finish_reason marked timeout');
+    AssertEqInt(Collector.Chunks.Count, 0, 'no chunks delivered before timeout');
+    { Negative status signals the synthetic-empty path. }
+    AssertTrue(R.StatusCode < 0, 'status code negative on timeout');
+  finally
+    Collector.Free;
+  end;
+  { Give the orphaned worker a moment to drain before the test exits;
+    the FreeOnTerminate worker will clean itself up. }
+  Sleep(5000);
+end;
+
+procedure TestRepairLeavesMatchedPairsAlone;
+var
+  Msgs: TMessageArray;
+  Asst: TMessage;
+  Tc: TToolCall;
+  Synth: Integer;
+begin
+  SetLength(Msgs, 3);
+  Msgs[0] := MakeMessage(mrUser, 'hi');
+
+  Asst := MakeMessage(mrAssistant, '');
+  Tc := Default(TToolCall);
+  Tc.Id := 'tc-1';
+  Tc.Func.Name := 'fs_read';
+  SetLength(Asst.ToolCalls, 1);
+  Asst.ToolCalls[0] := Tc;
+  Msgs[1] := Asst;
+
+  Msgs[2] := MakeMessage(mrTool, 'file contents');
+  Msgs[2].ToolCallId := 'tc-1';
+
+  Synth := RepairOrphanedToolCalls(Msgs);
+  AssertEqInt(Synth, 0, 'matched pair needs no repair');
+  AssertEqInt(Length(Msgs), 3, 'history length unchanged');
+end;
+
+procedure TestRepairSynthesizesStubsForOrphans;
+var
+  Msgs: TMessageArray;
+  Asst: TMessage;
+  Tc1, Tc2: TToolCall;
+  Synth: Integer;
+  i, StubIdx: Integer;
+begin
+  SetLength(Msgs, 2);
+  Msgs[0] := MakeMessage(mrUser, 'do two things');
+
+  Asst := MakeMessage(mrAssistant, '');
+  Tc1 := Default(TToolCall); Tc1.Id := 'tc-a'; Tc1.Func.Name := 'fs_read';
+  Tc2 := Default(TToolCall); Tc2.Id := 'tc-b'; Tc2.Func.Name := 'shell';
+  SetLength(Asst.ToolCalls, 2);
+  Asst.ToolCalls[0] := Tc1;
+  Asst.ToolCalls[1] := Tc2;
+  Msgs[1] := Asst;
+
+  { No mrTool messages follow -- both calls are orphaned. }
+  Synth := RepairOrphanedToolCalls(Msgs);
+  AssertEqInt(Synth, 2, 'two orphans repaired');
+  AssertEqInt(Length(Msgs), 4, 'history grew by two stubs');
+
+  { Stubs land immediately after the assistant turn, in array
+    order matching the tool_call sequence. }
+  StubIdx := -1;
+  for i := 0 to High(Msgs) do
+    if (Msgs[i].Role = mrTool) and (Msgs[i].ToolCallId = 'tc-a') then
+    begin
+      StubIdx := i;
+      Break;
+    end;
+  AssertTrue(StubIdx > 1, 'tc-a stub appears after the assistant turn');
+  AssertContains(Msgs[StubIdx].Content, 'missing',
+                 'stub content mentions repair');
+
+  StubIdx := -1;
+  for i := 0 to High(Msgs) do
+    if (Msgs[i].Role = mrTool) and (Msgs[i].ToolCallId = 'tc-b') then
+    begin
+      StubIdx := i;
+      Break;
+    end;
+  AssertTrue(StubIdx > 1, 'tc-b stub appears after the assistant turn');
+end;
+
+procedure TestRepairPartialOrphanMix;
+var
+  Msgs: TMessageArray;
+  Asst: TMessage;
+  Tc1, Tc2: TToolCall;
+  Synth, i, Stubs: Integer;
+begin
+  { Assistant emits two tool calls; only tc-a's result follows.
+    tc-b is orphaned -- exactly the parallel-tool-cancelled
+    scenario strict backends 400 on. }
+  SetLength(Msgs, 3);
+  Msgs[0] := MakeMessage(mrUser, 'do two things');
+
+  Asst := MakeMessage(mrAssistant, '');
+  Tc1 := Default(TToolCall); Tc1.Id := 'tc-a'; Tc1.Func.Name := 'fs_read';
+  Tc2 := Default(TToolCall); Tc2.Id := 'tc-b'; Tc2.Func.Name := 'shell';
+  SetLength(Asst.ToolCalls, 2);
+  Asst.ToolCalls[0] := Tc1;
+  Asst.ToolCalls[1] := Tc2;
+  Msgs[1] := Asst;
+
+  Msgs[2] := MakeMessage(mrTool, 'OK');
+  Msgs[2].ToolCallId := 'tc-a';
+
+  Synth := RepairOrphanedToolCalls(Msgs);
+  AssertEqInt(Synth, 1, 'only the orphan got a stub');
+  AssertEqInt(Length(Msgs), 4, 'history grew by one');
+
+  { Total tool messages: original tc-a result + one synth stub. }
+  Stubs := 0;
+  for i := 0 to High(Msgs) do
+    if Msgs[i].Role = mrTool then Inc(Stubs);
+  AssertEqInt(Stubs, 2, 'two tool messages after repair');
+end;
+
+procedure TestLoadFromEnv;
+var
+  Cfg: TStreamReliabilityConfig;
+begin
+  { Defaults come through when env unset. We can't reliably modify
+    process env from inside a test on every platform, but we CAN
+    verify the defaults map identically when no overrides exist. }
+  Cfg := LoadStreamReliabilityFromEnv(DefaultStreamReliabilityConfig);
+  AssertEqInt(Cfg.EmptyRetryAttempts,  2, 'default attempts');
+  AssertEqInt(Cfg.EmptyRetryBackoffMs, 750, 'default backoff');
+  AssertEqInt(Cfg.StreamIdleTimeoutMs, 150 * 1000, 'default idle timeout');
+  AssertTrue(Cfg.ToolCallRepairEnabled, 'default repair enabled');
+end;
+
+begin
+  TestIsEmptyTurn;                       WriteLn('  ok: IsEmptyTurn');
+  TestChatWithEmptyRetryHappyPath;       WriteLn('  ok: ChatWithEmptyRetry happy path');
+  TestChatWithEmptyRetryExhaustion;      WriteLn('  ok: ChatWithEmptyRetry exhaustion');
+  TestChatWithEmptyRetryDisabled;        WriteLn('  ok: ChatWithEmptyRetry disabled');
+  TestChatStreamHappyPath;               WriteLn('  ok: ChatStream happy path');
+  TestChatStreamIdleTimeout;             WriteLn('  ok: ChatStream idle timeout');
+  TestRepairLeavesMatchedPairsAlone;     WriteLn('  ok: Repair leaves matched pairs alone');
+  TestRepairSynthesizesStubsForOrphans;  WriteLn('  ok: Repair synthesizes stubs');
+  TestRepairPartialOrphanMix;            WriteLn('  ok: Repair partial-orphan mix');
+  TestLoadFromEnv;                       WriteLn('  ok: LoadStreamReliabilityFromEnv defaults');
+  WriteLn('PASS');
+end.

--- a/src/tests/stream_reliability_tests.pas
+++ b/src/tests/stream_reliability_tests.pas
@@ -92,11 +92,23 @@ type
     FSleepBefore: Integer;  { ms per Chat / ChatStream call }
     FChunkText:   string;   { if non-empty, ChatStream emits this as one chunk
                               before returning the scripted response }
+    FProtocolOnlyChunks: Boolean;
+                            { when True, ChatStream emits one empty 'text' chunk
+                              and one 'done' chunk before returning -- the
+                              "stream produced protocol events but no user-
+                              visible content" shape that finding #2 covers }
+    FRaiseFromStream: string;
+                            { when non-empty, ChatStream raises Exception with
+                              this message before producing any chunks --
+                              the DNS/socket/provider exception shape that
+                              finding #1 covers }
   public
     constructor Create;
     function ChatCallCount: Integer;
     procedure SetSleepBeforeMs(MS: Integer);
     procedure SetChunkText(const Text: string);
+    procedure SetProtocolOnlyChunks(V: Boolean);
+    procedure SetRaiseFromStream(const Msg: string);
     procedure AddScriptedEmpty;
     procedure AddScriptedContent(const Body: string);
     function Chat(const Messages: array of TMessage;
@@ -119,9 +131,11 @@ constructor TScriptedProvider.Create;
 begin
   inherited;
   SetLength(FScript, 0);
-  FCallCount   := 0;
-  FSleepBefore := 0;
-  FChunkText   := '';
+  FCallCount         := 0;
+  FSleepBefore       := 0;
+  FChunkText         := '';
+  FProtocolOnlyChunks := False;
+  FRaiseFromStream   := '';
 end;
 
 function TScriptedProvider.ChatCallCount: Integer; begin Result := FCallCount; end;
@@ -131,6 +145,12 @@ begin FSleepBefore := MS; end;
 
 procedure TScriptedProvider.SetChunkText(const Text: string);
 begin FChunkText := Text; end;
+
+procedure TScriptedProvider.SetProtocolOnlyChunks(V: Boolean);
+begin FProtocolOnlyChunks := V; end;
+
+procedure TScriptedProvider.SetRaiseFromStream(const Msg: string);
+begin FRaiseFromStream := Msg; end;
 
 procedure TScriptedProvider.AddScriptedEmpty;
 var
@@ -190,7 +210,19 @@ var
 begin
   if FSleepBefore > 0 then Sleep(FSleepBefore);
   Inc(FCallCount);
-  if (FChunkText <> '') and Assigned(OnChunk) then
+  if FRaiseFromStream <> '' then
+    raise Exception.Create(FRaiseFromStream);
+  if FProtocolOnlyChunks and Assigned(OnChunk) then
+  begin
+    Chunk := Default(TStreamChunk);
+    Chunk.Kind := 'text';
+    Chunk.Text := '';            { empty delta -- protocol event only }
+    OnChunk(Chunk);
+    Chunk := Default(TStreamChunk);
+    Chunk.Kind := 'done';
+    OnChunk(Chunk);
+  end
+  else if (FChunkText <> '') and Assigned(OnChunk) then
   begin
     Chunk := Default(TStreamChunk);
     Chunk.Kind := 'text';
@@ -428,6 +460,85 @@ begin
   Sleep(5000);
 end;
 
+procedure TestChatStreamExceptionMarkedAsFailure;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+  Collector: TStreamCollector;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  P.SetRaiseFromStream('simulated socket reset');
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.StreamIdleTimeoutMs := 5000;
+  Cfg.EmptyRetryAttempts  := 0;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+
+  Collector := TStreamCollector.Create;
+  try
+    SetLength(Tools, 0);
+    R := ChatStreamWithReliability(Pi, Msgs, Tools, 'fake',
+                                    DefaultChatOptions, Collector.OnChunk, Cfg);
+    AssertEqStr(R.FinishReason, 'error', 'exception turns into FinishReason=error');
+    AssertTrue(R.StatusCode < 0, 'status code negative on exception');
+    AssertContains(R.Content, 'simulated socket reset',
+                   'exception message surfaced in Content for the gateway');
+  finally
+    Collector.Free;
+  end;
+end;
+
+procedure TestProtocolOnlyChunksDoNotSuppressRetry;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+  Collector: TStreamCollector;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  { First call: empty TLLMResponse plus protocol-only chunks (one
+    empty 'text' delta + a 'done'). Second call: real content. }
+  P.SetProtocolOnlyChunks(True);
+  P.AddScriptedEmpty;
+  P.AddScriptedContent('recovered');
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.StreamIdleTimeoutMs := 5000;
+  Cfg.EmptyRetryAttempts  := 2;
+  Cfg.EmptyRetryBackoffMs := 50;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'ping');
+
+  Collector := TStreamCollector.Create;
+  try
+    SetLength(Tools, 0);
+    R := ChatStreamWithReliability(Pi, Msgs, Tools, 'fake',
+                                    DefaultChatOptions, Collector.OnChunk, Cfg);
+    { On the retry attempt the provider had its protocol-only flag
+      still set, but the scripted response carries content -- this
+      asserts the retry FIRED. Without the fix, FChunkCount would
+      have been bumped by the empty-text + done chunks of the
+      first call and the retry would have been skipped, leaving
+      R.Content empty. }
+    AssertEqStr(R.Content, 'recovered', 'retry fired despite protocol-only chunks');
+    AssertTrue(P.ChatCallCount >= 2, 'at least one retry attempted');
+  finally
+    Collector.Free;
+  end;
+end;
+
 procedure TestRepairLeavesMatchedPairsAlone;
 var
   Msgs: TMessageArray;
@@ -557,6 +668,8 @@ begin
   TestChatWithEmptyRetryDisabled;        WriteLn('  ok: ChatWithEmptyRetry disabled');
   TestChatStreamHappyPath;               WriteLn('  ok: ChatStream happy path');
   TestChatStreamIdleTimeout;             WriteLn('  ok: ChatStream idle timeout');
+  TestChatStreamExceptionMarkedAsFailure; WriteLn('  ok: ChatStream exception marked as failure');
+  TestProtocolOnlyChunksDoNotSuppressRetry; WriteLn('  ok: Protocol-only chunks do not suppress retry');
   TestRepairLeavesMatchedPairsAlone;     WriteLn('  ok: Repair leaves matched pairs alone');
   TestRepairSynthesizesStubsForOrphans;  WriteLn('  ok: Repair synthesizes stubs');
   TestRepairPartialOrphanMix;            WriteLn('  ok: Repair partial-orphan mix');


### PR DESCRIPTION
## Summary

UltraCode-Shim-shaped production polish for the OpenAI-compat surface (`/v1/chat`, `/v1/chat/completions`, `/v1/responses`). Three pieces, one new unit, one new test program:

- **Empty-turn auto-retry** — Provider returns 200 with empty `Content` + no tool calls + `finish_reason='stop'` (Together / OpenRouter route hiccups, MoonShot K2 brownouts, DeepSeek R1 thinking-token overflow). `ChatWithEmptyRetry` catches the shape and retries up to N times with exponential backoff. Wired into `RunToolLoop`'s primary `Provider.Chat` call (every loop-driven path inherits it) and into the gateway's `HandleResponses` passthrough `Chat` (bypasses the loop).
- **Idle-timeout kill for hung streams** — `ChatStreamWithReliability` runs `Provider.ChatStream` on a worker thread, watches the `OnChunk` timestamp from the calling thread, and on timeout detaches the worker (drains in background until Indy's `ReadTimeout` retires the socket) while returning a synthetic `finish_reason='timeout'` response. No leaked sockets, no leaked threads. Wired into `StreamResponsesViaProvider`; surfaced to the client as `response.failed`.
- **Tool-call repair** — Strict backends (DeepSeek, MiniMax-class) 400 when an assistant turn carries N tool_calls but the follow-up message history has fewer matched tool_results (parallel-tool-cancelled scenario). `RepairOrphanedToolCalls` walks `Msgs`, finds orphan ids, and inserts stub `mrTool` entries right after the assistant turn. Runs at the gateway boundary on `HandleChatCompletions`, `HandleResponses` passthrough, and `HandleResponses` legacy.

## Configuration

`TConfig.StreamReliability` (persisted under `"stream_reliability": {...}` in `config.json`), env-var overrides:

- `UC_EMPTY_RETRY_ATTEMPTS` (default 2)
- `UC_EMPTY_RETRY_BACKOFF_MS` (default 750)
- `UC_STREAM_IDLE_TIMEOUT_SEC` (default 150)
- `UC_TOOL_CALL_REPAIR` (default true)

`Cmd.Serve` and `Cmd.Gateway` call `LoadStreamReliabilityFromEnv` at startup; env wins over config.

## Compatibility

Default-zero records on `TToolLoopConfig.StreamReliability` (`EmptyRetryAttempts=0`) keep retry off, so channels and the embedder default to pre-PR behaviour. Only the gateway entry points and `Cmd.Agent`/`TPasClawAgent` (which now forward `Cfg.StreamReliability` explicitly) opt in.

## Files

- New: `src/pkg/stream/PasClaw.Stream.Reliability.pas`
- New: `src/tests/stream_reliability_tests.pas`
- Wired through: `TConfig`, `TToolLoopConfig`, `RunToolLoop`, the four gateway entry points, `Cmd.Serve`, `Cmd.Gateway`, `Cmd.Agent.BuildLoopConfig`, `TPasClawAgent.RunInteractive`

## Test plan

- [x] `make test` — full suite green (smoke + 24 unit-test programs incl. new `test-stream-reliability`)
- [x] `make all` — main binary builds from clean state
- [x] `IsEmptyTurn` rejects every non-empty-turn shape it shouldn't fire on
- [x] `ChatWithEmptyRetry` happy / exhaustion / disabled paths
- [x] `ChatStreamWithReliability` happy passthrough + idle-timeout detach
- [x] `RepairOrphanedToolCalls` leaves matched pairs alone, fully repairs all-orphan, and handles partial-orphan mix
- [x] `LoadStreamReliabilityFromEnv` defaults pass through unchanged
- [ ] Manual: point a real Codex/openai-python client at `pasclaw serve` with `UC_STREAM_IDLE_TIMEOUT_SEC=5` against a slow provider, confirm `response.failed` arrives at ~5s
- [ ] Manual: hand a synthetic orphaned-tool-call history to `/v1/chat/completions` against a DeepSeek-class backend, confirm 200 instead of 400

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_