### PR TITLE
kb: knowledgebase — RAG over operator documents (kb_search / kb_get)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ UNIT_DIRS = \
 	src/pkg/agent \
 	src/pkg/memory \
 	src/pkg/memory/localvector \
+	src/pkg/kb \
 	src/pkg/updater \
 	src/pkg/membench \
 	src/pkg/tui \
@@ -153,7 +154,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-kb-index print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -218,6 +219,7 @@ smoke: $(BIN)
 	NO_COLOR=1 $(BIN) update --check           >/dev/null && echo "  update    OK" ; \
 	NO_COLOR=1 $(BIN) membench --records 100   >/dev/null && echo "  membench  OK" ; \
 	NO_COLOR=1 $(BIN) learn                    >/dev/null && echo "  learn     OK" ; \
+	NO_COLOR=1 $(BIN) kb status                >/dev/null && echo "  kb        OK" ; \
 	echo "smoke: all commands OK"
 
 test-hashline: $(WEBUI_RES) | $(BUILDDIR) $(INDY_DIR)
@@ -381,4 +383,11 @@ test-session-search: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/session_search_tests.pas -o$(BUILDDIR)/session_search_tests
 	@PASCLAW_HOME=$(BUILDDIR)/session-search-test-home $(BUILDDIR)/session_search_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg
+# Knowledgebase — pure helpers (chunker, extension filter, binary sniff,
+# HTML strip). The SQLite paths are covered by `kb status` in smoke.
+test-kb-index: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/kb_index_tests.pas -o$(BUILDDIR)/kb_index_tests
+	@$(BUILDDIR)/kb_index_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-kb-index

--- a/README.md
+++ b/README.md
@@ -777,6 +777,48 @@ make server     # just the server sample
 
 `PasClaw.Component` is still available as the legacy unit name — it now re-exports everything from `PasClaw.Agent`, so existing code keeps compiling.
 
