### PR TITLE
checkpoints: auto-snapshot files before edits + TUI /undo (opt-in)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ UNIT_DIRS = \
 	src/pkg/search \
 	src/pkg/cron \
 	src/pkg/skills \
+	src/pkg/checkpoints \
 	src/pkg/session \
 	src/pkg/identity \
 	src/pkg/agent \
@@ -394,6 +395,13 @@ test-mcp-server: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/mcp_server_tests.pas -o$(BUILDDIR)/mcp_server_tests
 	@$(BUILDDIR)/mcp_server_tests
 
+# Checkpoints + /undo: file-edit rollback hooked into fs_write /
+# fs_edit_hashline. Pure on-disk snapshots; no model, no agent loop.
+test-checkpoints: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/checkpoints_tests.pas -o$(BUILDDIR)/checkpoints_tests
+	@$(BUILDDIR)/checkpoints_tests
+
 # MCP hub projection: transport routing for pasclaw.dev catalog entries
 # (http / sse / streamable-http / stdio). Pure JSON-in / record-out;
 # no network. Pins the regression that "10 entries skipped -- non-HTTP
@@ -416,4 +424,4 @@ test-kb-index: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/kb_index_tests.pas -o$(BUILDDIR)/kb_index_tests
 	@$(BUILDDIR)/kb_index_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-kb-index
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-kb-index

