### PR TITLE
Posix.Dlfcn handles are NativeUInt, not Pointer; init FPC TUI checkpoints

### DIFF
--- a/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
+++ b/src/pkg/memory/localvector/LocalVector.Sqlite3.pas
@@ -136,12 +136,13 @@ begin
   {$IFDEF FPC}
   Result := LoadLibrary(AName);
   {$ELSE}
-  { Delphi Linux: dlopen returns a Pointer; cast to TOrdHandle (which
-    is NativeUInt on non-Windows Delphi). RTLD_NOW resolves every
-    symbol up front so a missing entrypoint surfaces here, not on
-    the first call -- mirrors what FPC's LoadLibrary does internally
-    on POSIX. }
-  Result := TOrdHandle(dlopen(PAnsiChar(AnsiString(AName)), RTLD_NOW));
+  { Delphi Linux: Posix.Dlfcn declares dlopen returning the handle
+    as NativeUInt (the RTL wraps the POSIX void* as an ordinal, like
+    HMODULE on Windows), which is exactly TOrdHandle here -- no cast.
+    RTLD_NOW resolves every symbol up front so a missing entrypoint
+    surfaces here, not on the first call -- mirrors what FPC's
+    LoadLibrary does internally on POSIX. }
+  Result := dlopen(PAnsiChar(AnsiString(AName)), RTLD_NOW);
   {$ENDIF}
 {$ENDIF}
 end;
@@ -155,14 +156,15 @@ begin
   Result := GetProcedureAddress(h, AName);
   {$ELSE}
   { Delphi Linux equivalent of FPC's GetProcedureAddress -- dlsym
-    against the handle dlopen handed back.
-
-    Reinterpret-cast via PPointer(@h)^: dcc64 still rejects
-    Pointer(NativeUInt(h)) outright -- even though sizeof matches
-    on 64-bit, NativeUInt is a UInt64 alias and Delphi's typecast
-    rules block UInt64 -> Pointer. PPointer overlays the storage
-    bits of h on Pointer without going through an integer cast. }
-  Result := dlsym(PPointer(@h)^, PAnsiChar(AnsiString(AName)));
+    against the handle dlopen handed back. No cast: Delphi's
+    Posix.Dlfcn declares dlsym(Handle: NativeUInt; ...) -- the RTL
+    wraps the POSIX void* handle as an ordinal, same as HMODULE on
+    Windows -- and h is already that type. Every earlier attempt to
+    hand it a Pointer (Pointer(h), Pointer(NativeUInt(h)),
+    PPointer(@h)^) drew E2010 "UInt64 and Pointer" because the
+    PARAMETER wants the ordinal, not because the cast itself was
+    ill-formed. }
+  Result := dlsym(h, PAnsiChar(AnsiString(AName)));
   {$ENDIF}
 {$ENDIF}
 end;

--- a/src/pkg/memory/localvector/onnxruntime_pas_api.pas
+++ b/src/pkg/memory/localvector/onnxruntime_pas_api.pas
@@ -1066,11 +1066,11 @@ begin
   Result := LoadLibrary(PChar(AName));
   {$ELSE}
   { Delphi non-Windows (Linux64) -- there's no top-level LoadLibrary
-    overload here; route through Posix.Dlfcn.dlopen and cast the
-    Pointer handle back to TOrtLibHandle (= NativeUInt). RTLD_NOW
+    overload here; route through Posix.Dlfcn.dlopen, whose handle is
+    already declared NativeUInt (= TOrtLibHandle) by the RTL. RTLD_NOW
     surfaces a missing entrypoint up front, matching the loaded-or-
     not contract OrtRuntimeLoaded relies on. }
-  Result := TOrtLibHandle(dlopen(PAnsiChar(AnsiString(AName)), RTLD_NOW));
+  Result := dlopen(PAnsiChar(AnsiString(AName)), RTLD_NOW);
   {$ENDIF}
 {$ENDIF}
 end;
@@ -1083,12 +1083,11 @@ begin
   {$IFDEF MSWINDOWS}
   Result := GetProcAddress(AHandle, PAnsiChar(AnsiString(AName)));
   {$ELSE}
