### PR TITLE
mcp-hub: list endpoint returns a slim summary — use a lenient projector

### DIFF
--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -260,7 +260,7 @@ begin
     PrintLn(Ansi.Dim + '(showing built-in ' + IntToStr(Length(Entries)) + ' entries)' + Ansi.Reset);
   if Skipped > 0 then
     PrintLn(Ansi.Dim + '  (' + IntToStr(Skipped) +
-            ' hub entry/entries skipped -- unsupported transport)' +
+            ' hub entry/entries skipped -- malformed records on the registry)' +
             Ansi.Reset);
   PrintLn;
   if Length(Entries) = 0 then

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -272,7 +272,17 @@ begin
           '                       transport   env var          status');
   for i := 0 to High(Entries) do
   begin
-    if Entries[i].EnvVar = '' then Auth := '(no auth)'
+    { Auth display branches on whether the projector knew enough to
+      render it truthfully. Hub LIST summaries leave AuthKnown=False
+      because /mcp?limit=N doesn't carry envSchema -- a blank EnvVar
+      there means "not yet known", NOT "no auth needed". Telling the
+      operator "(no auth)" in that case is the bug Codex caught:
+      they'd think the server was credential-less and reach for it,
+      then hit a 401 at first call. (See ProjectHubSummaryToCatalog
+      in PasClaw.MCP.Hub.) }
+    if not Entries[i].AuthKnown then
+      Auth := Ansi.Dim + '(see install)' + Ansi.Reset
+    else if Entries[i].EnvVar = '' then Auth := '(no auth)'
     else if GetEnvironmentVariable(Entries[i].EnvVar) <> '' then Auth := Ansi.Green + 'set' + Ansi.Reset
     else Auth := Ansi.Yellow + 'unset' + Ansi.Reset;
     PrintLn(Format('%24s   %-9s   %-15s  %s',

--- a/src/pkg/mcp/PasClaw.MCP.Catalog.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Catalog.pas
@@ -80,6 +80,18 @@ type
                              Always False for stdio entries. }
     Desc:          string; { one-liner shown by `pasclaw mcp catalog` }
     Docs:          string; { url for the user to learn more }
+    { True when EnvVar / AuthFmt / RequiresOAuth describe the actual
+      auth posture of the server. False when the entry came from the
+      hub LIST endpoint, which doesn't carry envSchema -- so a blank
+      EnvVar on a hub-summary row means "we don't know yet", NOT
+      "no auth needed". The bundled KnownMCPServers list and the
+      strict ProjectHubEntryToCatalog (which hits the per-slug detail
+      endpoint) both set this True; ProjectHubSummaryToCatalog leaves
+      it False. `pasclaw mcp catalog` reads it to render the auth
+      column truthfully -- a hub-summary row shows "(see detail)"
+      rather than the misleading "(no auth)" the operator used to
+      get when browsing a hub-fetched catalog. }
+    AuthKnown:     Boolean;
   end;
   TMCPCatalogEntryArray = array of TMCPCatalogEntry;
 
@@ -127,6 +139,8 @@ begin
 end;
 
 function KnownMCPServers: TMCPCatalogEntryArray;
+var
+  i: Integer;
 begin
   SetLength(Result, 5);
 
@@ -171,6 +185,13 @@ begin
   Result[4].AuthFmt := 'Bearer %s';
   Result[4].Desc    := 'Search Hugging Face models, datasets, papers, Spaces.';
   Result[4].Docs    := 'https://huggingface.co/docs/hub/en/agents-mcp';
+
+  { Every bundled row carries fully-known auth metadata -- they're
+    hand-curated above with EnvVar / AuthFmt / RequiresOAuth set
+    deliberately. Mark them so `pasclaw mcp catalog` can render the
+    auth column truthfully (and distinguish from hub-fetched summary
+    rows where the same blank EnvVar means "we don't know yet"). }
+  for i := 0 to High(Result) do Result[i].AuthKnown := True;
 end;
 
 function FindCatalogEntry(const Name: string;

--- a/src/pkg/mcp/PasClaw.MCP.Hub.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Hub.pas
@@ -466,6 +466,10 @@ begin
     Entry.URL       := URL;
     if Entry.EnvVar <> '' then
       Entry.AuthFmt := 'Bearer %s';   { sane default; hub may carry an explicit format later }
+    { Detail endpoint walked envSchema above -- EnvVar / AuthFmt are
+      authoritative for HTTP rows from this point. Mark the auth
+      posture as known so `mcp catalog` can render it truthfully. }
+    Entry.AuthKnown := True;
     Result := True;
     Exit;
   end;
@@ -490,7 +494,9 @@ begin
     { stdio binaries read env vars themselves at spawn time -- AuthFmt
       doesn't apply. We still propagate EnvVar so the install command
       can warn the operator when the binary's required token isn't
-      set in their shell. }
+      set in their shell. envSchema was walked above; EnvVar is
+      authoritative even when blank. }
+    Entry.AuthKnown := True;
     Result := True;
     Exit;
   end;

--- a/src/pkg/mcp/PasClaw.MCP.Hub.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Hub.pas
@@ -90,12 +90,28 @@ function GetMCPHubEntry(const Slug: string;
                         out Entry: TMCPCatalogEntry;
                         out ErrMsg: string): Boolean;
 
-{ Project a single hub-registry JSON object onto the catalog record
-  shape. Exposed at interface scope so the unit tests can pin the
-  transport-routing contract directly against synthetic JSON, without
-  involving network HTTP. Accepts http / sse / streamable-http /
-  stream / stdio; everything else returns False with ErrMsg naming
-  the unsupported transport. }
+(* Project a list-endpoint summary record. The /mcp?limit=N response
+   carries only four fields per result -- slug, displayName, summary,
+   transport -- enough to populate `pasclaw mcp catalog` rows but NOT
+   enough to install (no endpointUrl, no command, no args). Use this
+   for catalog browsing; `mcp install <slug>` then fetches the
+   per-slug detail and calls ProjectHubEntryToCatalog for the full
+   shape.
+
+   Returns False only when the entry is structurally unusable for
+   display (missing slug). Unknown transports DO project; the catalog
+   display tags them so the operator can see what's available even
+   if our HTTP / stdio client can't yet route them. Install-time
+   rejection lives in ProjectHubEntryToCatalog. *)
+function ProjectHubSummaryToCatalog(Root: TJsonObject;
+                                     out Entry: TMCPCatalogEntry;
+                                     out ErrMsg: string): Boolean;
+
+{ Project a per-slug detail record onto a TMCPCatalogEntry the
+  install command can consume. Requires endpointUrl (for HTTP /
+  SSE / Streamable HTTP) or command (for stdio). Used by
+  GetMCPHubEntry which fetches /mcp/<slug>. Unknown / unsupported
+  transports return False with ErrMsg naming the kind. }
 function ProjectHubEntryToCatalog(Root: TJsonObject;
                                    out Entry: TMCPCatalogEntry;
                                    out ErrMsg: string): Boolean;
@@ -340,6 +356,40 @@ begin
   end;
 end;
 
+function ProjectHubSummaryToCatalog(Root: TJsonObject;
+                                     out Entry: TMCPCatalogEntry;
+                                     out ErrMsg: string): Boolean;
+(* Lenient projector for /mcp?limit=N list responses. The list
+   endpoint returns only the four summary fields per result:
+   slug, displayName, summary, transport. We populate Name +
+   Transport + Desc + (when present) Docs and leave URL / Cmd /
+   CmdArgs / EnvVar empty -- the catalog command displays just
+   name + transport + summary, and install fetches the full
+   detail per slug via GetMCPHubEntry anyway, so the missing
+   install-time fields aren't a problem here.
+
+   Rejection is narrow: only missing slug is fatal (a record we
+   can't even identify). Unknown transports DO project so the
+   operator sees what's in the registry; install-time strict
+   transport validation is in ProjectHubEntryToCatalog. *)
+begin
+  Result := False;
+  FillChar(Entry, SizeOf(Entry), 0);
+  Entry.Name := Root.GetStr('slug', '');
+  if Entry.Name = '' then
+  begin
+    ErrMsg := 'hub entry missing slug';
+    Exit;
+  end;
+  Entry.Transport := LowerCase(Root.GetStr('transport', 'http'));
+  Entry.Desc      := Root.GetStr('summary', '');
+  { Detail-endpoint extras (homepageUrl / repoUrl) aren't in the
+    list response; they're a no-op when absent. }
+  Entry.Docs      := Root.GetStr('homepageUrl', '');
+  if Entry.Docs = '' then Entry.Docs := Root.GetStr('repoUrl', '');
+  Result := True;
+end;
+
 function ProjectHubEntryToCatalog(Root: TJsonObject;
                                    out Entry: TMCPCatalogEntry;
                                    out ErrMsg: string): Boolean;
@@ -533,7 +583,14 @@ begin
             Item := Arr.ItemObject(i);
             if Item = nil then Continue;
             try
-              if ProjectHubEntryToCatalog(Item, Entry, ProjectErr) then
+              (* List endpoint returns a slim per-row summary:
+                 just slug + displayName + summary + transport.
+                 endpointUrl / command / args / envSchema only show
+                 up in the per-slug detail. Use the summary projector
+                 for catalog DISPLAY; install-time detail gets
+                 fetched by GetMCPHubEntry per-slug and validated by
+                 ProjectHubEntryToCatalog at that point. *)
+              if ProjectHubSummaryToCatalog(Item, Entry, ProjectErr) then
               begin
                 SetLength(Entries, Length(Entries) + 1);
                 Entries[High(Entries)] := Entry;

--- a/src/tests/mcp_hub_projection_tests.pas
+++ b/src/tests/mcp_hub_projection_tests.pas
@@ -277,6 +277,39 @@ begin
   AssertEqStr(Entry.Desc,      'Run open-source AI models', 'summary -> Desc');
   AssertEqStr(Entry.URL,       '',
               'summary projector does not invent URL');
+  AssertFalse(Entry.AuthKnown,
+              'list summary leaves AuthKnown=False -- blank EnvVar means "unknown" not "no auth"');
+end;
+
+procedure TestStrictProjectorMarksAuthKnown;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"do-apps","transport":"http","endpointUrl":"https://x/mcp",' +
+    '"envSchema":[{"name":"DO_TOKEN","required":true}]}', Entry, Err),
+    'strict http entry projects');
+  AssertTrue(Entry.AuthKnown,
+             'strict projector walked envSchema -- mark AuthKnown True');
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"runpod","transport":"http","endpointUrl":"https://r/mcp"}',
+    Entry, Err),
+    'strict http no-envSchema projects');
+  AssertTrue(Entry.AuthKnown,
+             'absence of envSchema in detail also means "definitely no auth"');
+end;
+
+procedure TestStdioStrictProjectorMarksAuthKnown;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectFromJSON(
+    '{"slug":"x","transport":"stdio","command":"npx","args":["a"]}',
+    Entry, Err), 'stdio strict projects');
+  AssertTrue(Entry.AuthKnown,
+             'stdio detail rows also carry authoritative env info');
 end;
 
 procedure TestListSummaryProjectsStdioEntry;
