### PR TITLE
mcp: accept sse / streamable-http / stdio hub transports (was HTTP-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,16 @@ test-mcp-server: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/mcp_server_tests.pas -o$(BUILDDIR)/mcp_server_tests
 	@$(BUILDDIR)/mcp_server_tests
 
+# MCP hub projection: transport routing for pasclaw.dev catalog entries
+# (http / sse / streamable-http / stdio). Pure JSON-in / record-out;
+# no network. Pins the regression that "10 entries skipped -- non-HTTP
+# transports not supported yet" actually meant "SSE-tagged HTTP
+# endpoints our client already speaks were being dropped".
+test-mcp-hub-projection: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/mcp_hub_projection_tests.pas -o$(BUILDDIR)/mcp_hub_projection_tests
+	@$(BUILDDIR)/mcp_hub_projection_tests
+
 test-session-search: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/session_search_tests.pas -o$(BUILDDIR)/session_search_tests
@@ -406,4 +416,4 @@ test-kb-index: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/kb_index_tests.pas -o$(BUILDDIR)/kb_index_tests
 	@$(BUILDDIR)/kb_index_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-kb-index
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-kb-index

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -221,6 +221,20 @@ begin
   Result := 0;
 end;
 
+function TransportLabel(const Entry: TMCPCatalogEntry): string;
+{ Short tag for the catalog display. The bundled KnownMCPServers
+  list leaves Transport empty (HTTP-only by convention); treat that
+  as 'http' so the column never looks blank. Hub entries carry the
+  literal transport string verbatim so a hub-marked 'sse' row shows
+  up as sse -- helpful when debugging the rare older-spec server
+  that doesn't quite speak Streamable HTTP. }
+begin
+  if Entry.Transport = '' then
+    Result := 'http'
+  else
+    Result := LowerCase(Entry.Transport);
+end;
+
 function DoCatalog: Integer;
 var
   Entries: TMCPCatalogEntryArray;
@@ -246,7 +260,7 @@ begin
     PrintLn(Ansi.Dim + '(showing built-in ' + IntToStr(Length(Entries)) + ' entries)' + Ansi.Reset);
   if Skipped > 0 then
     PrintLn(Ansi.Dim + '  (' + IntToStr(Skipped) +
-            ' hub entry/entries skipped -- non-HTTP transports not supported yet)' +
+            ' hub entry/entries skipped -- unsupported transport)' +
             Ansi.Reset);
   PrintLn;
   if Length(Entries) = 0 then
@@ -254,13 +268,16 @@ begin
     PrintLn('(catalog empty)');
     Exit(0);
   end;
-  PrintLn(Ansi.Bold + 'name' + Ansi.Reset + '                       env var               status');
+  PrintLn(Ansi.Bold + 'name' + Ansi.Reset +
+          '                       transport   env var          status');
   for i := 0 to High(Entries) do
   begin
     if Entries[i].EnvVar = '' then Auth := '(no auth)'
     else if GetEnvironmentVariable(Entries[i].EnvVar) <> '' then Auth := Ansi.Green + 'set' + Ansi.Reset
     else Auth := Ansi.Yellow + 'unset' + Ansi.Reset;
-    PrintLn(Format('%24s   %18s   %s', [Entries[i].Name, Entries[i].EnvVar, Auth]));
+    PrintLn(Format('%24s   %-9s   %-15s  %s',
+                    [Entries[i].Name, TransportLabel(Entries[i]),
+                     Entries[i].EnvVar, Auth]));
     if Entries[i].Desc <> '' then
       PrintLn('                            ' + Ansi.Dim + Entries[i].Desc + Ansi.Reset);
   end;
@@ -335,12 +352,28 @@ begin
   else
     PrintLn(Ansi.Dim + '  resolved from pasclaw.dev hub' + Ansi.Reset);
 
-  { OAuth-only servers (Replicate today) install with no header -- the
-    HTTP client reads the on-disk token store at request time. Prompt
-    the user to run `mcp auth` so the next test/serve has a token. }
-  if Entry.RequiresOAuth then
+  HeaderVal := '';
+  if CatalogEntryIsStdio(Entry) then
   begin
-    HeaderVal := '';
+    { stdio binaries inherit the spawning shell's environment; if the
+      hub flagged a required env var, surface it so the operator
+      knows to set it before `pasclaw mcp test` / `serve` /
+      `gateway`. No Authorization header juggling -- the binary
+      handles auth internally. }
+    if (Entry.EnvVar <> '') and (GetEnvironmentVariable(Entry.EnvVar) = '') then
+    begin
+      PrintLn(Ansi.Yellow + '! ' + Ansi.Reset + 'env var ' + Entry.EnvVar +
+              ' is not set. Installing anyway; the stdio server may');
+      PrintLn('  reject requests until you ' +
+              Ansi.Bold + 'export ' + Entry.EnvVar + '=...' + Ansi.Reset +
+              ' and re-spawn pasclaw.');
+    end;
+  end
+  else if Entry.RequiresOAuth then
+  begin
+    { OAuth-only servers (Replicate today) install with no header -- the
+      HTTP client reads the on-disk token store at request time. Prompt
+      the user to run `mcp auth` so the next test/serve has a token. }
     if HasStoredTokens(Entry.Name) then
       PrintLn(Ansi.Dim + '  using existing OAuth tokens at ' +
               OAuthTokenPath(Entry.Name) + Ansi.Reset)
@@ -369,12 +402,24 @@ begin
   try
     { Replace any prior install of this catalog entry rather than
       creating a duplicate (idempotent refresh after the user sets
-      the env var). }
+      the env var). For stdio entries Cmd holds the executable and
+      Args holds the joined argv tail; for HTTP / SSE / Streamable
+      HTTP entries Cmd holds the URL and Args holds the Authorization
+      header value. The ://-vs-not heuristic in PasClaw.MCP.Bridge.
+      IsHttpUrl picks the right client at spawn time. }
     for i := 0 to High(Cfg.MCPServers) do
       if SameText(Cfg.MCPServers[i].Name, Entry.Name) then
       begin