+### Knowledgebase (RAG over your documents)
+
+Index reference documents — manuals, books, source trees — so the agent can
+retrieve them while answering ("Big RAG" style, but operator-curated):
+
+```sh
+pasclaw kb add ~/docs/delphi-book.md ~/projects/mylib/   # files and/or dirs
+pasclaw kb list
+pasclaw kb search "constructor constraints in generics"
+pasclaw kb sync          # after documents change
+pasclaw kb status
+pasclaw kb remove ~/projects/mylib/
+```
+
+Documents are indexed **in place** (never copied) into `workspace/kb.db`,
+chunked by paragraph (~1.6 KB target). Supported types: markdown, plain
+text, HTML (tag-stripped), and common source-code extensions (`.pas`,
+`.dpr`, `.c`, `.py`, ...). **PDFs are not supported** — convert first, e.g.
+`pdftotext book.pdf book.txt`.
+
+Once at least one source is registered, two read-only agent tools appear
+automatically (and not before, so the model never sees an empty KB):
+
+| Tool | Purpose |
+|------|---------|
+| `kb_search(query, k)` | Search the corpus; returns `path#cN` citations + snippets + scores. |
+| `kb_get(path, chunk, window)` | Expand a citation into full chunk text ± `window` neighbouring chunks. |
+
+Ranking is SQLite FTS5 BM25 out of the box. When the local embedding
+runtime is provisioned (`pasclaw memory provision` — the same sqlite-vec +
+ONNX Runtime + MiniLM artifacts `memory_search` uses, gated by the same
+`vector_search_enabled` flag), the KB automatically upgrades to **hybrid
+keyword + semantic** ranking with Reciprocal Rank Fusion; embeddings are
+computed locally and never leave the host. The vector sidecar
+(`workspace/kb.db.vec`) is rebuilt by `kb sync` when documents change.
+Unlike `memory_search`, the KB does **not** re-index on every query — `kb
+sync` is the explicit refresh, keeping `kb_search` fast on large corpora.
+
+Conversation memory (`memory_search`) and the knowledgebase are deliberately
+separate: one answers "what did we decide earlier", the other "what do my
+reference documents say".
+
 ### Maintenance and diagnostics
 
 ```sh

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -34,6 +34,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
@@ -171,6 +172,7 @@ begin
   RegisterShellTool(Result);
   RegisterExecuteCodeTool(Result);
   RegisterMemoryTools(Result);
+  RegisterKBTools(Result);
   RegisterSessionSearchTool(Result);
   { web_search registers only when a real provider is configured
     (Brave / Tavily / Perplexity / Gemini key, or SearXNG base URL).

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -33,6 +33,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
@@ -178,6 +179,7 @@ begin
       RegisterShellTool(Reg);
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);
+      RegisterKBTools(Reg);
       RegisterSessionSearchTool(Reg);
       if HasConfiguredWebSearchProvider(Cfg) then
         RegisterWebSearchTool(Reg)

--- a/src/cmd/PasClaw.Cmd.KB.pas
+++ b/src/cmd/PasClaw.Cmd.KB.pas
@@ -1,0 +1,329 @@
+(*
+  PasClaw.Cmd.KB - manage the knowledgebase ("add documents to the
+  agent's reference corpus and search them").
+
+    pasclaw kb add <path> [...]   Register file(s)/director(ies) as
+                                  sources, then sync. Documents are
+                                  indexed in place, never copied.
+    pasclaw kb remove <path>      Unregister a source and drop its rows.
+    pasclaw kb list               Registered sources with counts.
+    pasclaw kb sync               Re-walk all sources (mtime-incremental).
+    pasclaw kb search <query>     Search from the CLI (same backend the
+                                  agent's kb_search tool uses).
+    pasclaw kb get <path> <cN>    Print a chunk plus neighbours.
+    pasclaw kb status             DB path, backend, corpus counts.
+
+  Index: SQLite FTS5 BM25 always; hybrid FTS+vector automatically when
+  the localvector runtime is provisioned (`pasclaw memory provision`)
+  and vector_search_enabled is on — the exact same artifacts and flag
+  memory_search uses. PDFs are not supported: convert to text or
+  markdown first.
+*)
+unit PasClaw.Cmd.KB;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+function Cmd_KB_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, Classes, DateUtils,
+  PasClaw.CliUI,
+  PasClaw.KB.Index;
+
+procedure Help;
+begin
+  PrintLn('Usage: pasclaw kb <subcommand>');
+  PrintLn;
+  PrintLn('Knowledgebase: index reference documents (text / markdown / source');
+  PrintLn('code) so the agent can retrieve them with kb_search + kb_get.');
+  PrintLn;
+  PrintLn('Subcommands:');
+  PrintLn('  add <path> [...]    Register file(s) or director(ies), then sync');
+  PrintLn('  remove <path>       Unregister a source and drop its documents');
+  PrintLn('  list                Show registered sources with counts');
+  PrintLn('  sync                Re-index changed/added/removed documents');
+  PrintLn('  search <query> [k]  Search the knowledgebase (default k=5)');
+  PrintLn('  get <path> <cN> [w] Print chunk N of a document (+w neighbours)');
+  PrintLn('  status              Show DB location, backend, and corpus size');
+  PrintLn;
+  PrintLn('Notes:');
+  PrintLn('  - Documents are indexed in place; edits need `pasclaw kb sync`.');
+  PrintLn('  - PDFs are not supported: convert to text/markdown first');
+  PrintLn('    (e.g. `pdftotext book.pdf book.txt`).');
+  PrintLn('  - Vector (semantic) ranking activates automatically once');
+  PrintLn('    `pasclaw memory provision` has installed the local embedding');
+  PrintLn('    runtime; otherwise search is keyword (FTS5 BM25) only.');
+end;
+
+function OpenIndex(out Idx: IKBIndex): Boolean;
+begin
+  Idx := NewKBIndex;
+  Result := Idx.Open(DefaultKBDbPath);
+  if not Result then
+  begin
+    Idx := nil;
+    PrintErr('could not open ' + DefaultKBDbPath +
+             ' (libsqlite3 missing or path unwritable)');
+  end;
+end;
+
+function RunAdd(const Argv: array of string): Integer;
+var
+  Idx: IKBIndex;
+  Err: string;
+  i, Files, Chunks, Added: Integer;
+begin
+  Result := 1;
+  if Length(Argv) = 0 then
+  begin
+    PrintErr('usage: pasclaw kb add <file-or-directory> [...]');
+    Exit;
+  end;
+  if not OpenIndex(Idx) then Exit;
+  try
+    Added := 0;
+    for i := 0 to High(Argv) do
+      if Idx.AddSource(Argv[i], Err) then
+      begin
+        PrintLn(Ansi.Green + '+ ' + Ansi.Reset + ExpandFileName(Argv[i]));
+        Inc(Added);
+      end
+      else
+        PrintErr('skip ' + Argv[i] + ': ' + Err);
+    if Added = 0 then Exit;
+
+    PrintLn('indexing...');
+    Idx.Sync(Files, Chunks);
+    PrintLn(Format('indexed %d file(s), %d chunk(s)', [Files, Chunks]));
+    Result := 0;
+  finally
+    Idx := nil;
+  end;
+end;
+
+function RunRemove(const Argv: array of string): Integer;
+var
+  Idx: IKBIndex;
+  Err: string;
+begin
+  Result := 1;
+  if Length(Argv) = 0 then
+  begin
+    PrintErr('usage: pasclaw kb remove <path>');
+    Exit;
+  end;
+  if not OpenIndex(Idx) then Exit;
+  try
+    if Idx.RemoveSource(Argv[0], Err) then
+    begin
+      PrintLn(Ansi.Red + '- ' + Ansi.Reset + ExpandFileName(Argv[0]));
+      Result := 0;
+    end
+    else
+      PrintErr(Err);
+  finally
+    Idx := nil;
+  end;
+end;
+
+function RunList: Integer;
+var
+  Idx: IKBIndex;
+  Sources: TKBSourceArray;
+  i: Integer;
+begin
+  Result := 1;
+  if not OpenIndex(Idx) then Exit;
+  try
+    Sources := Idx.GetSources;
+    if Length(Sources) = 0 then
+    begin
+      PrintLn('(no sources — `pasclaw kb add <path>` to register documents)');
+      Exit(0);
+    end;
+    for i := 0 to High(Sources) do
+      PrintLn(Format('%s'#10'    %d file(s), %d chunk(s), added %s',
+        [Sources[i].Root, Sources[i].Files, Sources[i].Chunks,
+         FormatDateTime('yyyy-mm-dd', UnixToDateTime(Sources[i].AddedAt, False))]));
+    Result := 0;
+  finally
+    Idx := nil;
+  end;
+end;
+
+function RunSync: Integer;
+var
+  Idx: IKBIndex;
+  Files, Chunks: Integer;
+begin
+  Result := 1;
+  if not OpenIndex(Idx) then Exit;
+  try
+    Idx.Sync(Files, Chunks);
+    if Files = 0 then
+      PrintLn('up to date')
+    else
+      PrintLn(Format('re-indexed %d file(s), %d chunk(s)', [Files, Chunks]));
+    Result := 0;
+  finally
+    Idx := nil;
+  end;
+end;
+
+function RunSearch(const Argv: array of string): Integer;
+var
+  Idx:  IKBIndex;
+  Hits: TKBHitArray;
+  K, i: Integer;
+begin
+  Result := 1;
+  if Length(Argv) = 0 then
+  begin
+    PrintErr('usage: pasclaw kb search <query> [k]');
+    Exit;
+  end;
+  K := 5;
+  if Length(Argv) >= 2 then K := StrToIntDef(Argv[1], 5);
+  if not OpenIndex(Idx) then Exit;
+  try
+    Hits := Idx.Search(Argv[0], K);
+    if Length(Hits) = 0 then
+    begin
+      PrintLn('(no matches)');
+      Exit(0);
+    end;
+    for i := 0 to High(Hits) do
+    begin
+      PrintLn(Format('%s#c%d  ' + Ansi.Dim + '(score=%.3f)' + Ansi.Reset,
+                     [Hits[i].Path, Hits[i].ChunkNo, Hits[i].Score]));
+      PrintLn('  ' + Hits[i].Snippet);
+      if i < High(Hits) then PrintLn;
+    end;
+    Result := 0;
+  finally
+    Idx := nil;
+  end;
+end;
+
+function RunGet(const Argv: array of string): Integer;
+var
+  Idx: IKBIndex;
+  ChunkNo, Window: Integer;
+  S, NumArg: string;
+begin
+  Result := 1;
+  if Length(Argv) < 2 then
+  begin
+    PrintErr('usage: pasclaw kb get <path> <chunk> [window]');
+    Exit;
+  end;
+  { Accept both bare numbers and the c-prefixed citation form kb_search
+    prints (`12` or `c12`). }
+  NumArg := Argv[1];
+  if (NumArg <> '') and ((NumArg[1] = 'c') or (NumArg[1] = 'C')) then
+    NumArg := Copy(NumArg, 2, MaxInt);
+  ChunkNo := StrToIntDef(NumArg, -1);
+  if ChunkNo < 0 then
+  begin
+    PrintErr('chunk must be a number (e.g. 12 or c12)');
+    Exit;
+  end;
+  Window := 1;
+  if Length(Argv) >= 3 then Window := StrToIntDef(Argv[2], 1);
+
+  if not OpenIndex(Idx) then Exit;
+  try
+    S := Idx.GetChunks(ExpandFileName(Argv[0]), ChunkNo, Window);
+    if S = '' then
+      { Paths are stored absolute, but show mercy on exact-string input
+        from a kb_search hit (already absolute). }
+      S := Idx.GetChunks(Argv[0], ChunkNo, Window);
+    if S = '' then
+    begin
+      PrintErr('no such chunk — use the exact path printed by kb search');
+      Exit;
+    end;
+    PrintLn(S);
+    Result := 0;
+  finally
+    Idx := nil;
+  end;
+end;
+
+function RunStatus: Integer;
+var
+  Idx: IKBIndex;
+  S:   TKBStats;
+begin
+  Result := 1;
+  PrintLn('db:      ' + DefaultKBDbPath);
+  if not FileExists(DefaultKBDbPath) then
+  begin
+    PrintLn('status:  not created yet — `pasclaw kb add <path>` to start');
+    Exit(0);
+  end;
+  if not OpenIndex(Idx) then Exit;
+  try
+    S := Idx.Stats;
+    PrintLn(Format('corpus:  %d source(s), %d file(s), %d chunk(s)',
+                   [S.Sources, S.Files, S.Chunks]));
+    if S.VectorReady then
+      PrintLn('backend: hybrid FTS5 + vector (localvector runtime provisioned)')
+    else
+      PrintLn('backend: FTS5 keyword only ' + Ansi.Dim +
+              '(run `pasclaw memory provision` to enable semantic ranking)' +
+              Ansi.Reset);
+    Result := 0;
+  finally
+    Idx := nil;
+  end;
+end;
+
+function Tail(const Argv: array of string): TArray<string>;
+var
+  i: Integer;
+begin
+  SetLength(Result, 0);
+  if Length(Argv) <= 1 then Exit;
+  SetLength(Result, Length(Argv) - 1);
+  for i := 1 to High(Argv) do Result[i - 1] := Argv[i];
+end;
+
+function Cmd_KB_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then
+  begin
+    Help;
+    Exit(1);
+  end;
+  Sub := LowerCase(Argv[0]);
+  if (Sub = '-h') or (Sub = '--help') or (Sub = 'help') then
+  begin
+    Help;
+    Exit(0);
+  end;
+  if Sub = 'add'    then Exit(RunAdd(Tail(Argv)));
+  if Sub = 'remove' then Exit(RunRemove(Tail(Argv)));
+  if Sub = 'list'   then Exit(RunList);
+  if Sub = 'sync'   then Exit(RunSync);
+  if Sub = 'search' then Exit(RunSearch(Tail(Argv)));
+  if Sub = 'get'    then Exit(RunGet(Tail(Argv)));
+  if Sub = 'status' then Exit(RunStatus);
+  PrintErr('unknown kb subcommand: ' + Sub + sLineBreak);
+  Help;
+  Result := 1;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -54,6 +54,7 @@ uses
   PasClaw.Cmd.Post,
   PasClaw.Cmd.Membench,
   PasClaw.Cmd.Memory,
+  PasClaw.Cmd.KB,
   PasClaw.Cmd.ToolRPC,
   PasClaw.Cmd.Export,
   PasClaw.Cmd.Runbook,
@@ -111,7 +112,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 25);
+  SetLength(Sub, 26);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
@@ -133,10 +134,11 @@ begin
   Sub[18] := 'steer        Push a mid-loop follow-up into a running agent';
   Sub[19] := 'update       Self-update PasClaw';
   Sub[20] := 'memory       Provision the hybrid memory_search runtime';
-  Sub[21] := 'learn        Mine sessions for recurring tool failures';
-  Sub[22] := 'export       Render memory/skills/sandbox into AGENTS.md / CLAUDE.md / Cursor / Gemini / Zed';
-  Sub[23] := 'runbook      Ask the model to probe the project and write a starter AGENTS.md';
-  Sub[24] := 'version      Show version info';
+  Sub[21] := 'kb           Manage the knowledgebase (index documents for the agent)';
+  Sub[22] := 'learn        Mine sessions for recurring tool failures';
+  Sub[23] := 'export       Render memory/skills/sandbox into AGENTS.md / CLAUDE.md / Cursor / Gemini / Zed';
+  Sub[24] := 'runbook      Ask the model to probe the project and write a starter AGENTS.md';
+  Sub[25] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -187,6 +189,7 @@ begin
   else if Cmd = 'post'     then Result := Cmd_Post_Run(Argv)
   else if Cmd = 'membench' then Result := Cmd_Membench_Run(Argv)
   else if Cmd = 'memory'   then Result := Cmd_Memory_Run(Argv)
+  else if Cmd = 'kb'       then Result := Cmd_KB_Run(Argv)
   { Internal callback channel for execute_code's tool-RPC. Not
     listed in `pasclaw --help` -- the underscore prefix marks it
     as not-for-humans. See PasClaw.Cmd.ToolRPC for the wire shape. }

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -46,6 +46,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
@@ -132,6 +133,7 @@ begin
       RegisterShellTool(Reg);
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);
+      RegisterKBTools(Reg);
       RegisterSessionSearchTool(Reg);
       if HasConfiguredWebSearchProvider(Cfg) then
         RegisterWebSearchTool(Reg)

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -26,6 +26,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
@@ -104,6 +105,7 @@ begin
       RegisterShellTool(Reg);
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);
+      RegisterKBTools(Reg);
       RegisterSessionSearchTool(Reg);
       if HasConfiguredWebSearchProvider(Cfg) then
         RegisterWebSearchTool(Reg)

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -311,6 +311,7 @@ uses
   PasClaw.Tools.FS,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
@@ -480,6 +481,7 @@ begin
   RegisterFSTools(FRegistry, FUseHashline);
   RegisterShellTool(FRegistry);
   RegisterMemoryTools(FRegistry);
+  RegisterKBTools(FRegistry);
   if HasConfiguredWebSearchProvider(FConfig) then
     RegisterWebSearchTool(FRegistry)
   else
@@ -883,6 +885,7 @@ begin
     RegisterFSTools(FRegistry, FEnableHashline);
     RegisterShellTool(FRegistry);
     RegisterMemoryTools(FRegistry);
+    RegisterKBTools(FRegistry);
     if HasConfiguredWebSearchProvider(FConfig) then
       RegisterWebSearchTool(FRegistry)
     else

--- a/src/pkg/kb/PasClaw.KB.Index.pas
+++ b/src/pkg/kb/PasClaw.KB.Index.pas
@@ -406,6 +406,9 @@ type
     procedure RebuildVectorSidecar;
     function  EmbedText(const T: string): TArray<Single>;
     function  ChunkCount: Int64;
+    procedure SetMeta(const Key, Val: string);
+    function  GetMetaI64(const Key: string; out Val: Int64): Boolean;
+    function  VectorInSync: Boolean;
   public
     constructor Create;
     destructor  Destroy; override;
@@ -780,7 +783,10 @@ begin
       Result[i].Root := Roots[i];
       if QueryI64('SELECT added_at FROM kb_sources WHERE root = :r',
                   ['r'], [Roots[i]], V) then Result[i].AddedAt := V;
-      if QueryI64('SELECT COUNT(*) FROM kb_files WHERE root = :r',
+      { nchunks > 0: rows with 0 chunks are skip markers (oversized /
+        binary files tracked only so sync doesn't re-read them), not
+        retrievable documents. }
+      if QueryI64('SELECT COUNT(*) FROM kb_files WHERE nchunks > 0 AND root = :r',
                   ['r'], [Roots[i]], V) then Result[i].Files := V;
       if QueryI64('SELECT COUNT(*) FROM kb_chunks WHERE path IN ' +
                   '(SELECT path FROM kb_files WHERE root = :r)',
@@ -838,29 +844,65 @@ end;
 
 procedure TKBIndexImpl.ReindexFile(const Path, Root: string; Mtime: Int64;
                                    var ChunksIndexed: Integer);
+{ Called only for files that are new or whose mtime advanced — so
+  whatever rows are currently indexed for Path are stale by
+  definition. Every early-out below must therefore DropFile first, or
+  searches keep serving the previous version of a file that is now
+  unindexable (Codex P2 on PR #214: file grew past the size cap).
+
+  Deterministic skips (oversized, binary) additionally record a
+  kb_files row with nchunks=0: the mtime gate in Sync then stops
+  re-reading the same unindexable file on every pass. Transient
+  failures (unreadable) record nothing so the next sync retries. }
+
+  function FileSizeOf(const P: string): Int64;
+  var
+    Sr: TSearchRec;
+  begin
+    Result := 0;
+    if FindFirst(P, faAnyFile, Sr) = 0 then
+    begin
+      Result := Sr.Size;
+      FindClose(Sr);
+    end;
+  end;
+
+  procedure RecordSkipped;
+  begin
+    ExecP('INSERT INTO kb_files (path, root, mtime, nchunks) VALUES (:p, :r, :m, 0)',
+          ['p', 'r'], [Path, Root], ['m'], [Mtime]);
+  end;
+
 var
   Body, Ext: string;
   Chunks: TArray<string>;
   j: Integer;
 begin
+  { Size gate BEFORE reading: rejecting a 100 MB dump shouldn't cost
+    reading 100 MB every sync. }
+  if FileSizeOf(Path) > KB_MAX_FILE_BYTES then
+  begin
+    LogWarn('kb.index: %s is %d bytes (> %d) — skipping',
+            [Path, FileSizeOf(Path), KB_MAX_FILE_BYTES]);
+    DropFile(Path);
+    RecordSkipped;
+    Exit;
+  end;
   try
     Body := ReadFileText(Path);
   except
     on E: Exception do
     begin
       LogWarn('kb.index: read %s failed (%s) — skipping', [Path, E.Message]);
+      DropFile(Path);
       Exit;
     end;
-  end;
-  if Length(Body) > KB_MAX_FILE_BYTES then
-  begin
-    LogWarn('kb.index: %s is %d bytes (> %d) — skipping',
-            [Path, Length(Body), KB_MAX_FILE_BYTES]);
-    Exit;
   end;
   if KBLooksBinary(Copy(Body, 1, 4096)) then
   begin
     LogDebug('kb.index: %s looks binary — skipping', [Path]);
+    DropFile(Path);
+    RecordSkipped;
     Exit;
   end;
 
@@ -948,8 +990,14 @@ begin
   { Vector sidecar follows the chunk population. Rebuilt wholesale on
     any change — IVectorStore has no per-source delete, and sync is an
     explicit operator action where a few extra seconds of embedding is
-    acceptable. No-op when the vector runtime isn't provisioned. }
-  if Changed and TryEnsureVector then
+    acceptable. ALSO rebuilt when the sidecar is missing or stale even
+    though no file changed: the operator may have provisioned the
+    vector runtime AFTER the corpus was indexed, and without this the
+    new sidecar would stay empty forever (Codex P1 on PR #214). The
+    ChunkCount>0 guard keeps an empty corpus from loading the ONNX
+    model on every sync just to rebuild nothing. No-op when the vector
+    runtime isn't provisioned (TryEnsureVector is the gate). }
+  if (ChunkCount > 0) and (Changed or not VectorInSync) and TryEnsureVector then
     RebuildVectorSidecar;
 end;
 
@@ -1035,6 +1083,34 @@ begin
     Result := 0;
 end;
 
+procedure TKBIndexImpl.SetMeta(const Key, Val: string);
+begin
+  ExecP('INSERT OR REPLACE INTO kb_meta (key, val) VALUES (:k, :v)',
+        ['k', 'v'], [Key, Val], [], []);
+end;
+
+function TKBIndexImpl.GetMetaI64(const Key: string; out Val: Int64): Boolean;
+begin
+  Result := QueryI64('SELECT CAST(val AS INTEGER) FROM kb_meta WHERE key = :k',
+                     ['k'], [Key], Val);
+end;
+
+function TKBIndexImpl.VectorInSync: Boolean;
+{ True iff the vector sidecar exists on disk AND its recorded chunk
+  population matches kb_chunks. The 'vec_chunks' meta row is written
+  only by a fully successful RebuildVectorSidecar (it is poisoned to -1
+  while a rebuild is in flight), so a missing/half-built/stale sidecar
+  always reads as out of sync. Gates both Search's vector path (an
+  out-of-sync sidecar would silently hide documents — Codex P1 on
+  PR #214) and Sync's rebuild decision. }
+var
+  Recorded: Int64;
+begin
+  Result := FileExists(VecSidecarPath) and
+            GetMetaI64('vec_chunks', Recorded) and
+            (Recorded = ChunkCount);
+end;
+
 procedure TKBIndexImpl.RebuildVectorSidecar;
 var
   Rows: TStringList;
@@ -1044,6 +1120,11 @@ var
   Emb: TArray<Single>;
 begin
   if FStore = nil then Exit;
+  { Poison the sync marker first: if this rebuild dies mid-flight the
+    sidecar must read as out-of-sync (-1 can never equal a COUNT), so
+    Search keeps using FTS instead of the half-built store. The real
+    count is recorded only after a clean CommitBatch. }
+  SetMeta('vec_chunks', '-1');
   { Recreate the sidecar from scratch: close, delete the file, reopen.
     The chunk store in kb.db is the source of truth. }
   try FStore.CloseStore; except end;
@@ -1081,10 +1162,13 @@ begin
         end;
       end;
       FStore.CommitBatch;
+      SetMeta('vec_chunks', IntToStr(Rows.Count));
       LogDebug('kb.index: vector sidecar rebuilt (%d chunks)', [Rows.Count]);
     except
       on E: Exception do
       begin
+        { Meta stays at the -1 poison: the sidecar reads out-of-sync
+          and the next Sync retries the rebuild. }
         LogWarn('kb.index: vector rebuild failed mid-batch — %s', [E.Message]);
         try FStore.CommitBatch; except end;
       end;
@@ -1111,13 +1195,17 @@ begin
   if not FOpen then Exit;
   if K <= 0 then K := 5;
 
-  { Hybrid path when provisioned: the sidecar's internal FTS+vec RRF
-    fusion ranks; chunk text comes back as the snippet (same trade
-    PasClaw.Memory.Vector makes). Guard: a sidecar that has fallen
-    behind the chunk store (e.g. vector provisioned after the last
-    sync) is rebuilt on the next Sync, not here — Search must stay
-    cheap. }
-  if TryEnsureVector then
+  { Hybrid path when provisioned AND the sidecar matches the chunk
+    store: the sidecar's internal FTS+vec RRF fusion ranks; chunk text
+    comes back as the snippet (same trade PasClaw.Memory.Vector makes).
+
+    VectorInSync must gate BEFORE TryEnsureVector: an out-of-sync or
+    not-yet-built sidecar (vector provisioned after the last sync)
+    would otherwise be created empty right here and silently hide
+    every document (Codex P1 on PR #214). Until the operator runs
+    `pasclaw kb sync`, queries stay on the always-correct FTS path —
+    the rebuild itself belongs in Sync, Search must stay cheap. }
+  if VectorInSync and TryEnsureVector then
   begin
     try
       Emb := EmbedText(Query);
@@ -1293,7 +1381,9 @@ begin
   Result.VectorReady := False;
   if not FOpen then Exit;
   if QueryI64('SELECT COUNT(*) FROM kb_sources', [], [], V) then Result.Sources := V;
-  if QueryI64('SELECT COUNT(*) FROM kb_files',   [], [], V) then Result.Files   := V;
+  { nchunks > 0 — skip markers aren't documents; see GetSources. }
+  if QueryI64('SELECT COUNT(*) FROM kb_files WHERE nchunks > 0', [], [], V) then
+    Result.Files := V;
   if QueryI64('SELECT COUNT(*) FROM kb_chunks',  [], [], V) then Result.Chunks  := V;
   Cfg := LoadConfig;
   try

--- a/src/pkg/kb/PasClaw.KB.Index.pas
+++ b/src/pkg/kb/PasClaw.KB.Index.pas
@@ -1,0 +1,1307 @@
+(*
+  PasClaw.KB.Index - the knowledgebase ("Big RAG") document index.
+
+  Separate from conversation memory (the PasClaw.Memory units) by design: memory
+  answers "what did we decide earlier", the KB answers "what do my
+  reference documents say". Mixing the two degrades both retrieval
+  intents, so the KB gets its own database (workspace/kb.db), its own
+  registry of document sources, and its own agent tools (kb_search /
+  kb_get in PasClaw.Tools.KB).
+
+  Model:
+    - `pasclaw kb add <file-or-dir>` registers a SOURCE (absolute path)
+      in kb_sources. Documents are indexed IN PLACE — never copied.
+    - Sync walks every source, picks up supported text/markdown/source
+      files (see KB_EXTENSIONS), chunks them (KBChunkDocument), and
+      maintains an FTS5 index incrementally by mtime. Files that
+      disappeared are dropped.
+    - Search runs FTS5 BM25 over chunks. When the localvector runtime
+      is provisioned (sqlite-vec + ONNX Runtime + embedding model — the
+      exact same artifacts memory_search uses, gated by the same
+      vector_search_enabled config flag) a vector sidecar (kb.db.vec)
+      is kept alongside and Search routes through the hybrid
+      FTS+vec store with RRF fusion instead.
+    - GetChunks returns a window of chunks around a hit so the model
+      can pull more context after a search ("kb_get").
+
+  The FTS5 chunk store in kb.db is always the source of truth; the
+  vector sidecar is a derived ranking structure, rebuilt when the chunk
+  population changes (IVectorStore has no per-source delete, so the
+  rebuild is wholesale — acceptable because sync is an explicit CLI
+  action, not a per-query hot path).
+
+  Anything that can fail at runtime (no libsqlite3, no vector
+  provisioning) degrades: Open returns False, vector falls back to
+  FTS-only — same philosophy as memory_search.
+*)
+unit PasClaw.KB.Index;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TKBHit = record
+    Path:    string;
+    ChunkNo: Integer;
+    Snippet: string;
+    Score:   Double;
+  end;
+  TKBHitArray = array of TKBHit;
+
+  TKBSource = record
+    Root:    string;
+    AddedAt: Int64;
+    Files:   Integer;
+    Chunks:  Integer;
+  end;
+  TKBSourceArray = array of TKBSource;
+
+  TKBStats = record
+    Sources: Integer;
+    Files:   Integer;
+    Chunks:  Integer;
+    { True when the vector runtime artifacts are on disk AND
+      vector_search_enabled is set — i.e. Search would attempt the
+      hybrid backend. Presence check only; nothing is loaded. }
+    VectorReady: Boolean;
+  end;
+
+  IKBIndex = interface
+    ['{0E7C51D2-8B4A-4F3E-9D26-5A1C7F8E2B40}']
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    function  AddSource(const Root: string; out Err: string): Boolean;
+    function  RemoveSource(const Root: string; out Err: string): Boolean;
+    function  GetSources: TKBSourceArray;
+    { Walk all sources; (re)index added/changed files, drop vanished
+      ones. Returns how many files were (re)indexed and how many chunks
+      they produced. Cheap when nothing changed (mtime comparisons). }
+    procedure Sync(out FilesIndexed, ChunksIndexed: Integer);
+    function  Search(const Query: string; K: Integer): TKBHitArray;
+    { Chunks [ChunkNo-Window .. ChunkNo+Window] of Path, concatenated
+      with "--- path#cN ---" headers. '' when the path/chunk is
+      unknown. }
+    function  GetChunks(const Path: string; ChunkNo, Window: Integer): string;
+    function  Stats: TKBStats;
+  end;
+
+function NewKBIndex: IKBIndex;
+
+{ <home>/workspace/kb.db — nested JoinPath, not a 'workspace/kb.db'
+  literal, for the same Windows mixed-separator reason documented in
+  PasClaw.Memory.Vector.CacheDir. }
+function DefaultKBDbPath: string;
+
+(* ---- pure helpers, exposed for tests ---------------------------------- *)
+
+{ Paragraph-accumulating chunker. Splits on blank lines, packs
+  paragraphs into chunks of ~KB_CHUNK_TARGET bytes (hard cap
+  KB_CHUNK_MAX, oversized paragraphs split at line — then byte —
+  boundaries without breaking UTF-8 sequences). Returns no empties. }
+function KBChunkDocument(const Text: string): TArray<string>;
+
+{ True when the file extension is in the supported text/source set. }
+function KBExtSupported(const Path: string): Boolean;
+
+{ Cheap binary sniff: a NUL byte in the head means "not text, skip". }
+function KBLooksBinary(const Head: string): Boolean;
+
+{ Minimal HTML-to-text: drops <script>/<style> blocks, strips tags,
+  decodes the half-dozen entities that matter for retrieval. }
+function KBStripHtml(const Html: string): string;
+
+const
+  KB_CHUNK_TARGET = 1600;
+  KB_CHUNK_MAX    = 3200;
+  { Files larger than this are skipped (with a log line) — a converted
+    book lands well under it; anything bigger is usually a data dump
+    that would swamp the index. }
+  KB_MAX_FILE_BYTES = 4 * 1024 * 1024;
+
+implementation
+
+uses
+  DateUtils, StrUtils,
+  {$IFDEF FPC}
+  sqldb, sqlite3conn,
+  {$ELSE}
+  FireDAC.Comp.Client, FireDAC.Phys.SQLite, FireDAC.Stan.Def,
+  FireDAC.Stan.Async, FireDAC.Stan.Param, FireDAC.DApt,
+  {$ENDIF}
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Logger,
+  PasClaw.Memory.Index,        { SanitizeFtsQuery }
+  LocalVector.VectorStore,
+  LocalVector.Embedder,
+  LocalVector.Tokenizer,
+  LocalVector.Models,
+  LocalVector.OrtProvision;
+
+const
+  { Extensions indexed by Sync. Lowercase, with dot. Plain-text reads;
+    .html/.htm additionally pass through KBStripHtml. PDFs are NOT
+    supported — convert to text/markdown first (kb add tells the user
+    this when it skips one). }
+  KB_EXTENSIONS: array[0..38] of string = (
+    '.md', '.markdown', '.txt', '.text', '.rst', '.adoc', '.org',
+    '.pas', '.pp', '.inc', '.dpr', '.lpr',
+    '.c', '.h', '.cc', '.cpp', '.hpp', '.cs', '.java', '.go', '.rs',
+    '.js', '.ts', '.py', '.rb', '.php', '.swift', '.kt', '.sql',
+    '.sh', '.bat', '.ps1',
+    '.json', '.yaml', '.yml', '.toml', '.ini', '.csv',
+    '.html');
+
+function DefaultKBDbPath: string;
+begin
+  Result := JoinPath(JoinPath(GetHome, 'workspace'), 'kb.db');
+end;
+
+(* ======================= pure helpers ================================ *)
+
+function KBExtSupported(const Path: string): Boolean;
+var
+  Ext: string;
+  i:   Integer;
+begin
+  Ext := LowerCase(ExtractFileExt(Path));
+  if Ext = '.htm' then Ext := '.html';
+  for i := Low(KB_EXTENSIONS) to High(KB_EXTENSIONS) do
+    if Ext = KB_EXTENSIONS[i] then Exit(True);
+  Result := False;
+end;
+
+function KBLooksBinary(const Head: string): Boolean;
+var
+  i: Integer;
+begin
+  for i := 1 to Length(Head) do
+    if Head[i] = #0 then Exit(True);
+  Result := False;
+end;
+
+function KBStripHtml(const Html: string): string;
+
+  { Delete every block between StartTag and EndTag (case-insensitive),
+    e.g. <script ...> ... </script>. }
+  function DropBlocks(const S, TagName: string): string;
+  var
+    L, Lo: string;
+    A, B:  Integer;
+  begin
+    Result := S;
+    Lo := LowerCase(Result);
+    L  := '<' + TagName;
+    A  := Pos(L, Lo);
+    while A > 0 do
+    begin
+      B := Pos('</' + TagName, Lo);
+      if (B = 0) or (B < A) then
+        { Unclosed block — drop to end of input; better to lose tail
+          markup than index a megabyte of JavaScript. }
+        B := Length(Result) + 1
+      else
+      begin
+        B := PosEx('>', Lo, B);
+        if B = 0 then B := Length(Result) + 1;
+      end;
+      Delete(Result, A, B - A + 1);
+      Lo := LowerCase(Result);
+      A  := Pos(L, Lo);
+    end;
+  end;
+
+var
+  S:       string;
+  i, Tag:  Integer;
+  Out_:    TStringBuilder;
+begin
+  S := DropBlocks(Html, 'script');
+  S := DropBlocks(S, 'style');
+
+  Out_ := TStringBuilder.Create;
+  try
+    Tag := 0;
+    for i := 1 to Length(S) do
+    begin
+      if S[i] = '<' then Inc(Tag)
+      else if S[i] = '>' then begin if Tag > 0 then Dec(Tag); Out_.Append(' '); end
+      else if Tag = 0 then Out_.Append(S[i]);
+    end;
+    Result := Out_.ToString;
+  finally
+    Out_.Free;
+  end;
+
+  Result := StringReplace(Result, '&nbsp;', ' ',  [rfReplaceAll, rfIgnoreCase]);
+  Result := StringReplace(Result, '&amp;',  '&',  [rfReplaceAll, rfIgnoreCase]);
+  Result := StringReplace(Result, '&lt;',   '<',  [rfReplaceAll, rfIgnoreCase]);
+  Result := StringReplace(Result, '&gt;',   '>',  [rfReplaceAll, rfIgnoreCase]);
+  Result := StringReplace(Result, '&quot;', '"',  [rfReplaceAll, rfIgnoreCase]);
+  Result := StringReplace(Result, '&#39;',  '''', [rfReplaceAll, rfIgnoreCase]);
+end;
+
+procedure AppendChunk(var Arr: TArray<string>; const S: string);
+var
+  T: string;
+begin
+  T := Trim(S);
+  if T = '' then Exit;
+  SetLength(Arr, Length(Arr) + 1);
+  Arr[High(Arr)] := T;
+end;
+
+function KBChunkDocument(const Text: string): TArray<string>;
+
+  { Split an oversized paragraph at line boundaries, hard-slicing any
+    single line longer than KB_CHUNK_MAX without cutting a UTF-8
+    sequence in half (back up over continuation bytes). }
+  procedure SplitBig(var Arr: TArray<string>; const Para: string);
+  var
+    Lines: TStringList;
+    Acc, L: string;
+    i, Len: Integer;
+  begin
+    Lines := TStringList.Create;
+    try
+      Lines.Text := Para;
+      Acc := '';
+      for i := 0 to Lines.Count - 1 do
+      begin
+        L := Lines[i];
+        while Length(L) > KB_CHUNK_MAX do
+        begin
+          Len := KB_CHUNK_MAX;
+          { Don't split inside a UTF-8 multi-byte sequence: byte values
+            $80..$BF are continuation bytes. }
+          while (Len > 1) and ((Byte(L[Len + 1]) and $C0) = $80) do Dec(Len);
+          AppendChunk(Arr, Acc);
+          Acc := '';
+          AppendChunk(Arr, Copy(L, 1, Len));
+          L := Copy(L, Len + 1, MaxInt);
+        end;
+        if (Acc <> '') and (Length(Acc) + Length(L) + 1 > KB_CHUNK_MAX) then
+        begin
+          AppendChunk(Arr, Acc);
+          Acc := '';
+        end;
+        if Acc = '' then Acc := L else Acc := Acc + #10 + L;
+      end;
+      AppendChunk(Arr, Acc);
+    finally
+      Lines.Free;
+    end;
+  end;
+
+var
+  Norm, Para, Acc: string;
+  Paras: TStringList;
+  i, P, Start: Integer;
+begin
+  SetLength(Result, 0);
+  Norm := StringReplace(Text, #13#10, #10, [rfReplaceAll]);
+  Norm := StringReplace(Norm, #13, #10, [rfReplaceAll]);
+  if Trim(Norm) = '' then Exit;
+
+  { Split into paragraphs on blank lines (a run of \n where the line
+    between is empty/whitespace). }
+  Paras := TStringList.Create;
+  try
+    Start := 1;
+    P := 1;
+    while P <= Length(Norm) do
+    begin
+      if (Norm[P] = #10) then
+      begin
+        { Look ahead: is the next line blank? }
+        i := P + 1;
+        while (i <= Length(Norm)) and ((Norm[i] = ' ') or (Norm[i] = #9)) do Inc(i);
+        if (i <= Length(Norm)) and (Norm[i] = #10) then
+        begin
+          Paras.Add(Copy(Norm, Start, P - Start));
+          { Skip the whole blank run. }
+          while (i <= Length(Norm)) and
+                ((Norm[i] = #10) or (Norm[i] = ' ') or (Norm[i] = #9)) do Inc(i);
+          Start := i;
+          P := i;
+          Continue;
+        end;
+      end;
+      Inc(P);
+    end;
+    if Start <= Length(Norm) then
+      Paras.Add(Copy(Norm, Start, MaxInt));
+
+    Acc := '';
+    for i := 0 to Paras.Count - 1 do
+    begin
+      Para := Trim(Paras[i]);
+      if Para = '' then Continue;
+      if Length(Para) > KB_CHUNK_MAX then
+      begin
+        AppendChunk(Result, Acc);
+        Acc := '';
+        SplitBig(Result, Para);
+        Continue;
+      end;
+      if (Acc <> '') and (Length(Acc) + Length(Para) + 2 > KB_CHUNK_TARGET) then
+      begin
+        AppendChunk(Result, Acc);
+        Acc := '';
+      end;
+      if Acc = '' then Acc := Para else Acc := Acc + #10#10 + Para;
+    end;
+    AppendChunk(Result, Acc);
+  finally
+    Paras.Free;
+  end;
+end;
+
+(* ======================= index implementation ======================== *)
+
+type
+  TKBIndexImpl = class(TInterfacedObject, IKBIndex)
+  private
+    {$IFDEF FPC}
+    FConn: TSQLite3Connection;
+    FTx:   TSQLTransaction;
+    {$ELSE}
+    FConn: TFDConnection;
+    {$ENDIF}
+    FOpen:   Boolean;
+    FDbPath: string;
+    { Vector sidecar (lazy). Mirrors PasClaw.Memory.Vector: every
+      missing artifact degrades to FTS-only silently. }
+    FVecTried: Boolean;
+    FStore:     IVectorStore;
+    FEmbedder:  TEmbedder;
+    FTokenizer: TBertTokenizer;
+    FModelSpec: TModelSpec;
+    procedure ExecSQL(const SQL: string);
+    procedure ExecP(const SQL: string;
+                    const SN: array of string; const SV: array of string;
+                    const INames: array of string; const IV: array of Int64);
+    function  QueryI64(const SQL: string;
+                       const SN: array of string; const SV: array of string;
+                       out Val: Int64): Boolean;
+    function  QueryStrings(const SQL: string;
+                           const SN: array of string; const SV: array of string): TStringList;
+    procedure EnsureSchema;
+    procedure ReindexFile(const Path, Root: string; Mtime: Int64;
+                          var ChunksIndexed: Integer);
+    procedure DropFile(const Path: string);
+    procedure CollectFiles(const Root: string; Known: TStringList);
+    function  VecSidecarPath: string;
+    function  TryEnsureVector: Boolean;
+    procedure RebuildVectorSidecar;
+    function  EmbedText(const T: string): TArray<Single>;
+    function  ChunkCount: Int64;
+  public
+    constructor Create;
+    destructor  Destroy; override;
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    function  AddSource(const Root: string; out Err: string): Boolean;
+    function  RemoveSource(const Root: string; out Err: string): Boolean;
+    function  GetSources: TKBSourceArray;
+    procedure Sync(out FilesIndexed, ChunksIndexed: Integer);
+    function  Search(const Query: string; K: Integer): TKBHitArray;
+    function  GetChunks(const Path: string; ChunkNo, Window: Integer): string;
+    function  Stats: TKBStats;
+  end;
+
+function NewKBIndex: IKBIndex;
+begin
+  Result := TKBIndexImpl.Create;
+end;
+
+{ Artifact presence — same paths PasClaw.Memory.Vector resolves. Kept
+  in sync manually; both read <home>/cache/localvector/. }
+function VectorArtifactsPresent(const Spec: TModelSpec): Boolean;
+var
+  CacheDir, ExtPath, ModelDir: string;
+begin
+  CacheDir := JoinPath(JoinPath(GetHome, 'cache'), 'localvector');
+  {$IFDEF MSWINDOWS}
+  ExtPath := JoinPath(CacheDir, 'vec0.dll');
+  {$ELSE}
+    {$IFDEF DARWIN}
+    ExtPath := JoinPath(CacheDir, 'vec0.dylib');
+    {$ELSE}
+    ExtPath := JoinPath(CacheDir, 'vec0.so');
+    {$ENDIF}
+  {$ENDIF}
+  ModelDir := JoinPath(JoinPath(CacheDir, 'models'), Spec.SubDir);
+  Result := FileExists(ExtPath) and
+            FileExists(JoinPath(ModelDir, 'model.onnx')) and
+            FileExists(JoinPath(ModelDir, 'vocab.txt'));
+end;
+
+constructor TKBIndexImpl.Create;
+begin
+  inherited Create;
+  if not FindModelSpec(DEFAULT_MODEL, FModelSpec) then
+    raise Exception.CreateFmt(
+      'localvector default model "%s" not in registry', [DEFAULT_MODEL]);
+end;
+
+destructor TKBIndexImpl.Destroy;
+begin
+  Close;
+  FEmbedder.Free;
+  FTokenizer.Free;
+  inherited;
+end;
+
+procedure TKBIndexImpl.ExecSQL(const SQL: string);
+{$IFDEF FPC}
+begin
+  FConn.ExecuteDirect(SQL);
+  FTx.CommitRetaining;
+end;
+{$ELSE}
+begin
+  FConn.ExecSQL(SQL);
+end;
+{$ENDIF}
+
+procedure TKBIndexImpl.ExecP(const SQL: string;
+                             const SN: array of string; const SV: array of string;
+                             const INames: array of string; const IV: array of Int64);
+{$IFDEF FPC}
+var
+  Q: TSQLQuery;
+  i: Integer;
+begin
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text := SQL;
+    for i := 0 to High(SN) do Q.Params.ParamByName(SN[i]).AsString := SV[i];
+    for i := 0 to High(INames) do Q.Params.ParamByName(INames[i]).AsLargeInt := IV[i];
+    Q.ExecSQL;
+    FTx.CommitRetaining;
+  finally
+    Q.Free;
+  end;
+end;
+{$ELSE}
+var
+  Q: TFDQuery;
+  i: Integer;
+begin
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := SQL;
+    for i := 0 to High(SN) do Q.ParamByName(SN[i]).AsString := SV[i];
+    for i := 0 to High(INames) do Q.ParamByName(INames[i]).AsLargeInt := IV[i];
+    Q.ExecSQL;
+  finally
+    Q.Free;
+  end;
+end;
+{$ENDIF}
+
+function TKBIndexImpl.QueryI64(const SQL: string;
+                               const SN: array of string; const SV: array of string;
+                               out Val: Int64): Boolean;
+{$IFDEF FPC}
+var
+  Q: TSQLQuery;
+  i: Integer;
+begin
+  Result := False;
+  Val := 0;
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text := SQL;
+    for i := 0 to High(SN) do Q.Params.ParamByName(SN[i]).AsString := SV[i];
+    Q.Open;
+    if not Q.EOF then
+    begin
+      Val := Q.Fields[0].AsLargeInt;
+      Result := True;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ELSE}
+var
+  Q: TFDQuery;
+  i: Integer;
+begin
+  Result := False;
+  Val := 0;
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := SQL;
+    for i := 0 to High(SN) do Q.ParamByName(SN[i]).AsString := SV[i];
+    Q.Open;
+    if not Q.Eof then
+    begin
+      Val := Q.Fields[0].AsLargeInt;
+      Result := True;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ENDIF}
+
+function TKBIndexImpl.QueryStrings(const SQL: string;
+                                   const SN: array of string; const SV: array of string): TStringList;
+{$IFDEF FPC}
+var
+  Q: TSQLQuery;
+  i: Integer;
+begin
+  Result := TStringList.Create;
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text := SQL;
+    for i := 0 to High(SN) do Q.Params.ParamByName(SN[i]).AsString := SV[i];
+    Q.Open;
+    while not Q.EOF do
+    begin
+      Result.Add(Q.Fields[0].AsString);
+      Q.Next;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ELSE}
+var
+  Q: TFDQuery;
+  i: Integer;
+begin
+  Result := TStringList.Create;
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text := SQL;
+    for i := 0 to High(SN) do Q.ParamByName(SN[i]).AsString := SV[i];
+    Q.Open;
+    while not Q.Eof do
+    begin
+      Result.Add(Q.Fields[0].AsString);
+      Q.Next;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+{$ENDIF}
+
+procedure TKBIndexImpl.EnsureSchema;
+begin
+  ExecSQL(
+    'CREATE TABLE IF NOT EXISTS kb_sources (' +
+    '  root TEXT PRIMARY KEY,' +
+    '  added_at INTEGER NOT NULL)');
+  ExecSQL(
+    'CREATE TABLE IF NOT EXISTS kb_files (' +
+    '  path TEXT PRIMARY KEY,' +
+    '  root TEXT NOT NULL,' +
+    '  mtime INTEGER NOT NULL,' +
+    '  nchunks INTEGER NOT NULL)');
+  ExecSQL(
+    'CREATE TABLE IF NOT EXISTS kb_chunks (' +
+    '  id INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  path TEXT NOT NULL,' +
+    '  chunk_no INTEGER NOT NULL,' +
+    '  body TEXT NOT NULL,' +
+    '  UNIQUE(path, chunk_no))');
+  ExecSQL(
+    'CREATE VIRTUAL TABLE IF NOT EXISTS kb_fts USING fts5(' +
+    '  path UNINDEXED, chunk_no UNINDEXED, body,' +
+    '  tokenize=''porter unicode61'')');
+  ExecSQL(
+    'CREATE TABLE IF NOT EXISTS kb_meta (' +
+    '  key TEXT PRIMARY KEY, val TEXT NOT NULL)');
+end;
+
+function TKBIndexImpl.Open(const DbPath: string): Boolean;
+begin
+  Result := False;
+  if FOpen then Exit(True);
+  FDbPath := DbPath;
+  try
+    EnsureDir(ExtractFileDir(DbPath));
+    {$IFDEF FPC}
+    FConn := TSQLite3Connection.Create(nil);
+    FTx   := TSQLTransaction.Create(nil);
+    FConn.DatabaseName := DbPath;
+    FConn.Transaction  := FTx;
+    FTx.Database       := FConn;
+    FConn.Open;
+    FTx.StartTransaction;
+    {$ELSE}
+    FConn := TFDConnection.Create(nil);
+    FConn.DriverName := 'SQLite';
+    FConn.Params.Values['Database'] := DbPath;
+    FConn.LoginPrompt := False;
+    FConn.Connected := True;
+    {$ENDIF}
+    EnsureSchema;
+    FOpen := True;
+    Result := True;
+    LogDebug('kb.index: opened %s', [DbPath]);
+  except
+    on E: Exception do
+    begin
+      LogWarn('kb.index: failed to open %s (%s) — knowledgebase disabled',
+              [DbPath, E.Message]);
+      {$IFDEF FPC}
+      FreeAndNil(FTx);
+      FreeAndNil(FConn);
+      {$ELSE}
+      FreeAndNil(FConn);
+      {$ENDIF}
+      FOpen := False;
+    end;
+  end;
+end;
+
+procedure TKBIndexImpl.Close;
+begin
+  if FStore <> nil then
+  begin
+    try FStore.CloseStore; except end;
+    FStore := nil;
+  end;
+  if not FOpen then Exit;
+  try
+    {$IFDEF FPC}
+    if (FTx <> nil) and FTx.Active then FTx.Commit;
+    if (FConn <> nil) and FConn.Connected then FConn.Close;
+    FreeAndNil(FTx);
+    FreeAndNil(FConn);
+    {$ELSE}
+    if (FConn <> nil) and FConn.Connected then FConn.Connected := False;
+    FreeAndNil(FConn);
+    {$ENDIF}
+  except
+    on E: Exception do
+      LogWarn('kb.index: close error: %s', [E.Message]);
+  end;
+  FOpen := False;
+end;
+
+function TKBIndexImpl.AddSource(const Root: string; out Err: string): Boolean;
+var
+  Abs: string;
+  Dummy: Int64;
+begin
+  Result := False;
+  Err := '';
+  if not FOpen then begin Err := 'knowledgebase database not open'; Exit; end;
+  Abs := ExpandFileName(Root);
+  if not (FileExists(Abs) or DirectoryExists(Abs)) then
+  begin
+    Err := 'no such file or directory: ' + Abs;
+    Exit;
+  end;
+  if FileExists(Abs) and not KBExtSupported(Abs) then
+  begin
+    Err := 'unsupported file type: ' + ExtractFileExt(Abs) +
+           ' (text/markdown/source only — convert PDFs to text first)';
+    Exit;
+  end;
+  if QueryI64('SELECT 1 FROM kb_sources WHERE root = :r', ['r'], [Abs], Dummy) then
+  begin
+    Err := 'already registered: ' + Abs;
+    Exit;
+  end;
+  ExecP('INSERT INTO kb_sources (root, added_at) VALUES (:r, :t)',
+        ['r'], [Abs], ['t'], [DateTimeToUnix(Now, False)]);
+  Result := True;
+end;
+
+function TKBIndexImpl.RemoveSource(const Root: string; out Err: string): Boolean;
+var
+  Abs: string;
+  Dummy: Int64;
+  Paths: TStringList;
+  i: Integer;
+begin
+  Result := False;
+  Err := '';
+  if not FOpen then begin Err := 'knowledgebase database not open'; Exit; end;
+  Abs := ExpandFileName(Root);
+  if not QueryI64('SELECT 1 FROM kb_sources WHERE root = :r', ['r'], [Abs], Dummy) then
+  begin
+    Err := 'not a registered source: ' + Abs;
+    Exit;
+  end;
+  Paths := QueryStrings('SELECT path FROM kb_files WHERE root = :r', ['r'], [Abs]);
+  try
+    for i := 0 to Paths.Count - 1 do
+      DropFile(Paths[i]);
+  finally
+    Paths.Free;
+  end;
+  ExecP('DELETE FROM kb_sources WHERE root = :r', ['r'], [Abs], [], []);
+  Result := True;
+end;
+
+function TKBIndexImpl.GetSources: TKBSourceArray;
+var
+  Roots: TStringList;
+  i: Integer;
+  V: Int64;
+begin
+  SetLength(Result, 0);
+  if not FOpen then Exit;
+  Roots := QueryStrings('SELECT root FROM kb_sources ORDER BY root', [], []);
+  try
+    SetLength(Result, Roots.Count);
+    for i := 0 to Roots.Count - 1 do
+    begin
+      Result[i].Root := Roots[i];
+      if QueryI64('SELECT added_at FROM kb_sources WHERE root = :r',
+                  ['r'], [Roots[i]], V) then Result[i].AddedAt := V;
+      if QueryI64('SELECT COUNT(*) FROM kb_files WHERE root = :r',
+                  ['r'], [Roots[i]], V) then Result[i].Files := V;
+      if QueryI64('SELECT COUNT(*) FROM kb_chunks WHERE path IN ' +
+                  '(SELECT path FROM kb_files WHERE root = :r)',
+                  ['r'], [Roots[i]], V) then Result[i].Chunks := V;
+    end;
+  finally
+    Roots.Free;
+  end;
+end;
+
+procedure TKBIndexImpl.CollectFiles(const Root: string; Known: TStringList);
+
+  procedure Walk(const Dir: string);
+  var
+    Rec: TSearchRec;
+    Sub: string;
+  begin
+    if FindFirst(JoinPath(Dir, '*'), faAnyFile, Rec) = 0 then
+    try
+      repeat
+        if (Rec.Name = '.') or (Rec.Name = '..') then Continue;
+        { Dot-dirs (.git, .svn, ...) and node_modules are never useful
+          knowledge and routinely explode the file count. }
+        if (Rec.Attr and faDirectory) <> 0 then
+        begin
+          if (Rec.Name <> '') and (Rec.Name[1] = '.') then Continue;
+          if SameText(Rec.Name, 'node_modules') then Continue;
+          Walk(JoinPath(Dir, Rec.Name));
+          Continue;
+        end;
+        Sub := JoinPath(Dir, Rec.Name);
+        if KBExtSupported(Sub) then Known.Add(Sub);
+      until FindNext(Rec) <> 0;
+    finally
+      FindClose(Rec);
+    end;
+  end;
+
+begin
+  if FileExists(Root) then
+  begin
+    if KBExtSupported(Root) then Known.Add(Root);
+  end
+  else if DirectoryExists(Root) then
+    Walk(Root);
+end;
+
+procedure TKBIndexImpl.DropFile(const Path: string);
+begin
+  ExecP('DELETE FROM kb_fts WHERE rowid IN ' +
+        '(SELECT id FROM kb_chunks WHERE path = :p)', ['p'], [Path], [], []);
+  ExecP('DELETE FROM kb_chunks WHERE path = :p', ['p'], [Path], [], []);
+  ExecP('DELETE FROM kb_files  WHERE path = :p', ['p'], [Path], [], []);
+end;
+
+procedure TKBIndexImpl.ReindexFile(const Path, Root: string; Mtime: Int64;
+                                   var ChunksIndexed: Integer);
+var
+  Body, Ext: string;
+  Chunks: TArray<string>;
+  j: Integer;
+begin
+  try
+    Body := ReadFileText(Path);
+  except
+    on E: Exception do
+    begin
+      LogWarn('kb.index: read %s failed (%s) — skipping', [Path, E.Message]);
+      Exit;
+    end;
+  end;
+  if Length(Body) > KB_MAX_FILE_BYTES then
+  begin
+    LogWarn('kb.index: %s is %d bytes (> %d) — skipping',
+            [Path, Length(Body), KB_MAX_FILE_BYTES]);
+    Exit;
+  end;
+  if KBLooksBinary(Copy(Body, 1, 4096)) then
+  begin
+    LogDebug('kb.index: %s looks binary — skipping', [Path]);
+    Exit;
+  end;
+
+  Ext := LowerCase(ExtractFileExt(Path));
+  if (Ext = '.html') or (Ext = '.htm') then
+    Body := KBStripHtml(Body);
+
+  Chunks := KBChunkDocument(Body);
+
+  DropFile(Path);
+  ExecP('INSERT INTO kb_files (path, root, mtime, nchunks) VALUES (:p, :r, :m, :n)',
+        ['p', 'r'], [Path, Root], ['m', 'n'], [Mtime, Length(Chunks)]);
+  for j := 0 to High(Chunks) do
+  begin
+    ExecP('INSERT INTO kb_chunks (path, chunk_no, body) VALUES (:p, :n, :b)',
+          ['p', 'b'], [Path, Chunks[j]], ['n'], [j]);
+    ExecP('INSERT INTO kb_fts (rowid, path, chunk_no, body) VALUES (' +
+          '(SELECT id FROM kb_chunks WHERE path = :p AND chunk_no = :n), :p, :n, :b)',
+          ['p', 'b'], [Path, Chunks[j]], ['n'], [j]);
+  end;
+  Inc(ChunksIndexed, Length(Chunks));
+end;
+
+procedure TKBIndexImpl.Sync(out FilesIndexed, ChunksIndexed: Integer);
+var
+  Roots, Known, Indexed: TStringList;
+  RootOf: TStringList;            { parallel to Known: owning root }
+  i: Integer;
+  Mtime, Idx: Int64;
+  Dt: TDateTime;
+  Changed: Boolean;
+begin
+  FilesIndexed  := 0;
+  ChunksIndexed := 0;
+  if not FOpen then Exit;
+  Changed := False;
+
+  Roots  := QueryStrings('SELECT root FROM kb_sources ORDER BY root', [], []);
+  Known  := TStringList.Create;
+  RootOf := TStringList.Create;
+  try
+    for i := 0 to Roots.Count - 1 do
+    begin
+      Known.Clear;
+      CollectFiles(Roots[i], Known);
+      RootOf.AddStrings(Known);   { just to keep all-known across roots }
+      { (re)index new/changed files under this root }
+      while Known.Count > 0 do
+      begin
+        if FileAge(Known[0], Dt) then
+        begin
+          Mtime := DateTimeToUnix(Dt, False);
+          if (not QueryI64('SELECT mtime FROM kb_files WHERE path = :p',
+                           ['p'], [Known[0]], Idx)) or (Idx < Mtime) then
+          begin
+            ReindexFile(Known[0], Roots[i], Mtime, ChunksIndexed);
+            Inc(FilesIndexed);
+            Changed := True;
+          end;
+        end;
+        Known.Delete(0);
+      end;
+    end;
+
+    { Drop rows whose file vanished (or whose extension support was
+      removed). RootOf holds every path seen this pass across all
+      sources. }
+    Indexed := QueryStrings('SELECT path FROM kb_files', [], []);
+    try
+      for i := 0 to Indexed.Count - 1 do
+        if RootOf.IndexOf(Indexed[i]) < 0 then
+        begin
+          DropFile(Indexed[i]);
+          Changed := True;
+        end;
+    finally
+      Indexed.Free;
+    end;
+  finally
+    Roots.Free;
+    Known.Free;
+    RootOf.Free;
+  end;
+
+  { Vector sidecar follows the chunk population. Rebuilt wholesale on
+    any change — IVectorStore has no per-source delete, and sync is an
+    explicit operator action where a few extra seconds of embedding is
+    acceptable. No-op when the vector runtime isn't provisioned. }
+  if Changed and TryEnsureVector then
+    RebuildVectorSidecar;
+end;
+
+function TKBIndexImpl.VecSidecarPath: string;
+begin
+  Result := FDbPath + '.vec';
+end;
+
+function TKBIndexImpl.EmbedText(const T: string): TArray<Single>;
+var
+  TokenIds: TArray<Int64>;
+const
+  MAX_SEQ_LEN = 256;  { same bound PasClaw.Memory.Vector uses }
+begin
+  TokenIds := FTokenizer.Encode(UnicodeString(T), MAX_SEQ_LEN);
+  Result := FEmbedder.Embed(TokenIds, FModelSpec.Pooling,
+                            FModelSpec.NeedsTokenTypeIds,
+                            {ANormalize=} True,
+                            {AVerbose=}  False);
+end;
+
+function TKBIndexImpl.TryEnsureVector: Boolean;
+var
+  Cfg: TConfig;
+  CacheDir, ExtPath: string;
+begin
+  if FStore <> nil then Exit(True);
+  if FVecTried then Exit(False);
+  FVecTried := True;
+  Result := False;
+
+  Cfg := LoadConfig;
+  try
+    if not Cfg.VectorSearchEnabled then Exit;
+  finally
+    Cfg.Free;
+  end;
+  if not VectorArtifactsPresent(FModelSpec) then
+  begin
+    LogDebug('kb.index: vector runtime not provisioned — FTS5-only ' +
+             '(run `pasclaw memory provision`)', []);
+    Exit;
+  end;
+
+  CacheDir := JoinPath(JoinPath(GetHome, 'cache'), 'localvector');
+  {$IFDEF MSWINDOWS}
+  ExtPath := JoinPath(CacheDir, 'vec0.dll');
+  {$ELSE}
+    {$IFDEF DARWIN}
+    ExtPath := JoinPath(CacheDir, 'vec0.dylib');
+    {$ELSE}
+    ExtPath := JoinPath(CacheDir, 'vec0.so');
+    {$ENDIF}
+  {$ENDIF}
+  try
+    EnsureOnnxRuntime(CacheDir, {AAllowDownload=} False, {AVerbose=} False);
+    FTokenizer := TBertTokenizer.Create(
+      JoinPath(JoinPath(JoinPath(CacheDir, 'models'), FModelSpec.SubDir), 'vocab.txt'),
+      FModelSpec.DoLowerCase);
+    FEmbedder := TEmbedder.Create(
+      JoinPath(JoinPath(JoinPath(CacheDir, 'models'), FModelSpec.SubDir), 'model.onnx'));
+    FEmbedder.Load({AVerbose=} False);
+    FStore := CreateVectorStore;
+    FStore.OpenStore(VecSidecarPath, ExtPath);
+    FStore.InitSchema(FModelSpec.Dim, FModelSpec.Key);
+    Result := True;
+    LogDebug('kb.index: vector sidecar active (%s, dim=%d)',
+             [FModelSpec.Key, FModelSpec.Dim]);
+  except
+    on E: Exception do
+    begin
+      LogDebug('kb.index: vector init failed (%s) — FTS5-only', [E.Message]);
+      if FStore <> nil then begin try FStore.CloseStore; except end; FStore := nil; end;
+      FreeAndNil(FEmbedder);
+      FreeAndNil(FTokenizer);
+    end;
+  end;
+end;
+
+function TKBIndexImpl.ChunkCount: Int64;
+begin
+  if not QueryI64('SELECT COUNT(*) FROM kb_chunks', [], [], Result) then
+    Result := 0;
+end;
+
+procedure TKBIndexImpl.RebuildVectorSidecar;
+var
+  Rows: TStringList;
+  i, T1, T2: Integer;
+  Line, Path, Body: string;
+  ChunkNo: Integer;
+  Emb: TArray<Single>;
+begin
+  if FStore = nil then Exit;
+  { Recreate the sidecar from scratch: close, delete the file, reopen.
+    The chunk store in kb.db is the source of truth. }
+  try FStore.CloseStore; except end;
+  FStore := nil;
+  if FileExists(VecSidecarPath) then DeleteFile(VecSidecarPath);
+  FVecTried := False;
+  if not TryEnsureVector then Exit;
+
+  { Tab-encoded triple per row: path<TAB>chunk_no<TAB>body. Paths and
+    chunk numbers cannot contain TABs; the body may, so split only the
+    first two. }
+  Rows := QueryStrings(
+    'SELECT path || char(9) || chunk_no || char(9) || body ' +
+    'FROM kb_chunks ORDER BY path, chunk_no', [], []);
+  try
+    FStore.BeginBatch;
+    try
+      for i := 0 to Rows.Count - 1 do
+      begin
+        Line := Rows[i];
+        T1 := Pos(#9, Line);
+        if T1 = 0 then Continue;
+        T2 := PosEx(#9, Line, T1 + 1);
+        if T2 = 0 then Continue;
+        Path    := Copy(Line, 1, T1 - 1);
+        ChunkNo := StrToIntDef(Copy(Line, T1 + 1, T2 - T1 - 1), 0);
+        Body    := Copy(Line, T2 + 1, MaxInt);
+        try
+          Emb := EmbedText(Body);
+          FStore.AddChunk(Path, ChunkNo, Body, Emb);
+        except
+          on E: Exception do
+            LogDebug('kb.index: embed failed for %s#c%d — %s',
+                     [Path, ChunkNo, E.Message]);
+        end;
+      end;
+      FStore.CommitBatch;
+      LogDebug('kb.index: vector sidecar rebuilt (%d chunks)', [Rows.Count]);
+    except
+      on E: Exception do
+      begin
+        LogWarn('kb.index: vector rebuild failed mid-batch — %s', [E.Message]);
+        try FStore.CommitBatch; except end;
+      end;
+    end;
+  finally
+    Rows.Free;
+  end;
+end;
+
+function TKBIndexImpl.Search(const Query: string; K: Integer): TKBHitArray;
+var
+  Emb: TArray<Single>;
+  VHits: TSearchHits;
+  i: Integer;
+  Sanitized: string;
+{$IFDEF FPC}
+  Q: TSQLQuery;
+{$ELSE}
+  Q: TFDQuery;
+{$ENDIF}
+  N: Integer;
+begin
+  SetLength(Result, 0);
+  if not FOpen then Exit;
+  if K <= 0 then K := 5;
+
+  { Hybrid path when provisioned: the sidecar's internal FTS+vec RRF
+    fusion ranks; chunk text comes back as the snippet (same trade
+    PasClaw.Memory.Vector makes). Guard: a sidecar that has fallen
+    behind the chunk store (e.g. vector provisioned after the last
+    sync) is rebuilt on the next Sync, not here — Search must stay
+    cheap. }
+  if TryEnsureVector then
+  begin
+    try
+      Emb := EmbedText(Query);
+      VHits := FStore.Search(Query, Emb, smHybrid, K);
+      SetLength(Result, Length(VHits));
+      for i := 0 to High(VHits) do
+      begin
+        Result[i].Path    := VHits[i].Source;
+        Result[i].ChunkNo := VHits[i].ChunkIndex;
+        Result[i].Snippet := VHits[i].Text;
+        Result[i].Score   := VHits[i].Score;
+      end;
+      Exit;
+    except
+      on E: Exception do
+        LogDebug('kb.index: vector search failed (%s) — FTS5 fallback',
+                 [E.Message]);
+    end;
+  end;
+
+  Sanitized := SanitizeFtsQuery(Query);
+  if Sanitized = '' then Exit;
+
+  {$IFDEF FPC}
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.Database := FConn;
+    Q.SQL.Text :=
+      'SELECT path, chunk_no, snippet(kb_fts, 2, ''«'', ''»'', ''…'', 24), bm25(kb_fts) ' +
+      'FROM kb_fts WHERE kb_fts MATCH :q ORDER BY bm25(kb_fts) LIMIT :k';
+    Q.Params.ParamByName('q').AsString  := Sanitized;
+    Q.Params.ParamByName('k').AsInteger := K;
+    try
+      Q.Open;
+    except
+      on E: Exception do
+      begin
+        LogWarn('kb.index: search %s failed (%s)', [Query, E.Message]);
+        Exit;
+      end;
+    end;
+    N := 0;
+    while (not Q.EOF) and (N < K) do
+    begin
+      SetLength(Result, N + 1);
+      Result[N].Path    := Q.Fields[0].AsString;
+      Result[N].ChunkNo := Q.Fields[1].AsInteger;
+      Result[N].Snippet := Q.Fields[2].AsString;
+      Result[N].Score   := Q.Fields[3].AsFloat;
+      Inc(N);
+      Q.Next;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+  {$ELSE}
+  Q := TFDQuery.Create(nil);
+  try
+    Q.Connection := FConn;
+    Q.SQL.Text :=
+      'SELECT path, chunk_no, snippet(kb_fts, 2, ''«'', ''»'', ''…'', 24), bm25(kb_fts) ' +
+      'FROM kb_fts WHERE kb_fts MATCH :q ORDER BY bm25(kb_fts) LIMIT :k';
+    Q.ParamByName('q').AsString  := Sanitized;
+    Q.ParamByName('k').AsInteger := K;
+    try
+      Q.Open;
+    except
+      on E: Exception do
+      begin
+        LogWarn('kb.index: search %s failed (%s)', [Query, E.Message]);
+        Exit;
+      end;
+    end;
+    N := 0;
+    while (not Q.Eof) and (N < K) do
+    begin
+      SetLength(Result, N + 1);
+      Result[N].Path    := Q.Fields[0].AsString;
+      Result[N].ChunkNo := Q.Fields[1].AsInteger;
+      Result[N].Snippet := Q.Fields[2].AsString;
+      Result[N].Score   := Q.Fields[3].AsFloat;
+      Inc(N);
+      Q.Next;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+  {$ENDIF}
+end;
+
+function TKBIndexImpl.GetChunks(const Path: string; ChunkNo, Window: Integer): string;
+var
+  Lo, Hi: Integer;
+  Sb: TStringBuilder;
+{$IFDEF FPC}
+  Q: TSQLQuery;
+{$ELSE}
+  Q: TFDQuery;
+{$ENDIF}
+begin
+  Result := '';
+  if not FOpen then Exit;
+  if Window < 0 then Window := 0;
+  Lo := ChunkNo - Window;
+  if Lo < 0 then Lo := 0;
+  Hi := ChunkNo + Window;
+
+  Sb := TStringBuilder.Create;
+  try
+    {$IFDEF FPC}
+    Q := TSQLQuery.Create(nil);
+    try
+      Q.Database := FConn;
+      Q.SQL.Text :=
+        'SELECT chunk_no, body FROM kb_chunks ' +
+        'WHERE path = :p AND chunk_no BETWEEN :a AND :b ORDER BY chunk_no';
+      Q.Params.ParamByName('p').AsString  := Path;
+      Q.Params.ParamByName('a').AsInteger := Lo;
+      Q.Params.ParamByName('b').AsInteger := Hi;
+      Q.Open;
+      while not Q.EOF do
+      begin
+        if Sb.Length > 0 then Sb.Append(#10#10);
+        Sb.Append(Format('--- %s#c%d ---', [Path, Q.Fields[0].AsInteger]));
+        Sb.Append(#10);
+        Sb.Append(Q.Fields[1].AsString);
+        Q.Next;
+      end;
+      Q.Close;
+    finally
+      Q.Free;
+    end;
+    {$ELSE}
+    Q := TFDQuery.Create(nil);
+    try
+      Q.Connection := FConn;
+      Q.SQL.Text :=
+        'SELECT chunk_no, body FROM kb_chunks ' +
+        'WHERE path = :p AND chunk_no BETWEEN :a AND :b ORDER BY chunk_no';
+      Q.ParamByName('p').AsString  := Path;
+      Q.ParamByName('a').AsInteger := Lo;
+      Q.ParamByName('b').AsInteger := Hi;
+      Q.Open;
+      while not Q.Eof do
+      begin
+        if Sb.Length > 0 then Sb.Append(#10#10);
+        Sb.Append(Format('--- %s#c%d ---', [Path, Q.Fields[0].AsInteger]));
+        Sb.Append(#10);
+        Sb.Append(Q.Fields[1].AsString);
+        Q.Next;
+      end;
+      Q.Close;
+    finally
+      Q.Free;
+    end;
+    {$ENDIF}
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
+end;
+
+function TKBIndexImpl.Stats: TKBStats;
+var
+  V: Int64;
+  Cfg: TConfig;
+begin
+  Result.Sources := 0;
+  Result.Files   := 0;
+  Result.Chunks  := 0;
+  Result.VectorReady := False;
+  if not FOpen then Exit;
+  if QueryI64('SELECT COUNT(*) FROM kb_sources', [], [], V) then Result.Sources := V;
+  if QueryI64('SELECT COUNT(*) FROM kb_files',   [], [], V) then Result.Files   := V;
+  if QueryI64('SELECT COUNT(*) FROM kb_chunks',  [], [], V) then Result.Chunks  := V;
+  Cfg := LoadConfig;
+  try
+    Result.VectorReady := Cfg.VectorSearchEnabled and
+                          VectorArtifactsPresent(FModelSpec);
+  finally
+    Cfg.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.KB.pas
+++ b/src/pkg/tools/PasClaw.Tools.KB.pas
@@ -1,0 +1,266 @@
+(*
+  PasClaw.Tools.KB - registers the knowledgebase tools (kb_search, kb_get).
+
+  The knowledgebase is the operator-curated document corpus managed by
+  `pasclaw kb add/sync` (PasClaw.Cmd.KB / PasClaw.KB.Index) — reference
+  documents, NOT conversation memory (that's memory_search).
+
+  Registration is conditional: when no kb.db exists, or it has no
+  registered sources, neither tool is registered — the model never
+  sees a knowledgebase it can't use. When sources exist the tool
+  description embeds the live corpus size so the model knows the KB
+  is worth consulting.
+
+  kb_search returns path#cN citations; kb_get expands a citation into
+  the chunk text plus a window of neighbouring chunks, so the model can
+  search cheap (snippets) and then pull exactly the context it needs.
+
+  Unlike memory_search there is NO implicit sync on the query path:
+  KB corpora can be thousands of chunks and (when the vector runtime
+  is provisioned) re-embedding is expensive. `pasclaw kb sync` is the
+  explicit refresh; the tool descriptions say so.
+*)
+unit PasClaw.Tools.KB;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterKBTools(R: TToolRegistry);
+
+implementation
+
+uses
+  Classes,
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Logger,
+  PasClaw.KB.Index;
+
+function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  V := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      V := Obj.GetStr(Field, '');
+      Result := V <> '';
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function ParseIntArg(const ArgsJSON, Field: string; Default: Integer): Integer;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      if Obj.Has(Field) then Result := Obj.GetInt(Field, Default);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := Default;
+  end;
+end;
+
+function Tool_KBSearch(const ArgsJSON: string; out ErrMsg: string): string;
+const
+  DefaultK = 5;
+  MaxK     = 25;
+var
+  Query: string;
+  K, i:  Integer;
+  Idx:   IKBIndex;
+  Hits:  TKBHitArray;
+  Lines: TStringList;
+begin
+  ErrMsg := '';
+  Result := '';
+
+  if not ParseStringArg(ArgsJSON, 'query', Query) then
+  begin
+    ErrMsg := 'missing required argument: query';
+    Exit;
+  end;
+  K := ParseIntArg(ArgsJSON, 'k', DefaultK);
+  if K < 1    then K := 1;
+  if K > MaxK then K := MaxK;
+
+  Idx := NewKBIndex;
+  if not Idx.Open(DefaultKBDbPath) then
+  begin
+    Idx := nil;
+    ErrMsg := 'knowledgebase unavailable (libsqlite3 missing or unreadable)';
+    Exit;
+  end;
+  try
+    Hits := Idx.Search(Query, K);
+  finally
+    Idx := nil;  { interface release closes the DB }
+  end;
+
+  if Length(Hits) = 0 then
+    Exit(Format('(no knowledgebase matches for %s — if documents changed ' +
+                'recently the operator may need to run `pasclaw kb sync`)',
+                [Query]));
+
+  Lines := TStringList.Create;
+  try
+    Lines.Add(Format('%d knowledgebase match(es) for %s:', [Length(Hits), Query]));
+    Lines.Add('');
+    for i := 0 to High(Hits) do
+    begin
+      Lines.Add(Format('%s#c%d  (score=%.3f)',
+                       [Hits[i].Path, Hits[i].ChunkNo, Hits[i].Score]));
+      Lines.Add('  ' + Hits[i].Snippet);
+      if i < High(Hits) then Lines.Add('');
+    end;
+    Result := Lines.Text;
+  finally
+    Lines.Free;
+  end;
+
+  LogDebug('kb_search query=%s k=%d hits=%d', [Query, K, Length(Hits)]);
+end;
+
+function Tool_KBGet(const ArgsJSON: string; out ErrMsg: string): string;
+const
+  DefaultWindow = 1;
+  MaxWindow     = 5;
+var
+  Path:    string;
+  ChunkNo: Integer;
+  Window:  Integer;
+  Idx:     IKBIndex;
+begin
+  ErrMsg := '';
+  Result := '';
+
+  if not ParseStringArg(ArgsJSON, 'path', Path) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit;
+  end;
+  ChunkNo := ParseIntArg(ArgsJSON, 'chunk', -1);
+  if ChunkNo < 0 then
+  begin
+    ErrMsg := 'missing required argument: chunk (the cN number from a kb_search hit)';
+    Exit;
+  end;
+  Window := ParseIntArg(ArgsJSON, 'window', DefaultWindow);
+  if Window < 0 then Window := 0;
+  if Window > MaxWindow then Window := MaxWindow;
+
+  Idx := NewKBIndex;
+  if not Idx.Open(DefaultKBDbPath) then
+  begin
+    Idx := nil;
+    ErrMsg := 'knowledgebase unavailable (libsqlite3 missing or unreadable)';
+    Exit;
+  end;
+  try
+    Result := Idx.GetChunks(Path, ChunkNo, Window);
+  finally
+    Idx := nil;
+  end;
+
+  if Result = '' then
+    Result := Format('(no chunk %d for %s in the knowledgebase — use the ' +
+                     'exact path and cN number from a kb_search result)',
+                     [ChunkNo, Path]);
+  LogDebug('kb_get path=%s chunk=%d window=%d', [Path, ChunkNo, Window]);
+end;
+
+procedure RegisterKBTools(R: TToolRegistry);
+var
+  T:     TTool;
+  Idx:   IKBIndex;
+  S:     TKBStats;
+  Sized: string;
+begin
+  if R = nil then Exit;
+
+  { No kb.db on disk → the operator never created a knowledgebase;
+    don't register (and don't create the DB as a side effect of tool
+    registration). }
+  if not FileExists(DefaultKBDbPath) then Exit;
+
+  Idx := NewKBIndex;
+  if not Idx.Open(DefaultKBDbPath) then
+  begin
+    Idx := nil;
+    Exit;
+  end;
+  try
+    S := Idx.Stats;
+  finally
+    Idx := nil;
+  end;
+  if S.Sources = 0 then Exit;
+
+  Sized := Format('%d document(s) in %d chunk(s) from %d source(s)',
+                  [S.Files, S.Chunks, S.Sources]);
+
+  T.Name        := 'kb_search';
+  T.Description :=
+    'Search the operator''s knowledgebase — a curated set of reference ' +
+    'documents (manuals, books, source code) indexed for retrieval; ' +
+    'currently ' + Sized + '. Use it whenever the question may be ' +
+    'answered by those documents. Returns up to k hits as path#cN + ' +
+    'snippet + score; pass interesting hits to kb_get for full context. ' +
+    'The index refreshes only via `pasclaw kb sync`.';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"query":{"type":"string","description":"Search query — plain natural language is fine."},' +
+    '"k":{"type":"integer","minimum":1,"maximum":25,"description":"Max results (default 5)."}' +
+    '},"required":["query"]}';
+  T.Handler     := Tool_KBSearch;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;
+  R.Register(T);
+
+  T.Name        := 'kb_get';
+  T.Description :=
+    'Fetch full chunk text from the knowledgebase around a kb_search hit. ' +
+    'Give the exact path and cN chunk number from a hit; window controls ' +
+    'how many neighbouring chunks are included on each side (default 1).';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"path":{"type":"string","description":"Document path exactly as returned by kb_search."},' +
+    '"chunk":{"type":"integer","minimum":0,"description":"Chunk number (the N in #cN)."},' +
+    '"window":{"type":"integer","minimum":0,"maximum":5,"description":"Neighbour chunks each side (default 1)."}' +
+    '},"required":["path","chunk"]}';
+  T.Handler     := Tool_KBGet;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;
+  R.Register(T);
+end;
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.pas
+++ b/src/pkg/tools/PasClaw.Tools.pas
@@ -82,6 +82,7 @@ uses
   PasClaw.Tools.WebFetch,
   PasClaw.Tools.Shell,
   PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
   PasClaw.Tools.FS;
 
 procedure TWebSearchTool.Install(R: TToolRegistry);
@@ -112,6 +113,7 @@ end;
 procedure TMemoryTool.Install(R: TToolRegistry);
 begin
   RegisterMemoryTools(R);
+  RegisterKBTools(R);
 end;
 
 function TMemoryTool.Category: TToolCategory;

--- a/src/tests/kb_index_tests.pas
+++ b/src/tests/kb_index_tests.pas
@@ -1,0 +1,155 @@
+program kb_index_tests;
+{ Pure-function coverage for the knowledgebase unit: the chunker, the
+  extension filter, the binary sniff, and the HTML stripper. The
+  SQLite-backed paths are exercised end to end by `pasclaw kb` against
+  a temp PASCLAW_HOME in the smoke suite — these tests stay
+  dependency-free so they run on any build host. }
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.KB.Index;
+
+procedure Fail(const Msg: string);
+begin
+  Writeln('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail(Msg);
+end;
+
+procedure TestChunkEmpty;
+begin
+  AssertTrue(Length(KBChunkDocument('')) = 0, 'empty input -> no chunks');
+  AssertTrue(Length(KBChunkDocument(#10#10'   '#10)) = 0,
+             'whitespace-only input -> no chunks');
+end;
+
+procedure TestChunkSmallDocIsOneChunk;
+var
+  C: TArray<string>;
+begin
+  C := KBChunkDocument('Para one.'#10#10'Para two.');
+  AssertTrue(Length(C) = 1, Format('small doc packs to 1 chunk (got %d)', [Length(C)]));
+  AssertTrue(Pos('Para one.', C[0]) > 0, 'chunk keeps first paragraph');
+  AssertTrue(Pos('Para two.', C[0]) > 0, 'chunk keeps second paragraph');
+end;
+
+procedure TestChunkSplitsAtTarget;
+var
+  A, B: string;
+  C: TArray<string>;
+begin
+  A := StringOfChar('a', KB_CHUNK_TARGET - 100);
+  B := StringOfChar('b', KB_CHUNK_TARGET - 100);
+  C := KBChunkDocument(A + #10#10 + B);
+  AssertTrue(Length(C) = 2, Format('two near-target paragraphs -> 2 chunks (got %d)', [Length(C)]));
+end;
+
+procedure TestChunkHardCap;
+var
+  C: TArray<string>;
+  i: Integer;
+begin
+  { One giant single-line paragraph must be split into <= KB_CHUNK_MAX
+    slices rather than emitted whole. }
+  C := KBChunkDocument(StringOfChar('x', 3 * KB_CHUNK_MAX + 17));
+  AssertTrue(Length(C) >= 3, Format('giant paragraph split (got %d chunks)', [Length(C)]));
+  for i := 0 to High(C) do
+    AssertTrue(Length(C[i]) <= KB_CHUNK_MAX,
+               Format('chunk %d within hard cap (%d bytes)', [i, Length(C[i])]));
+end;
+
+procedure TestChunkUtf8NotSplit;
+{$IFDEF FPC}
+const
+  { é as explicit UTF-8 bytes — a textual 'é' literal would be
+    re-encoded through the system codepage and degrade to '?' under a
+    C/POSIX locale, silently deflating the run below the cap. Same
+    codepage-tag rationale as toolview_tests' EllipsisGlyph. }
+  E2 = #$C3#$A9;
+var
+  S: string;
+  C: TArray<string>;
+  i, j: Integer;
+begin
+  { A giant run of 2-byte UTF-8 chars: no chunk may end on a lead byte
+    or start on a continuation byte. Byte-level slicing only exists on
+    FPC (strings are bytes); Delphi's UTF-16 Copy can't split a BMP
+    char, so the property holds there by construction. }
+  S := '';
+  for i := 1 to (KB_CHUNK_MAX div 2) + 50 do S := S + E2;
+  C := KBChunkDocument(S);
+  AssertTrue(Length(C) >= 2, 'utf8 run splits into multiple chunks');
+  for i := 0 to High(C) do
+  begin
+    j := Length(C[i]);
+    AssertTrue((Byte(C[i][1]) and $C0) <> $80, 'chunk does not start mid-sequence');
+    AssertTrue((Byte(C[i][j]) and $C0) = $80,
+               'two-byte char chunk ends on its continuation byte');
+  end;
+end;
+{$ELSE}
+begin
+  { See FPC branch — not meaningful on UTF-16 strings. }
+end;
+{$ENDIF}
+
+procedure TestChunkCrlf;
+var
+  C: TArray<string>;
+begin
+  C := KBChunkDocument('one'#13#10#13#10'two');
+  AssertTrue(Length(C) = 1, 'CRLF blank line still separates paragraphs and packs');
+  AssertTrue(Pos('one', C[0]) > 0, 'CRLF doc keeps content');
+end;
+
+procedure TestExtSupported;
+begin
+  AssertTrue(KBExtSupported('/x/doc.md'),    '.md supported');
+  AssertTrue(KBExtSupported('/x/Unit1.PAS'), '.pas supported (case-insensitive)');
+  AssertTrue(KBExtSupported('/x/page.htm'),  '.htm aliases .html');
+  AssertTrue(not KBExtSupported('/x/book.pdf'), '.pdf NOT supported');
+  AssertTrue(not KBExtSupported('/x/image.png'), '.png not supported');
+  AssertTrue(not KBExtSupported('/x/noext'),     'no extension not supported');
+end;
+
+procedure TestLooksBinary;
+begin
+  AssertTrue(KBLooksBinary('abc'#0'def'), 'NUL byte -> binary');
+  AssertTrue(not KBLooksBinary('plain text, ümlauts, 中文'), 'text -> not binary');
+end;
+
+procedure TestStripHtml;
+var
+  S: string;
+begin
+  S := KBStripHtml('<html><head><style>.x{color:red}</style>' +
+                   '<script>alert(1)</script></head>' +
+                   '<body><h1>Title</h1><p>Hello &amp; welcome</p></body></html>');
+  AssertTrue(Pos('Title', S) > 0,          'keeps heading text');
+  AssertTrue(Pos('Hello & welcome', S) > 0, 'decodes &amp;');
+  AssertTrue(Pos('alert', S) = 0,          'drops script body');
+  AssertTrue(Pos('color:red', S) = 0,      'drops style body');
+  AssertTrue(Pos('<', S) = 0,              'strips all tags');
+end;
+
+begin
+  TestChunkEmpty;
+  TestChunkSmallDocIsOneChunk;
+  TestChunkSplitsAtTarget;
+  TestChunkHardCap;
+  TestChunkUtf8NotSplit;
+  TestChunkCrlf;
+  TestExtSupported;
+  TestLooksBinary;
+  TestStripHtml;
+  Writeln('PASS');
+end.


### PR DESCRIPTION
## Knowledgebase: RAG over operator documents

"Big RAG"-style document retrieval for the agent: register reference documents (manuals, books, source trees), and the agent can search and read them while answering.

```sh
pasclaw kb add ~/docs/delphi-book.md ~/projects/mylib/
pasclaw kb search "constructor constraints in generics"
```

Once the corpus is non-empty, two **read-only** agent tools register automatically (and not before — the model never sees an empty KB; the tool description embeds the live corpus size):

| Tool | Purpose |
|---|---|
| `kb_search(query, k)` | Search; returns `path#cN` citations + snippets + scores |
| `kb_get(path, chunk, window)` | Expand a citation into full chunk text ± neighbouring chunks |

