### PR TITLE
mcp: inbound MCP server mode — serve memory_search / kb_search / SCARS live

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,13 @@ test-stream-reliability: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/stream_reliability_tests.pas -o$(BUILDDIR)/stream_reliability_tests
 	@$(BUILDDIR)/stream_reliability_tests
 
+# MCP server core: JSON-RPC dispatch over a synthetic TToolRegistry.
+# Covers tools/list filtering, tools/call dispatch, allowlist, error shapes.
+test-mcp-server: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/mcp_server_tests.pas -o$(BUILDDIR)/mcp_server_tests
+	@$(BUILDDIR)/mcp_server_tests
+
 test-session-search: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/session_search_tests.pas -o$(BUILDDIR)/session_search_tests
@@ -399,4 +406,4 @@ test-kb-index: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/kb_index_tests.pas -o$(BUILDDIR)/kb_index_tests
 	@$(BUILDDIR)/kb_index_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-kb-index
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-kb-index

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -81,6 +81,13 @@ type
     NoMCP:       Boolean;
     NoTools:     Boolean;
     NoHashline:  Boolean;
+    { Inbound MCP server. Same shape as Cmd.Serve -- 0 means /mcp is
+      mounted on the main listener alongside /v1/*; >0 spawns a
+      second listener bound to that port serving /mcp only. Both
+      share the gateway's tool registry so memory_search /
+      kb_search / session_search are one source of truth. }
+    MCPPort:        Integer;
+    MCPAllowWrite:  Boolean;
   end;
 
 function ParseGw(const Argv: array of string; const Cfg: TConfig): TGwArgs;
@@ -109,9 +116,11 @@ begin
   Result.IRCNick    := GetEnvironmentVariable('PASCLAW_IRC_NICK');
   Result.IRCChannel := GetEnvironmentVariable('PASCLAW_IRC_CHANNEL');
   Result.IRCPassword := GetEnvironmentVariable('PASCLAW_IRC_PASSWORD');
-  Result.NoMCP      := False;
-  Result.NoTools    := False;
-  Result.NoHashline := False;
+  Result.NoMCP         := False;
+  Result.NoTools       := False;
+  Result.NoHashline    := False;
+  Result.MCPPort       := 0;
+  Result.MCPAllowWrite := False;
   i := 0;
   while i <= High(Argv) do
   begin
@@ -140,6 +149,8 @@ begin
     if Argv[i] = '--no-mcp'       then begin Result.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-tools'     then begin Result.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
+    if Argv[i] = '--mcp-port'     then begin if i < High(Argv) then Result.MCPPort := StrToIntDef(Argv[i + 1], 0); Inc(i, 2); Continue; end;
+    if Argv[i] = '--mcp-allow-write' then begin Result.MCPAllowWrite := True; Inc(i); Continue; end;
     Inc(i);
   end;
 end;
@@ -152,7 +163,7 @@ var
   Err: string;
   Reg: TToolRegistry;
   MCPClients: TMCPClientList;
-  Server: TGatewayServer;
+  Server, MCPServer: TGatewayServer;
   Telegram: TTelegramChannel;
   Line: TLineBot;
   WhatsApp: TWhatsAppBot;
@@ -217,6 +228,17 @@ begin
     end;
 
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
+    Server.SetMCPAllowMutating(Args.MCPAllowWrite);
+    { Optional /mcp companion listener. See the long-form comment in
+      Cmd.Serve for the same wiring -- one source of truth for the
+      tool registry, two HTTP listeners when isolation matters. }
+    MCPServer := nil;
+    if Args.MCPPort > 0 then
+    begin
+      MCPServer := TGatewayServer.Create(Cfg, Provider, Reg);
+      MCPServer.SetMCPAllowMutating(Args.MCPAllowWrite);
+      MCPServer.SetMCPOnly(True);
+    end;
     Telegram := nil;
     Line     := nil;
     WhatsApp := nil;
@@ -289,12 +311,20 @@ begin
       end;
 
       Server.Start(Args.Addr, Args.Port);
+      if MCPServer <> nil then
+        MCPServer.Start(Args.Addr, Args.MCPPort);
 
       PrintLn(Ansi.Bold + 'Gateway up.' + Ansi.Reset);
       PrintLn(Format('  http://%s:%d/v1/health', [Args.Addr, Args.Port]));
       PrintLn(Format('  http://%s:%d/v1/tools',  [Args.Addr, Args.Port]));
       PrintLn(Format('  POST http://%s:%d/v1/chat   {"message":"..."}',
                      [Args.Addr, Args.Port]));
+      if MCPServer <> nil then
+        PrintLn(Format('  POST http://%s:%d/mcp   (dedicated MCP listener)',
+                       [Args.Addr, Args.MCPPort]))
+      else
+        PrintLn(Format('  POST http://%s:%d/mcp   (alongside /v1/*)',
+                       [Args.Addr, Args.Port]));
       if Args.Line then
         PrintLn(Format('  POST http://%s:%d/webhooks/line   (LINE platform)',
                        [Args.Addr, Args.Port]));
@@ -331,7 +361,9 @@ begin
       if IRC      <> nil then IRC.Free;
       if Email    <> nil then begin Email.Stop; Email.Free; end;
       Server.Stop;
+      if MCPServer <> nil then MCPServer.Stop;
       Server.Free;
+      if MCPServer <> nil then MCPServer.Free;
       if Scheduler <> nil then Scheduler.Free;
       FreeMCPClients(MCPClients);
       if Reg <> nil then Reg.Free;

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -22,11 +22,16 @@ uses
   PasClaw.MCP.HttpClient,
   PasClaw.MCP.Catalog,
   PasClaw.MCP.Hub,
-  PasClaw.MCP.OAuth;
+  PasClaw.MCP.OAuth,
+  PasClaw.MCP.Server,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.Memory,
+  PasClaw.Tools.KB,
+  PasClaw.Tools.SessionSearch;
 
 procedure Help;
 begin
-  PrintLn('Usage: pasclaw mcp <list|add|remove|test|edit|show|catalog|search|install|auth> [args]');
+  PrintLn('Usage: pasclaw mcp <list|add|remove|test|edit|show|catalog|search|install|auth|stdio> [args]');
   PrintLn('  add <name> <cmd> [args]   register a new MCP server');
   PrintLn('  remove <name>             delete an MCP server entry');
   PrintLn('  list                      list configured servers');
@@ -39,6 +44,13 @@ begin
   PrintLn('  install <name>            add from hub or catalog (reads auth from env)');
   PrintLn('  auth <name>               run the OAuth 2.1 + PKCE flow for an OAuth-only');
   PrintLn('                            MCP server (opens browser, captures callback)');
+  PrintLn('  stdio [--allow-write]     run PasClaw as an MCP server over stdio.');
+  PrintLn('                            Exposes memory_search / kb_search /');
+  PrintLn('                            session_search (SCARS lives in workspace/memory)');
+  PrintLn('                            to any host that spawns MCP servers as');
+  PrintLn('                            subprocesses (Claude Desktop, Cursor, Codex CLI).');
+  PrintLn('                            Read-only by default; --allow-write opts in to');
+  PrintLn('                            mutating tools.');
 end;
 
 function DoList: Integer;
@@ -461,6 +473,68 @@ begin
   end;
 end;
 
+function DoStdio(const Argv: array of string): Integer;
+{ Run PasClaw as an inbound MCP server over stdin/stdout. Newline-
+  delimited JSON-RPC -- the same framing PasClaw.MCP.StdioClient
+  uses when consuming external MCP servers.
+
+  Loop: read one line from stdin, hand it to TMCPServerCore.HandleRequest,
+  write the non-empty response back. EOF on stdin ends the loop and the
+  process exits 0. Tool failures land as isError content (not transport
+  errors) so the host keeps the session alive. Logs go to stderr only --
+  stdout MUST stay clean JSON-RPC, otherwise the host's parser bails.
+
+  Tool surface: same read-only slice as the HTTP /mcp route --
+  memory_search / memory_get / kb_search / kb_get / session_search.
+  SCARS lives inside workspace/memory/SCARS.md so it's reachable
+  through memory_search; no separate "scars" tool to maintain.
+  --allow-write also exposes the mutating tools (off by default). }
+var
+  i: Integer;
+  AllowWrite: Boolean;
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Line, Resp: string;
+begin
+  AllowWrite := False;
+  for i := 1 to High(Argv) do
+    if (Argv[i] = '--allow-write') or (Argv[i] = '--mcp-allow-write') then
+      AllowWrite := True;
+
+  { Stdio MCP runs without a chat provider -- we never call out to an
+    LLM, we just expose corpora to the host. Register the read-only
+    data tools directly; skip RegisterFSTools / RegisterShellTool /
+    RegisterExecuteCodeTool (writes / shell-out / sandbox), keep the
+    surface scoped to the "live source of truth" data. The HTTP
+    --mcp-allow-write knob also tightens this -- but for stdio,
+    register-only-what-we-want-to-expose stays a hard wall. }
+  Reg := TToolRegistry.Create;
+  try
+    RegisterMemoryTools(Reg);
+    RegisterKBTools(Reg);
+    RegisterSessionSearchTool(Reg);
+    Srv := TMCPServerCore.Create(Reg, AllowWrite, '');
+    try
+      while not Eof(Input) do
+      begin
+        ReadLn(Input, Line);
+        if Trim(Line) = '' then Continue;
+        Resp := Srv.HandleRequest(Line);
+        if Resp <> '' then
+        begin
+          WriteLn(Output, Resp);
+          Flush(Output);
+        end;
+      end;
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+  Result := 0;
+end;
+
 function Cmd_MCP_Run(const Argv: array of string): Integer;
 var
   Sub: string;
@@ -477,6 +551,7 @@ begin
   else if Sub = 'search'  then Result := DoSearch(Argv)
   else if Sub = 'install' then Result := DoInstall(Argv)
   else if Sub = 'auth'    then Result := DoAuth(Argv)
+  else if Sub = 'stdio'   then Result := DoStdio(Argv)
   else begin Help; Result := 1; end;
 end;
 

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -8,6 +8,15 @@
     pasclaw serve --debug                 # log every request + response body
     pasclaw serve --max-iter 40           # raise the tool-loop cap (default 25)
     pasclaw serve --no-hashline           # raw fs_read; skip fs_edit_hashline + fs_grep
+    pasclaw serve --mcp-port 8089         # also expose MCP on its own port
+                                          # (default: mounted on /mcp on the
+                                          # main port -- alongside /v1)
+    pasclaw serve --mcp-allow-write       # let MCP clients call mutating
+                                          # tools too (fs_write, shell, ...).
+                                          # OFF by default -- a foreign MCP
+                                          # host calling fs_write on the
+                                          # operator's box is exactly the
+                                          # bad outcome sandbox exists for.
 
   Exposes POST /v1/chat/completions on the configured port. Any client
   that speaks the OpenAI Chat Completions API (openai-python, openai-node,
@@ -62,26 +71,36 @@ uses
 
 type
   TServeArgs = record
-    Addr:        string;
-    Port:        Integer;
-    NoMCP:       Boolean;
-    NoTools:     Boolean;
-    Debug:       Boolean;
-    MaxIter:     Integer;
-    NoHashline:  Boolean;
+    Addr:           string;
+    Port:           Integer;
+    NoMCP:          Boolean;
+    NoTools:        Boolean;
+    Debug:          Boolean;
+    MaxIter:        Integer;
+    NoHashline:     Boolean;
+    { Inbound MCP server: when MCPPort = 0 (default) the /mcp surface
+      is mounted on the main listener at POST /mcp + POST /v1/mcp/rpc.
+      When > 0 the gateway spins up a second listener bound to that
+      port that serves /mcp ONLY -- useful when a heavy /v1/responses
+      streaming load might otherwise compete with MCP requests for
+      Indy worker threads. }
+    MCPPort:        Integer;
+    MCPAllowWrite:  Boolean;
   end;
 
 function ParseServe(const Argv: array of string; const Cfg: TConfig): TServeArgs;
 var
   i: Integer;
 begin
-  Result.Addr       := Cfg.Gateway.BindAddr;
-  Result.Port       := Cfg.Gateway.Port;
-  Result.NoMCP      := False;
-  Result.NoTools    := False;
-  Result.Debug      := False;
-  Result.MaxIter    := 25;  { matches TGatewayServer.Create default }
-  Result.NoHashline := False;
+  Result.Addr          := Cfg.Gateway.BindAddr;
+  Result.Port          := Cfg.Gateway.Port;
+  Result.NoMCP         := False;
+  Result.NoTools       := False;
+  Result.Debug         := False;
+  Result.MaxIter       := 25;  { matches TGatewayServer.Create default }
+  Result.NoHashline    := False;
+  Result.MCPPort       := 0;
+  Result.MCPAllowWrite := False;
   i := 0;
   while i <= High(Argv) do
   begin
@@ -93,6 +112,8 @@ begin
                                       begin Result.Debug       := True; Inc(i); Continue; end;
     if Argv[i] = '--max-iter'     then begin if i < High(Argv) then Result.MaxIter := StrToIntDef(Argv[i + 1], Result.MaxIter); Inc(i, 2); Continue; end;
     if Argv[i] = '--no-hashline'  then begin Result.NoHashline := True; Inc(i); Continue; end;
+    if Argv[i] = '--mcp-port'     then begin if i < High(Argv) then Result.MCPPort := StrToIntDef(Argv[i + 1], 0); Inc(i, 2); Continue; end;
+    if Argv[i] = '--mcp-allow-write' then begin Result.MCPAllowWrite := True; Inc(i); Continue; end;
     Inc(i);
   end;
   if Result.MaxIter < 1 then Result.MaxIter := 1;
@@ -106,7 +127,7 @@ var
   Err: string;
   Reg: TToolRegistry;
   MCPClients: TMCPClientList;
-  Server: TGatewayServer;
+  Server, MCPServer: TGatewayServer;
   Skills: TSkillSpecArray;
   BaseURL: string;
 begin
@@ -168,14 +189,44 @@ begin
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
     Server.DebugIO := Args.Debug;
     Server.MaxIter := Args.MaxIter;
+    Server.SetMCPAllowMutating(Args.MCPAllowWrite);
+
+    { Optional companion listener dedicated to /mcp. When MCPPort is
+      0 the main listener already serves /mcp alongside /v1/* on one
+      port -- "live alongside the OpenAI-compat API". When non-zero,
+      we spin a second TGatewayServer in MCP-only mode on that port
+      so heavy /v1/responses streaming load can't compete with MCP
+      requests for Indy worker threads. Both listeners share the
+      same tool registry so they see exactly the same memory_search
+      / kb_search / session_search results -- one source of truth. }
+    MCPServer := nil;
+    if Args.MCPPort > 0 then
+    begin
+      MCPServer := TGatewayServer.Create(Cfg, Provider, Reg);
+      MCPServer.DebugIO := Args.Debug;
+      MCPServer.SetMCPAllowMutating(Args.MCPAllowWrite);
+      MCPServer.SetMCPOnly(True);
+    end;
     try
       Server.Start(Args.Addr, Args.Port);
+      if MCPServer <> nil then
+        MCPServer.Start(Args.Addr, Args.MCPPort);
 
       BaseURL := Format('http://%s:%d/v1', [Args.Addr, Args.Port]);
       PrintLn(Ansi.Bold + 'OpenAI-compatible server up.' + Ansi.Reset);
       PrintLn('  base_url: ' + BaseURL);
       PrintLn('  model:    ' + Cfg.DefaultModel);
       PrintLn(Format('  max-iter: %d', [Args.MaxIter]));
+      if MCPServer <> nil then
+        PrintLn(Format('  mcp:      http://%s:%d/mcp (dedicated listener)',
+                       [Args.Addr, Args.MCPPort]))
+      else
+        PrintLn(Format('  mcp:      http://%s:%d/mcp (mounted on main port)',
+                       [Args.Addr, Args.Port]));
+      if Args.MCPAllowWrite then
+        PrintLn('            mutating tools EXPOSED to MCP clients (--mcp-allow-write)')
+      else
+        PrintLn('            read-only tools only -- pass --mcp-allow-write to flip');
       PrintLn;
       PrintLn(Ansi.Dim + '  Example (openai-python):' + Ansi.Reset);
       PrintLn('    client = OpenAI(base_url="' + BaseURL + '", api_key="sk-pasclaw")');
@@ -192,7 +243,9 @@ begin
       Server.WaitForStop;
     finally
       Server.Stop;
+      if MCPServer <> nil then MCPServer.Stop;
       Server.Free;
+      if MCPServer <> nil then MCPServer.Free;
       FreeMCPClients(MCPClients);
       if Reg <> nil then Reg.Free;
     end;

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -46,13 +46,37 @@ uses
   PasClaw.Config,
   PasClaw.Cmd.Root;
 
+function IsStdioMCPInvocation: Boolean;
+{ When invoked as `pasclaw mcp stdio`, stdout MUST stay clean JSON-RPC
+  -- the host process pipes our stdout into its parser, and a banner
+  on the first read would crash it. Same goes for the legacy
+  __tool subprocess RPC. Skip the banner in those cases; the user
+  on a real terminal still gets the full visual. }
+var
+  i: Integer;
+  Cmd, Next: string;
+begin
+  Result := False;
+  if ParamCount < 1 then Exit;
+  Cmd := ParamStr(1);
+  if Cmd = '__tool' then Exit(True);
+  if Cmd <> 'mcp' then Exit;
+  for i := 2 to ParamCount do
+  begin
+    Next := ParamStr(i);
+    if (Next = '') or (Next[1] = '-') then Continue;
+    Exit(Next = 'stdio');
+  end;
+end;
+
 var
   ExitCode_: Integer;
 begin
   { Detect color support before any output so the banner respects NO_COLOR. }
   CliUI_Init(EarlyColorDisabled);
 
-  PrintBanner;
+  if not IsStdioMCPInvocation then
+    PrintBanner;
   ApplyTimezoneFromEnv;
 
   ExitCode_ := RunRootCommand;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -211,6 +211,7 @@
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.HttpClient.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Catalog.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Bridge.pas"/>
+        <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Server.pas"/>
 
         <!-- pkg/gateway -->
         <DCCReference Include="..\pkg\gateway\PasClaw.Gateway.Server.pas"/>

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -13,6 +13,15 @@
     POST /v1/responses             -> OpenAI Responses-compatible
                                       (request: {model, input, ...},
                                        response: {id, output[{content}], usage})
+    POST /mcp                      -> inbound MCP server: JSON-RPC 2.0
+                                      over HTTP. Exposes memory_search /
+                                      kb_search / session_search / SCARS
+                                      live to external MCP hosts (Claude
+                                      Desktop, Cursor, Codex CLI). Read-
+                                      only by default; --mcp-allow-write
+                                      opts in to mutating tools. Aliased
+                                      at POST /v1/mcp/rpc so version-
+                                      prefixed deployments stay greppable.
     GET  /v1/models                -> OpenAI-compatible model list
     GET  /v1/version               -> build version
 
@@ -38,7 +47,8 @@ uses
   PasClaw.Config,
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
-  PasClaw.Tools.Registry;
+  PasClaw.Tools.Registry,
+  PasClaw.MCP.Server;
 
 type
   { Method-of-object signature any channel (LINE, WhatsApp, Slack Events
@@ -65,6 +75,22 @@ type
     FMaxIter:  Integer;
     FWebhookPaths:    TStringList;
     FWebhookHandlers: array of TWebhookHandler;
+    { Lazily-built inbound MCP server core. Created on the first
+      POST /mcp; lifetime tracks FRegistry. Nil when the registry
+      itself is nil (no tools to expose). The gateway exposes the
+      MCP surface at /mcp (and aliased at /v1/mcp/rpc to keep
+      version-prefixed deployments grep-friendly) so other
+      runtimes can consume PasClaw's memory_search / kb_search /
+      session_search live, against the same corpus the local CLI
+      sees. See PasClaw.MCP.Server for the core. }
+    FMCPInbound:     TMCPServerCore;
+    FMCPInboundLock: TCriticalSection;
+    FMCPAllowMutating: Boolean;
+    FMCPAllowList:     array of string;
+    FMCPOnly:          Boolean;
+    function  GetOrCreateMCPInbound: TMCPServerCore;
+    procedure HandleMCPRequest(ARequest: TIdHTTPRequestInfo;
+                                AResp: TIdHTTPResponseInfo);
     function DispatchWebhook(AContext: TIdContext;
                              ARequest: TIdHTTPRequestInfo;
                              AResponse: TIdHTTPResponseInfo): Boolean;
@@ -119,6 +145,20 @@ type
       to match what typical code agents need for read-debug-edit cycles;
       legacy /v1/chat keeps its 8-iteration cap unchanged. }
     property MaxIter: Integer read FMaxIter write FMaxIter;
+    { MCP inbound server policy. SetMCPAllowMutating(True) lets the
+      inbound /mcp surface expose tcMutating tools (fs_write, shell,
+      fs_edit_hashline) too -- off by default. SetMCPAllowList
+      restricts exposure to a fixed name list (in addition to the
+      mutating gate). Both invalidate any existing core so the next
+      request sees the new policy. }
+    procedure SetMCPAllowMutating(V: Boolean);
+    procedure SetMCPAllowList(const Names: array of string);
+    { When True, this gateway responds only to /mcp / /v1/mcp/rpc
+      (and the bare GET / health probes); every other route 404s.
+      Used when --mcp-port spins up a second listener dedicated to
+      the MCP surface so a heavy /v1/responses streaming load
+      can't compete with MCP requests for Indy worker threads. }
+    procedure SetMCPOnly(V: Boolean);
     procedure Start(const BindAddr: string; Port: Integer);
     procedure Stop;
     procedure WaitForStop;
@@ -298,6 +338,10 @@ begin
   FHTTP.OnCommandGet := OnCommandGet;
   FHTTP.KeepAlive    := True;
   FHTTP.ServerSoftware := 'PasClaw/' + FormatVersion;
+  FMCPInbound       := nil;
+  FMCPInboundLock   := TCriticalSection.Create;
+  FMCPAllowMutating := False;
+  SetLength(FMCPAllowList, 0);
 end;
 
 destructor TGatewayServer.Destroy;
@@ -306,7 +350,70 @@ begin
   FHTTP.Free;
   FStopFlag.Free;
   FWebhookPaths.Free;
+  if FMCPInbound <> nil then FMCPInbound.Free;
+  FMCPInboundLock.Free;
   inherited Destroy;
+end;
+
+procedure TGatewayServer.SetMCPAllowMutating(V: Boolean);
+{ Opt-in: when True, the inbound MCP server exposes mutating tools
+  (fs_write / shell / fs_edit_hashline) too. Off by default because
+  letting a foreign MCP host call fs_write on the operator's box is
+  exactly the bad outcome the sandbox layer exists to prevent.
+  Recreate the core if it already exists so the new policy applies
+  on the next /mcp request. }
+begin
+  FMCPInboundLock.Acquire;
+  try
+    FMCPAllowMutating := V;
+    if FMCPInbound <> nil then
+    begin
+      FMCPInbound.Free;
+      FMCPInbound := nil;
+    end;
+  finally
+    FMCPInboundLock.Release;
+  end;
+end;
+
+procedure TGatewayServer.SetMCPAllowList(const Names: array of string);
+var
+  i: Integer;
+begin
+  FMCPInboundLock.Acquire;
+  try
+    SetLength(FMCPAllowList, Length(Names));
+    for i := 0 to High(Names) do FMCPAllowList[i] := Names[i];
+    if FMCPInbound <> nil then
+    begin
+      FMCPInbound.Free;
+      FMCPInbound := nil;
+    end;
+  finally
+    FMCPInboundLock.Release;
+  end;
+end;
+
+procedure TGatewayServer.SetMCPOnly(V: Boolean);
+begin
+  FMCPOnly := V;
+end;
+
+function TGatewayServer.GetOrCreateMCPInbound: TMCPServerCore;
+begin
+  FMCPInboundLock.Acquire;
+  try
+    if (FMCPInbound = nil) and (FRegistry <> nil) then
+    begin
+      FMCPInbound := TMCPServerCore.Create(FRegistry, FMCPAllowMutating,
+                                            FormatVersion);
+      if Length(FMCPAllowList) > 0 then
+        FMCPInbound.SetAllowList(FMCPAllowList);
+    end;
+    Result := FMCPInbound;
+  finally
+    FMCPInboundLock.Release;
+  end;
 end;
 
 procedure TGatewayServer.MountWebhook(const Path: string; Handler: TWebhookHandler);
@@ -414,6 +521,62 @@ begin
   WriteBodyStream(AResp, Body);
 end;
 
+procedure TGatewayServer.HandleMCPRequest(ARequest: TIdHTTPRequestInfo;
+                                           AResp: TIdHTTPResponseInfo);
+{ Inbound MCP server entry. Reads one JSON-RPC request from the POST
+  body, dispatches via TMCPServerCore, writes the response (or 204
+  for notifications). One-shot per request; no SSE / streaming -- the
+  MCP Streamable HTTP spec allows a plain JSON response, and that's
+  enough for the read-corpus surface we expose. Server-pushed
+  notifications (the optional GET /mcp side of the transport) is a
+  follow-up. }
+var
+  Body: string;
+  Bytes: TBytes;
+  Core: TMCPServerCore;
+  RespLine: string;
+begin
+  Body := '';
+  if ARequest.PostStream <> nil then
+  begin
+    ARequest.PostStream.Position := 0;
+    SetLength(Bytes, ARequest.PostStream.Size);
+    if ARequest.PostStream.Size > 0 then
+    begin
+      ARequest.PostStream.ReadBuffer(Bytes[0], ARequest.PostStream.Size);
+      Body := TEncoding.UTF8.GetString(Bytes);
+    end;
+  end;
+  if Trim(Body) = '' then
+  begin
+    WriteJSON(AResp, 400,
+      '{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"empty body"}}');
+    Exit;
+  end;
+  if FDebugIO then
+    LogDebug('mcp <- %s', [Copy(Body, 1, 200)]);
+
+  Core := GetOrCreateMCPInbound;
+  if Core = nil then
+  begin
+    WriteJSON(AResp, 503,
+      '{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"no tool registry"}}');
+    Exit;
+  end;
+
+  RespLine := Core.HandleRequest(Body);
+  if RespLine = '' then
+  begin
+    { Notification path -- spec says no body. 204 No Content. }
+    AResp.ResponseNo  := 204;
+    AResp.ContentText := '';
+    Exit;
+  end;
+  if FDebugIO then
+    LogDebug('mcp -> %s', [Copy(RespLine, 1, 200)]);
+  WriteJSON(AResp, 200, RespLine);
+end;
+
 { TGatewayServer.WriteSSE removed -- dead method, see class
   declaration. dcc64 H2219 cleanup. }
 
@@ -430,6 +593,24 @@ begin
   ResponseStarted := False;
   LogDebug('gateway: %s %s', [ARequest.Command, Doc]);
 
+  { MCP-only listener: when this gateway was spun up as the
+    --mcp-port companion, the only routes it honours are the
+    inbound MCP endpoints plus a minimal health probe. Everything
+    else 404s -- the operator wired the second listener for
+    isolation, and silently fanning out /v1/chat traffic to it
+    would defeat the purpose. }
+  if FMCPOnly then
+  begin
+    if (ARequest.Command = 'POST') and
+       ((Doc = '/mcp') or (Doc = '/v1/mcp/rpc')) then
+      HandleMCPRequest(ARequest, AResponse)
+    else if (ARequest.Command = 'GET') and (Doc = '/v1/health') then
+      HandleHealth(AResponse)
+    else
+      WriteJSON(AResponse, 404, '{"error":"mcp-only listener; route not found"}');
+    Exit;
+  end;
+
   try
     if      (ARequest.Command = 'GET')  and (Doc = '/v1/health')  then HandleHealth(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/version') then HandleVersion(AResponse)
@@ -440,6 +621,8 @@ begin
       HandleChatCompletions(AContext, ARequest, AResponse, IsChatCompletionsStream, ResponseStarted)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/responses') then
       HandleResponses(AContext, ARequest, AResponse, IsChatCompletionsStream, ResponseStarted)
+    else if (ARequest.Command = 'POST') and ((Doc = '/mcp') or (Doc = '/v1/mcp/rpc')) then
+      HandleMCPRequest(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/models')  then HandleModels(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/mcp')     then HandleMCPList(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/cron')    then HandleCronList(AResponse)

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -360,8 +360,13 @@ procedure TGatewayServer.SetMCPAllowMutating(V: Boolean);
   (fs_write / shell / fs_edit_hashline) too. Off by default because
   letting a foreign MCP host call fs_write on the operator's box is
   exactly the bad outcome the sandbox layer exists to prevent.
-  Recreate the core if it already exists so the new policy applies
-  on the next /mcp request. }
+
+  Call BEFORE Start: the operator-facing wiring in Cmd.Serve /
+  Cmd.Gateway does exactly this, so the policy is locked in before
+  any /mcp request can race the setter. We invalidate any
+  pre-built core for completeness, but freeing it while a request
+  thread holds a pointer to it would be a use-after-free -- callers
+  that change the policy at runtime must serialise externally. }
 begin
   FMCPInboundLock.Acquire;
   try

--- a/src/pkg/mcp/PasClaw.MCP.Server.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Server.pas
@@ -356,60 +356,41 @@ begin
   end;
 end;
 
-function ExtractIdRaw(const Line: string): string;
-{ Walk the JSON-RPC request line and pull out the verbatim id value
-  -- a number ("42"), a quoted string ("\"req-1\""), or null. We need
-  the raw literal because numeric ids must echo back as numbers and
-  string ids as strings; round-tripping through GetInt / GetStr in
-  PasClaw.JSON would force a type choice. Returns 'null' when id is
-  missing, malformed, or explicitly null. Tolerant of whitespace and
-  works on a single-object request -- the only shape MCP allows. }
+function ExtractIdRaw(Obj: TJsonObject): string;
+{ Return the JSON literal for the request's id field so we can echo
+  it back unchanged -- a numeric id ("42") stays numeric, a string id
+  ("\"req-1\"") stays a string. Reads from the PARSED object rather
+  than the raw line, so an "id" key sitting inside a nested params
+  field can't confuse a substring scan. Returns 'null' for missing /
+  unparseable ids.
+
+  Detection trick: GetStr returns the supplied default when the field
+  exists but isn't a string -- so a sentinel default that can never
+  appear in valid JSON (a literal NUL+SOH+STX triplet -- control chars
+  must be escaped in JSON strings) lets us reliably distinguish
+  "string id" from "numeric id". }
+const
+  StringSentinel = #0#1#2;
 var
-  i, n, Start: Integer;
-  Marker, Body: string;
+  S: string;
+  I: Int64;
 begin
   Result := 'null';
-  Marker := '"id"';
-  n := Length(Line);
-  i := Pos(Marker, Line);
-  if i <= 0 then Exit;
-  i := i + Length(Marker);
-  while (i <= n) and ((Line[i] = ' ') or (Line[i] = #9)) do Inc(i);
-  if (i > n) or (Line[i] <> ':') then Exit;
-  Inc(i);
-  while (i <= n) and ((Line[i] = ' ') or (Line[i] = #9)) do Inc(i);
-  if i > n then Exit;
-  if Line[i] = '"' then
+  if (Obj = nil) or (not Obj.Has('id')) then Exit;
+  S := Obj.GetStr('id', StringSentinel);
+  if S <> StringSentinel then
   begin
-    { Quoted string id. Walk until the closing unescaped quote. }
-    Start := i;
-    Inc(i);
-    while i <= n do
-    begin
-      if (Line[i] = '\') and (i < n) then
-        Inc(i, 2)
-      else if Line[i] = '"' then
-      begin
-        Result := Copy(Line, Start, i - Start + 1);
-        Exit;
-      end
-      else
-        Inc(i);
-    end;
-    { Unterminated quoted id -- treat as null rather than risk
-      a malformed echo. }
+    Result := '"' + JsonEscape(S) + '"';
     Exit;
   end;
-  { Numeric or null literal: read until a delimiter. }
-  Start := i;
-  while (i <= n) and (not (Line[i] in [',', '}', ' ', #9, #10, #13])) do
-    Inc(i);
-  Body := Trim(Copy(Line, Start, i - Start));
-  if Body = '' then Exit;
-  if Body = 'null' then Exit;
-  { Anything else -- caller already validated this is JSON, so we
-    trust the literal as either an integer or a fraction. }
-  Result := Body;
+  { Not a string -- emit numeric form. GetInt's default is harmless
+    here because Has() already confirmed the field is present, so
+    the return value is the id itself (or 0 for an unusual null /
+    float id, which is the best we can do without round-tripping
+    floating-point literals -- the spec discourages float ids
+    anyway, hosts use ints or strings). }
+  I := Obj.GetInt('id', 0);
+  Result := IntToStr(I);
 end;
 
 function TMCPServerCore.HandleRequest(const ALine: string): string;
@@ -419,8 +400,6 @@ var
 begin
   Result := '';
   if Trim(ALine) = '' then Exit;
-
-  Id := ExtractIdRaw(ALine);
 
   Obj := nil;
   try
@@ -436,6 +415,7 @@ begin
   end;
   try
     Method := Obj.GetStr('method', '');
+    Id     := ExtractIdRaw(Obj);
     ParamsObj := Obj.ChildObject('params');
     Params := '';
     if ParamsObj <> nil then

--- a/src/pkg/mcp/PasClaw.MCP.Server.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Server.pas
@@ -1,0 +1,474 @@
+(*
+  PasClaw.MCP.Server - inbound MCP server core: dispatches JSON-RPC 2.0
+  requests against a curated read-only slice of the tool registry so
+  external runtimes (Claude Desktop, Cursor, Codex CLI, any MCP host)
+  can consume PasClaw's memory_search / kb_search / session_search /
+  SCARS live, against the SAME corpus the local CLI sees. Completes
+  the "source of truth" story the static export commands started.
+
+  This unit is TRANSPORT-AGNOSTIC: HandleRequest takes a single
+  JSON-RPC request line and returns the response line. The HTTP route
+  in PasClaw.Gateway.Server and the stdio loop in PasClaw.Cmd.MCP
+  both call into it -- one source of truth for the protocol, two
+  transports.
+
+  Tool surface (read-only by default):
+
+    - memory_search / memory_get / memory_fetch    : workspace/memory
+                                                     (incl. SCARS.md)
+    - kb_search / kb_get                           : knowledgebase corpus
+    - session_search                               : past sessions
+    - any other tcReadOnly tool registered in the parent registry
+
+  Operators who want write tools exposed pass AllowMutating := True at
+  Create. Off by default because letting a foreign MCP host call
+  fs_write / shell on the operator's box is exactly the bad outcome
+  the sandbox layer exists to prevent.
+
+  Implements just enough of the MCP spec for the read-corpus case:
+
+    - initialize                  -> serverInfo + capabilities
+    - notifications/initialized   -> ack (no response, void)
+    - ping                        -> {}
+    - tools/list                  -> tool descriptors
+    - tools/call                  -> dispatch via TToolRegistry
+
+  resources/* and prompts/* are not advertised; a future revision can
+  fold skills in as MCP prompts (a better fit than as tools, since a
+  skill on its own without the parent LLM isn't directly callable).
+*)
+unit PasClaw.MCP.Server;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+const
+  MCPServerProtocolVersion = '2024-11-05';
+  MCPServerName            = 'pasclaw';
+
+type
+  TMCPServerCore = class
+  private
+    FRegistry:      TToolRegistry;
+    FAllowMutating: Boolean;
+    FAllowList:     array of string;  { empty = "all tcReadOnly tools" }
+    FVersion:       string;
+    function IsExposed(const Name: string): Boolean;
+    function HandleInitialize(const Params, Id: string): string;
+    function HandleToolsList(const Id: string): string;
+    function HandleToolsCall(const Params, Id: string): string;
+    function HandlePing(const Id: string): string;
+    function ErrorResponse(const Id: string; Code: Integer;
+                            const Message: string): string;
+    function SuccessResponse(const Id, ResultJSON: string): string;
+  public
+    constructor Create(ARegistry: TToolRegistry; AAllowMutating: Boolean;
+                       const AVersion: string);
+    destructor Destroy; override;
+
+    { Restrict exposure to a specific name list (in addition to the
+      mutating gate). Empty array = "no name filter, expose whatever
+      passes the mutating gate". Set this when the operator wants to
+      narrow the MCP surface to e.g. just memory_search + kb_search. }
+    procedure SetAllowList(const Names: array of string);
+
+    { HandleRequest:
+        ALine -- one JSON-RPC request line (newline-stripped).
+        Returns the response line ('' for notifications which by spec
+        get no response).
+      Idempotent + thread-safe (TToolRegistry handles its own locking).
+      Never raises; all errors land as JSON-RPC error responses. }
+    function HandleRequest(const ALine: string): string;
+
+    property AllowMutating: Boolean read FAllowMutating;
+  end;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger;
+
+constructor TMCPServerCore.Create(ARegistry: TToolRegistry;
+                                   AAllowMutating: Boolean;
+                                   const AVersion: string);
+begin
+  inherited Create;
+  FRegistry      := ARegistry;
+  FAllowMutating := AAllowMutating;
+  FVersion       := AVersion;
+  if FVersion = '' then FVersion := '0.1';
+  SetLength(FAllowList, 0);
+end;
+
+destructor TMCPServerCore.Destroy;
+begin
+  { Registry is owned by the caller -- the gateway / cmd hands us a
+    reference, lifetime tracks the gateway server itself. }
+  inherited Destroy;
+end;
+
+procedure TMCPServerCore.SetAllowList(const Names: array of string);
+var
+  i: Integer;
+begin
+  SetLength(FAllowList, Length(Names));
+  for i := 0 to High(Names) do FAllowList[i] := Names[i];
+end;
+
+function TMCPServerCore.IsExposed(const Name: string): Boolean;
+var
+  T: TTool;
+  i: Integer;
+begin
+  Result := False;
+  if FRegistry = nil then Exit;
+  if not FRegistry.Find(Name, T) then Exit;
+  if (not FAllowMutating) and (T.Category <> tcReadOnly) then Exit;
+  if Length(FAllowList) > 0 then
+  begin
+    Result := False;
+    for i := 0 to High(FAllowList) do
+      if FAllowList[i] = Name then Exit(True);
+  end
+  else
+    Result := True;
+end;
+
+function TMCPServerCore.ErrorResponse(const Id: string; Code: Integer;
+                                       const Message: string): string;
+var
+  Root, Err: TJsonObject;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('jsonrpc', '2.0');
+    { Id may be either a string or a number on the wire. We preserve
+      what the client sent verbatim by emitting via PutRaw when the
+      input looks numeric (no quotes / no "null"), otherwise as
+      string. Empty = notification id (no response expected, but
+      callers may still ask for one for trace symmetry). }
+    if (Id = '') or (Id = 'null') then
+      { Spec: error responses MUST carry id=null when the request id
+        couldn't be determined. }
+      Root.PutRaw('id', 'null')
+    else
+      Root.PutRaw('id', Id);
+    Err := TJsonObject.Create;
+    Err.PutInt('code',    Code);
+    Err.PutStr('message', Message);
+    Root.PutObject('error', Err);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TMCPServerCore.SuccessResponse(const Id, ResultJSON: string): string;
+var
+  Root: TJsonObject;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('jsonrpc', '2.0');
+    if (Id = '') or (Id = 'null') then
+      Root.PutRaw('id', 'null')
+    else
+      Root.PutRaw('id', Id);
+    Root.PutRaw('result', ResultJSON);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TMCPServerCore.HandleInitialize(const Params, Id: string): string;
+var
+  ResObj, Caps, ToolsCap, ServerInfo: TJsonObject;
+begin
+  { Params currently ignored. A future revision can negotiate
+    protocolVersion / capabilities; for v1 we advertise the fixed
+    tool surface. }
+  if Params <> '' then ;  { silence unused-param hint on Delphi }
+
+  ResObj := TJsonObject.Create;
+  try
+    ResObj.PutStr('protocolVersion', MCPServerProtocolVersion);
+    Caps := TJsonObject.Create;
+    ToolsCap := TJsonObject.Create;
+    { listChanged: false -- we don't push notifications when the
+      registry updates. Skill loaders fire at startup before we
+      announce, so the list is stable for the session. }
+    ToolsCap.PutBool('listChanged', False);
+    Caps.PutObject('tools', ToolsCap);
+    ResObj.PutObject('capabilities', Caps);
+    ServerInfo := TJsonObject.Create;
+    ServerInfo.PutStr('name',    MCPServerName);
+    ServerInfo.PutStr('version', FVersion);
+    ResObj.PutObject('serverInfo', ServerInfo);
+    Result := SuccessResponse(Id, ResObj.ToJSON);
+  finally
+    ResObj.Free;
+  end;
+end;
+
+function TMCPServerCore.HandleToolsList(const Id: string): string;
+var
+  ResObj, ToolObj: TJsonObject;
+  Arr: TJsonArray;
+  Names: TStringArray;
+  i: Integer;
+  T: TTool;
+begin
+  ResObj := TJsonObject.Create;
+  try
+    Arr := TJsonArray.Create;
+    if FRegistry <> nil then
+    begin
+      Names := FRegistry.Names;
+      for i := 0 to High(Names) do
+      begin
+        if not IsExposed(Names[i]) then Continue;
+        if not FRegistry.Find(Names[i], T) then Continue;
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('name',        T.Name);
+        ToolObj.PutStr('description', T.Description);
+        { Schema is already a JSON object (string form). PutRaw keeps
+          the nested shape intact -- PutStr would double-quote it. }
+        if Trim(T.Schema) <> '' then
+          ToolObj.PutRaw('inputSchema', T.Schema)
+        else
+          ToolObj.PutRaw('inputSchema', '{"type":"object"}');
+        Arr.AddObject(ToolObj);
+      end;
+    end;
+    ResObj.PutArray('tools', Arr);
+    Result := SuccessResponse(Id, ResObj.ToJSON);
+  finally
+    ResObj.Free;
+  end;
+end;
+
+function TMCPServerCore.HandleToolsCall(const Params, Id: string): string;
+var
+  ParamsObj, ArgsObj, ResObj, ContentObj: TJsonObject;
+  Arr: TJsonArray;
+  ToolName, ArgsJSON, Output, Err: string;
+begin
+  ToolName := '';
+  ArgsJSON := '{}';
+
+  ParamsObj := TJsonObject.Parse(Params);
+  if ParamsObj = nil then
+  begin
+    Result := ErrorResponse(Id, -32602, 'invalid tools/call params');
+    Exit;
+  end;
+  try
+    ToolName := ParamsObj.GetStr('name', '');
+    ArgsObj  := ParamsObj.ChildObject('arguments');
+    if ArgsObj <> nil then
+    try
+      ArgsJSON := ArgsObj.ToJSON;
+    finally
+      ArgsObj.Free;
+    end;
+  finally
+    ParamsObj.Free;
+  end;
+
+  if ToolName = '' then
+  begin
+    Result := ErrorResponse(Id, -32602, 'tools/call requires "name"');
+    Exit;
+  end;
+  if not IsExposed(ToolName) then
+  begin
+    { -32601 is JSON-RPC "method not found"; MCP overloads it as
+      "tool not exposed" since the wire shape is the same. }
+    Result := ErrorResponse(Id, -32601,
+                             'tool not exposed: ' + ToolName);
+    Exit;
+  end;
+
+  LogDebug('mcp-server: tools/call name=%s args=%s',
+           [ToolName, Copy(ArgsJSON, 1, 200)]);
+  Output := FRegistry.RunTool(ToolName, ArgsJSON, Err);
+  if Err <> '' then
+  begin
+    { Surface the tool error inside an isError result content block
+      (per MCP) rather than a JSON-RPC error -- the spec distinguishes
+      transport errors (JSON-RPC) from tool errors (isError content).
+      Hosts render isError=true with a different glyph but keep the
+      session alive, which is what we want for "memory index temporarily
+      offline" style failures. }
+    ResObj := TJsonObject.Create;
+    try
+      Arr := TJsonArray.Create;
+      ContentObj := TJsonObject.Create;
+      ContentObj.PutStr('type', 'text');
+      ContentObj.PutStr('text', '[error] ' + Err);
+      Arr.AddObject(ContentObj);
+      ResObj.PutArray('content', Arr);
+      ResObj.PutBool('isError', True);
+      Result := SuccessResponse(Id, ResObj.ToJSON);
+    finally
+      ResObj.Free;
+    end;
+    Exit;
+  end;
+
+  ResObj := TJsonObject.Create;
+  try
+    Arr := TJsonArray.Create;
+    ContentObj := TJsonObject.Create;
+    ContentObj.PutStr('type', 'text');
+    ContentObj.PutStr('text', Output);
+    Arr.AddObject(ContentObj);
+    ResObj.PutArray('content', Arr);
+    Result := SuccessResponse(Id, ResObj.ToJSON);
+  finally
+    ResObj.Free;
+  end;
+end;
+
+function TMCPServerCore.HandlePing(const Id: string): string;
+var
+  Empty: TJsonObject;
+begin
+  Empty := TJsonObject.Create;
+  try
+    Result := SuccessResponse(Id, Empty.ToJSON);
+  finally
+    Empty.Free;
+  end;
+end;
+
+function ExtractIdRaw(const Line: string): string;
+{ Walk the JSON-RPC request line and pull out the verbatim id value
+  -- a number ("42"), a quoted string ("\"req-1\""), or null. We need
+  the raw literal because numeric ids must echo back as numbers and
+  string ids as strings; round-tripping through GetInt / GetStr in
+  PasClaw.JSON would force a type choice. Returns 'null' when id is
+  missing, malformed, or explicitly null. Tolerant of whitespace and
+  works on a single-object request -- the only shape MCP allows. }
+var
+  i, n, Start: Integer;
+  Marker, Body: string;
+begin
+  Result := 'null';
+  Marker := '"id"';
+  n := Length(Line);
+  i := Pos(Marker, Line);
+  if i <= 0 then Exit;
+  i := i + Length(Marker);
+  while (i <= n) and ((Line[i] = ' ') or (Line[i] = #9)) do Inc(i);
+  if (i > n) or (Line[i] <> ':') then Exit;
+  Inc(i);
+  while (i <= n) and ((Line[i] = ' ') or (Line[i] = #9)) do Inc(i);
+  if i > n then Exit;
+  if Line[i] = '"' then
+  begin
+    { Quoted string id. Walk until the closing unescaped quote. }
+    Start := i;
+    Inc(i);
+    while i <= n do
+    begin
+      if (Line[i] = '\') and (i < n) then
+        Inc(i, 2)
+      else if Line[i] = '"' then
+      begin
+        Result := Copy(Line, Start, i - Start + 1);
+        Exit;
+      end
+      else
+        Inc(i);
+    end;
+    { Unterminated quoted id -- treat as null rather than risk
+      a malformed echo. }
+    Exit;
+  end;
+  { Numeric or null literal: read until a delimiter. }
+  Start := i;
+  while (i <= n) and (not (Line[i] in [',', '}', ' ', #9, #10, #13])) do
+    Inc(i);
+  Body := Trim(Copy(Line, Start, i - Start));
+  if Body = '' then Exit;
+  if Body = 'null' then Exit;
+  { Anything else -- caller already validated this is JSON, so we
+    trust the literal as either an integer or a fraction. }
+  Result := Body;
+end;
+
+function TMCPServerCore.HandleRequest(const ALine: string): string;
+var
+  Obj, ParamsObj: TJsonObject;
+  Method, Id, Params: string;
+begin
+  Result := '';
+  if Trim(ALine) = '' then Exit;
+
+  Id := ExtractIdRaw(ALine);
+
+  Obj := nil;
+  try
+    Obj := TJsonObject.Parse(ALine);
+  except
+    Result := ErrorResponse('null', -32700, 'parse error');
+    Exit;
+  end;
+  if Obj = nil then
+  begin
+    Result := ErrorResponse('null', -32700, 'parse error');
+    Exit;
+  end;
+  try
+    Method := Obj.GetStr('method', '');
+    ParamsObj := Obj.ChildObject('params');
+    Params := '';
+    if ParamsObj <> nil then
+    try
+      Params := ParamsObj.ToJSON;
+    finally
+      ParamsObj.Free;
+    end;
+  finally
+    Obj.Free;
+  end;
+
+  if Method = '' then
+  begin
+    Result := ErrorResponse(Id, -32600, 'invalid request: missing "method"');
+    Exit;
+  end;
+
+  { Notifications: methods that start with "notifications/" carry no
+    id, expect no response. Silence is the correct reply. }
+  if (Id = 'null') and (Copy(Method, 1, Length('notifications/')) = 'notifications/') then
+  begin
+    LogDebug('mcp-server: notification %s', [Method]);
+    Result := '';
+    Exit;
+  end;
+
+  if      Method = 'initialize'  then Result := HandleInitialize(Params, Id)
+  else if Method = 'tools/list'  then Result := HandleToolsList(Id)
+  else if Method = 'tools/call'  then Result := HandleToolsCall(Params, Id)
+  else if Method = 'ping'        then Result := HandlePing(Id)
+  else
+    Result := ErrorResponse(Id, -32601, 'method not found: ' + Method);
+end;
+
+end.

--- a/src/tests/mcp_server_tests.pas
+++ b/src/tests/mcp_server_tests.pas
@@ -1,0 +1,479 @@
+program mcp_server_tests;
+(*
+  Covers PasClaw.MCP.Server -- the inbound MCP server core that exposes
+  a curated read-only slice of the tool registry as MCP tools, so
+  external runtimes (Claude Desktop, Cursor, Codex CLI, any MCP host)
+  consume PasClaw's memory_search / kb_search / session_search live.
+
+  Strategy: build a TToolRegistry with two synthetic tools (one
+  tcReadOnly, one tcMutating), feed JSON-RPC request lines through
+  TMCPServerCore.HandleRequest, parse the response, assert shape +
+  values. No network, no real MCP host.
+
+  Pins contracts the protocol surface needs:
+    - initialize round-trip carries serverInfo + tools capability
+    - notifications/initialized produces no response (notification)
+    - tools/list filters out tcMutating by default
+    - tools/list includes tcMutating when AllowMutating=true
+    - tools/call dispatches into the registry and returns the result
+      in the MCP "content[]" shape
+    - tools/call against a mutating tool with AllowMutating=false
+      returns method-not-found (tool not exposed)
+    - tools/call against an unknown name returns method-not-found
+    - tool failures land as isError=true with content (not a
+      JSON-RPC error), so hosts keep the session alive
+    - unknown methods return -32601 method-not-found
+    - malformed JSON returns -32700 parse error with id=null
+    - explicit SetAllowList narrows the surface further
+    - request id type round-trips: numeric in -> numeric out,
+      string in -> string out, missing -> null in error responses
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  PasClaw.JSON,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.MCP.Server;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Copy(Got, 1, 200) + '", want "' +
+          Copy(Want, 1, 200) + '")');
+end;
+
+function StripSpaces(const S: string): string;
+var
+  i, k: Integer;
+begin
+  SetLength(Result, Length(S));
+  k := 0;
+  for i := 1 to Length(S) do
+    if S[i] <> ' ' then
+    begin
+      Inc(k);
+      Result[k] := S[i];
+    end;
+  SetLength(Result, k);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  { Strip ASCII spaces from both sides so tests aren't tied to the
+    JSON serialiser's choice of whitespace ("a" : 1 vs "a":1). }
+  if Pos(StripSpaces(Needle), StripSpaces(Haystack)) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' +
+          Copy(Haystack, 1, 300) + '")');
+end;
+
+procedure AssertNotContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(StripSpaces(Needle), StripSpaces(Haystack)) > 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" was present in "' +
+          Copy(Haystack, 1, 300) + '")');
+end;
+
+function MemoryHandler(const ArgsJSON: string; out ErrMsg: string): string;
+{ Fake memory_search: echoes back the q field so we can verify the
+  registry got the right arguments. }
+var
+  Obj: TJsonObject;
+  Q: string;
+begin
+  ErrMsg := '';
+  Q := '';
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj <> nil then
+  try
+    Q := Obj.GetStr('q', '');
+  finally
+    Obj.Free;
+  end;
+  Result := 'mem-result for q=' + Q;
+end;
+
+function FailingHandler(const ArgsJSON: string; out ErrMsg: string): string;
+begin
+  Result  := '';
+  ErrMsg  := 'simulated tool failure';
+  if ArgsJSON = '' then ;
+end;
+
+function ShellHandler(const ArgsJSON: string; out ErrMsg: string): string;
+{ Fake mutating tool to verify the gate skips it by default. }
+begin
+  ErrMsg := '';
+  Result := 'shell-result';
+  if ArgsJSON = '' then ;
+end;
+
+procedure RegisterFakeTools(Reg: TToolRegistry);
+var
+  T: TTool;
+begin
+  T := Default(TTool);
+  T.Name        := 'memory_search';
+  T.Description := 'search workspace memory';
+  T.Schema      := '{"type":"object","properties":{"q":{"type":"string"}}}';
+  T.Category    := tcReadOnly;
+  T.Handler     := MemoryHandler;
+  Reg.Register(T);
+
+  T := Default(TTool);
+  T.Name        := 'session_search';
+  T.Description := 'search past sessions';
+  T.Schema      := '{"type":"object"}';
+  T.Category    := tcReadOnly;
+  T.Handler     := MemoryHandler;
+  Reg.Register(T);
+
+  T := Default(TTool);
+  T.Name        := 'shell';
+  T.Description := 'run a shell command';
+  T.Schema      := '{"type":"object"}';
+  T.Category    := tcMutating;
+  T.Handler     := ShellHandler;
+  Reg.Register(T);
+
+  T := Default(TTool);
+  T.Name        := 'broken_search';
+  T.Description := 'always fails';
+  T.Schema      := '{"type":"object"}';
+  T.Category    := tcReadOnly;
+  T.Handler     := FailingHandler;
+  Reg.Register(T);
+end;
+
+procedure TestInitializeRoundTrip;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Req, Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '1.2.3');
+    try
+      Req := '{"jsonrpc":"2.0","id":1,"method":"initialize",' +
+             '"params":{"protocolVersion":"2024-11-05",' +
+             '"capabilities":{},"clientInfo":{"name":"t","version":"0"}}}';
+      Resp := Srv.HandleRequest(Req);
+      AssertContains(Resp, '"id":1', 'numeric id echoed as number');
+      AssertContains(Resp, 'serverInfo',     'serverInfo present');
+      AssertContains(Resp, '"name":"pasclaw"', 'server name = pasclaw');
+      AssertContains(Resp, '"version":"1.2.3"', 'server version surfaced');
+      AssertContains(Resp, 'protocolVersion', 'protocolVersion in result');
+      AssertContains(Resp, '"tools":{',      'tools capability advertised');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestInitializedNotificationHasNoResponse;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","method":"notifications/initialized"}');
+      AssertEqStr(Resp, '', 'notification produces empty response');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestToolsListFiltersMutating;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list"}');
+      AssertContains(Resp, '"name":"memory_search"', 'memory_search exposed');
+      AssertContains(Resp, '"name":"session_search"', 'session_search exposed');
+      AssertContains(Resp, '"name":"broken_search"',  'broken_search exposed');
+      AssertNotContains(Resp, '"name":"shell"',
+                        'mutating shell tool filtered out by default');
+      AssertContains(Resp, '"inputSchema"', 'inputSchema present');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestToolsListWithMutatingAllowed;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, True, '');  { allow mutating }
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list"}');
+      AssertContains(Resp, '"name":"shell"',
+                      'shell tool exposed when allow_mutating');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestToolsCallHappyPath;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":3,"method":"tools/call",' +
+        '"params":{"name":"memory_search","arguments":{"q":"SCARS"}}}');
+      AssertContains(Resp, '"id":3',         'id echoed');
+      AssertContains(Resp, '"content"',      'MCP content[] shape');
+      AssertContains(Resp, '"type":"text"',  'content type = text');
+      AssertContains(Resp, 'mem-result for q=SCARS',
+                      'tool output reached MCP response');
+      AssertNotContains(Resp, '"isError":true', 'no isError on happy path');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestToolsCallToolErrorLandsAsIsError;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":4,"method":"tools/call",' +
+        '"params":{"name":"broken_search","arguments":{}}}');
+      AssertContains(Resp, '"isError":true',
+                      'tool failures land as isError=true');
+      AssertContains(Resp, 'simulated tool failure',
+                      'error text surfaced as content');
+      AssertNotContains(Resp, '"error":', 'no JSON-RPC error wrapper');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestToolsCallMutatingGateBlocks;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":5,"method":"tools/call",' +
+        '"params":{"name":"shell","arguments":{}}}');
+      AssertContains(Resp, '"error"',          'JSON-RPC error returned');
+      AssertContains(Resp, '"code":-32601',    'method-not-found code');
+      AssertContains(Resp, 'tool not exposed', 'message identifies the gate');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestToolsCallUnknownToolErrors;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":6,"method":"tools/call",' +
+        '"params":{"name":"no_such_tool","arguments":{}}}');
+      AssertContains(Resp, '"code":-32601',
+                      'unknown tool -> method-not-found');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestUnknownMethodErrors;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":"r1","method":"resources/list"}');
+      AssertContains(Resp, '"code":-32601',
+                      'unimplemented method -> method-not-found');
+      AssertContains(Resp, '"id":"r1"', 'string id round-trips');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestParseErrorReturnsNullId;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest('{not json}');
+      AssertContains(Resp, '"code":-32700', 'parse-error code');
+      AssertContains(Resp, '"id":null',     'id=null on parse error');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestAllowListNarrowsSurface;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+  Only: array of string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      SetLength(Only, 1);
+      Only[0] := 'memory_search';
+      Srv.SetAllowList(Only);
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":7,"method":"tools/list"}');
+      AssertContains(Resp,    '"name":"memory_search"', 'allowlist keeps memory_search');
+      AssertNotContains(Resp, '"name":"session_search"',
+                        'allowlist drops session_search');
+      AssertNotContains(Resp, '"name":"broken_search"',
+                        'allowlist drops broken_search');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestPingRoundTrip;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":8,"method":"ping"}');
+      AssertContains(Resp, '"id":8',   'numeric id echoed');
+      AssertContains(Resp, '"result"', 'ping returns a result');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
+begin
+  TestInitializeRoundTrip;                  WriteLn('  ok: initialize');
+  TestInitializedNotificationHasNoResponse; WriteLn('  ok: initialized notification (no response)');
+  TestToolsListFiltersMutating;             WriteLn('  ok: tools/list filters mutating');
+  TestToolsListWithMutatingAllowed;         WriteLn('  ok: tools/list with mutating allowed');
+  TestToolsCallHappyPath;                   WriteLn('  ok: tools/call happy path');
+  TestToolsCallToolErrorLandsAsIsError;     WriteLn('  ok: tools/call tool-error -> isError');
+  TestToolsCallMutatingGateBlocks;          WriteLn('  ok: tools/call mutating gate blocks');
+  TestToolsCallUnknownToolErrors;           WriteLn('  ok: tools/call unknown tool errors');
+  TestUnknownMethodErrors;                  WriteLn('  ok: unknown method errors');
+  TestParseErrorReturnsNullId;              WriteLn('  ok: parse error returns id=null');
+  TestAllowListNarrowsSurface;              WriteLn('  ok: allowlist narrows surface');
+  TestPingRoundTrip;                        WriteLn('  ok: ping round-trip');
+  WriteLn('PASS');
+end.

--- a/src/tests/mcp_server_tests.pas
+++ b/src/tests/mcp_server_tests.pas
@@ -441,6 +441,35 @@ begin
   end;
 end;
 
+procedure TestIdNestedInParamsDoesNotConfuseEcho;
+(* Defends the id extraction against ids buried inside params -- the
+   outer id is what gets echoed back, regardless of any "id"-named
+   fields in the nested argument blob. With the old string-scanner
+   implementation a request with params arriving BEFORE the outer
+   id could echo back the inner id (Pos hit it first). The
+   parsed-object lookup picks the top-level "id" unambiguously. *)
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","params":{"id":"inner"},"id":99,"method":"ping"}');
+      AssertContains(Resp, '"id":99', 'outer numeric id wins over nested string id');
+      AssertNotContains(Resp, '"id":"inner"',
+                        'nested id never leaks into the echo');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
 procedure TestPingRoundTrip;
 var
   Reg: TToolRegistry;
@@ -474,6 +503,7 @@ begin
   TestUnknownMethodErrors;                  WriteLn('  ok: unknown method errors');
   TestParseErrorReturnsNullId;              WriteLn('  ok: parse error returns id=null');
   TestAllowListNarrowsSurface;              WriteLn('  ok: allowlist narrows surface');
+  TestIdNestedInParamsDoesNotConfuseEcho;   WriteLn('  ok: id-in-params does not leak into echo');
   TestPingRoundTrip;                        WriteLn('  ok: ping round-trip');
   WriteLn('PASS');
 end.


### PR DESCRIPTION
## Summary

External MCP runtimes (Claude Desktop, Cursor, Codex CLI, anything that speaks MCP) can now consume PasClaw's `memory_search`, `kb_search`, `session_search`, and SCARS (workspace/memory/SCARS.md is reachable through `memory_search`) live against the **same corpus** the local CLI sees. Completes the source-of-truth story the static export commands started — no more drifting copies for "atlas" / "hermes"-style consumers.

## Three transport surfaces, one core

- **`POST /mcp` on the existing gateway listener** — alongside `/v1/*` on the same port, no extra daemon. Uses the MCP Streamable HTTP transport's plain-JSON response shape.
- **Dedicated `--mcp-port`** — `pasclaw serve --mcp-port 8089` (and `pasclaw gateway --mcp-port 8089`) spins up a second `TGatewayServer` in MCP-only mode, so a heavy `/v1/responses` streaming load can't compete with MCP requests for Indy worker threads. Both listeners share one `TToolRegistry` — same answers.
- **`pasclaw mcp stdio`** — newline-delimited JSON-RPC on stdin/stdout for hosts (Claude Desktop config, Cursor, Codex CLI) that spawn MCP servers as subprocesses. Banner is suppressed on stdio so JSON-RPC parsers never see a stray UTF-8 box-drawing character.

## Safety posture

- **Read-only by default.** `TMCPServerCore` filters to `tcReadOnly` tools (`memory_search` / `memory_get` / `kb_search` / `kb_get` / `session_search`). A foreign MCP host calling `fs_write` or `shell` on the operator's box is exactly the bad outcome sandbox exists for.
- **`--mcp-allow-write`** opts in to mutating tools when the operator actually wants the full surface.
- **Per-name allowlist** (`SetMCPAllowList`) lets callers narrow exposure further.
- **Tool failures → MCP `isError`** content blocks (not transport errors), so hosts keep the session alive when e.g. the memory index goes temporarily offline.

## MCP protocol surface implemented

`initialize` · `notifications/initialized` · `ping` · `tools/list` · `tools/call`.

`resources/*` and `prompts/*` are deliberately unimplemented in v1; a future revision can map skills to MCP prompts (a better semantic fit than as tools, since a skill on its own without the parent LLM isn't directly callable).

## Files

- **New**: `src/pkg/mcp/PasClaw.MCP.Server.pas` (transport-agnostic core, ~370 lines)
- **New**: `src/tests/mcp_server_tests.pas` (12 cases covering protocol shapes + mutating gate + allowlist + id type round-trip + parse error + isError + ping)
- **Wired**: `src/pkg/gateway/PasClaw.Gateway.Server.pas` (route + MCP-only mode + per-instance policy)
- **Wired**: `src/cmd/PasClaw.Cmd.Serve.pas` + `src/cmd/PasClaw.Cmd.Gateway.pas` (CLI flags + dual-listener spawn)
- **Wired**: `src/cmd/PasClaw.Cmd.MCP.pas` (new `stdio` subverb)
- `src/pasclaw/PasClaw.dpr` (suppress banner under `mcp stdio`)
- `src/pasclaw/PasClaw.dproj` (DCCReference for new unit)
- `Makefile` (new `test-mcp-server` target, added to umbrella `test`)

## Test plan

- [x] `make test` — full suite green incl. new `test-mcp-server`
- [x] Live HTTP probe: `pasclaw serve --port 18099` then `curl POST /mcp` for `initialize` / `tools/list` / `tools/call fs_write` (blocked) / `/v1/health` (still works alongside)
- [x] Stdio: `printf '%s\n' '{...initialize...}' '{...tools/list...}' | pasclaw mcp stdio` returns two clean JSON-RPC responses (no banner)
- [ ] Delphi dcc64 build — needs your local toolchain

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_