### PR TITLE
localvector: dlopen / dlsym for Delphi non-Windows (was: dcc64 Linux E2010/E2003)

### DIFF
--- a/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
+++ b/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
@@ -34,7 +34,16 @@ uses
 {$IFDEF MSWINDOWS}
   , {$IFDEF FPC}Windows{$ELSE}Winapi.Windows{$ENDIF}
 {$ELSE}
-  {$IFDEF FPC}, dynlibs{$ENDIF}
+  {$IFDEF FPC}
+  , dynlibs
+  {$ELSE}
+  { Delphi non-Windows (Linux64) -- the FPC `dynlibs` unit doesn't
+    exist here, so we get dlopen / dlsym out of Posix.Dlfcn instead.
+    Without this import the original {$ELSE} branch tried to call
+    FPC's LoadLibrary(string) and GetProcedureAddress, which dcc64
+    on Linux can't resolve. }
+  , Posix.Dlfcn
+  {$ENDIF}
 {$ENDIF}
   ;
 
@@ -123,7 +132,16 @@ begin
 {$IFDEF MSWINDOWS}
   Result := LoadLibrary(PChar(AName));
 {$ELSE}
+  {$IFDEF FPC}
   Result := LoadLibrary(AName);
+  {$ELSE}
+  { Delphi Linux: dlopen returns a Pointer; cast to TOrdHandle (which
+    is NativeUInt on non-Windows Delphi). RTLD_NOW resolves every
+    symbol up front so a missing entrypoint surfaces here, not on
+    the first call -- mirrors what FPC's LoadLibrary does internally
+    on POSIX. }
+  Result := TOrdHandle(dlopen(PAnsiChar(AnsiString(AName)), RTLD_NOW));
+  {$ENDIF}
 {$ENDIF}
 end;
 
@@ -132,7 +150,13 @@ begin
 {$IFDEF MSWINDOWS}
   Result := GetProcAddress(h, PAnsiChar(AnsiString(AName)));
 {$ELSE}
+  {$IFDEF FPC}
   Result := GetProcedureAddress(h, AName);
+  {$ELSE}
+  { Delphi Linux equivalent of FPC's GetProcedureAddress -- dlsym
+    against the handle dlopen handed back. }
+  Result := dlsym(Pointer(h), PAnsiChar(AnsiString(AName)));
+  {$ENDIF}
 {$ENDIF}
 end;
 

--- a/src/pkg/memory/localvector/onnxruntime_pas_api.pas
+++ b/src/pkg/memory/localvector/onnxruntime_pas_api.pas
@@ -975,7 +975,12 @@ type
   const DefaultLanguageProjection = OrtLanguageProjection.ORT_PROJECTION_CPLUSPLUS;
 
 type
-  TOrtLibHandle = {$IFDEF FPC}TLibHandle{$ELSE}HMODULE{$ENDIF};
+  TOrtLibHandle =
+    {$IFDEF FPC}
+      TLibHandle
+    {$ELSE}
+      {$IFDEF MSWINDOWS}HMODULE{$ELSE}NativeUInt{$ENDIF}
+    {$ENDIF};
   TfnOrtGetApiBase = function: POrtApiBase; cdecl;
   TfnOrtAppendCPU = function(options: POrtSessionOptions; use_arena: longint): POrtStatus; cdecl;
   TfnOrtAppendDev = function(options: POrtSessionOptions; device_id: longint): POrtStatus; cdecl;
@@ -1057,7 +1062,16 @@ begin
 {$IFDEF FPC}
   Result := LoadLibrary(AName);
 {$ELSE}
+  {$IFDEF MSWINDOWS}
   Result := LoadLibrary(PChar(AName));
+  {$ELSE}
+  { Delphi non-Windows (Linux64) -- there's no top-level LoadLibrary
+    overload here; route through Posix.Dlfcn.dlopen and cast the
+    Pointer handle back to TOrtLibHandle (= NativeUInt). RTLD_NOW
+    surfaces a missing entrypoint up front, matching the loaded-or-
+    not contract OrtRuntimeLoaded relies on. }
+  Result := TOrtLibHandle(dlopen(PAnsiChar(AnsiString(AName)), RTLD_NOW));
+  {$ENDIF}
 {$ENDIF}
 end;
 
@@ -1066,7 +1080,12 @@ begin
 {$IFDEF FPC}
   Result := GetProcedureAddress(AHandle, AName);
 {$ELSE}
+  {$IFDEF MSWINDOWS}
   Result := GetProcAddress(AHandle, PAnsiChar(AnsiString(AName)));
+  {$ELSE}
+  { Delphi Linux: dlsym against the dlopen handle. }
+  Result := dlsym(Pointer(AHandle), PAnsiChar(AnsiString(AName)));
+  {$ENDIF}
 {$ENDIF}
 end;
 


### PR DESCRIPTION
## Summary

You reported:

```
[DCC Error] LocalVector.Sqlite3.pas(126): E2010 Incompatible types: 'PWideChar' and 'string'
[DCC Error] LocalVector.Sqlite3.pas(135): E2003 Undeclared identifier: 'GetProcedureAddress'
```

Both come from the `{$ELSE}` (non-Windows) branches in `ldLib` / `ldProc` assuming FPC's `dynlibs` unit is available. FPC's `LoadLibrary` takes a `string` and `GetProcedureAddress` accepts `string + handle` — but `dcc64` on Linux has neither symbol. The `{$ELSE}` branch was unguarded for the **Delphi-non-Windows** case, so dcc64 hit the FPC-flavoured calls and errored.

## Fix

Split the `{$ELSE}` branches into the existing FPC path and a new Delphi-Linux path that routes through `Posix.Dlfcn`:

- **`LocalVector.Sqlite3.pas`** — `, Posix.Dlfcn` added to the uses clause for Delphi non-Windows. `ldLib` uses `dlopen(PAnsiChar, RTLD_NOW)` and casts the `Pointer` back to `TOrdHandle` (already `NativeUInt` on that target). `ldProc` uses `dlsym`.

- **`onnxruntime_pas_api.pas`** — same pattern of bug (`LoadLibrary(PChar)` + `GetProcAddress`) which compiles on Delphi Windows but not Linux — the `LoadLibrary` PChar overload only ships in `Winapi.Windows`. Same split applied. The `TOrtLibHandle` alias also gets a `NativeUInt` branch for Delphi non-Windows since `HMODULE` is `Winapi.Windows`-only.

`RTLD_NOW` (not `RTLD_LAZY`) so a missing entrypoint surfaces here, not on the first call — matches what FPC's `LoadLibrary` does internally on POSIX, and what `OrtRuntimeLoaded` / `Sqlite3Loaded` ("is the dynamic library actually usable") are asking.

## Test plan

- [x] FPC `make smoke` — all subcommands OK
- [x] FPC `make test` — full suite green
- [ ] **Delphi Linux**: build via dcc64 on your box — should no longer fail with E2010 / E2003 at those line numbers

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_