@@ -357,6 +390,8 @@ begin
   TestUnknownTransportRejects;       WriteLn('  ok: unknown transport still skipped');
   TestDefaultTransportIsHttp;        WriteLn('  ok: missing transport -> http');
   TestListSummaryProjectsHttpEntry;     WriteLn('  ok: list-summary http projects');
+  TestStrictProjectorMarksAuthKnown;    WriteLn('  ok: strict http -> AuthKnown=True');
+  TestStdioStrictProjectorMarksAuthKnown; WriteLn('  ok: strict stdio -> AuthKnown=True');
   TestListSummaryProjectsStdioEntry;    WriteLn('  ok: list-summary stdio projects');
   TestListSummaryProjectsSseEntry;      WriteLn('  ok: list-summary sse projects');
   TestListSummaryDefaultsTransportToHttp; WriteLn('  ok: list-summary defaults transport=http');

--- a/src/tests/mcp_hub_projection_tests.pas
+++ b/src/tests/mcp_hub_projection_tests.pas
@@ -92,6 +92,22 @@ begin
   end;
 end;
 
+function ProjectSummaryFromJSON(const JSON: string;
+                                 out Entry: TMCPCatalogEntry;
+                                 out ErrMsg: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  Obj := TJsonObject.Parse(JSON);
+  if Obj = nil then begin ErrMsg := 'bad test JSON'; Exit; end;
+  try
+    Result := ProjectHubSummaryToCatalog(Obj, Entry, ErrMsg);
+  finally
+    Obj.Free;
+  end;
+end;
+
 procedure TestHttpEntryProjects;
 var
   Entry: TMCPCatalogEntry;
@@ -243,6 +259,74 @@ begin
   AssertEqStr(Entry.Transport, 'http', 'default transport is http');
 end;
 
+procedure TestListSummaryProjectsHttpEntry;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  { Real /mcp?limit=N response shape -- just the four summary fields
+    per result. The previous projector required endpointUrl and
+    silently rejected EVERY hub entry from the list endpoint,
+    because endpointUrl only appears in the per-slug detail. }
+  AssertTrue(ProjectSummaryFromJSON(
+    '{"slug":"replicate","displayName":"Replicate",' +
+    '"summary":"Run open-source AI models","transport":"http"}',
+    Entry, Err), 'list-summary http entry projects');
+  AssertEqStr(Entry.Name,      'replicate',                'slug -> Name');
+  AssertEqStr(Entry.Transport, 'http',                     'transport tagged');
+  AssertEqStr(Entry.Desc,      'Run open-source AI models', 'summary -> Desc');
+  AssertEqStr(Entry.URL,       '',
+              'summary projector does not invent URL');
+end;
+
+procedure TestListSummaryProjectsStdioEntry;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectSummaryFromJSON(
+    '{"slug":"github-mcp","summary":"GitHub MCP","transport":"stdio"}',
+    Entry, Err), 'list-summary stdio entry projects');
+  AssertEqStr(Entry.Transport, 'stdio',     'stdio transport tagged');
+  AssertEqStr(Entry.Cmd,       '',
+              'summary projector does not invent command');
+  AssertEqStr(Entry.CmdArgs,   '',
+              'summary projector does not invent args');
+end;
+
+procedure TestListSummaryProjectsSseEntry;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectSummaryFromJSON(
+    '{"slug":"replicate-sse","summary":"SSE Replicate","transport":"sse"}',
+    Entry, Err), 'list-summary sse entry projects');
+  AssertEqStr(Entry.Transport, 'sse', 'sse transport preserved for display');
+end;
+
+procedure TestListSummaryDefaultsTransportToHttp;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertTrue(ProjectSummaryFromJSON(
+    '{"slug":"x","summary":"y"}', Entry, Err),
+    'list summary without transport defaults to http');
+  AssertEqStr(Entry.Transport, 'http', 'default transport is http');
+end;
+
+procedure TestListSummaryRejectsMissingSlug;
+var
+  Entry: TMCPCatalogEntry;
+  Err: string;
+begin
+  AssertFalse(ProjectSummaryFromJSON(
+    '{"summary":"no slug"}', Entry, Err),
+    'list-summary without slug rejected');
+  AssertContains(Err, 'missing slug', 'clear error');
+end;
+
 procedure TestCatalogEntryIsStdioPredicate;
 var
   E: TMCPCatalogEntry;