--- a/build-delphi.bat
+++ b/build-delphi.bat
@@ -42,7 +42,7 @@ if errorlevel 1 (
 if not exist "build\delphi\%PLATFORM%\%CONFIG%" mkdir "build\delphi\%PLATFORM%\%CONFIG%" || exit /b 1
 if not exist "build\delphi\%PLATFORM%\%CONFIG%\dcu" mkdir "build\delphi\%PLATFORM%\%CONFIG%\dcu" || exit /b 1
 
-set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\stream;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\crypto;src\pkg\net;src\pkg\search;src\pkg\cron;src\pkg\skills;src\pkg\session;src\pkg\identity;src\pkg\agent;src\pkg\memory;src\pkg\memory\localvector;src\pkg\kb;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\markdown;src\pkg\vendor\dmvcframework"
+set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\stream;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\crypto;src\pkg\net;src\pkg\search;src\pkg\cron;src\pkg\skills;src\pkg\checkpoints;src\pkg\session;src\pkg\identity;src\pkg\agent;src\pkg\memory;src\pkg\memory\localvector;src\pkg\kb;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\markdown;src\pkg\vendor\dmvcframework"
 
 echo Building %DPR% with dcc64.exe...
 rem -DPASCLAW_NETHTTP routes outbound HTTP through System.Net.HttpClient

--- a/build-fpc.bat
+++ b/build-fpc.bat
@@ -52,7 +52,7 @@ if errorlevel 1 (
 popd
 
 set "FPCFLAGS=-MDelphi -Sh -O2 -Xs -XX"
-set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\stream -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\crypto -Fusrc\pkg\net -Fusrc\pkg\search -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\session -Fusrc\pkg\identity -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\memory\localvector -Fusrc\pkg\kb -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\pkg\markdown -Fusrc\cmd"
+set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\stream -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\crypto -Fusrc\pkg\net -Fusrc\pkg\search -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\checkpoints -Fusrc\pkg\session -Fusrc\pkg\identity -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\memory\localvector -Fusrc\pkg\kb -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\pkg\markdown -Fusrc\cmd"
 set "FPCFLAGS=%FPCFLAGS% -Fu%INDY_DIR%\Lib\Core -Fu%INDY_DIR%\Lib\Protocols -Fu%INDY_DIR%\Lib\System -Fi%INDY_DIR%\Lib\Core -Fi%INDY_DIR%\Lib\Protocols -Fi%INDY_DIR%\Lib\System"
 if not "%ICONVENC_DIR%"=="" set "FPCFLAGS=%FPCFLAGS% -Fu%ICONVENC_DIR%"
 set "FPCFLAGS=%FPCFLAGS% -FE%BUILDDIR% -FU%BUILDDIR%\lib"

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -395,6 +395,48 @@ begin
   end;
 end;
 
+procedure PromptCheckpoints(Cfg: TConfig);
+{ Opt-in toggle for per-edit checkpoints + `/undo`. Off by default
+  because it can be heavy -- a turn that fs_writes a 5 MB generated
+  file copies the whole 5 MB into the per-turn snapshot dir. Bounded
+  by checkpoints_keep_last (default 32) but the upper bound is still
+  controlled by the operator's intent, so we ask. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Checkpoints + /undo' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Auto-snapshot files BEFORE fs_write / fs_edit_hashline mutates them. ' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'The TUI ' + Ansi.Reset + Ansi.Bold + '/undo' + Ansi.Reset +
+    Ansi.Dim + ' [N] command rewinds N turns by restoring those captures.' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Storage: workspace/checkpoints/<session>/turn-NNNN/ (the last 32 turns).' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '(Off by default -- can be heavy when the model writes large files. ' +
+    'No rollback story without this.)' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable checkpoints [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.CheckpointsEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+            ' checkpoints enabled (last 32 turns kept per session)');
+  end
+  else
+  begin
+    Cfg.CheckpointsEnabled := False;
+    PrintLn('  ' + Ansi.Dim +
+            '(skipped -- flip checkpoints_enabled in config.json to enable later)' +
+            Ansi.Reset);
+  end;
+end;
+
 procedure PromptStatsCollection(Cfg: TConfig);
 { Opt-in toggle for persisting per-session usage stats (tokens,
   turns, tool calls, truncation savings) into the session JSON so
@@ -906,6 +948,7 @@ begin
     PromptVectorSearch(Cfg);
     PromptKnowledgebase(Cfg);
     PromptStatsCollection(Cfg);
+    PromptCheckpoints(Cfg);
     PromptAutoRouter(Cfg);
 
     SaveConfig(Cfg);

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -154,6 +154,8 @@ begin
     TUIInst.SessionId          := A.Session;
     TUIInst.ThemeName          := A.Theme;
     TUIInst.RenderMarkdownEnabled := Cfg.RenderMarkdown;
+    TUIInst.CheckpointsEnabled    := Cfg.CheckpointsEnabled;
+    TUIInst.CheckpointsKeepLast   := Cfg.CheckpointsKeepLast;
     TUIInst.BgCoordinator      := BgCoord;
     try
       TUIInst.Run;

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -180,6 +180,9 @@
 
         <!-- pkg/stream -->
         <DCCReference Include="..\pkg\stream\PasClaw.Stream.Reliability.pas"/>
+
+        <!-- pkg/checkpoints -->
+        <DCCReference Include="..\pkg\checkpoints\PasClaw.Checkpoints.pas"/>
 
         <!-- pkg/tokenizer -->
         <DCCReference Include="..\pkg\tokenizer\PasClaw.Tokenizer.pas"/>

--- a/src/pkg/checkpoints/PasClaw.Checkpoints.pas
+++ b/src/pkg/checkpoints/PasClaw.Checkpoints.pas
@@ -93,7 +93,7 @@ type
   TRestoredFileArray = array of TRestoredFile;
 
 procedure InitCheckpoints(const Cfg: TCheckpointConfig);
-procedure BeginTurn(TurnNumber: Integer);
+procedure BeginTurn;
 procedure SnapshotBeforeWrite(const Path: string);
 
 function CheckpointsEnabled: Boolean;
@@ -266,6 +266,18 @@ begin
 end;
 
 procedure InitCheckpoints(const Cfg: TCheckpointConfig);
+{ Resume the per-session counter from on-disk state. PasClaw can restart
+  between turns -- the next BeginTurn must land on turn (MaxExisting + 1)
+  so we don't clobber the previous run's snapshots. Codex P2 on PR #221:
+  the old design relied on the caller passing a TurnNumber sourced from
+  TSession.Meta.Stats.Turns, which only increments when stats collection
+  is enabled; with stats off (the default) every TUI turn called
+  BeginTurn(1) and rewrote turn-0001's manifest. Fixed by making the
+  module own its own monotonically-increasing counter, independent of
+  the optional session-stats field. }
+var
+  Names: TStringList;
+  i, T, MaxT: Integer;
 begin
   GLock.Acquire;
   try
@@ -282,8 +294,24 @@ begin
     if Cfg.KeepLast > 0 then GKeep := Cfg.KeepLast
     else GKeep := DefaultKeepLastTurns;
     EnsureDir(SessionDir);
-    LogDebug('checkpoints: enabled session=%s root=%s keep=%d',
-             [GSession, GRoot, GKeep]);
+    { Scan for the highest existing turn-NNNN under SessionDir so
+      BeginTurn picks up where the previous run left off. }
+    MaxT := 0;
+    Names := TStringList.Create;
+    try
+      ListSubdirs(SessionDir, Names);
+      for i := 0 to Names.Count - 1 do
+      begin
+        if (Length(Names[i]) < 9) or (Copy(Names[i], 1, 5) <> 'turn-') then Continue;
+        T := StrToIntDef(Copy(Names[i], 6, MaxInt), -1);
+        if T > MaxT then MaxT := T;
+      end;
+    finally
+      Names.Free;
+    end;
+    GTurn := MaxT;  { BeginTurn will Inc this to MaxT+1 before snapshotting }
+    LogDebug('checkpoints: enabled session=%s root=%s keep=%d resume_turn=%d',
+             [GSession, GRoot, GKeep, GTurn]);
   finally
     GLock.Release;
   end;
@@ -309,12 +337,19 @@ begin
   end;
 end;
 
-procedure BeginTurn(TurnNumber: Integer);
+procedure BeginTurn;
+{ Advance the per-session turn counter and reset per-turn state.
+  Codex P2 on PR #221: caller no longer passes a TurnNumber sourced
+  from TSession.Meta.Stats.Turns (which depends on stats_collection_
+  enabled). The module owns its own counter, initialised from
+  on-disk state at InitCheckpoints, so checkpoints turn numbering
+  is independent of the optional stats subsystem AND survives
+  pasclaw restarts cleanly. }
 begin
   GLock.Acquire;
   try
     if not GEnabled then Exit;
-    GTurn := TurnNumber;
+    Inc(GTurn);
     GTurnBlobCount := 0;
     GTurnPaths.Clear;
     GTurnEntries.Clear;

--- a/src/pkg/checkpoints/PasClaw.Checkpoints.pas
+++ b/src/pkg/checkpoints/PasClaw.Checkpoints.pas
@@ -1,0 +1,671 @@
+(*
+  PasClaw.Checkpoints - opt-in file-edit rollback. Snapshots files before
+  fs_write / fs_edit_hashline mutates them; `/undo N` rewinds N turns
+  by restoring the contents that were captured at the START of each
+  turn touched.
+
+  Why opt-in (off by default):
+
+    - "Could be heavy". A turn that fs_writes a 5 MB generated file
+      copies that 5 MB into workspace/checkpoints/<session>/turn-NNN/.
+      Over a long session that adds up. The bundle defaults to keeping
+      the last 32 turns; that's a sensible bound but only relative
+      to the operator's intent. They tell us via `pasclaw onboard`.
+
+    - Filesystem cost outside the workspace. The fs tools accept any
+      path the sandbox allows; we snapshot regardless. An operator
+      who flips checkpoints on and then asks the model to edit a 2 GB
+      logfile pays for it.
+
+  Storage layout (per session):
+
+      $PASCLAW_HOME/workspace/checkpoints/<session-id>/
+        turn-0001/
+          manifest.json   { "turn":1, "ts":"…", "files":[{path,blob,size}] }
+          blobs/0000.bin
+          blobs/0001.bin
+        turn-0002/
+          …
+
+  Per turn, every snapshotted file is copied verbatim under blobs/NNNN.bin
+  with the original path recorded in manifest.json. The "blob index"
+  decouples on-disk names from path strings, so weird input -- absolute
+  paths, paths with `..`, paths with whitespace -- needs no escaping.
+
+  `/undo N` then iterates turn-(CurrentTurn) downto turn-(CurrentTurn-N+1),
+  restoring each file recorded in those manifests. Files the model
+  CREATED during the rewound turns (no pre-write snapshot exists) are
+  LEFT IN PLACE -- v1 is conservative; deleting model-created files is
+  a follow-up. Restoration order within a single turn doesn't matter
+  (each file is restored to its pre-turn state once); across turns we
+  iterate newest -> oldest so the EARLIEST captured state wins for any
+  file that was edited across multiple of the rewound turns. That's
+  symmetric with how SnapshotBeforeWrite itself is idempotent within
+  one turn -- the first capture is the keeper.
+
+  Thread-safety: SnapshotBeforeWrite is called from RunToolLoop's
+  per-tool dispatch, which can be parallel for tcReadOnly batches.
+  fs_write and fs_edit_hashline are tcMutating so they don't race in
+  practice -- but the unit uses a critical section anyway so a future
+  batching change (or an embedder calling from a thread) stays safe.
+*)
+unit PasClaw.Checkpoints;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs;
+
+const
+  DefaultKeepLastTurns = 32;
+
+type
+  TCheckpointConfig = record
+    Enabled:   Boolean;
+    { Per-session subdirectory key. Empty disables checkpoints
+      even when Enabled is True -- the agent loop has no session
+      to scope snapshots to. }
+    SessionId: string;
+    { Root directory under which <SessionId>/turn-NNNN/ lives.
+      Typically $PASCLAW_HOME/workspace/checkpoints. The unit
+      creates the dir as needed. }
+    Root:      string;
+    { Maximum turn dirs to retain per session. Older dirs auto-
+      pruned at BeginTurn time so long sessions don't grow the
+      disk indefinitely. 0 means "default" (32). }
+    KeepLast:  Integer;
+  end;
+
+  TRestoredFile = record
+    Path:        string;
+    BlobIdx:     Integer;
+    SnappedTurn: Integer;
+    BytesRestored: Int64;
+  end;
+  TRestoredFileArray = array of TRestoredFile;
+
+procedure InitCheckpoints(const Cfg: TCheckpointConfig);
+procedure BeginTurn(TurnNumber: Integer);
+procedure SnapshotBeforeWrite(const Path: string);
+
+function CheckpointsEnabled: Boolean;
+function CurrentTurnNumber: Integer;
+function CountSnapshottedTurns(out OldestTurn, NewestTurn: Integer): Integer;
+
+function UndoTurns(N: Integer; out Restored: TRestoredFileArray;
+                   out ErrMsg: string): Boolean;
+
+implementation
+
+uses
+  DateUtils,
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Logger;
+
+procedure ListSubdirs(const Dir: string; List: TStringList);
+{ Local helper: enumerate the immediate subdirectory names of Dir
+  into List. Skips `.` and `..`. PasClaw.Utils doesn't export a
+  cross-compiler dirwalker, so the unit keeps its own. }
+var
+  SR: TSearchRec;
+begin
+  if (Dir = '') or (not DirectoryExists(Dir)) then Exit;
+  if FindFirst(JoinPath(Dir, '*'), faAnyFile or faDirectory, SR) = 0 then
+  try
+    repeat
+      if ((SR.Attr and faDirectory) <> 0) and
+         (SR.Name <> '.') and (SR.Name <> '..') then
+        List.Add(SR.Name);
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+procedure RemoveTreeRecursive(const Path: string);
+{ Best-effort `rm -rf`. Used to prune old turn dirs. Errors get
+  swallowed; the next prune pass picks up the dangling entries. }
+var
+  SR: TSearchRec;
+  Child: string;
+begin
+  if (Path = '') or (not DirectoryExists(Path)) then
+  begin
+    if FileExists(Path) then DeleteFile(Path);
+    Exit;
+  end;
+  if FindFirst(JoinPath(Path, '*'), faAnyFile or faDirectory, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Child := JoinPath(Path, SR.Name);
+      if (SR.Attr and faDirectory) <> 0 then
+        RemoveTreeRecursive(Child)
+      else
+        DeleteFile(Child);
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  RemoveDir(Path);
+end;
+
+var
+  GLock:    TCriticalSection;
+  GEnabled: Boolean;
+  GSession: string;
+  GRoot:    string;
+  GKeep:    Integer;
+  GTurn:    Integer;
+  { Files already snapshotted in the CURRENT turn; the second + nth
+    snapshot of the same path within one turn is a no-op so we keep
+    the earliest captured state. Cleared at BeginTurn. }
+  GTurnPaths: TStringList;
+  GTurnBlobCount: Integer;
+  { In-memory record of the current turn's manifest entries. Each
+    SnapshotBeforeWrite appends one TStringList row formatted as
+    "blob|size|path" and rewrites the manifest.json atomically.
+    Holding the array in memory avoids parsing manifest.json every
+    snapshot -- the previous load-modify-save dance through the JSON
+    unit was leaking references on the second invocation per turn. }
+  GTurnEntries: TStringList;
+  GTurnTimestamp: string;
+
+function SessionDir: string;
+begin
+  if (GRoot = '') or (GSession = '') then
+    Exit('');
+  Result := JoinPath(GRoot, GSession);
+end;
+
+function TurnDir(TurnNumber: Integer): string;
+begin
+  if SessionDir = '' then Exit('');
+  Result := JoinPath(SessionDir, Format('turn-%4.4d', [TurnNumber]));
+end;
+
+function CurrentTurnDir: string;
+begin
+  Result := TurnDir(GTurn);
+end;
+
+function CurrentBlobsDir: string;
+begin
+  if CurrentTurnDir = '' then Exit('');
+  Result := JoinPath(CurrentTurnDir, 'blobs');
+end;
+
+function CurrentManifestPath: string;
+begin
+  if CurrentTurnDir = '' then Exit('');
+  Result := JoinPath(CurrentTurnDir, 'manifest.json');
+end;
+
+procedure PruneOldTurns;
+{ Walk SessionDir; drop the OLDEST turn-NNNN entries until the count
+  fits the budget. Called at the TOP of each BeginTurn, so the cap is
+  KeepLast - 1 -- the new turn about to start will add one more dir,
+  and we want the post-snapshot total to be at most KeepLast.
+
+  Best-effort: removal failures get logged but don't abort the next
+  snapshot. The next BeginTurn picks up any dangling entry. }
+var
+  Dir, Path: string;
+  Names: TStringList;
+  Budget, i: Integer;
+begin
+  Dir := SessionDir;
+  if Dir = '' then Exit;
+  if not DirectoryExists(Dir) then Exit;
+  Budget := GKeep - 1;
+  if Budget < 0 then Budget := 0;
+  Names := TStringList.Create;
+  try
+    ListSubdirs(Dir, Names);
+    Names.Sorted := True;
+    { Filter to turn-* entries only. }
+    for i := Names.Count - 1 downto 0 do
+      if (Length(Names[i]) < 5) or (Copy(Names[i], 1, 5) <> 'turn-') then
+        Names.Delete(i);
+    while Names.Count > Budget do
+    begin
+      Path := JoinPath(Dir, Names[0]);
+      try
+        RemoveTreeRecursive(Path);
+      except
+        on E: Exception do
+          LogWarn('checkpoints: prune %s failed: %s', [Path, E.Message]);
+      end;
+      Names.Delete(0);
+    end;
+  finally
+    Names.Free;
+  end;
+end;
+
+procedure ResetState;
+begin
+  GEnabled := False;
+  GSession := '';
+  GRoot    := '';
+  GKeep    := DefaultKeepLastTurns;
+  GTurn    := 0;
+  if GTurnPaths <> nil then GTurnPaths.Clear;
+  if GTurnEntries <> nil then GTurnEntries.Clear;
+  GTurnBlobCount := 0;
+  GTurnTimestamp := '';
+end;
+
+procedure InitCheckpoints(const Cfg: TCheckpointConfig);
+begin
+  GLock.Acquire;
+  try
+    ResetState;
+    if (not Cfg.Enabled) or (Cfg.SessionId = '') or (Cfg.Root = '') then
+    begin
+      LogDebug('checkpoints: disabled (enabled=%s session=%s root=%s)',
+               [BoolToStr(Cfg.Enabled, True), Cfg.SessionId, Cfg.Root]);
+      Exit;
+    end;
+    GEnabled := True;
+    GSession := Cfg.SessionId;
+    GRoot    := Cfg.Root;
+    if Cfg.KeepLast > 0 then GKeep := Cfg.KeepLast
+    else GKeep := DefaultKeepLastTurns;
+    EnsureDir(SessionDir);
+    LogDebug('checkpoints: enabled session=%s root=%s keep=%d',
+             [GSession, GRoot, GKeep]);
+  finally
+    GLock.Release;
+  end;
+end;
+
+function CheckpointsEnabled: Boolean;
+begin
+  GLock.Acquire;
+  try
+    Result := GEnabled;
+  finally
+    GLock.Release;
+  end;
+end;
+
+function CurrentTurnNumber: Integer;
+begin
+  GLock.Acquire;
+  try
+    Result := GTurn;
+  finally
+    GLock.Release;
+  end;
+end;
+
+procedure BeginTurn(TurnNumber: Integer);
+begin
+  GLock.Acquire;
+  try
+    if not GEnabled then Exit;
+    GTurn := TurnNumber;
+    GTurnBlobCount := 0;
+    GTurnPaths.Clear;
+    GTurnEntries.Clear;
+    GTurnTimestamp := FormatDateTime('yyyy-mm-dd"T"hh:nn:ss', Now);
+    { The turn dir + blob dir lazy-create on first snapshot; we
+      don't want to litter empty dirs for turns that don't touch
+      the FS. Prune happens here so the operator sees the dir size
+      drop right at the start of each new turn. }
+    PruneOldTurns;
+  finally
+    GLock.Release;
+  end;
+end;
+
+function ReadFileBytes(const Path: string; out Bytes: TBytes): Boolean;
+var
+  F: TFileStream;
+begin
+  Result := False;
+  if not FileExists(Path) then Exit;
+  F := TFileStream.Create(Path, fmOpenRead or fmShareDenyNone);
+  try
+    SetLength(Bytes, F.Size);
+    if F.Size > 0 then
+      F.ReadBuffer(Bytes[0], F.Size);
+    Result := True;
+  finally
+    F.Free;
+  end;
+end;
+
+procedure WriteFileBytes(const Path: string; const Bytes: TBytes);
+var
+  F: TFileStream;
+begin
+  EnsureDir(ExtractFilePath(Path));
+  F := TFileStream.Create(Path, fmCreate);
+  try
+    if Length(Bytes) > 0 then
+      F.WriteBuffer(Bytes[0], Length(Bytes));
+  finally
+    F.Free;
+  end;
+end;
+
+procedure WriteCurrentManifest;
+{ Render GTurnEntries as a fresh JSON object and overwrite
+  manifest.json. Atomic on POSIX (rename is atomic via WriteFileText
+  if it uses tmp+rename; SysUtils' default doesn't, but a partially-
+  written manifest is recoverable -- the snapshot blob it would have
+  named is already on disk from before the manifest write). }
+var
+  Root, Entry: TJsonObject;
+  Arr: TJsonArray;
+  i, Pipe1, Pipe2, Size: Integer;
+  Line, BlobName, PathStr, SizeStr: string;
+begin
+  EnsureDir(CurrentTurnDir);
+  Root := TJsonObject.Create;
+  try
+    Root.PutInt('turn', GTurn);
+    Root.PutStr('ts',   GTurnTimestamp);
+    Arr := TJsonArray.Create;
+    try
+      for i := 0 to GTurnEntries.Count - 1 do
+      begin
+        Line := GTurnEntries[i];
+        Pipe1 := Pos('|', Line);
+        if Pipe1 <= 0 then Continue;
+        BlobName := Copy(Line, 1, Pipe1 - 1);
+        Pipe2 := Pos('|', Line, Pipe1 + 1);
+        if Pipe2 <= 0 then Continue;
+        SizeStr := Copy(Line, Pipe1 + 1, Pipe2 - Pipe1 - 1);
+        PathStr := Copy(Line, Pipe2 + 1, MaxInt);
+        Size := StrToIntDef(SizeStr, 0);
+        Entry := TJsonObject.Create;
+        Entry.PutStr('path', PathStr);
+        Entry.PutStr('blob', BlobName);
+        Entry.PutInt('size', Size);
+        Arr.AddObject(Entry);
+      end;
+      Root.PutArray('files', Arr);
+    except
+      Arr.Free;
+      raise;
+    end;
+    WriteFileText(CurrentManifestPath, Root.ToJSON);
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure SnapshotBeforeWrite(const Path: string);
+var
+  AbsPath: string;
+  Bytes: TBytes;
+  BlobName, BlobPath: string;
+begin
+  GLock.Acquire;
+  try
+    if (not GEnabled) or (GTurn <= 0) then Exit;
+    AbsPath := ExpandFileName(Path);
+    if GTurnPaths.IndexOf(AbsPath) >= 0 then
+    begin
+      { Already snapshotted earlier in this turn -- keep the
+        earliest state. fs_edit_hashline that touches the same file
+        twice in one turn must roll back to BEFORE the first edit,
+        not BEFORE the second. }
+      Exit;
+    end;
+    if not ReadFileBytes(AbsPath, Bytes) then
+    begin
+      { Truly-new file (didn't exist before the model wrote it).
+        Record nothing -- on /undo we leave model-created files in
+        place. The operator can rm them; the alternative ("delete
+        any file created during a rewound turn") risks data loss
+        if the model also re-wrote an unrelated file as part of
+        the same turn. }
+      GTurnPaths.Add(AbsPath);  { still mark so a later edit in
+                                  this same turn doesn't try to
+                                  snapshot a file the model just
+                                  created -- the original-state
+                                  "no file" is already implied. }
+      Exit;
+    end;
+    EnsureDir(CurrentBlobsDir);
+    BlobName := Format('%4.4d.bin', [GTurnBlobCount]);
+    BlobPath := JoinPath(CurrentBlobsDir, BlobName);
+    WriteFileBytes(BlobPath, Bytes);
+    GTurnEntries.Add(BlobName + '|' + IntToStr(Length(Bytes)) + '|' + AbsPath);
+    WriteCurrentManifest;
+
+    GTurnPaths.Add(AbsPath);
+    Inc(GTurnBlobCount);
+    LogDebug('checkpoints: turn=%d snap %s (%d bytes -> %s)',
+             [GTurn, AbsPath, Length(Bytes), BlobName]);
+  finally
+    GLock.Release;
+  end;
+end;
+
+function CountSnapshottedTurns(out OldestTurn, NewestTurn: Integer): Integer;
+var
+  Dir, NameStr: string;
+  Names: TStringList;
+  i, T, Lo, Hi: Integer;
+begin
+  Result    := 0;
+  OldestTurn := 0;
+  NewestTurn := 0;
+  GLock.Acquire;
+  try
+    Dir := SessionDir;
+    if (not GEnabled) or (Dir = '') or (not DirectoryExists(Dir)) then Exit;
+    Names := TStringList.Create;
+    try
+      ListSubdirs(Dir, Names);
+      Lo := MaxInt;
+      Hi := -1;
+      for i := 0 to Names.Count - 1 do
+      begin
+        NameStr := Names[i];
+        if (Length(NameStr) < 9) or (Copy(NameStr, 1, 5) <> 'turn-') then Continue;
+        T := StrToIntDef(Copy(NameStr, 6, MaxInt), -1);
+        if T < 0 then Continue;
+        Inc(Result);
+        if T < Lo then Lo := T;
+        if T > Hi then Hi := T;
+      end;
+      if Result > 0 then
+      begin
+        OldestTurn := Lo;
+        NewestTurn := Hi;
+      end;
+    finally
+      Names.Free;
+    end;
+  finally
+    GLock.Release;
+  end;
+end;
+
+function UndoTurns(N: Integer; out Restored: TRestoredFileArray;
+                   out ErrMsg: string): Boolean;
+var
+  Dir, ManifestPath, S, BlobName, BlobPath, EntryPath: string;
+  RawSize: Int64;
+  Names: TStringList;
+  TurnNumbers: array of Integer;
+  i, j, T, Hit, RawCount: Integer;
+  ManRoot: TJsonObject;
+  Files: TJsonArray;
+  FileObj: TJsonObject;
+  AlreadyRestored: TStringList;
+  Bytes: TBytes;
+  RestoredEntry: TRestoredFile;
+begin
+  Result := False;
+  SetLength(Restored, 0);
+  ErrMsg := '';
+  GLock.Acquire;
+  try
+    if not GEnabled then
+    begin
+      ErrMsg := 'checkpoints not enabled for this session';
+      Exit;
+    end;
+    if N <= 0 then
+    begin
+      ErrMsg := 'argument must be a positive turn count';
+      Exit;
+    end;
+    Dir := SessionDir;
+    if (Dir = '') or (not DirectoryExists(Dir)) or (GTurn <= 0) then
+    begin
+      ErrMsg := 'no snapshots recorded for this session yet';
+      Exit;
+    end;
+    Names := TStringList.Create;
+    try
+      ListSubdirs(Dir, Names);
+      SetLength(TurnNumbers, 0);
+      for i := 0 to Names.Count - 1 do
+      begin
+        if (Length(Names[i]) < 9) or (Copy(Names[i], 1, 5) <> 'turn-') then Continue;
+        T := StrToIntDef(Copy(Names[i], 6, MaxInt), -1);
+        if T < 0 then Continue;
+        SetLength(TurnNumbers, Length(TurnNumbers) + 1);
+        TurnNumbers[High(TurnNumbers)] := T;
+      end;
+    finally
+      Names.Free;
+    end;
+    if Length(TurnNumbers) = 0 then
+    begin
+      { GTurn > 0 (checked above) so the session HAS begun turns, but
+        none of them touched files yet. /undo is a friendly no-op
+        here rather than an error -- the operator sees "0 files
+        restored" and moves on. The hard-fail case (no BeginTurn
+        ever called) was caught above. }
+      Result := True;
+      Exit;
+    end;
+    { Sort ascending so we walk OLDEST -> newest. Then for any file
+      that appears across multiple of the rewound turns, the manifest
+      from the EARLIEST turn in the range wins (because the
+      AlreadyRestored set blocks the later turns). That gives
+      "restore everything to the state at the start of the oldest
+      rewound turn" -- exactly what `/undo N` from turn HEAD means.
+
+      Then we trim TurnNumbers down to just the last N entries -- the
+      newest N turns. Trim before walking, not before sort, so the
+      trim picks up the actually-newest turns regardless of
+      filesystem enumeration order. }
+    for i := 0 to High(TurnNumbers) - 1 do
+      for j := i + 1 to High(TurnNumbers) do
+        if TurnNumbers[j] < TurnNumbers[i] then
+        begin
+          T := TurnNumbers[i];
+          TurnNumbers[i] := TurnNumbers[j];
+          TurnNumbers[j] := T;
+        end;
+    if N > Length(TurnNumbers) then N := Length(TurnNumbers);
+    if Length(TurnNumbers) > N then
+    begin
+      { Drop the OLDEST (Length-N) entries; we only walk the newest N. }
+      for i := 0 to N - 1 do
+        TurnNumbers[i] := TurnNumbers[Length(TurnNumbers) - N + i];
+      SetLength(TurnNumbers, N);
+    end;
+    AlreadyRestored := TStringList.Create;
+    try
+      { TurnNumbers now contains exactly the last N turns in
+        ascending order. Walk oldest -> newest. }
+      for Hit := 0 to High(TurnNumbers) do
+      begin
+        T := TurnNumbers[Hit];
+        ManifestPath := JoinPath(JoinPath(Dir, Format('turn-%4.4d', [T])),
+                                  'manifest.json');
+        if not FileExists(ManifestPath) then Continue;
+        S := ReadFileText(ManifestPath);
+        ManRoot := TJsonObject.Parse(S);
+        if ManRoot = nil then Continue;
+        try
+          Files := ManRoot.ChildArray('files');
+          if Files = nil then Continue;
+          try
+            for i := 0 to Files.Count - 1 do
+            begin
+              FileObj := Files.ItemObject(i);
+              if FileObj = nil then Continue;
+              try
+                EntryPath := FileObj.GetStr('path', '');
+                BlobName  := FileObj.GetStr('blob', '');
+                RawSize   := FileObj.GetInt('size', 0);
+                if (EntryPath = '') or (BlobName = '') then Continue;
+                if AlreadyRestored.IndexOf(EntryPath) >= 0 then Continue;
+                BlobPath := JoinPath(
+                  JoinPath(JoinPath(Dir, Format('turn-%4.4d', [T])), 'blobs'),
+                  BlobName);
+                if not ReadFileBytes(BlobPath, Bytes) then Continue;
+                try
+                  WriteFileBytes(EntryPath, Bytes);
+                except
+                  on E: Exception do
+                  begin
+                    LogWarn('checkpoints: restore %s failed: %s',
+                            [EntryPath, E.Message]);
+                    Continue;
+                  end;
+                end;
+                AlreadyRestored.Add(EntryPath);
+                RestoredEntry.Path          := EntryPath;
+                RawCount := Length(Bytes);
+                RestoredEntry.BytesRestored := RawCount;
+                if RawSize = 0 then ;  { silence unused warning -- kept
+                                         for future schema use }
+                RestoredEntry.BlobIdx     := i;
+                RestoredEntry.SnappedTurn := T;
+                SetLength(Restored, Length(Restored) + 1);
+                Restored[High(Restored)] := RestoredEntry;
+              finally
+                FileObj.Free;
+              end;
+            end;
+          finally
+            Files.Free;
+          end;
+        finally
+          ManRoot.Free;
+        end;
+      end;
+    finally
+      AlreadyRestored.Free;
+    end;
+    Result := True;
+  finally
+    GLock.Release;
+  end;
+end;
+
+initialization
+  GLock := TCriticalSection.Create;
+  GTurnPaths := TStringList.Create;
+  GTurnPaths.CaseSensitive := True;
+  GTurnEntries := TStringList.Create;
+  ResetState;
+
+finalization
+  GLock.Free;
+  GTurnPaths.Free;
+  GTurnEntries.Free;
+
+end.

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -409,6 +409,17 @@ type
        this flag (it keeps an in-memory accumulator), so flipping
        it off doesn't disable the in-process view. *)
     StatsCollectionEnabled: Boolean;
+    (* Per-edit checkpoints + `/undo`. When True, fs_write and
+       fs_edit_hashline snapshot the pre-edit bytes of every file they
+       touch into workspace/checkpoints/<session-id>/turn-NNNN/ before
+       writing; the TUI's /undo command rewinds N turns by restoring
+       those captures. Off by default because it can be heavy -- a
+       turn that overwrites a 5 MB generated file copies the whole 5 MB
+       per turn. KeepLast caps how many turn dirs survive (older auto-
+       pruned). 0 means default (32). Opt in via `pasclaw onboard` or
+       by flipping checkpoints_enabled in config.json. *)
+    CheckpointsEnabled:    Boolean;
+    CheckpointsKeepLast:   Integer;
     AutoRouter:           TAutoRouterConfig;
     AnthropicServerTools: TAnthropicServerToolsConfig;
     OpenAIServerTools:    TOpenAIServerToolsConfig;
@@ -480,6 +491,8 @@ begin
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   ToolOutputCap        := 0;     { off by default; operators opt in. See TConfig.ToolOutputCap. }
   StatsCollectionEnabled := False; { opt-in via onboarding; see TConfig.StatsCollectionEnabled. }
+  CheckpointsEnabled     := False; { opt-in via onboarding; see TConfig.CheckpointsEnabled. }
+  CheckpointsKeepLast    := 0;     { 0 means default (32) inside PasClaw.Checkpoints. }
   AutoRouter.Enabled        := False;  { opt-in via onboarding; see TAutoRouterConfig. }
   AutoRouter.EasyProvider   := '';
   AutoRouter.EasyModel      := '';
@@ -664,6 +677,10 @@ begin
       Root.PutInt('tool_output_cap', ToolOutputCap);
     if StatsCollectionEnabled then
       Root.PutBool('stats_collection_enabled', True);
+    if CheckpointsEnabled then
+      Root.PutBool('checkpoints_enabled', True);
+    if CheckpointsKeepLast > 0 then
+      Root.PutInt('checkpoints_keep_last', CheckpointsKeepLast);
     if AutoRouter.Enabled
        or (AutoRouter.EasyProvider <> '')
        or (AutoRouter.EasyModel <> '')
@@ -882,6 +899,9 @@ begin
     ToolOutputCap       := Integer(Root.GetInt('tool_output_cap', ToolOutputCap));
     StatsCollectionEnabled := Root.GetBool('stats_collection_enabled',
                                            StatsCollectionEnabled);
+    CheckpointsEnabled  := Root.GetBool('checkpoints_enabled', CheckpointsEnabled);
+    CheckpointsKeepLast := Integer(Root.GetInt('checkpoints_keep_last',
+                                                CheckpointsKeepLast));
 
     Obj := Root.ChildObject('auto_router');
     if Obj <> nil then

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -42,7 +42,8 @@ uses
   PasClaw.JSON,
   PasClaw.Utils,
   PasClaw.Hashline,
-  PasClaw.Tools.Sandbox;
+  PasClaw.Tools.Sandbox,
+  PasClaw.Checkpoints;
 
 var
   GHashlineEnabled: Boolean = True;
@@ -201,6 +202,12 @@ begin
     Lines.Free;
   end;
   try
+    { Checkpoint hook: snapshot the file's current bytes BEFORE we
+      overwrite. No-op when checkpoints are disabled, when the file
+      didn't exist (the model is creating it; /undo leaves new files
+      in place), or when we already snapshotted this path earlier in
+      the same turn. See PasClaw.Checkpoints for the storage layout. }
+    SnapshotBeforeWrite(Path);
     WriteFileText(Path, Content);
     if Stripped then
       Result := Format('wrote %d bytes to %s (stripped hashline prefixes)', [Length(Content), Path])
@@ -308,6 +315,10 @@ begin
   try
     for i := 0 to High(Plans) do
     begin
+      { Same checkpoint hook as fs_write. Plans[i].Path has already
+        passed the sandbox + stale-hash gates above, so the file
+        definitely exists and we want its pre-edit bytes. }
+      SnapshotBeforeWrite(Plans[i].Path);
       WriteFileText(Plans[i].Path, Plans[i].NewBody);
       Sb.Append(Format('%s: wrote %d bytes (%d edits)',
                        [Plans[i].Path, Length(Plans[i].NewBody), Plans[i].EditCount]));

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -92,6 +92,16 @@ type
                                          loop is running, the result must land
                                          in the ORIGINATING session, never in
                                          whatever FSession now points at }
+    FPendingCheckpointRewire: Boolean;  { Codex P2 on PR #221: when the operator
+                                          switches sessions while a tool loop is
+                                          still running, the loop's FS-write
+                                          hooks would otherwise see the new
+                                          session's globals and write snapshots
+                                          under the WRONG session. Defer the
+                                          checkpoints rewire until
+                                          PollLoopWorker observes loop
+                                          completion; set this flag in
+                                          SelectSession to remind ourselves. }
     FMenuOpen:          Boolean;       { theme picker overlay active }
     FMenuSelIdx:        Integer;       { highlighted theme in the menu }
     FMenuOrigTheme:     string;        { theme name to revert to on Escape }
@@ -1020,7 +1030,13 @@ begin
   FInputBuf := '';
   Flash('session: ' + FSession.Meta.Id);
   RefreshSessions;
-  RewireCheckpoints;
+  if FLoopThread = nil then
+    RewireCheckpoints
+  else
+    { Loop still owns the checkpoints globals -- defer until it's
+      done so its in-flight fs_write hooks stay scoped to its
+      originating session. Codex P2 on PR #221. }
+    FPendingCheckpointRewire := True;
 end;
 
 procedure TTUI.RewireCheckpoints;
@@ -1104,7 +1120,10 @@ begin
     FSession := TSession.Create('');
     FInputBuf := '';
     FChatScroll := 0;
-    RewireCheckpoints;
+    if FLoopThread = nil then
+      RewireCheckpoints
+    else
+      FPendingCheckpointRewire := True;
   end;
   RefreshSessions;
   FConfirmDelete := False;
@@ -1120,11 +1139,14 @@ begin
 
   { Open a fresh checkpoints turn so any fs_write / fs_edit_hashline
     this loop fires lands in turn-NNNN/ under this session. No-op
-    when checkpoints aren't enabled. We use Stats.Turns+1 because
-    Stats.Turns reflects COMPLETED turns; the one we're about to
-    run is the next ordinal. }
-  if FSession <> nil then
-    BeginTurn(FSession.Meta.Stats.Turns + 1);
+    when checkpoints aren't enabled. The checkpoints module owns
+    the turn counter internally (resumed from on-disk state at
+    InitCheckpoints), so we don't pass a number here -- Codex P2
+    on PR #221: the previous design pulled the turn number from
+    TSession.Meta.Stats.Turns, which only increments when stats
+    collection is enabled, so with stats off every turn called
+    BeginTurn(1) and overwrote the same manifest. }
+  BeginTurn;
 
   { Append the user's turn to history BEFORE kicking off the loop so
     it shows up in the chat pane immediately (next redraw). }
@@ -1302,6 +1324,14 @@ begin
     FLoopSessionId := '';
     Flash(Format('timed out after %ds', [TimeoutSec]));
     RefreshSessions;
+    { Same deferred-rewire finalisation as the success / failure
+      paths below -- a timeout still ends the loop, so any pending
+      session switch is now safe to apply. }
+    if FPendingCheckpointRewire then
+    begin
+      FPendingCheckpointRewire := False;
+      RewireCheckpoints;
+    end;
     Exit;
   end;
 
@@ -1327,6 +1357,17 @@ begin
   Worker.Free;
   FLoopThread := nil;
   FLoopSessionId := '';
+  { Codex P2 on PR #221: the operator may have switched sessions
+    while this loop was running. The rewire was deferred so the
+    loop's fs_write hooks stayed scoped to FLoopSessionId; now that
+    the loop has finished, rebind checkpoints to whatever session
+    the operator is actually looking at. No-op when no switch
+    happened. }
+  if FPendingCheckpointRewire then
+  begin
+    FPendingCheckpointRewire := False;
+    RewireCheckpoints;
+  end;
 end;
 
 procedure TTUI.SubmitInput;
@@ -2422,14 +2463,10 @@ begin
   end;
 
   { FPC legacy REPL: same checkpoints turn boundary as the positioned
-    TUI's StartTurn. Use the session's persisted turn counter when
-    one's attached; otherwise fall back to the checkpoints module's
-    own running counter so `/undo` still works within the running
-    process. }
-  if FSession <> nil then
-    BeginTurn(FSession.Meta.Stats.Turns + 1)
-  else
-    BeginTurn(CurrentTurnNumber + 1);
+    TUI's StartTurn. The checkpoints module owns the counter
+    (resumed from on-disk state); see the matching comment in
+    StartTurn for the Codex P2 / stats-decoupling story. }
+  BeginTurn;
 
   SetLength(Msgs, 1);
   Msgs[0] := MakeMessage(mrUser, Text);

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -162,6 +162,8 @@ type
     procedure RefreshSessions;
     procedure SelectSession(Id: string);
     procedure StartNewSession;
+    procedure RewireCheckpoints;
+    procedure HandleUndoCommand(const Args: string);
     procedure DeleteSelectedSession;
     procedure PersistSession;
     procedure Flash(const Msg: string);
@@ -187,6 +189,13 @@ type
        and Codex P2 on PR #118. *)
     PromptCacheEnabled: Boolean;
     PromptCacheTTL:     string;
+    { Per-edit checkpoints. Cmd_TUI_Run forwards Cfg.CheckpointsEnabled
+      and Cfg.CheckpointsKeepLast here so onboarding's opt-in survives
+      into the live TUI loop. When the operator switches sessions the
+      TUI rewires the checkpoints module to the new session's subdir
+      so /undo stays bound to whatever's on screen. }
+    CheckpointsEnabled:    Boolean;
+    CheckpointsKeepLast:   Integer;
     (* When True, the assistant's reply is run through
        PasClaw.Markdown.Render before being printed -- headings and
        fenced code blocks get ANSI styling, raw stars and hashes
@@ -245,6 +254,9 @@ uses
   PasClaw.Tools.Shell.Filters,     { ShellFilterCalls / BytesSaved
                                      -- also surfaced in /stats }
   PasClaw.Agent.Steering,
+  PasClaw.Checkpoints,             { InitCheckpoints / BeginTurn / UndoTurns
+                                     -- /undo slash command + per-turn
+                                     snapshot bookkeeping. }
   PasClaw.Markdown.Render,
   PasClaw.Providers.Catalog,       { TProviderSpec -- for TModelRefreshThread }
   PasClaw.Config
@@ -1008,6 +1020,57 @@ begin
   FInputBuf := '';
   Flash('session: ' + FSession.Meta.Id);
   RefreshSessions;
+  RewireCheckpoints;
+end;
+
+procedure TTUI.RewireCheckpoints;
+{ Point the checkpoints module at the active session. No-op when
+  the operator hasn't opted in (CheckpointsEnabled=False on the
+  public TUI field, set by Cmd.TUI from Cfg.CheckpointsEnabled).
+  Called whenever FSession changes (new / load / switch). The
+  per-turn BeginTurn call inside StartTurn does the actual edge-
+  triggering; this just sets the session subdir. }
+var
+  CC: TCheckpointConfig;
+begin
+  if FSession = nil then Exit;
+  CC.Enabled   := CheckpointsEnabled;
+  CC.SessionId := FSession.Meta.Id;
+  CC.Root      := JoinPath(GetHome, 'workspace/checkpoints');
+  CC.KeepLast  := CheckpointsKeepLast;
+  InitCheckpoints(CC);
+end;
+
+procedure TTUI.HandleUndoCommand(const Args: string);
+{ `/undo` -> rewind 1 turn; `/undo N` -> rewind N turns. Restores
+  file contents that were captured at the start of each rewound turn.
+  Files the model CREATED inside the rewound window are left in
+  place (v1 conservative semantic; see PasClaw.Checkpoints). }
+var
+  N: Integer;
+  Restored: TRestoredFileArray;
+  Err: string;
+  Trimmed: string;
+begin
+  Trimmed := Trim(Args);
+  if Trimmed = '' then
+    N := 1
+  else
+    N := StrToIntDef(Trimmed, -1);
+  if N <= 0 then
+  begin
+    Flash('/undo: argument must be a positive turn count');
+    Exit;
+  end;
+  if not UndoTurns(N, Restored, Err) then
+  begin
+    Flash('/undo: ' + Err);
+    Exit;
+  end;
+  if Length(Restored) = 0 then
+    Flash(Format('/undo %d: no files to restore', [N]))
+  else
+    Flash(Format('/undo %d: restored %d file(s)', [N, Length(Restored)]));
 end;
 
 procedure TTUI.StartNewSession;
@@ -1041,6 +1104,7 @@ begin
     FSession := TSession.Create('');
     FInputBuf := '';
     FChatScroll := 0;
+    RewireCheckpoints;
   end;
   RefreshSessions;
   FConfirmDelete := False;
@@ -1053,6 +1117,14 @@ var
 begin
   if (FProvider = nil) or (Trim(UserText) = '') then Exit;
   if FLoopThread <> nil then Exit;   { already in flight }
+
+  { Open a fresh checkpoints turn so any fs_write / fs_edit_hashline
+    this loop fires lands in turn-NNNN/ under this session. No-op
+    when checkpoints aren't enabled. We use Stats.Turns+1 because
+    Stats.Turns reflects COMPLETED turns; the one we're about to
+    run is the next ordinal. }
+  if FSession <> nil then
+    BeginTurn(FSession.Meta.Stats.Turns + 1);
 
   { Append the user's turn to history BEFORE kicking off the loop so
     it shows up in the chat pane immediately (next redraw). }
@@ -1285,7 +1357,7 @@ begin
       end;
     end
     else if Text = '/help' then
-      Flash('keys: Tab swap pane | N new | D del | Q quit | /theme | /model | /stats')
+      Flash('keys: Tab swap | N new | D del | Q quit | /theme | /model | /stats | /undo [N]')
     else if (Text = '/tools') and (FRegistry <> nil) then
       Flash(Format('registered tools: %d', [FRegistry.Count]))
     else if Text = '/theme' then
@@ -1294,6 +1366,8 @@ begin
       OpenModelMenu
     else if Text = '/stats' then
       OpenStatsOverlay
+    else if (Text = '/undo') or (Copy(Text, 1, 6) = '/undo ') then
+      HandleUndoCommand(Copy(Text, 7, MaxInt))
     else
       Flash('unknown: ' + Text);
     FInputBuf := '';
@@ -2111,6 +2185,7 @@ begin
   end;
   FSession := TSession.Create(SessionId);
   RefreshSessions;
+  RewireCheckpoints;
 
   Flash('session: ' + FSession.Meta.Id);
 
@@ -2315,6 +2390,11 @@ begin
   if Cmd = '/clear' then begin Print(#27'[2J' + #27'[H'); DrawHeader; Exit; end;
   if Cmd = '/tools' then begin ShowTools; Exit; end;
   if Cmd = '/help'  then begin ShowHelp;  Exit; end;
+  if (Cmd = '/undo') or (Copy(Cmd, 1, 6) = '/undo ') then
+  begin
+    HandleUndoCommand(Copy(Cmd, 7, MaxInt));
+    Exit;
+  end;
   if Cmd = '/model' then begin ShowCachedModelsFPC(FModel, ''); Exit; end;
   if (Length(Cmd) > 7) and (Copy(Cmd, 1, 7) = '/model ') then
   begin
@@ -2340,6 +2420,16 @@ begin
             '(offline - no provider configured)');
     Exit;
   end;
+
+  { FPC legacy REPL: same checkpoints turn boundary as the positioned
+    TUI's StartTurn. Use the session's persisted turn counter when
+    one's attached; otherwise fall back to the checkpoints module's
+    own running counter so `/undo` still works within the running
+    process. }
+  if FSession <> nil then
+    BeginTurn(FSession.Meta.Stats.Turns + 1)
+  else
+    BeginTurn(CurrentTurnNumber + 1);
 
   SetLength(Msgs, 1);
   Msgs[0] := MakeMessage(mrUser, Text);

--- a/src/tests/checkpoints_tests.pas
+++ b/src/tests/checkpoints_tests.pas
@@ -115,7 +115,7 @@ var
   P: string;
 begin
   SetupDisabled;
-  BeginTurn(1);
+  BeginTurn;
   P := ScratchPath('disabled.txt');
   WriteScratch(P, 'original');
   SnapshotBeforeWrite(P);
@@ -135,7 +135,7 @@ begin
   P := ScratchPath('a.txt');
   WriteScratch(P, 'original');
 
-  BeginTurn(1);
+  BeginTurn;
   SnapshotBeforeWrite(P);
   WriteFileText(P, 'modified by model');
 
@@ -155,7 +155,7 @@ begin
   P := ScratchPath('b.txt');
   WriteScratch(P, 'state-A');
 
-  BeginTurn(2);
+  BeginTurn;
   SnapshotBeforeWrite(P);              { captures state-A }
   WriteFileText(P, 'state-B');
   SnapshotBeforeWrite(P);              { no-op: keep state-A }
@@ -177,15 +177,15 @@ begin
   P := ScratchPath('c.txt');
   WriteScratch(P, 'gen-1');
 
-  BeginTurn(1);
+  BeginTurn;
   SnapshotBeforeWrite(P);
   WriteFileText(P, 'gen-2');
 
-  BeginTurn(2);
+  BeginTurn;
   SnapshotBeforeWrite(P);
   WriteFileText(P, 'gen-3');
 
-  BeginTurn(3);
+  BeginTurn;
   SnapshotBeforeWrite(P);
   WriteFileText(P, 'gen-4');
 
@@ -204,7 +204,7 @@ begin
   P := ScratchPath('d.txt');
   WriteScratch(P, 'v0');
 
-  BeginTurn(1);
+  BeginTurn;
   SnapshotBeforeWrite(P);
   WriteFileText(P, 'v1');
 
@@ -220,7 +220,7 @@ var
   Err: string;
 begin
   SetupSession('reject', 0);
-  BeginTurn(1);
+  BeginTurn;
   AssertFalse(UndoTurns(0, Restored, Err),
               'undo 0 rejected');
   AssertContains(Err, 'positive', 'clear error message');
@@ -260,7 +260,7 @@ begin
   P := ScratchPath('e-new.txt');
   if FileExists(P) then DeleteFile(P);
 
-  BeginTurn(1);
+  BeginTurn;
   SnapshotBeforeWrite(P);          { file does not exist -- no blob written }
   WriteFileText(P, 'created by model');
 
@@ -288,7 +288,7 @@ begin
   WriteScratch(P, 'seed');
   for i := 1 to 6 do
   begin
-    BeginTurn(i);
+    BeginTurn;
     SnapshotBeforeWrite(P);
     WriteFileText(P, 'gen-' + IntToStr(i));
   end;
@@ -297,6 +297,54 @@ begin
               'only last 3 turn dirs remain after auto-prune');
   AssertEqInt(OldestTurn, 4, 'oldest is turn 4');
   AssertEqInt(NewestTurn, 6, 'newest is turn 6');
+end;
+
+procedure TestInitResumesFromExistingTurnDirs;
+(* Codex P2 on PR #221: the old design pulled the turn number from
+   TSession.Meta.Stats.Turns, which only increments when
+   stats_collection_enabled is True. With stats off (the default),
+   every TUI turn called BeginTurn(1) and overwrote turn-0001's
+   manifest. Fix: the module owns its own counter and resumes from
+   the highest existing turn-NNNN dir at InitCheckpoints. This test
+   pins that resume: drop a turn-0007 dir on disk, re-Init, and
+   verify the next BeginTurn lands on turn-0008. *)
+var
+  Cfg: TCheckpointConfig;
+  P: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+  Old, NewestT: Integer;
+begin
+  SetupSession('resume', 0);
+  P := ScratchPath('h.txt');
+  WriteScratch(P, 'baseline');
+
+  BeginTurn;   { turn-0001 }
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'edited-1');
+
+  { Pretend we just relaunched pasclaw: re-Init the same session.
+    The module should rediscover turn-0001 and resume from there. }
+  Cfg.Enabled   := True;
+  Cfg.SessionId := 'resume';
+  Cfg.Root      := JoinPath(GTmpRoot, 'cp');
+  Cfg.KeepLast  := 0;
+  InitCheckpoints(Cfg);
+
+  AssertEqInt(CountSnapshottedTurns(Old, NewestT), 1, 'one turn on disk');
+  AssertEqInt(NewestT, 1, 'newest is 1');
+
+  BeginTurn;   { should land on turn-0002, NOT turn-0001 again }
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'edited-2');
+
+  AssertEqInt(CountSnapshottedTurns(Old, NewestT), 2,
+              'second BeginTurn after resume created a NEW turn dir');
+  AssertEqInt(NewestT, 2, 'newest is 2 (resumed correctly)');
+
+  AssertTrue(UndoTurns(1, Restored, Err), 'undo 1');
+  AssertEqStr(ReadFileText(P), 'edited-1',
+              'undo 1 rolls back to state at start of turn-0002');
 end;
 
 procedure TestMultipleFilesInOneTurn;
@@ -311,7 +359,7 @@ begin
   WriteScratch(P1, 'one-original');
   WriteScratch(P2, 'two-original');
 
-  BeginTurn(1);
+  BeginTurn;
   SnapshotBeforeWrite(P1);
   SnapshotBeforeWrite(P2);
   WriteFileText(P1, 'one-modified');
@@ -358,6 +406,7 @@ begin
     TestUndoWhenDisabledFails;                WriteLn('  ok: undo when disabled fails');
     TestModelCreatedFilesAreLeftInPlace;      WriteLn('  ok: model-created files left in place');
     TestKeepLastPrunesOlderTurns;             WriteLn('  ok: KeepLast prunes older turns');
+    TestInitResumesFromExistingTurnDirs;      WriteLn('  ok: Init resumes turn counter from disk');
     TestMultipleFilesInOneTurn;               WriteLn('  ok: multiple files in one turn');
     WriteLn('PASS');
   finally

--- a/src/tests/checkpoints_tests.pas
+++ b/src/tests/checkpoints_tests.pas
@@ -1,0 +1,366 @@
+program checkpoints_tests;
+(*
+  Covers PasClaw.Checkpoints -- the opt-in file-edit rollback that
+  fs_write and fs_edit_hashline hook into so a TUI /undo can rewind
+  N turns by restoring the pre-edit bytes.
+
+  Strategy: no model, no agent loop. Drive InitCheckpoints +
+  BeginTurn + SnapshotBeforeWrite + UndoTurns directly against
+  scratch files in a temp dir, then assert the file contents and
+  the on-disk manifest.
+
+  Pinned contracts:
+    - Disabled state is a no-op (no checkpoint dir, no snapshot)
+    - SnapshotBeforeWrite captures the file's pre-edit bytes
+    - Idempotency: snapshotting the same path twice in one turn
+      keeps the EARLIEST capture (so a turn that edits a file
+      twice still rolls back to the very first state)
+    - UndoTurns(1) restores the file to its state at the START
+      of the current turn
+    - UndoTurns(N) walks N turns; the EARLIEST capture across
+      those N wins for any file edited multiple times
+    - UndoTurns rejects N=0, N<0, and returns an explanatory
+      ErrMsg when the session has no recorded turns
+    - Files the model CREATED inside a rewound turn (no
+      pre-snapshot exists) are left in place by /undo -- v1's
+      conservative semantic
+    - KeepLast auto-prunes older turn dirs at BeginTurn time
+    - CountSnapshottedTurns reports the live turn range
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  PasClaw.Utils,
+  PasClaw.Checkpoints;
+
+var
+  GTmpRoot: string;
+  GWorkDir: string;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertFalse(Cond: Boolean; const Msg: string);
+begin
+  if Cond then Fail_(Msg);
+end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Copy(Got, 1, 200) + '", want "' +
+          Copy(Want, 1, 200) + '")');
+end;
+
+procedure AssertEqInt(Got, Want: Integer; const Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Format('%s (got %d, want %d)', [Msg, Got, Want]));
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing)');
+end;
+
+procedure SetupSession(const SessionId: string; KeepLast: Integer);
+var
+  Cfg: TCheckpointConfig;
+begin
+  Cfg.Enabled   := True;
+  Cfg.SessionId := SessionId;
+  Cfg.Root      := JoinPath(GTmpRoot, 'cp');
+  Cfg.KeepLast  := KeepLast;
+  InitCheckpoints(Cfg);
+end;
+
+procedure SetupDisabled;
+var
+  Cfg: TCheckpointConfig;
+begin
+  Cfg.Enabled   := False;
+  Cfg.SessionId := 'irrelevant';
+  Cfg.Root      := JoinPath(GTmpRoot, 'cp');
+  Cfg.KeepLast  := 0;
+  InitCheckpoints(Cfg);
+end;
+
+function ScratchPath(const Name: string): string;
+begin
+  Result := JoinPath(GWorkDir, Name);
+end;
+
+procedure WriteScratch(const Path, Content: string);
+begin
+  EnsureDir(ExtractFilePath(Path));
+  WriteFileText(Path, Content);
+end;
+
+procedure TestDisabledIsNoOp;
+var
+  P: string;
+begin
+  SetupDisabled;
+  BeginTurn(1);
+  P := ScratchPath('disabled.txt');
+  WriteScratch(P, 'original');
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'modified');
+  AssertFalse(CheckpointsEnabled, 'disabled state reports disabled');
+  AssertFalse(DirectoryExists(JoinPath(GTmpRoot, 'cp')),
+              'no cp dir created when disabled');
+end;
+
+procedure TestUndoSingleTurn;
+var
+  P: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('undo1', 0);
+  P := ScratchPath('a.txt');
+  WriteScratch(P, 'original');
+
+  BeginTurn(1);
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'modified by model');
+
+  AssertTrue(UndoTurns(1, Restored, Err), 'undo 1 succeeded');
+  AssertEqStr(Err, '', 'no error');
+  AssertEqInt(Length(Restored), 1, 'one file restored');
+  AssertEqStr(ReadFileText(P), 'original', 'file rolled back');
+end;
+
+procedure TestIdempotentSnapshotKeepsEarliestState;
+var
+  P: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('idem', 0);
+  P := ScratchPath('b.txt');
+  WriteScratch(P, 'state-A');
+
+  BeginTurn(2);
+  SnapshotBeforeWrite(P);              { captures state-A }
+  WriteFileText(P, 'state-B');
+  SnapshotBeforeWrite(P);              { no-op: keep state-A }
+  WriteFileText(P, 'state-C');
+
+  AssertTrue(UndoTurns(1, Restored, Err),
+             'undo rolls back to state-A');
+  AssertEqStr(ReadFileText(P), 'state-A',
+              'earliest captured state wins inside a turn');
+end;
+
+procedure TestUndoAcrossTurns;
+var
+  P: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('across', 0);
+  P := ScratchPath('c.txt');
+  WriteScratch(P, 'gen-1');
+
+  BeginTurn(1);
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'gen-2');
+
+  BeginTurn(2);
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'gen-3');
+
+  BeginTurn(3);
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'gen-4');
+
+  AssertTrue(UndoTurns(2, Restored, Err), 'undo 2 OK');
+  AssertEqStr(ReadFileText(P), 'gen-2',
+              'undo 2 turns -> restore start-of-turn-2 (= gen-2)');
+end;
+
+procedure TestUndoBeyondHistoryClampsToWhatExists;
+var
+  P: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('clamp', 0);
+  P := ScratchPath('d.txt');
+  WriteScratch(P, 'v0');
+
+  BeginTurn(1);
+  SnapshotBeforeWrite(P);
+  WriteFileText(P, 'v1');
+
+  AssertTrue(UndoTurns(50, Restored, Err),
+             'undo of 50 against 1 turn still succeeds (clamps)');
+  AssertEqStr(ReadFileText(P), 'v0',
+              'rolled all the way back to v0');
+end;
+
+procedure TestUndoRejectsZeroAndNegative;
+var
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('reject', 0);
+  BeginTurn(1);
+  AssertFalse(UndoTurns(0, Restored, Err),
+              'undo 0 rejected');
+  AssertContains(Err, 'positive', 'clear error message');
+  AssertFalse(UndoTurns(-3, Restored, Err),
+              'undo -3 rejected');
+end;
+
+procedure TestUndoOnEmptySessionReportsClearly;
+var
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('empty', 0);
+  AssertFalse(UndoTurns(1, Restored, Err),
+              'no turns yet -> undo fails');
+  AssertContains(Err, 'no snapshots', 'message names the cause');
+end;
+
+procedure TestUndoWhenDisabledFails;
+var
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupDisabled;
+  AssertFalse(UndoTurns(1, Restored, Err),
+              'disabled checkpoints -> undo fails');
+  AssertContains(Err, 'not enabled', 'message names the cause');
+end;
+
+procedure TestModelCreatedFilesAreLeftInPlace;
+var
+  P: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('newfile', 0);
+  P := ScratchPath('e-new.txt');
+  if FileExists(P) then DeleteFile(P);
+
+  BeginTurn(1);
+  SnapshotBeforeWrite(P);          { file does not exist -- no blob written }
+  WriteFileText(P, 'created by model');
+
+  AssertTrue(UndoTurns(1, Restored, Err), 'undo runs without error');
+  { File still exists -- v1 leaves model-created files in place. }
+  AssertTrue(FileExists(P), 'newly-created file survives undo');
+  AssertEqStr(ReadFileText(P), 'created by model',
+              'contents unchanged for model-created file');
+end;
+
+procedure TestKeepLastPrunesOlderTurns;
+var
+  Cfg: TCheckpointConfig;
+  P: string;
+  i: Integer;
+  OldestTurn, NewestTurn: Integer;
+begin
+  Cfg.Enabled   := True;
+  Cfg.SessionId := 'prune';
+  Cfg.Root      := JoinPath(GTmpRoot, 'cp');
+  Cfg.KeepLast  := 3;
+  InitCheckpoints(Cfg);
+
+  P := ScratchPath('f.txt');
+  WriteScratch(P, 'seed');
+  for i := 1 to 6 do
+  begin
+    BeginTurn(i);
+    SnapshotBeforeWrite(P);
+    WriteFileText(P, 'gen-' + IntToStr(i));
+  end;
+
+  AssertEqInt(CountSnapshottedTurns(OldestTurn, NewestTurn), 3,
+              'only last 3 turn dirs remain after auto-prune');
+  AssertEqInt(OldestTurn, 4, 'oldest is turn 4');
+  AssertEqInt(NewestTurn, 6, 'newest is turn 6');
+end;
+
+procedure TestMultipleFilesInOneTurn;
+var
+  P1, P2: string;
+  Restored: TRestoredFileArray;
+  Err: string;
+begin
+  SetupSession('multi', 0);
+  P1 := ScratchPath('g1.txt');
+  P2 := ScratchPath('g2.txt');
+  WriteScratch(P1, 'one-original');
+  WriteScratch(P2, 'two-original');
+
+  BeginTurn(1);
+  SnapshotBeforeWrite(P1);
+  SnapshotBeforeWrite(P2);
+  WriteFileText(P1, 'one-modified');
+  WriteFileText(P2, 'two-modified');
+
+  AssertTrue(UndoTurns(1, Restored, Err), 'undo OK');
+  AssertEqInt(Length(Restored), 2, 'two files restored');
+  AssertEqStr(ReadFileText(P1), 'one-original', 'p1 rolled back');
+  AssertEqStr(ReadFileText(P2), 'two-original', 'p2 rolled back');
+end;
+
+procedure CleanupTmp;
+begin
+  if (GTmpRoot <> '') and DirectoryExists(GTmpRoot) then
+  begin
+    { Best-effort recursive rm via simple shellout -- POSIX only. }
+    {$IFDEF UNIX}
+    ExecuteProcess('/bin/sh', ['-c', 'rm -rf "' + GTmpRoot + '"']);
+    {$ENDIF}
+  end;
+end;
+
+begin
+  Randomize;  { without this, Random returns the same sequence every
+                run -- and a leftover tmp dir from a prior run breaks
+                the "disabled is no-op" test that checks the cp dir
+                doesn't exist. }
+  GTmpRoot := JoinPath(GetTempDir, 'pasclaw-cp-test-' + IntToStr(Random(MaxInt)));
+  { Defensive: nuke any leftover dir with this exact name (extremely
+    rare collision under a seeded Random; cheap insurance). }
+  {$IFDEF UNIX}
+  ExecuteProcess('/bin/sh', ['-c', 'rm -rf "' + GTmpRoot + '"']);
+  {$ENDIF}
+  GWorkDir := JoinPath(GTmpRoot, 'work');
+  EnsureDir(GWorkDir);
+  try
+    TestDisabledIsNoOp;                       WriteLn('  ok: disabled is no-op');
+    TestUndoSingleTurn;                       WriteLn('  ok: undo single turn');
+    TestIdempotentSnapshotKeepsEarliestState; WriteLn('  ok: idempotent snapshot keeps earliest');
+    TestUndoAcrossTurns;                      WriteLn('  ok: undo across turns');
+    TestUndoBeyondHistoryClampsToWhatExists;  WriteLn('  ok: undo beyond history clamps');
+    TestUndoRejectsZeroAndNegative;           WriteLn('  ok: undo rejects non-positive N');
+    TestUndoOnEmptySessionReportsClearly;     WriteLn('  ok: undo on empty session');
+    TestUndoWhenDisabledFails;                WriteLn('  ok: undo when disabled fails');
+    TestModelCreatedFilesAreLeftInPlace;      WriteLn('  ok: model-created files left in place');
+    TestKeepLastPrunesOlderTurns;             WriteLn('  ok: KeepLast prunes older turns');
+    TestMultipleFilesInOneTurn;               WriteLn('  ok: multiple files in one turn');
+    WriteLn('PASS');
+  finally
+    CleanupTmp;
+  end;
+end.


### PR DESCRIPTION
## Summary

We had no rollback story at all. When the model `fs_writes` the wrong file, or `fs_edit_hashlines` into a state the operator doesn't want, the only recovery was undo-by-hand from version control — if there even was any.

This PR adds opt-in **checkpoints + a TUI `/undo` command**:

- **Auto-snapshot.** `fs_write` and `fs_edit_hashline` now snapshot the pre-edit bytes of every file they touch into `$PASCLAW_HOME/workspace/checkpoints/<session>/turn-NNNN/` BEFORE writing. Per-turn `manifest.json` + per-file blob.
- **`/undo [N]`.** Rewinds N turns by restoring those captures. Walks oldest→newest across the rewound range so the EARLIEST captured pre-state of each file wins; `/undo 2` from turn HEAD therefore restores everything to the state at the start of (HEAD-1), even if some files were edited in multiple of the rewound turns.
- **Model-created files left in place.** v1 conservative semantic — deleting model-created files risks data loss if the model also rewrote an unrelated file in the same turn.
- **Idempotent.** Snapshotting the same file twice in one turn keeps the earliest capture; `/undo` still rolls back to before the first edit.
- **`KeepLast` auto-prunes** at `BeginTurn` so per-session disk usage is bounded (default 32).

## Off by default

You warned this can be heavy — a turn that `fs_writes` a 5 MB generated file copies the whole 5 MB into the per-turn dir. So:

- `TConfig.CheckpointsEnabled` defaults `False`; `CheckpointsKeepLast` defaults `0` (= module default 32). Both round-trip through `config.json`.
- `pasclaw onboard` asks opt-in style with explicit "can be heavy" warning.
- `Cmd.TUI` forwards `Cfg.CheckpointsEnabled` + `KeepLast` onto the TUI instance.
- `StartTurn` (positioned TUI) and `HandleUserInput` (FPC legacy REPL) both call `BeginTurn` so each user message opens a fresh turn dir.

## Files

- **New**: `src/pkg/checkpoints/PasClaw.Checkpoints.pas` — transport-agnostic, thread-safe (per-instance CS), ~440 lines.
- **New**: `src/tests/checkpoints_tests.pas` — 11 cases (disabled no-op, single + cross-turn undo, idempotency, clamp, reject paths, model-created-files-left-in-place, `KeepLast` pruning, multi-file per turn).
- `src/pkg/tools/PasClaw.Tools.FS.pas` — `SnapshotBeforeWrite` hooked into both write tools.
- `src/pkg/config/PasClaw.Config.pas` — fields + JSON round-trip.
- `src/cmd/PasClaw.Cmd.Onboard.pas` — `PromptCheckpoints` opt-in question.
- `src/pkg/tui/PasClaw.TUI.pas` — `/undo` slash command + `BeginTurn` per turn + `RewireCheckpoints` per session switch.
- `src/cmd/PasClaw.Cmd.TUI.pas` — forwards config fields onto the TUI.
- `Makefile`, `src/pasclaw/PasClaw.dproj`, `build-delphi.bat`, `build-fpc.bat` — search paths for the new unit + `test-checkpoints` target.

## Test plan

- [x] `make test` — full suite green incl. new `test-checkpoints` (11/11)
- [x] `make smoke` — all subcommands OK
- [ ] Manual: `pasclaw onboard` — verify the new "Enable checkpoints" prompt appears between Stats and AutoRouter
- [ ] Manual: enable, `pasclaw tui`, ask the model to edit a file, then `/undo` — verify the file rolls back; check `workspace/checkpoints/<session>/turn-NNNN/` exists
- [ ] Manual: `/undo 3` after 3 edits across 3 turns — verify file restores to its state before turn N-2
- [ ] Delphi `dcc64` build picks up the new unit (FPC verified locally)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_