### PR TITLE
dproj: add pkg\stream to Delphi unit search paths

### DIFF
--- a/samples/component-console/SampleConsole.dproj
+++ b/samples/component-console/SampleConsole.dproj
@@ -48,7 +48,7 @@
           PasClaw.* unit the sample's `uses` clause references. The list
           mirrors src/pasclaw/PasClaw.dproj's DCC_UnitSearchPath.
         -->
-        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\stream;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
 
         <!--
           Namespace prefixes so bare unit names ("SysUtils", "Classes",

--- a/samples/component-console/SampleServer.dproj
+++ b/samples/component-console/SampleServer.dproj
@@ -48,7 +48,7 @@
           PasClaw.* unit the sample's `uses` clause references. The list
           mirrors src/pasclaw/PasClaw.dproj's DCC_UnitSearchPath.
         -->
-        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\stream;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
 
         <!--
           Namespace prefixes so bare unit names ("SysUtils", "Classes",

--- a/samples/component-console/SampleSimple.dproj
+++ b/samples/component-console/SampleSimple.dproj
@@ -48,7 +48,7 @@
           PasClaw.* unit the sample's `uses` clause references. The list
           mirrors src/pasclaw/PasClaw.dproj's DCC_UnitSearchPath.
         -->
-        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\src\cmd;..\..\src\pkg\cliui;..\..\src\pkg\utils;..\..\src\pkg\logger;..\..\src\pkg\config;..\..\src\pkg\json;..\..\src\pkg\providers;..\..\src\pkg\stream;..\..\src\pkg\tokenizer;..\..\src\pkg\tools;..\..\src\pkg\mcp;..\..\src\pkg\gateway;..\..\src\pkg\channels;..\..\src\pkg\crypto;..\..\src\pkg\net;..\..\src\pkg\search;..\..\src\pkg\cron;..\..\src\pkg\skills;..\..\src\pkg\agent;..\..\src\pkg\memory;..\..\src\pkg\updater;..\..\src\pkg\membench;..\..\src\pkg\tui;..\..\src\pkg\platform;..\..\src\pkg\hashline;..\..\src\pkg\component;..\..\src\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
 
         <!--
           Namespace prefixes so bare unit names ("SysUtils", "Classes",

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -177,6 +177,9 @@
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Factory.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Models.pas"/>
         <DCCReference Include="..\pkg\providers\PasClaw.Providers.Stream.pas"/>
+
+        <!-- pkg/stream -->
+        <DCCReference Include="..\pkg\stream\PasClaw.Stream.Reliability.pas"/>
 
         <!-- pkg/tokenizer -->
         <DCCReference Include="..\pkg\tokenizer\PasClaw.Tokenizer.pas"/>


### PR DESCRIPTION
## Summary

PR #213 introduced `src/pkg/stream/PasClaw.Stream.Reliability.pas` but only added the new directory to the FPC `Makefile`'s `UNIT_DIRS`. The Delphi dcc64 builds (`src/pasclaw/PasClaw.dproj` plus the three `samples/component-console/Sample*.dproj`) didn't pick it up, so they fail at the entry of nearly every compilation unit with:

```
[dcc64 Fatal Error] PasClaw.Config.pas(16): F2613 Unit 'PasClaw.Stream.Reliability' not found.
```

`PasClaw.Config` imports `PasClaw.Stream.Reliability` to surface the new `TStreamReliabilityConfig` record as a field of `TConfig` — that's the file the compiler hits first when crawling the dependency tree.

## Fix

- Add `..\pkg\stream` (or `..\..\src\pkg\stream` for the sample dprojs) to the `<DCC_UnitSearchPath>` in all four `.dproj` files.
- Add the explicit `<DCCReference>` for the new unit in `PasClaw.dproj` so it shows up in the IDE project tree next to `PasClaw.Providers.*`.

## Test plan

- [x] FPC build still green (`make smoke`)
- [ ] Delphi build (dcc64) compiles `PasClaw.dproj` without F2613
- [ ] Delphi build of `SampleConsole.dproj` / `SampleServer.dproj` / `SampleSimple.dproj` compiles cleanly

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_