### PR TITLE
build: add src/pkg/kb to Delphi + Windows unit search paths (fix dcc64 F2613)

### DIFF
--- a/build-delphi.bat
+++ b/build-delphi.bat
@@ -42,7 +42,7 @@ if errorlevel 1 (
 if not exist "build\delphi\%PLATFORM%\%CONFIG%" mkdir "build\delphi\%PLATFORM%\%CONFIG%" || exit /b 1
 if not exist "build\delphi\%PLATFORM%\%CONFIG%\dcu" mkdir "build\delphi\%PLATFORM%\%CONFIG%\dcu" || exit /b 1
 
-set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\cron;src\pkg\skills;src\pkg\agent;src\pkg\memory;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\vendor\dmvcframework"
+set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\stream;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\crypto;src\pkg\net;src\pkg\search;src\pkg\cron;src\pkg\skills;src\pkg\session;src\pkg\identity;src\pkg\agent;src\pkg\memory;src\pkg\memory\localvector;src\pkg\kb;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\markdown;src\pkg\vendor\dmvcframework"
 
 echo Building %DPR% with dcc64.exe...
 rem -DPASCLAW_NETHTTP routes outbound HTTP through System.Net.HttpClient

--- a/build-fpc.bat
+++ b/build-fpc.bat
@@ -52,7 +52,7 @@ if errorlevel 1 (
 popd
 
 set "FPCFLAGS=-MDelphi -Sh -O2 -Xs -XX"
-set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\cmd"
+set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\stream -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\crypto -Fusrc\pkg\net -Fusrc\pkg\search -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\session -Fusrc\pkg\identity -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\memory\localvector -Fusrc\pkg\kb -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\pkg\markdown -Fusrc\cmd"
 set "FPCFLAGS=%FPCFLAGS% -Fu%INDY_DIR%\Lib\Core -Fu%INDY_DIR%\Lib\Protocols -Fu%INDY_DIR%\Lib\System -Fi%INDY_DIR%\Lib\Core -Fi%INDY_DIR%\Lib\Protocols -Fi%INDY_DIR%\Lib\System"
 if not "%ICONVENC_DIR%"=="" set "FPCFLAGS=%FPCFLAGS% -Fu%ICONVENC_DIR%"
 set "FPCFLAGS=%FPCFLAGS% -FE%BUILDDIR% -FU%BUILDDIR%\lib"

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names


### PR DESCRIPTION
## Fix: `F2613 Unit 'PasClaw.KB.Index' not found` (dcc64)

The knowledgebase package (`src/pkg/kb`, added in #214) was wired into the Makefile's `UNIT_DIRS` but **not** into the Delphi/Windows build configs, which keep their own unit-path lists. So the Linux/macOS (FPC/Makefile) build worked, but Delphi (and Windows-FPC) couldn't find `PasClaw.KB.Index`:

```
[dcc64 Fatal Error] PasClaw.Tools.KB.pas(49): F2613 Unit 'PasClaw.KB.Index' not found.
```

## What was wrong
- **`src/pasclaw/PasClaw.dproj`** (`DCC_UnitSearchPath`) — missing only `..\pkg\kb`. This is what produced the F2613 under RAD Studio / msbuild.
- **`build-delphi.bat`** (`UNIT_PATH`) and **`build-fpc.bat`** (`FPCFLAGS`) — both had drifted well behind the Makefile: each was missing `stream`, `crypto`, `net`, `search`, `session`, `identity`, `memory\localvector`, `markdown`, **and** `kb`.

## Fix
Resync all three Windows/Delphi unit-path lists to the Makefile's package set — adds `kb` everywhere plus the other drifted packages, so Delphi and Windows-FPC match the Linux/macOS build. **Pure search-path additions; no source changes.**

## Verification
I can't run `dcc64` here (no Delphi/Windows toolchain), but verified by inspection that `PasClaw.KB.Index` / `PasClaw.Tools.KB` / `PasClaw.Cmd.KB` live under `src/pkg/kb` + `src/cmd`, which are now present on all three lists, and that the three lists match the Makefile's package set. The FPC Makefile build (which already had `kb`) is unaffected.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_