-  { Delphi Linux: dlsym against the dlopen handle. Reinterpret via
-    PPointer(@AHandle)^ -- dcc64 still rejects Pointer(NativeUInt(AHandle))
-    because NativeUInt is a UInt64 alias and Delphi blocks UInt64 ->
-    Pointer regardless of size match. PPointer overlays the storage
-    bits without an integer cast. }
-  Result := dlsym(PPointer(@AHandle)^, PAnsiChar(AnsiString(AName)));
+  { Delphi Linux: dlsym against the dlopen handle. No cast --
+    Posix.Dlfcn declares dlsym(Handle: NativeUInt; ...), so the
+    ordinal handle is passed straight through. See the matching
+    comment in LocalVector.Sqlite3.ldProc for the E2010 history. }
+  Result := dlsym(AHandle, PAnsiChar(AnsiString(AName)));
   {$ENDIF}
 {$ENDIF}
 end;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -2569,7 +2569,21 @@ end;
 procedure TTUI.Run;
 var
   Line: string;
+  CC: TCheckpointConfig;
 begin
+  { Wire the checkpoints module before the REPL starts. The Delphi
+    positioned TUI does this via RewireCheckpoints on every session
+    switch; the FPC REPL is single-session with no FSession, so we
+    initialize once here against the same fixed key HandleUserInput
+    already uses for the background-subagent coordinator. Without
+    this, BeginTurn snapshots nothing and /undo always reported
+    "checkpoints not enabled". Codex P2 on PR #226. }
+  CC.Enabled   := CheckpointsEnabled;
+  CC.SessionId := 'fpc-tui-session';
+  CC.Root      := JoinPath(GetHome, 'workspace/checkpoints');
+  CC.KeepLast  := CheckpointsKeepLast;
+  InitCheckpoints(CC);
+
   Print(#27'[2J' + #27'[H');
   DrawHeader;
   PrintLn(Ansi.Dim + '/help for commands, /quit to exit' + Ansi.Reset);


### PR DESCRIPTION
Fixes the lingering dcc64 Linux E2010 at the `dlsym` call, plus the legit Codex P2 from #226's review.

## Summary

### `LocalVector.Sqlite3.pas` + `onnxruntime_pas_api.pas` — Posix.Dlfcn handles are ordinals, not pointers

Third round of `E2010 Incompatible types: 'UInt64' and 'Pointer'` at the `dlsym` call — `Pointer(h)` (#224), `Pointer(NativeUInt(h))` (#225), and `PPointer(@h)^` (#226) all drew the identical error. The root cause was on the **other side of the call** the whole time: Delphi's `Posix.Dlfcn` declares `dlopen` returning `NativeUInt` and `dlsym` taking `(Handle: NativeUInt; ...)` — the RTL wraps the POSIX `void*` handle as an ordinal, the same way `HMODULE` works on Windows. The E2010 was the **parameter** rejecting our `Pointer`, not a failing cast. (Evidence: the error persisted no matter which flavor of `Pointer` we produced, and the neighbouring `dlopen` line never errored.)

Fix: pass the `TOrdHandle` / `TOrtLibHandle` (both `= NativeUInt` in this branch) straight through with **no cast**, and drop the now-pointless cast on the `dlopen` result. Comments updated to stop claiming `dlopen` returns a `Pointer`.

### `PasClaw.TUI.pas` — initialize checkpoints on the FPC REPL path (Codex P2 on #226, legit)

The FPC line-based REPL's `/undo` handler calls `UndoTurns`, but nothing on the FPC startup path ever called `InitCheckpoints` (`RewireCheckpoints` is Delphi-positioned-TUI-only), so the checkpoints module stayed disabled and `/undo` always reported "checkpoints not enabled" even with `CheckpointsEnabled` forwarded from config. `TTUI.Run` (FPC block) now initializes checkpoints once before the REPL loop, keyed on the same fixed `'fpc-tui-session'` id `HandleUserInput` already uses for the background-subagent coordinator (the FPC REPL is single-session with no `FSession`).

## Test plan

- [x] FPC `make smoke` clean.
- [x] Full `make test` green (includes checkpoints + goals-runner + TUI-adjacent suites).
- [ ] dcc64 Linux: `LocalVector.Sqlite3.pas(165)` E2010 cleared; same for `onnxruntime_pas_api.pas`'s `ortDoGetProc`.
- [ ] FPC TUI manual check: enable checkpoints in config, run `pasclaw tui`, make an edit turn, `/undo` restores instead of "checkpoints not enabled".

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_