### PR TITLE
Cmd.Agent: TGoalCmdCallbacks helper for of-object callbacks (dcc64 + FPC)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -414,6 +414,130 @@ begin
   end;
 end;
 
+type
+  PMessageArray = ^TMessageArray;
+  PStringRef    = ^string;
+
+  { Bundles the per-/goal-call state that GoalRunner's of-object
+    callbacks need into a real method-of-object form. The
+    TGoalTurnFn / TGoalProgressFn callbacks in PasClaw.Agent.Goals
+    are `of object`; Delphi (dcc64) rejects assigning a nested
+    procedure to an of-object type (FPC tolerates it via the
+    `is nested` calling convention, but Delphi has no equivalent),
+    so the /goal handler bundles the captures into this helper and
+    hands TurnFn / Progress as proper method pointers. The pMsgs /
+    pSysPromptOverride fields point back at RunInteractive's local
+    vars so the runner can mutate them in place, matching what the
+    original nested-procedure form did via lexical capture. }
+  TGoalCmdCallbacks = class
+    Cfg:                TConfig;
+    A:                  TAgentArgs;
+    Provider:           ILLMProvider;
+    Reg:                TToolRegistry;
+    Model:              string;
+    Handlers:           TLoopHandlers;
+    Session:            TSession;
+    BgCoord:            TBackgroundSpawnCoordinator;
+    pMsgs:              PMessageArray;
+    pSysPromptOverride: PStringRef;
+    procedure PersistSessionCb;
+    function  TurnFn(const UserMsg: string;
+                      var Hist: TMessageArray;
+                      out Reply: string): Boolean;
+    procedure Progress(IterNo, MaxIter: Integer; const Reply: string);
+  end;
+
+procedure TGoalCmdCallbacks.PersistSessionCb;
+var j: Integer;
+begin
+  if Session = nil then Exit;
+  SetLength(Session.Messages, Length(pMsgs^));
+  for j := 0 to High(pMsgs^) do Session.Messages[j] := pMsgs^[j];
+  Session.Meta.SystemPromptOverride := pSysPromptOverride^;
+  Session.Meta.Model := Model;
+  if Provider <> nil then Session.Meta.Provider := Provider.GetName;
+  Session.AutoTitle;
+  Session.Touch;
+  Session.Save;
+end;
+
+function TGoalCmdCallbacks.TurnFn(const UserMsg: string;
+                                   var Hist: TMessageArray;
+                                   out Reply: string): Boolean;
+{ TGoalTurnFn implementation -- one agent turn during the Ralph loop.
+  Mirrors the relevant subset of RunInteractive's main `while Inputs
+  do` body: append user message, build the same LoopCfg, run BeginTurn
+  (checkpoints) then RunToolLoop, swap Hist for the loop's compaction-
+  aware history. Compaction summary survives across iterations because
+  pSysPromptOverride^ is the enclosing RunInteractive's var.
+
+  Deliberately skips a couple of bells the main loop has on each user-
+  typed turn (auto-router, working-state prefix, /think one-shot):
+  those depend on UI state that doesn't apply to the judge-driven
+  Continue stream. Operators who want them per-turn on a goal run
+  should drive each step interactively. }
+var
+  GLoop: TToolLoopResult;
+  GCfg:  TToolLoopConfig;
+  k:     Integer;
+begin
+  Result := False;
+  Reply := '';
+  SetLength(Hist, Length(Hist) + 1);
+  Hist[High(Hist)] := MakeMessage(mrUser, UserMsg);
+
+  GCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers);
+  if pSysPromptOverride^ <> '' then
+    GCfg.Options.SystemPrompt := pSysPromptOverride^;
+  if Session <> nil then
+  begin
+    GCfg.Options.CacheKey := Session.Meta.Id;
+    GCfg.SteeringKey      := Session.Meta.Id;
+    if BgCoord <> nil then
+    begin
+      BgCoord.SetKey(Session.Meta.Id);
+      GCfg.BackgroundDrainKey := Session.Meta.Id;
+    end;
+  end;
+
+  BeginTurn;
+  if not RunToolLoop(GCfg, Hist, GLoop) then Exit;
+
+  { RunToolLoop returns FinalMessages BEFORE the final non-tool
+    assistant text -- the regular CLI / TUI paths explicitly append
+    Loop.Content afterwards. Mirror that here, otherwise the
+    assistant's actual answer gets dropped from history and the next
+    judge-driven turn (and the persisted session) only see the tool
+    transcript. Codex P1 on PR #223. }
+  Hist := GLoop.FinalMessages;
+  if Trim(GLoop.Content) <> '' then
+  begin
+    SetLength(Hist, Length(Hist) + 1);
+    Hist[High(Hist)] := MakeMessage(mrAssistant, GLoop.Content);
+  end;
+  Reply := GLoop.Content;
+  if Trim(Reply) = '' then Reply := '(no reply)';
+  if GLoop.FinalSystemPrompt <> '' then
+    pSysPromptOverride^ := GLoop.FinalSystemPrompt;
+
+  { Mirror Msgs from the local var the main loop reads on subsequent
+    iterations. The goal runner walks Hist; copy it back so a follow-
+    up user turn (after the goal loop ends) picks up the same compacted
+    state. pMsgs^ is the enclosing RunInteractive's array; rebuilding
+    it keeps /undo, /compact, /status all consistent. }
+  SetLength(pMsgs^, Length(Hist));
+  for k := 0 to High(Hist) do pMsgs^[k] := Hist[k];
+  PersistSessionCb;
+  Result := True;
+end;
+
+procedure TGoalCmdCallbacks.Progress(IterNo, MaxIter: Integer; const Reply: string);
+begin
+  PrintLn(Ansi.Dim + Format('— goal iter %d/%d —', [IterNo, MaxIter]) + Ansi.Reset);
+  PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset + ': ' +
+          MaybeRender(Cfg, Reply));
+end;
+
 procedure RunInteractive(const Cfg: TConfig; const A: TAgentArgs);
 var
   Line: string;
@@ -484,93 +608,20 @@ var
     InitCheckpoints(CC);
   end;
 
-  function GoalTurnRunner(const UserMsg: string;
-                           var Hist: TMessageArray;
-                           out Reply: string): Boolean;
-  { TGoalTurnFn implementation -- runs ONE agent turn during the
-    Ralph loop. Mirrors the relevant subset of the main `while
-    Inputs do` body just below: append user message, build the
-    same LoopCfg the main loop uses, run BeginTurn (checkpoints)
-    then RunToolLoop, swap Hist for the loop's compaction-aware
-    history. Compaction summary survives across iterations because
-    SystemPromptOverride is the enclosing var.
-
-    Deliberately skips a couple of bells the main loop has on each
-    user-typed turn (auto-router, working-state prefix, /think one-
-    shot): those depend on UI state that doesn't apply to the
-    judge-driven Continue stream. Operators who want them per-turn
-    on a goal run should drive each step interactively. }
-  var
-    GLoop: TToolLoopResult;
-    GCfg: TToolLoopConfig;
-    k: Integer;
-  begin
-    Result := False;
-    Reply := '';
-    SetLength(Hist, Length(Hist) + 1);
-    Hist[High(Hist)] := MakeMessage(mrUser, UserMsg);
-
-    GCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers);
-    if SystemPromptOverride <> '' then
-      GCfg.Options.SystemPrompt := SystemPromptOverride;
-    if Session <> nil then
-    begin
-      GCfg.Options.CacheKey := Session.Meta.Id;
-      GCfg.SteeringKey      := Session.Meta.Id;
-      if BgCoord <> nil then
-      begin
-        BgCoord.SetKey(Session.Meta.Id);
-        GCfg.BackgroundDrainKey := Session.Meta.Id;
-      end;
-    end;
-
-    BeginTurn;
-    if not RunToolLoop(GCfg, Hist, GLoop) then Exit;
-
-    { RunToolLoop returns FinalMessages BEFORE the final non-tool
-      assistant text -- the regular CLI / TUI paths explicitly append
-      Loop.Content afterwards. Mirror that here, otherwise the
-      assistant's actual answer gets dropped from history and the
-      next judge-driven turn (and the persisted session) only see
-      the tool transcript. Codex P1 on PR #223. }
-    Hist := GLoop.FinalMessages;
-    if Trim(GLoop.Content) <> '' then
-    begin
-      SetLength(Hist, Length(Hist) + 1);
-      Hist[High(Hist)] := MakeMessage(mrAssistant, GLoop.Content);
-    end;
-    Reply := GLoop.Content;
-    if Trim(Reply) = '' then Reply := '(no reply)';
-    if GLoop.FinalSystemPrompt <> '' then
-      SystemPromptOverride := GLoop.FinalSystemPrompt;
-
-    { Mirror Msgs from the local var the main loop reads on
-      subsequent iterations. The goal runner walks Hist; we
-      copy it back so a follow-up user turn (after the goal
-      loop ends) picks up the same compacted state. The local
-      Msgs is the enclosing RunInteractive's array; rebuilding
-      it keeps /undo, /compact, /status all consistent. }
-    SetLength(Msgs, Length(Hist));
-    for k := 0 to High(Hist) do Msgs[k] := Hist[k];
-    PersistSession;
-    Result := True;
-  end;
-
-  procedure GoalProgress(IterNo, MaxIter: Integer; const Reply: string);
-  begin
-    PrintLn(Ansi.Dim + Format('— goal iter %d/%d —', [IterNo, MaxIter]) + Ansi.Reset);
-    PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset + ': ' +
-            MaybeRender(Cfg, Reply));
-  end;
-
   procedure HandleGoalCommand(const Args: string);
   { /goal <objective> or /goal --max N <objective>. Spins up a
-    TGoalRunner that pumps GoalTurnRunner through up to MaxIter
+    TGoalRunner that pumps Callbacks.TurnFn through up to MaxIter
     judge-arbitrated turns. The judge model defaults to the
     primary Model -- the operator can wire a cheaper one via
-    Cfg.AutoRouter.EasyModel in a follow-up. }
+    Cfg.AutoRouter.EasyModel in a follow-up.
+
+    Callbacks wraps the per-turn / per-progress state in a method-
+    of-object form because TGoalTurnFn / TGoalProgressFn are
+    `of object` and dcc64 refuses to assign a nested procedure to
+    an of-object type. See TGoalCmdCallbacks above. }
   var
     Runner: TGoalRunner;
+    Callbacks: TGoalCmdCallbacks;
     Trimmed, Goal: string;
     MaxIter: Integer;
     R: TGoalResult;
@@ -610,9 +661,22 @@ var
     PrintLn(Ansi.Bold + '— goal —' + Ansi.Reset + ' ' + Goal +
             Ansi.Dim + Format('  (budget=%d)', [MaxIter]) + Ansi.Reset);
 
-    Runner := TGoalRunner.Create(Provider, Model, MaxIter, GoalTurnRunner);
+    Callbacks := TGoalCmdCallbacks.Create;
+    Callbacks.Cfg                := Cfg;
+    Callbacks.A                  := A;
+    Callbacks.Provider           := Provider;
+    Callbacks.Reg                := Reg;
+    Callbacks.Model              := Model;
+    Callbacks.Handlers           := Handlers;
+    Callbacks.Session            := Session;
+    Callbacks.BgCoord            := BgCoord;
+    Callbacks.pMsgs              := @Msgs;
+    Callbacks.pSysPromptOverride := @SystemPromptOverride;
+
+    Runner := TGoalRunner.Create(Provider, Model, MaxIter, Callbacks.TurnFn);
     try
-      Runner.OnProgress := GoalProgress;
+     try
+      Runner.OnProgress := Callbacks.Progress;
       HistAlias := nil;
       SetLength(HistAlias, Length(Msgs));
       for k := 0 to High(Msgs) do HistAlias[k] := Msgs[k];
@@ -636,8 +700,11 @@ var
       end;
       if Trim(R.Reason) <> '' then
         PrintLn(Ansi.Dim + '  judge: ' + Trim(R.Reason) + Ansi.Reset);
-    finally
+     finally
       Runner.Free;
+     end;
+    finally
+      Callbacks.Free;
     end;
   end;
 

--- a/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
+++ b/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
@@ -155,11 +155,14 @@ begin
   Result := GetProcedureAddress(h, AName);
   {$ELSE}
   { Delphi Linux equivalent of FPC's GetProcedureAddress -- dlsym
-    against the handle dlopen handed back. }
-  { Two-step cast: Delphi rejects a direct Pointer(UInt64) typecast,
-    so go via NativeUInt (which is the underlying integer type of
-    TOrdHandle in this branch). }
-  Result := dlsym(Pointer(NativeUInt(h)), PAnsiChar(AnsiString(AName)));
+    against the handle dlopen handed back.
+
+    Reinterpret-cast via PPointer(@h)^: dcc64 still rejects
+    Pointer(NativeUInt(h)) outright -- even though sizeof matches
+    on 64-bit, NativeUInt is a UInt64 alias and Delphi's typecast
+    rules block UInt64 -> Pointer. PPointer overlays the storage
+    bits of h on Pointer without going through an integer cast. }
+  Result := dlsym(PPointer(@h)^, PAnsiChar(AnsiString(AName)));
   {$ENDIF}
 {$ENDIF}
 end;

--- a/src/pkg/memory/localvector/onnxruntime_pas_api.pas
+++ b/src/pkg/memory/localvector/onnxruntime_pas_api.pas
@@ -1083,10 +1083,12 @@ begin
   {$IFDEF MSWINDOWS}
   Result := GetProcAddress(AHandle, PAnsiChar(AnsiString(AName)));
   {$ELSE}
-  { Delphi Linux: dlsym against the dlopen handle. Two-step cast --
-    Delphi rejects direct Pointer(UInt64), so go via NativeUInt
-    (the underlying integer type of TOrtLibHandle in this branch). }
-  Result := dlsym(Pointer(NativeUInt(AHandle)), PAnsiChar(AnsiString(AName)));
+  { Delphi Linux: dlsym against the dlopen handle. Reinterpret via
+    PPointer(@AHandle)^ -- dcc64 still rejects Pointer(NativeUInt(AHandle))
+    because NativeUInt is a UInt64 alias and Delphi blocks UInt64 ->
+    Pointer regardless of size match. PPointer overlays the storage
+    bits without an integer cast. }
+  Result := dlsym(PPointer(@AHandle)^, PAnsiChar(AnsiString(AName)));
   {$ENDIF}
 {$ENDIF}
 end;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -189,6 +189,7 @@ type
     procedure ShowHelp;
     procedure ShowTools;
     procedure HandleSlashCommand(const Cmd: string);
+    procedure HandleUndoCommand(const Args: string);
     procedure HandleUserInput(const Text: string);
     {$ENDIF}
   public
@@ -2444,6 +2445,38 @@ begin
     Exit;
   end;
   PrintLn(Ansi.Yellow + 'unknown command: ' + Cmd + Ansi.Reset);
+end;
+
+procedure TTUI.HandleUndoCommand(const Args: string);
+{ FPC line-based variant. The Delphi positioned TUI's HandleUndoCommand
+  routes operator-visible messages through Flash (a one-line transient
+  status slot at the bottom of the screen). The FPC REPL has no such
+  slot, so we PrintLn directly. Semantics match: parse N, call
+  UndoTurns, report what got restored. }
+var
+  N: Integer;
+  Restored: TRestoredFileArray;
+  Err, Trimmed: string;
+begin
+  Trimmed := Trim(Args);
+  if Trimmed = '' then
+    N := 1
+  else
+    N := StrToIntDef(Trimmed, -1);
+  if N <= 0 then
+  begin
+    PrintLn(Ansi.Yellow + '/undo: argument must be a positive turn count' + Ansi.Reset);
+    Exit;
+  end;
+  if not UndoTurns(N, Restored, Err) then
+  begin
+    PrintLn(Ansi.Yellow + '/undo: ' + Err + Ansi.Reset);
+    Exit;
+  end;
+  if Length(Restored) = 0 then
+    PrintLn(Ansi.Dim + Format('/undo %d: no files to restore', [N]) + Ansi.Reset)
+  else
+    PrintLn(Ansi.Green + Format('/undo %d: restored %d file(s)', [N, Length(Restored)]) + Ansi.Reset);
 end;
 
 procedure TTUI.HandleUserInput(const Text: string);


### PR DESCRIPTION
Three follow-up errors after #225.

## Summary

- **`PasClaw.Cmd.Agent.pas:613/615`** (dcc64 Windows64 E2009, also FPC E2250) — `HandleGoalCommand` was assigning two **nested procedures** to `TGoalTurnFn` / `TGoalProgressFn`, which are declared `of object`. Delphi refuses outright; FPC accepts via `is nested` but rejects the conversion to `of object`. Fix: wrap the per-call state in a `TGoalCmdCallbacks` helper class whose `TurnFn` / `Progress` are honest method-of-object methods. Mutable state that the old nested procs captured by lexical reference (`SystemPromptOverride`, `Msgs`) is exposed via `pMsgs` / `pSysPromptOverride` pointer fields that point back at `RunInteractive`'s locals. Everything else (Cfg, Provider, Reg, Model, A, Handlers, Session, BgCoord) is a plain field copy/reference — none of those change during a single `/goal` invocation. `PersistSession`'s logic moved into a method on the helper. Same behaviour, same Codex-P1 final-reply append, same `Msgs` mirror, same `FinalSystemPrompt` persistence.

- **`LocalVector.Sqlite3.pas:162` + `onnxruntime_pas_api.pas:1089`** (dcc64 Linux E2010 `UInt64` → `Pointer`) — #225's `Pointer(NativeUInt(h))` workaround turned out to be insufficient. Even though `NativeUInt = UInt64` on Linux64, dcc64 still refuses the `Pointer` cast because the typecast rules treat `UInt64` as a distinct named type from `Pointer`. **`PPointer(@h)^`** reinterprets the storage bits via address-of → pointer-to-pointer → dereference, bypassing the integer-cast check entirely.

- **`PasClaw.TUI.pas`** (collateral fix) — surfaced once `Cmd.Agent.pas` compiles again. The FPC line-based REPL's `HandleSlashCommand` calls `HandleUndoCommand`, but that method was declared only in the `{$IFNDEF FPC}` positioned-TUI block (it uses `Flash` / `FStatusFlash`, which don't exist on the FPC side). Pre-existing latent bug masked by the Cmd.Agent failure stopping the build earlier. Added an FPC-specific `HandleUndoCommand` that uses `PrintLn` instead of the positioned status-flash slot; semantics otherwise identical (parse N, call `UndoTurns`, report restored count).

## Test plan

- [x] FPC `make smoke` clean.
- [x] `make test` — `goals_runner_tests` (which exercises the `TGoalRunner` contract end-to-end with scripted judge + driver doubles) PASS, including `OnTurn abort -> gvAborted` and the budget/CONTINUE/MET shapes.
- [ ] dcc64 Windows64: lines 613/615 errors cleared.
- [ ] dcc64 Linux: line 162 `UInt64`/`Pointer` error cleared, plus the analogous `onnxruntime_pas_api.pas:1089`.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_