-        Cfg.MCPServers[i].Cmd     := Entry.URL;
-        Cfg.MCPServers[i].Args    := HeaderVal;
+        if CatalogEntryIsStdio(Entry) then
+        begin
+          Cfg.MCPServers[i].Cmd  := Entry.Cmd;
+          Cfg.MCPServers[i].Args := Entry.CmdArgs;
+        end
+        else
+        begin
+          Cfg.MCPServers[i].Cmd  := Entry.URL;
+          Cfg.MCPServers[i].Args := HeaderVal;
+        end;
         Cfg.MCPServers[i].Enabled := True;
         SaveConfig(Cfg);
         PrintLn(Ansi.Green + '✓ ' + Ansi.Reset + 'updated MCP server ' + Entry.Name);
@@ -383,9 +428,17 @@ begin
 
     n := Length(Cfg.MCPServers);
     SetLength(Cfg.MCPServers, n + 1);
-    Cfg.MCPServers[n].Name    := Entry.Name;
-    Cfg.MCPServers[n].Cmd     := Entry.URL;
-    Cfg.MCPServers[n].Args    := HeaderVal;
+    Cfg.MCPServers[n].Name := Entry.Name;
+    if CatalogEntryIsStdio(Entry) then
+    begin
+      Cfg.MCPServers[n].Cmd  := Entry.Cmd;
+      Cfg.MCPServers[n].Args := Entry.CmdArgs;
+    end
+    else
+    begin
+      Cfg.MCPServers[n].Cmd  := Entry.URL;
+      Cfg.MCPServers[n].Args := HeaderVal;
+    end;
     Cfg.MCPServers[n].Enabled := True;
     SaveConfig(Cfg);
     PrintLn(Ansi.Green + '✓ ' + Ansi.Reset + 'installed MCP server ' + Entry.Name);

--- a/src/pkg/mcp/PasClaw.MCP.Catalog.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Catalog.pas
@@ -45,25 +45,50 @@ interface
 type
   TMCPCatalogEntry = record
     Name:          string; { kebab-case identifier; what the user types }