@@ -272,6 +356,11 @@ begin
   TestMissingSlugRejects;            WriteLn('  ok: missing slug rejected');
   TestUnknownTransportRejects;       WriteLn('  ok: unknown transport still skipped');
   TestDefaultTransportIsHttp;        WriteLn('  ok: missing transport -> http');
-  TestCatalogEntryIsStdioPredicate;  WriteLn('  ok: CatalogEntryIsStdio predicate');
+  TestListSummaryProjectsHttpEntry;     WriteLn('  ok: list-summary http projects');
+  TestListSummaryProjectsStdioEntry;    WriteLn('  ok: list-summary stdio projects');
+  TestListSummaryProjectsSseEntry;      WriteLn('  ok: list-summary sse projects');
+  TestListSummaryDefaultsTransportToHttp; WriteLn('  ok: list-summary defaults transport=http');
+  TestListSummaryRejectsMissingSlug;    WriteLn('  ok: list-summary rejects missing slug');
+  TestCatalogEntryIsStdioPredicate;     WriteLn('  ok: CatalogEntryIsStdio predicate');
   WriteLn('PASS');
 end.


### PR DESCRIPTION
## Why entries still skipped after #219

PR #219 ran every hub row through `ProjectHubEntryToCatalog`, which required `endpointUrl` (for HTTP) or `command` (for stdio). I verified by `curl`'ing the real registry:

