### PR TITLE
Platform: fix Delphi/POSIX backend against the real Posix.* declarations

### DIFF
--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -134,7 +134,9 @@ uses
     Winapi.Windows
   {$ELSE}
     Posix.Base, Posix.Unistd, Posix.Stdlib, Posix.SysWait,
-    Posix.Signal, Posix.SysTypes, Posix.SysSelect
+    Posix.Signal, Posix.SysTypes, Posix.SysSelect,
+    Posix.SysTime                  { timeval / Ptimeval for select() --
+                                     NOT re-exported by Posix.SysSelect }
   {$ENDIF}{$ENDIF};
 
 {$IFDEF FPC}
@@ -716,7 +718,10 @@ end;
 function TStdioProcess.WriteBytes(const Buf; Count: Integer): Integer;
 begin
   if FStdinFd < 0 then Exit(0);
-  Result := __write(FStdinFd, Buf, Count);
+  { @Buf: Delphi's Posix.Unistd declares __write(Handle, Buf: Pointer,
+    Count) -- an untyped const param doesn't implicitly convert, so
+    take its address explicitly. }
+  Result := __write(FStdinFd, @Buf, Count);
 end;
 
 function TStdioProcess.WriteLineUTF8(const S: string): Boolean;
@@ -730,7 +735,11 @@ end;
 function TStdioProcess.ReadAvailable(var Buf; BufSize: Integer): Integer;
 var
   Status, R, Waited: Integer;
-  TimeoutFd: TFDSet;
+  { fd_set, not FPC's TFDSet -- Delphi's Posix.SysSelect keeps the
+    C type name. Its FD_* helpers are __-prefixed (__FD_SET below)
+    because the bare name FD_SET would collide case-insensitively
+    with the fd_set type itself. }
+  TimeoutFd: fd_set;
   Tv: timeval;
 begin
   Result := 0;
@@ -739,13 +748,14 @@ begin
   while True do
   begin
     FillChar(TimeoutFd, SizeOf(TimeoutFd), 0);
-    FD_SET(FStdoutFd, TimeoutFd);
+    __FD_SET(FStdoutFd, TimeoutFd);
     Tv.tv_sec  := 0;
     Tv.tv_usec := 10 * 1000;   { 10 ms }
     Status := select(FStdoutFd + 1, @TimeoutFd, nil, nil, @Tv);
     if Status > 0 then
     begin
-      R := __read(FStdoutFd, Buf, BufSize);
+      { @Buf -- same Pointer-param contract as __write above. }
+      R := __read(FStdoutFd, @Buf, BufSize);
       if R > 0 then Exit(R);
       Exit;
     end;
@@ -760,7 +770,9 @@ var
   Status, R: Integer;
 begin
   if (FPid = 0) or not FStarted then Exit(False);
-  R := waitpid(FPid, Status, WNOHANG);
+  { @Status: Delphi's Posix.SysWait waitpid takes stat_loc: PInteger,
+    not a var param like FPC's fpWaitPid. }
+  R := waitpid(FPid, @Status, WNOHANG);
   if R = 0 then Exit(True);   { still running }
   if R = FPid then
   begin
@@ -809,7 +821,7 @@ begin
       end
       else if not P.Running then Break;
     end;
-    waitpid(P.FPid, Status, 0);
+    waitpid(P.FPid, @Status, 0);   { PInteger stat_loc -- see Running }
     if WIFEXITED(Status) then Result := WEXITSTATUS(Status) else Result := -1;
     if Acc.Size > 0 then
     begin


### PR DESCRIPTION
Fixes the nine dcc64-Linux errors in `PasClaw.Platform.pas`'s Delphi/POSIX backend (the `{$ELSE}` of MSWINDOWS for non-FPC builds). The block was written with FPC-flavoured names that don't exist in Delphi's `Posix.*` units. All fixes follow from the actual RTL declarations:

## Summary

- **Lines 719/748, E2010 "Pointer and untyped parameter"** — Delphi's `Posix.Unistd` declares `__write`/`__read` with `Buf: Pointer`, and an untyped param doesn't implicitly convert. Pass `@Buf` from `WriteBytes`/`ReadAvailable`'s untyped params.
- **Line 733, E2003 `TFDSet`** — that's FPC's name; Delphi's `Posix.SysSelect` keeps the C type name `fd_set`.
- **Line 734, E2003 `timeval`** — lives in `Posix.SysTime`, which wasn't in the uses clause (`Posix.SysSelect` does **not** re-export it). Added.
- **Line 742, E2029 "')' expected but ',' found"** — the interesting one: Delphi's FD helpers are `__`-prefixed (`__FD_SET`) because the bare name would collide case-insensitively with the `fd_set` **type**. dcc64 therefore parsed `FD_SET(fd, set)` as a *typecast of `fd_set`* and choked on the second argument. The 745/746/756 errors were cascades of this.
- **Lines 763/812, E2010 "PInteger and Integer"** — Delphi's `waitpid` takes `stat_loc: PInteger` (FPC's `fpWaitPid` uses a `var` param); pass `@Status`.

Also swept the rest of the Delphi-POSIX block for latent issues the compiler hadn't reached: `fork`/`dup2`/`__close`/`kill`/`_exit`/`WIFEXITED`/`WEXITSTATUS`/`select(@TimeoutFd, ..., @Tv)` all match their Delphi RTL declarations, and `FPid: Integer` ↔ `pid_t` converts implicitly.

## Test plan

- [x] FPC `make smoke` clean (FPC uses the fcl-process backend; this block isn't compiled there).
- [x] Full `make test` green.
- [ ] dcc64 Linux: all nine reported errors should clear.
- [ ] Delphi Linux runtime: `shell_exec` / MCP stdio spawn paths exercise `Spawn`/`ReadAvailable`/`Running` end-to-end.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_