-    URL:           string; { remote MCP endpoint (http:// or https://) }
-    EnvVar:        string; { env var holding the bearer token; '' if no auth
-                             and '' for OAuth servers -- see RequiresOAuth }
+    { Transport: '' / 'http' (default) -- the URL field carries the
+      remote endpoint. 'stdio' -- the Cmd + CmdArgs fields carry an
+      executable to spawn. Catalog entries from pasclaw.dev are the
+      common source of stdio rows; the bundled KnownMCPServers list
+      stays HTTP-only. }
+    Transport:     string;
+    URL:           string; { remote MCP endpoint (http:// or https://);
+                             empty for stdio entries }
+    Cmd:           string; { stdio: executable name (e.g. "npx",
+                             "uvx", "docker"). Empty for HTTP. }
+    CmdArgs:       string; { stdio: command-line args joined with
+                             spaces ("-y @modelcontextprotocol/server-github").
+                             Empty for HTTP. }
+    EnvVar:        string; { env var holding the bearer token (HTTP)
+                             or the first REQUIRED env var the
+                             stdio binary expects (e.g. GITHUB_TOKEN
+                             for the github stdio server). Empty
+                             when no auth is needed. }
     AuthFmt:       string; { Authorization-header value template, e.g. "Bearer %s".
                              Empty when no auth. Catalog install reads
                              GetEnvironmentVariable(EnvVar) and substitutes
                              it into AuthFmt to produce the literal header
-                             the HTTP MCP client stores in the args slot. }
+                             the HTTP MCP client stores in the args slot.
+                             Unused for stdio (the binary reads the env
+                             var itself from the spawning shell). }
     RequiresOAuth: Boolean;{ True when the remote uses OAuth 2.1 (MCP
                              Authorization spec -- discovery + PKCE + dynamic
                              client registration). `mcp install` writes the
                              entry with no header and prints a hint to run
                              `pasclaw mcp auth <name>`; the HTTP client
                              reads the resulting access token from the
-                             on-disk token store. Replicate is the v1 case. }
+                             on-disk token store. Replicate is the v1 case.
+                             Always False for stdio entries. }
     Desc:          string; { one-liner shown by `pasclaw mcp catalog` }
     Docs:          string; { url for the user to learn more }
   end;
   TMCPCatalogEntryArray = array of TMCPCatalogEntry;
+
+{ True when Entry.Transport names a stdio binary. Anything else --
+  empty, 'http', 'sse', 'streamable-http', 'stream' -- is treated as
+  a remote HTTP MCP server (TMCPHttpClient speaks Streamable HTTP and
+  accepts both JSON and SSE response bodies, so 'sse' rows from the
+  hub route through the same code path). }
+function CatalogEntryIsStdio(const Entry: TMCPCatalogEntry): Boolean;
 
 function KnownMCPServers: TMCPCatalogEntryArray;
 function FindCatalogEntry(const Name: string;
@@ -95,6 +120,11 @@ implementation
 
 uses
   SysUtils;
+
+function CatalogEntryIsStdio(const Entry: TMCPCatalogEntry): Boolean;
+begin
+  Result := SameText(Entry.Transport, 'stdio');
+end;
 
 function KnownMCPServers: TMCPCatalogEntryArray;
 begin

--- a/src/pkg/mcp/PasClaw.MCP.Hub.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Hub.pas
@@ -283,13 +283,48 @@ begin
   end;
 end;
 
+function ContainsWhitespace(const S: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := False;
+  for i := 1 to Length(S) do
+    if (S[i] = ' ') or (S[i] = #9) then Exit(True);
+end;
+
+function QuoteForSplitArgs(const S: string): string;
+{ Wrap an arg in double quotes when it carries whitespace so the
+  round-trip through PasClaw.MCP.StdioClient.SplitArgs gives the same
+  argv on the other side. SplitArgs honors paired single + double
+  quotes; if the arg itself contains double quotes we fall back to
+  single-quote wrap (and vice versa). Arg with BOTH quote kinds is
+  exotic enough that we let the worse-of-two outcomes through (double-
+  quote wrap; the inner double quote terminates early). The MCP
+  servers we route here ship short flag-shaped argv, so the both-
+  quote case never occurs in practice. }
+begin
+  if not ContainsWhitespace(S) then
+    Exit(S);
+  if Pos('"', S) = 0 then
+    Result := '"' + S + '"'
+  else if Pos('''', S) = 0 then
+    Result := '''' + S + ''''
+  else
+    Result := '"' + S + '"';
+end;
+
 function JoinHubArgs(Arr: TJsonArray): string;
 { Flatten a hub args[] string array into the space-joined form
   TMCPServer.Args stores. Hub entries spell each argv slot as its own
   string ("npx", "-y", "@modelcontextprotocol/server-github"); the
   installed config holds them as one space-separated token because
   PasClaw.Platform.TStdioProcess.Spawn re-tokenises via SplitArgs
-  (same convention the by-hand `pasclaw mcp add` path uses). }
+  (same convention the by-hand `pasclaw mcp add` path uses).
+
+  Args containing whitespace get quote-wrapped so the SplitArgs
+  round-trip rebuilds the original argv -- without that a hub
+  arg like "--prompt say hello" would re-split into three slots and
+  the spawned binary would see a broken flag. }
 var
   i: Integer;
   S: string;
@@ -301,7 +336,7 @@ begin
     S := Arr.ItemStr(i, '');
     if S = '' then Continue;
     if Result <> '' then Result := Result + ' ';
-    Result := Result + S;
+    Result := Result + QuoteForSplitArgs(S);
   end;
 end;
 

--- a/src/pkg/mcp/PasClaw.MCP.Hub.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Hub.pas
@@ -43,6 +43,7 @@ interface
 
 uses
   SysUtils,
+  PasClaw.JSON,
   PasClaw.MCP.Catalog;
 
 type
@@ -89,10 +90,19 @@ function GetMCPHubEntry(const Slug: string;
                         out Entry: TMCPCatalogEntry;
                         out ErrMsg: string): Boolean;
 
+{ Project a single hub-registry JSON object onto the catalog record
+  shape. Exposed at interface scope so the unit tests can pin the
+  transport-routing contract directly against synthetic JSON, without
+  involving network HTTP. Accepts http / sse / streamable-http /
+  stream / stdio; everything else returns False with ErrMsg naming
+  the unsupported transport. }
+function ProjectHubEntryToCatalog(Root: TJsonObject;
+                                   out Entry: TMCPCatalogEntry;
+                                   out ErrMsg: string): Boolean;
+
 implementation
 
 uses
-  PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Providers.HTTP;
 
@@ -273,12 +283,61 @@ begin
   end;
 end;
 
+function JoinHubArgs(Arr: TJsonArray): string;
+{ Flatten a hub args[] string array into the space-joined form
+  TMCPServer.Args stores. Hub entries spell each argv slot as its own
+  string ("npx", "-y", "@modelcontextprotocol/server-github"); the
+  installed config holds them as one space-separated token because
+  PasClaw.Platform.TStdioProcess.Spawn re-tokenises via SplitArgs
+  (same convention the by-hand `pasclaw mcp add` path uses). }
+var
+  i: Integer;
+  S: string;
+begin
+  Result := '';
+  if Arr = nil then Exit;
+  for i := 0 to Arr.Count - 1 do
+  begin
+    S := Arr.ItemStr(i, '');
+    if S = '' then Continue;
+    if Result <> '' then Result := Result + ' ';
+    Result := Result + S;
+  end;
+end;
+
 function ProjectHubEntryToCatalog(Root: TJsonObject;
                                    out Entry: TMCPCatalogEntry;
                                    out ErrMsg: string): Boolean;
+{ Map one hub-registry record onto a TMCPCatalogEntry the install
+  command can consume. Three transports are accepted:
+
+    "http"              -- single POST per request; the default.
+    "sse"   / "stream"  -- HTTP endpoint that streams responses as
+                            text/event-stream. PasClaw.MCP.HttpClient
+                            speaks the MCP Streamable HTTP transport,
+                            which Accepts both `application/json` and
+                            `text/event-stream` responses, so SSE rows
+                            from the hub install and connect through
+                            the same code path as plain HTTP. Older
+                            "long-lived GET + paired POST" SSE flavors
+                            aren't implemented; if a particular SSE
+                            server uses that older shape it will fail
+                            at connect-time with a clear HTTP error
+                            instead of being silently dropped at
+                            install-time.
+    "stdio"             -- spawn the listed command. The hub publishes
+                            command + args[]; we map them into
+                            TMCPCatalogEntry.Cmd and CmdArgs so the
+                            install path can write a normal
+                            TMCPServer row.
+
+  Any other transport value is rejected with a clear ErrMsg so the
+  caller can log "transport <x> not supported" rather than the prior
+  generic "v1 is HTTP-only" message that confused even the operators
+  whose entries WERE HTTP under the hood. }
 var
-  Transport, Slug, URL: string;
-  EnvArr: TJsonArray;
+  Transport, Slug, URL, Cmd: string;
+  EnvArr, ArgsArr: TJsonArray;
 begin
   Result := False;
   FillChar(Entry, SizeOf(Entry), 0);
@@ -289,20 +348,8 @@ begin
     Exit;
   end;
   Transport := LowerCase(Root.GetStr('transport', 'http'));
-  if Transport <> 'http' then
-  begin
-    ErrMsg := Format('transport %s not supported yet (v1 is HTTP-only)', [Transport]);
-    Exit;
-  end;
-  URL := Root.GetStr('endpointUrl', '');
-  if URL = '' then
-  begin
-    ErrMsg := 'hub entry missing endpointUrl';
-    Exit;
-  end;
 
   Entry.Name := Slug;
-  Entry.URL  := URL;
   Entry.Desc := Root.GetStr('summary', '');
   Entry.Docs := Root.GetStr('homepageUrl', '');
   if Entry.Docs = '' then Entry.Docs := Root.GetStr('repoUrl', '');
@@ -314,10 +361,56 @@ begin
   finally
     EnvArr.Free;
   end;
-  if Entry.EnvVar <> '' then
-    Entry.AuthFmt := 'Bearer %s';   { sane default; hub may carry an explicit format later }
 
-  Result := True;
+  if (Transport = 'http') or (Transport = 'sse') or
+     (Transport = 'streamable-http') or (Transport = 'stream') then
+  begin
+    URL := Root.GetStr('endpointUrl', '');
+    if URL = '' then
+    begin
+      ErrMsg := 'hub entry missing endpointUrl';
+      Exit;
+    end;
+    { Preserve the hub's transport name verbatim so `pasclaw mcp catalog`
+      can flag SSE entries to the user -- the install / connect path
+      treats them identically (TMCPHttpClient already accepts both
+      application/json and text/event-stream responses), but knowing
+      it's SSE up front helps debug the rare older-spec server that
+      doesn't speak Streamable HTTP. }
+    Entry.Transport := Transport;
+    Entry.URL       := URL;
+    if Entry.EnvVar <> '' then
+      Entry.AuthFmt := 'Bearer %s';   { sane default; hub may carry an explicit format later }
+    Result := True;
+    Exit;
+  end;
+
+  if Transport = 'stdio' then
+  begin
+    Cmd := Root.GetStr('command', '');
+    if Cmd = '' then
+    begin
+      ErrMsg := 'hub stdio entry missing command';
+      Exit;
+    end;
+    Entry.Transport := 'stdio';
+    Entry.Cmd       := Cmd;
+    ArgsArr := Root.ChildArray('args');
+    if ArgsArr <> nil then
+    try
+      Entry.CmdArgs := JoinHubArgs(ArgsArr);
+    finally
+      ArgsArr.Free;
+    end;
+    { stdio binaries read env vars themselves at spawn time -- AuthFmt
+      doesn't apply. We still propagate EnvVar so the install command
+      can warn the operator when the binary's required token isn't
+      set in their shell. }
+    Result := True;
+    Exit;
+  end;
+
+  ErrMsg := Format('transport %s not supported', [Transport]);
 end;
 
 function GetMCPHubEntry(const Slug: string;

--- a/src/tests/mcp_hub_projection_tests.pas
+++ b/src/tests/mcp_hub_projection_tests.pas
@@ -156,6 +156,25 @@ begin
   AssertTrue(CatalogEntryIsStdio(Entry), 'CatalogEntryIsStdio True for stdio');
 end;
 
+procedure TestStdioArgsWithWhitespaceRoundTripSafely;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  { Defensive: a hub arg that carries embedded whitespace must
+    quote-wrap so the SplitArgs round-trip on the consuming side
+    rebuilds the original argv. Without quoting, "--prompt say hello"
+    would re-split into three slots and the spawned MCP server
+    would see a broken flag. }
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"x","transport":"stdio","command":"runner",' +
+    '"args":["--mode","verbose","--prompt","say hello"]}', Entry, Err),
+    'stdio with whitespace arg projects');
+  AssertEqStr(Entry.CmdArgs,
+              '--mode verbose --prompt "say hello"',
+              'whitespace arg is quote-wrapped');
+end;
+
 procedure TestStdioEntryWithNoArgs;
 var
   Entry: TMCPCatalogEntry;
@@ -245,6 +264,8 @@ begin
   TestSseEntryProjectsAsHttpCompatible; WriteLn('  ok: sse entry projects (now accepted)');
   TestStreamableHttpProjects;        WriteLn('  ok: streamable-http projects');
   TestStdioEntryProjects;            WriteLn('  ok: stdio entry projects (now accepted)');
+  TestStdioArgsWithWhitespaceRoundTripSafely;
+                                     WriteLn('  ok: whitespace arg quoted for SplitArgs round-trip');
   TestStdioEntryWithNoArgs;          WriteLn('  ok: stdio with no args[] is ok');
   TestStdioMissingCommandRejects;    WriteLn('  ok: stdio without command rejected');
   TestHttpMissingEndpointRejects;    WriteLn('  ok: http without endpointUrl rejected');

--- a/src/tests/mcp_hub_projection_tests.pas
+++ b/src/tests/mcp_hub_projection_tests.pas
@@ -1,0 +1,256 @@
+program mcp_hub_projection_tests;
+(*
+  Covers PasClaw.MCP.Hub.ProjectHubEntryToCatalog -- the function that
+  maps one pasclaw.dev hub registry record onto a TMCPCatalogEntry the
+  install command can persist.
+
+  Before this PR, the projector rejected every transport != 'http' with
+  "v1 is HTTP-only". The user reported `pasclaw mcp catalog` showed
+  "10 hub entry/entries skipped" with only the bundled 5 visible --
+  9 of those skipped were actually `sse`-tagged HTTP endpoints
+  TMCPHttpClient already speaks (Streamable HTTP accepts both
+  application/json and text/event-stream response bodies), and 1 was
+  a stdio binary.
+
+  Contracts pinned here:
+
+    - Plain HTTP entries project as before (URL, EnvVar, AuthFmt
+      defaulted to "Bearer %s" when an env var is present).
+    - SSE-tagged entries project as HTTP for routing purposes
+      (Entry.URL populated) but preserve Transport='sse' verbatim
+      so the catalog display can flag it.
+    - 'streamable-http' / 'stream' variants project identically to
+      plain HTTP for the routing case.
+    - stdio entries project with Transport='stdio', Cmd holding the
+      executable, CmdArgs holding the joined argv tail.
+    - Truly unknown transports (e.g. 'websocket') still reject with
+      a clear "transport X not supported" ErrMsg.
+    - Missing slug, missing endpointUrl, missing command all reject
+      with specific ErrMsg.
+    - JoinHubArgs preserves argv order, ignores empties, joins
+      with single spaces -- matches the by-hand `pasclaw mcp add`
+      Args convention so TStdioProcess.SplitArgs round-trips.
+    - CatalogEntryIsStdio predicate is True only for the literal
+      'stdio' transport (case-insensitive); empty/http/sse all
+      return False.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  PasClaw.JSON,
+  PasClaw.MCP.Catalog,
+  PasClaw.MCP.Hub;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertFalse(Cond: Boolean; const Msg: string);
+begin
+  if Cond then Fail_(Msg);
+end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Copy(Got, 1, 200) + '", want "' +
+          Copy(Want, 1, 200) + '")');
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' +
+          Copy(Haystack, 1, 200) + '")');
+end;
+
+function ProjectFromJSON(const JSON: string;
+                         out Entry: TMCPCatalogEntry;
+                         out ErrMsg: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  Obj := TJsonObject.Parse(JSON);
+  if Obj = nil then begin ErrMsg := 'bad test JSON'; Exit; end;
+  try
+    Result := ProjectHubEntryToCatalog(Obj, Entry, ErrMsg);
+  finally
+    Obj.Free;
+  end;
+end;
+
+procedure TestHttpEntryProjects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"do-apps","transport":"http","endpointUrl":"https://apps.mcp.do.com/mcp",' +
+    '"summary":"DigitalOcean apps","envSchema":[{"name":"DIGITALOCEAN_TOKEN","required":true}]}',
+    Entry, Err), 'plain http entry projects');
+  AssertEqStr(Entry.Name,      'do-apps',                'slug -> Name');
+  AssertEqStr(Entry.Transport, 'http',                   'transport preserved');
+  AssertEqStr(Entry.URL,       'https://apps.mcp.do.com/mcp', 'endpointUrl -> URL');
+  AssertEqStr(Entry.EnvVar,    'DIGITALOCEAN_TOKEN',     'envSchema -> EnvVar');
+  AssertEqStr(Entry.AuthFmt,   'Bearer %s',              'sane AuthFmt default');
+  AssertFalse(CatalogEntryIsStdio(Entry),                'http entry is not stdio');
+end;
+
+procedure TestSseEntryProjectsAsHttpCompatible;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"hf-sse","transport":"sse","endpointUrl":"https://hf.example/mcp/sse",' +
+    '"summary":"HF over SSE","envSchema":[{"name":"HF_TOKEN","required":true}]}',
+    Entry, Err), 'sse entry now accepted');
+  AssertEqStr(Entry.Transport, 'sse', 'sse transport preserved for display');
+  AssertEqStr(Entry.URL, 'https://hf.example/mcp/sse', 'sse URL populated');
+  AssertEqStr(Entry.AuthFmt, 'Bearer %s', 'sse entry gets HTTP-style AuthFmt');
+  AssertFalse(CatalogEntryIsStdio(Entry), 'sse entry is not stdio');
+end;
+
+procedure TestStreamableHttpProjects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"streamable","transport":"streamable-http",' +
+    '"endpointUrl":"https://x.example/mcp"}', Entry, Err),
+    'streamable-http transport accepted');
+  AssertEqStr(Entry.Transport, 'streamable-http', 'literal transport preserved');
+  AssertEqStr(Entry.URL,       'https://x.example/mcp', 'URL projected');
+end;
+
+procedure TestStdioEntryProjects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"github","transport":"stdio","command":"npx",' +
+    '"args":["-y","@modelcontextprotocol/server-github"],' +
+    '"summary":"GitHub MCP","envSchema":[{"name":"GITHUB_TOKEN","required":true}]}',
+    Entry, Err), 'stdio entry now accepted');
+  AssertEqStr(Entry.Transport, 'stdio', 'stdio transport recorded');
+  AssertEqStr(Entry.Cmd, 'npx', 'command -> Cmd');
+  AssertEqStr(Entry.CmdArgs, '-y @modelcontextprotocol/server-github',
+              'args[] joined into CmdArgs');
+  AssertEqStr(Entry.EnvVar, 'GITHUB_TOKEN', 'envSchema -> EnvVar for stdio too');
+  AssertEqStr(Entry.URL, '', 'stdio entry has no URL');
+  AssertTrue(CatalogEntryIsStdio(Entry), 'CatalogEntryIsStdio True for stdio');
+end;
+
+procedure TestStdioEntryWithNoArgs;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"raw-binary","transport":"stdio","command":"my-mcp-server"}',
+    Entry, Err), 'stdio entry without args[] still projects');
+  AssertEqStr(Entry.Cmd,     'my-mcp-server', 'command projected');
+  AssertEqStr(Entry.CmdArgs, '',              'empty args ok');
+end;
+
+procedure TestStdioMissingCommandRejects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertFalse(ProjectFromJSON(
+    '{"slug":"x","transport":"stdio","args":["foo"]}', Entry, Err),
+    'stdio without command rejected');
+  AssertContains(Err, 'missing command', 'clear error message');
+end;
+
+procedure TestHttpMissingEndpointRejects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertFalse(ProjectFromJSON('{"slug":"x","transport":"http"}', Entry, Err),
+              'http without endpointUrl rejected');
+  AssertContains(Err, 'missing endpointUrl', 'clear error message');
+end;
+
+procedure TestMissingSlugRejects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertFalse(ProjectFromJSON(
+    '{"transport":"http","endpointUrl":"https://x"}', Entry, Err),
+    'slug-less entry rejected');
+  AssertContains(Err, 'missing slug', 'clear error message');
+end;
+
+procedure TestUnknownTransportRejects;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertFalse(ProjectFromJSON(
+    '{"slug":"x","transport":"websocket"}', Entry, Err),
+    'unknown transport still skipped');
+  AssertContains(Err, 'websocket',   'transport name surfaced in error');
+  AssertContains(Err, 'not supported', 'clear "not supported" message');
+end;
+
+procedure TestDefaultTransportIsHttp;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  { Hub entries without an explicit transport field default to HTTP. }
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"x","endpointUrl":"https://y"}', Entry, Err),
+    'missing transport defaults to http');
+  AssertEqStr(Entry.Transport, 'http', 'default transport is http');
+end;
+
+procedure TestCatalogEntryIsStdioPredicate;
+var
+  E: TMCPCatalogEntry;
+begin
+  E := Default(TMCPCatalogEntry);
+  AssertFalse(CatalogEntryIsStdio(E), 'empty transport is not stdio');
+  E.Transport := 'http';
+  AssertFalse(CatalogEntryIsStdio(E), 'http is not stdio');
+  E.Transport := 'sse';
+  AssertFalse(CatalogEntryIsStdio(E), 'sse is not stdio');
+  E.Transport := 'stdio';
+  AssertTrue(CatalogEntryIsStdio(E), 'literal stdio detected');
+  E.Transport := 'STDIO';
+  AssertTrue(CatalogEntryIsStdio(E), 'STDIO case-insensitive');
+end;
+
+begin
+  TestHttpEntryProjects;             WriteLn('  ok: http entry projects');
+  TestSseEntryProjectsAsHttpCompatible; WriteLn('  ok: sse entry projects (now accepted)');
+  TestStreamableHttpProjects;        WriteLn('  ok: streamable-http projects');
+  TestStdioEntryProjects;            WriteLn('  ok: stdio entry projects (now accepted)');
+  TestStdioEntryWithNoArgs;          WriteLn('  ok: stdio with no args[] is ok');
+  TestStdioMissingCommandRejects;    WriteLn('  ok: stdio without command rejected');
+  TestHttpMissingEndpointRejects;    WriteLn('  ok: http without endpointUrl rejected');
+  TestMissingSlugRejects;            WriteLn('  ok: missing slug rejected');
+  TestUnknownTransportRejects;       WriteLn('  ok: unknown transport still skipped');
+  TestDefaultTransportIsHttp;        WriteLn('  ok: missing transport -> http');
+  TestCatalogEntryIsStdioPredicate;  WriteLn('  ok: CatalogEntryIsStdio predicate');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## Why the 10 entries were skipped

`pasclaw mcp catalog` printed `(10 hub entry/entries skipped -- non-HTTP transports not supported yet)` and fell back to the bundled 5 because `ProjectHubEntryToCatalog` strictly required `transport: "http"`. In practice the pasclaw.dev hub publishes:

- **9 entries with `transport: "sse"`** — remote HTTP endpoints that stream responses via `text/event-stream`.
- **1 entry with `transport: "stdio"`** — a binary you spawn locally.

`TMCPHttpClient` already speaks the MCP Streamable HTTP transport (2025-03-26 spec) and `Accept`s **both** `application/json` and `text/event-stream` response bodies. So those 9 SSE rows would have **connected** if we'd let install through. The strict check was stale spelling discipline, not a real protocol gap.

## What this PR does

- **Accept `http` / `sse` / `streamable-http` / `stream`** as remote-HTTP-class transports; they project to the same `TMCPCatalogEntry` shape (URL + EnvVar + AuthFmt) and route through `TMCPHttpClient`. The hub's literal transport string is preserved on `Entry.Transport` so the catalog display can still flag SSE rows.
- **Accept `stdio`**: maps hub `{ command, args[] }` into new `TMCPCatalogEntry.Cmd` + `CmdArgs` slots. `JoinHubArgs` flattens the args array into space-separated form (same convention `pasclaw mcp add` already uses), and `DoInstall` persists them into `Cfg.MCPServers` as `Cmd` + `Args` — `TMCPStdioClient` picks them up via the existing `://`-vs-not heuristic in `PasClaw.MCP.Bridge`.
- **`DoInstall` branches on `CatalogEntryIsStdio`**: stdio entries skip the Authorization-header dance (the binary handles auth itself) but DO surface a warning when the hub-flagged required env var isn't set in the spawning shell.
- **`pasclaw mcp catalog` shows a new `transport` column**. Bundled `KnownMCPServers` rows default to `http` so the column never looks blank.
- **Truly unknown transports** (e.g. `websocket`) still reject with a clearer `"transport X not supported"` message; the count surfaces in the existing skip line.

## Files

- `src/pkg/mcp/PasClaw.MCP.Catalog.pas` — `Transport` / `Cmd` / `CmdArgs` fields on `TMCPCatalogEntry`; new `CatalogEntryIsStdio` predicate.
- `src/pkg/mcp/PasClaw.MCP.Hub.pas` — `ProjectHubEntryToCatalog` rewritten + exposed at interface scope so tests can pin it; `JoinHubArgs` helper for `args[]` flattening.
- `src/cmd/PasClaw.Cmd.MCP.pas` — `DoInstall` routes by transport; `DoCatalog` shows transport column; new `TransportLabel` helper.
- **New**: `src/tests/mcp_hub_projection_tests.pas` — 11 cases covering each transport branch and every reject path (missing slug / endpointUrl / command, unknown transport).
- `Makefile` — new `test-mcp-hub-projection` target wired into the umbrella `test`.

## Test plan

- [x] `make test` — full suite green incl. new `test-mcp-hub-projection` (11/11)
- [x] `make test-mcp-server` still green (no surface area collision with the new fields)
- [x] `pasclaw mcp catalog` smoke (live, in this sandbox: hub unreachable due to no libssl — falls back to the bundled 5 in the new column format)
- [ ] Live `pasclaw mcp catalog` against the real hub on a box with OpenSSL: should now show the 9 SSE + 1 stdio rows + bundled 5

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_