### PR TITLE
localvector: more dcc64 Linux fixes (comment, UInt64->Pointer, LongInt ref-counts)

### DIFF
--- a/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
+++ b/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
@@ -37,11 +37,12 @@ uses
   {$IFDEF FPC}
   , dynlibs
   {$ELSE}
-  { Delphi non-Windows (Linux64) -- the FPC `dynlibs` unit doesn't
-    exist here, so we get dlopen / dlsym out of Posix.Dlfcn instead.
-    Without this import the original {$ELSE} branch tried to call
-    FPC's LoadLibrary(string) and GetProcedureAddress, which dcc64
-    on Linux can't resolve. }
+  (* Delphi non-Windows (Linux64) -- the FPC `dynlibs` unit doesn't
+     exist here, so we get dlopen / dlsym out of Posix.Dlfcn instead.
+     Without this import the original non-FPC branch tried to call
+     FPC's LoadLibrary(string) and GetProcedureAddress, which dcc64
+     on Linux can't resolve. Paren-star delimiters so the IFDEF/ELSE
+     tokens inside this comment don't trip Delphi's preprocessor. *)
   , Posix.Dlfcn
   {$ENDIF}
 {$ENDIF}
@@ -155,7 +156,10 @@ begin
   {$ELSE}
   { Delphi Linux equivalent of FPC's GetProcedureAddress -- dlsym
     against the handle dlopen handed back. }
-  Result := dlsym(Pointer(h), PAnsiChar(AnsiString(AName)));
+  { Two-step cast: Delphi rejects a direct Pointer(UInt64) typecast,
+    so go via NativeUInt (which is the underlying integer type of
+    TOrdHandle in this branch). }
+  Result := dlsym(Pointer(NativeUInt(h)), PAnsiChar(AnsiString(AName)));
   {$ENDIF}
 {$ENDIF}
 end;

--- a/src/pkg/memory/localvector/onnxruntime.pas
+++ b/src/pkg/memory/localvector/onnxruntime.pas
@@ -135,7 +135,11 @@ type
     var
     // similar as overloading [] operators for property x[v: string]: integer read gx write sx; default;
     Instance: PT ; // default keyword for non property.
-    RefCount: PLongint;
+    { PInteger (not PLongint) -- on Delphi POSIX 64-bit LongInt widens
+      to 64 bits, which can't satisfy TInterlocked.Increment(var Integer).
+      Integer is 32-bit on every supported target (FPC delphi-mode,
+      Delphi Win, Delphi Linux64), matching the intended ref-count width. }
+    RefCount: PInteger;
     procedure DecRef();
 
     class operator Initialize({$ifdef fpc}var{$else}out{$endif} dst: TSmartPtr<T>);
@@ -162,7 +166,7 @@ type
   var
     // similar as overloading [] operators for property x[v: string]: integer read gx write sx; default;
     Instance: PT ; // default keyword for non property.
-    RefCount: PLongint;
+    RefCount: PInteger;  // see TSmartPtr<T> -- PInteger for dcc64 Linux compat
     DisposerFunc: TORTAllocatedFree;
     constructor Create(const val:PT;const aDisposer:TORTAllocatedFree);
     procedure DecRef();
@@ -216,7 +220,10 @@ type
   end;
   PMemHouseKeeper = ^TMemHouseKeeper;
   //TMemHouseKeeper = TOrderedKeyValueList<Pointer,PLongInt>;
-  TMemHouseKeeper = TOrderedKeyValueList<Pointer,TArray<LongInt>>;
+  TMemHouseKeeper = TOrderedKeyValueList<Pointer,TArray<Integer>>;
+  // PInteger / TArray<Integer> -- LongInt would be 64-bit on Delphi Linux64
+  // and break TInterlocked.Increment/Decrement(var Integer). Integer is
+  // 32-bit on every supported target, matching the intended ref-count width.
 
   {$endif}
 
@@ -1678,7 +1685,7 @@ end;
 procedure TORTBase<T>.NewRef;
 var
   //RefCount:PLongInt;
-  RefCount:TArray<LongInt>;
+  RefCount:TArray<Integer>;
 begin
 
  //New(RefCount);
@@ -1703,7 +1710,7 @@ end;
 procedure TORTBase<T>.Assign(const val: Pointer);
 var
   //RefCount:PLongInt;
-  RefCount:TArray<LongInt>;
+  RefCount:TArray<Integer>;
 begin
   if not HouseKeeper.TryGetValue(p_,RefCount) then RefCount:=nil;
   if RefCount <> nil then
@@ -1716,7 +1723,7 @@ end;
 procedure TORTBase<T>.DecRef;
 var
   //RefCount:PLongInt;
-  RefCount:TArray<LongInt>;
+  RefCount:TArray<Integer>;
 begin
   if not HouseKeeper.TryGetValue(p_,RefCount) then RefCount:=nil;
   {$IFDEF MEM_DEBUG}
@@ -1795,7 +1802,7 @@ begin
 end;
 
 class operator TORTBase<T>.Initialize({$ifdef fpc}outvar{$else}out{$endif} v: TORTBase<T>);
-var RefCount:PLongInt;
+var RefCount:PInteger;
 begin
   v.p_:=nil;
   if GetApi=nil then exit;
@@ -1840,7 +1847,7 @@ class operator TORTBase<T>.Assign(var dst: TORTBase<T>; const [ref] src: TORTBas
 {$endif}
 var
   //dRefCount,sRefCount:PLongInt;
-  dRefCount,sRefCount:TArray<LongInt>;
+  dRefCount,sRefCount:TArray<Integer>;
 begin
   if not HouseKeeper.TryGetValue(dst.p_,dRefCount) then dRefCount:=nil;
   if not HouseKeeper.TryGetValue(src.p_,sRefCount) then sRefCount:=nil;
@@ -1877,7 +1884,7 @@ begin
 class operator TORTBase<T>.AddRef(var src: TORTBase<T>);
 var
   //RefCount:PLongInt;
-  RefCount:TArray<LongInt>;
+  RefCount:TArray<Integer>;
 begin
   if not HouseKeeper.TryGetValue(src.p_,RefCount) then RefCount:=nil;
   {$IFDEF MEM_DEBUG}

--- a/src/pkg/memory/localvector/onnxruntime_pas_api.pas
+++ b/src/pkg/memory/localvector/onnxruntime_pas_api.pas
@@ -1083,8 +1083,10 @@ begin
   {$IFDEF MSWINDOWS}
   Result := GetProcAddress(AHandle, PAnsiChar(AnsiString(AName)));
   {$ELSE}
-  { Delphi Linux: dlsym against the dlopen handle. }
-  Result := dlsym(Pointer(AHandle), PAnsiChar(AnsiString(AName)));
+  { Delphi Linux: dlsym against the dlopen handle. Two-step cast --
+    Delphi rejects direct Pointer(UInt64), so go via NativeUInt
+    (the underlying integer type of TOrtLibHandle in this branch). }
+  Result := dlsym(Pointer(NativeUInt(AHandle)), PAnsiChar(AnsiString(AName)));
   {$ENDIF}
 {$ENDIF}
 end;


### PR DESCRIPTION
Follow-up to #224. Three further classes of dcc64-on-Linux errors surfaced after that PR merged.

## Summary

- **`LocalVector.Sqlite3.pas(42-44)` E2029/E2052** — the `{...}`-style comment I added in #224 quoted the literal token `{$ELSE}`. Delphi parses `{$...}` directives even inside `{...}` comments, so the lexer saw a bare `{$ELSE}` with no matching `{$IFDEF}` and tripped over the line that followed. Switched the comment to paren-star (`(* ... *)`) delimiters which are not directive-active.
- **`LocalVector.Sqlite3.pas(158)` & `onnxruntime_pas_api.pas(1087)` E2010** — `dlsym(Pointer(h), ...)` where `h: TOrdHandle = NativeUInt`. dcc64 rejects a direct `Pointer(UInt64)` cast. Two-step cast via `NativeUInt`: `Pointer(NativeUInt(h))`.
- **`onnxruntime.pas(1376/1414/1442/1458/1506/1536/1698/1735/1864)` E2250** — smart-pointer ref counts were typed `PLongint` / `TArray<LongInt>`. On Delphi POSIX 64-bit `LongInt` widens to 64 bits (LP64 model), so `TInterlocked.Increment(var Integer)` / `(var Int64)` had no overload matching `var LongInt`. Narrowed the storage to `PInteger` / `TArray<Integer>`: `Integer` is 32-bit on every supported target (FPC delphi-mode, Delphi Windows, Delphi Linux64), matching the intended ref-count width. Pure storage-type change — every call site already increments/decrements through an `Interlocked*` wrapper that accepts `Integer`.

## Test plan

- [x] FPC build of the three modified files clean (verified locally; pre-existing `PasClaw.Cmd.Agent.pas` nested-procedure errors on `main` are unrelated to this PR).
- [ ] dcc64 Linux: the nine `E2250` errors plus the three `E2029/E2052/E2010` errors should all clear.
- [ ] Existing FPC test suite (`make test`) — ref-count semantics unchanged; smart-pointer behaviour preserved (Integer/LongInt are the same 32-bit type on Windows and on FPC).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_