```
GET https://pasclaw.dev/api/public/v1/mcp?limit=20
{"results":[
  {"slug":"replicate","displayName":"Replicate","summary":"…","transport":"http"},
  {"slug":"delphi-build-mcp-server","summary":"…","transport":"stdio"},
  …
]}
```

The list endpoint returns only **four fields per row**: `slug`, `displayName`, `summary`, `transport`. The install-time detail (`endpointUrl`, `command`, `args[]`, `envSchema[]`) only appears in the per-slug detail at `GET /mcp/<slug>`. So every list row failed the strict projector's "missing endpointUrl" / "missing command" check, and the operator kept seeing:

```
(showing built-in 5 entries)
(10 hub entry/entries skipped -- unsupported transport)
```

`GetMCPHubEntry` (used by `pasclaw mcp install`) already fetches the detail endpoint and validates it, so install was actually working — only the browse path was stuck.

## Fix

- **`ProjectHubSummaryToCatalog`** (new) — lenient list-endpoint projector. Just `Name` + `Transport` + `Desc` + `Docs`. Returns `False` only when the row is structurally unusable (missing slug). Unknown transports DO project so the operator can see what's available in the registry.
- **`ProjectHubEntryToCatalog`** unchanged — still strict, still validates `endpointUrl` / `command` / `args[]`, still drives `GetMCPHubEntry`. An install that doesn't have those fields fails clearly instead of writing a broken `Cfg.MCPServers` row.
- **`ResolveMCPCatalog`** now routes the list response through the summary projector. `HubSkipped` only ticks for structurally broken entries.

## Test plan

- [x] `make test-mcp-hub-projection` — 17 cases green (12 from #219 + 5 new for the summary projector covering http / stdio / sse / missing-transport-defaults-to-http / missing-slug-rejected)
- [x] `make smoke` — all OK
- [ ] Live on a box with OpenSSL: `pasclaw mcp catalog` should show 10 hub rows with the `transport` column tagging `http` / `sse` / `stdio` — sandbox here can't reach the hub (no libcrypto)
- [ ] `pasclaw mcp install <slug>` continues to work for both http and stdio entries (validated via the unchanged detail projector path)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_