### PR TITLE
onboard: offer to index documents into the knowledgebase

### DIFF
--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -31,6 +31,7 @@ uses
   PasClaw.Providers.Catalog,
   PasClaw.Providers.Models,
   PasClaw.MCP.Catalog,
+  PasClaw.KB.Index,
   PasClaw.Cmd.Memory;
 
 function ReadLineEcho(const Prompt: string): string;
@@ -631,6 +632,85 @@ begin
       '(deferred -- run `pasclaw memory provision` when ready)' + Ansi.Reset);
 end;
 
+procedure PromptKnowledgebase(Cfg: TConfig);
+{ KB (RAG) opt-in. Gated on VectorSearchEnabled: the knowledgebase
+  still works FTS-only, but the natural moment to offer "index my
+  documents" is right after the user opted into local semantic search
+  -- that's the capability that makes a doc corpus worth pointing the
+  agent at. If they declined vectors we stay quiet and let them reach
+  it later via `pasclaw kb add`.
+
+  Adds operator-chosen director(ies)/file(s) as KB sources (indexed in
+  place, never copied) and runs one Sync. Default NO and an explicit
+  blank-to-finish loop: indexing reads real files (and, once the
+  embedding runtime is provisioned, embeds every chunk), so nothing is
+  touched unless the user asks. Missing libsqlite3 degrades to a
+  one-line skip -- same philosophy as the rest of onboarding. }
+var
+  Choice, Path, Abs, Err: string;
+  Idx: IKBIndex;
+  Added, Files, Chunks: Integer;
+begin
+  if not Cfg.VectorSearchEnabled then Exit;
+
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Knowledgebase (RAG over your documents)' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Index reference docs -- markdown, text, source code -- so the agent can' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'retrieve them with kb_search. Indexed in place; PDFs unsupported (convert first).' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Add documents to the knowledgebase now? [y/N]: ')));
+  if not ((Choice = 'y') or (Choice = 'yes')) then
+  begin
+    PrintLn('  ' + Ansi.Dim +
+      '(skipped -- add later with `pasclaw kb add <path>`)' + Ansi.Reset);
+    Exit;
+  end;
+
+  Idx := NewKBIndex;
+  if not Idx.Open(DefaultKBDbPath) then
+  begin
+    Idx := nil;
+    PrintLn('  ' + Ansi.Red + '✗' + Ansi.Reset +
+      ' knowledgebase unavailable (libsqlite3 missing) -- skipped');
+    Exit;
+  end;
+  try
+    Added := 0;
+    repeat
+      Path := Trim(ReadLineEcho('  Directory or file to add (blank to finish): '));
+      if Path = '' then Break;
+      Abs := ExpandHome(Path);   { ReadLine has no shell, so expand ~ ourselves }
+      if Idx.AddSource(Abs, Err) then
+      begin
+        PrintLn('    ' + Ansi.Green + '+' + Ansi.Reset + ' ' + ExpandFileName(Abs));
+        Inc(Added);
+      end
+      else
+        PrintLn('    ' + Ansi.Dim + 'skip: ' + Err + Ansi.Reset);
+    until False;
+
+    if Added = 0 then
+    begin
+      PrintLn('  ' + Ansi.Dim + '(nothing added)' + Ansi.Reset);
+      Exit;
+    end;
+
+    PrintLn('  indexing...');
+    Idx.Sync(Files, Chunks);
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+      Format(' indexed %d file(s), %d chunk(s)', [Files, Chunks]));
+    PrintLn('  ' + Ansi.Dim +
+      '(kb_search activates for the agent; `pasclaw kb sync` after documents change)' +
+      Ansi.Reset);
+  finally
+    Idx := nil;
+  end;
+end;
+
 procedure PromptMCPInstalls(Cfg: TConfig);
 var
   Entries: TMCPCatalogEntryArray;
@@ -813,6 +893,7 @@ begin
     PromptMCPInstalls(Cfg);
     PromptVaultTools(Cfg);
     PromptVectorSearch(Cfg);
+    PromptKnowledgebase(Cfg);
     PromptStatsCollection(Cfg);
     PromptAutoRouter(Cfg);
 

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -699,6 +699,17 @@ begin
       Exit;
     end;
 
+    { Persist the vector opt-in before indexing. Sync's TryEnsureVector
+      reloads config.json from disk to decide whether to build the vector
+      sidecar; onboarding's own SaveConfig runs later (end of
+      Cmd_Onboard_Run), so on a re-run that just flipped
+      vector_search_enabled false->true the on-disk value would still be
+      stale here and the sidecar would be skipped. Writing now makes the
+      flag Sync reads match what the user just chose (we only reach here
+      when VectorSearchEnabled is true). The trailing SaveConfig stays
+      and is idempotent. }
+    SaveConfig(Cfg);
+
     PrintLn('  indexing...');
     Idx.Sync(Files, Chunks);
     PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +


### PR DESCRIPTION
## What

Adds a `PromptKnowledgebase` step to `pasclaw onboard` that offers to index document directories/files into the RAG knowledgebase during setup.

## Why

The knowledgebase (`kb_search` / `kb_get`, added in #214) was previously only reachable via `pasclaw kb add` after onboarding. The natural moment to offer "index my documents" is right after the operator opts into local semantic search — that's the capability that makes pointing the agent at a doc corpus worthwhile.

## Behavior

- **Gated strictly on the vector-search opt-in** chosen earlier in the same flow (`Cfg.VectorSearchEnabled`). If the operator declines vectors, onboarding stays quiet and leaves `pasclaw kb add` for later.
- **Default NO**, with an explicit blank-to-finish add loop — nothing is touched unless the operator asks.
- Each entered directory/file becomes a KB source (indexed in place, never copied), then a single `Sync` runs so `kb_search` activates for the agent immediately.
- `ExpandHome` on entered paths (ReadLine has no shell to expand `~`).
- Missing `libsqlite3` degrades to a one-line skip, matching the rest of onboarding.

## Verification

- Clean FPC build (`rc=0`; only the pre-existing implicit-string-cast warnings).
- Gate verified both directions: vectors disabled → no KB prompt; vectors enabled → "Add documents to the knowledgebase now? [y/N]" appears.
- The add path reuses `AddSource` + `Sync`, already E2E-verified in #214.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_