### Design

- **Separate from conversation memory by intent**: `memory_search` answers "what did we decide earlier"; the KB answers "what do my reference documents say". Own DB (`workspace/kb.db`), own tools.
- **Indexed in place, never copied** — `kb add` registers sources; `kb sync` walks them mtime-incrementally. Sync is explicit (never on the query hot path), so `kb_search` stays fast on large corpora.
- **FTS5 BM25 always** (reuses `SanitizeFtsQuery` from memory). When the localvector runtime is provisioned (`pasclaw memory provision` — same artifacts + `vector_search_enabled` flag as `memory_search`), search upgrades automatically to **hybrid keyword+semantic** (RRF fusion) via a `kb.db.vec` sidecar rebuilt on sync. Embeddings stay local.
- **Ingestion**: paragraph-accumulating chunker (~1.6 KB target / 3.2 KB hard cap, UTF-8-sequence-safe splits), markdown/text/HTML(tag-stripped)/source extensions, binary sniff, 4 MB cap, dot-dir + `node_modules` skip. **PDFs intentionally unsupported** (convert with `pdftotext` first) — per scope decision.
- Graceful degradation everywhere, same philosophy as memory: missing libsqlite3 → tools report unavailable; missing vector runtime → FTS-only.

### Surface

- CLI: `pasclaw kb add|remove|list|sync|search|get|status` (+ root help/dispatch).
- `RegisterKBTools` wired at every `RegisterMemoryTools` site (agent, TUI, gateway, serve, embedded agent ×2, umbrella unit).
- README section; `make test-kb-index`; `kb status` in smoke.

### Verified (FPC 3.2.2, Linux)

- Full E2E against a real corpus: `add` → 2 files/2 chunks indexed; both searches hit the right documents with highlighted snippets and `#cN` citations; `get` returns full chunk + window; `sync` reports "up to date" (incremental); `remove` cleans all rows.
- Conditional registration confirmed via gateway `/v1/tools`: kb tools absent without a KB, `kb_search`+`kb_get` present with one.
- `make test` fully green including the new `kb_index_tests` (chunker incl. UTF-8 boundary handling with locale-safe byte literals, extension filter, binary sniff, HTML strip) and the `kb` smoke line.
- Delphi/FireDAC paths mirror `PasClaw.Memory.Index` exactly but are untested here (no Delphi in CI), same status as the rest of the codebase.

### Not in scope (per plan)

PDF extraction (Phase 2, skipped by decision), background re-sync, alternate embed models.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_