### PR TITLE
Cmd.Agent: paren-star a comment with literal braces; Updater: skip SysUtils.GetLastOSError

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -205,10 +205,14 @@ begin
     operator has flipped on Cfg.ToolOutputCap. The tool's only
     useful while truncation is active, so the flag gates both. }
   if EnableOutputCache then RegisterOutputCacheTool(Result);
-  { send_message gates itself: it registers only when config.json
-    declares named channels ("channels": [{name,kind,target}]), so
-    there's no flag to thread through here. The model can only post
-    to operator-declared targets -- see PasClaw.Tools.SendMessage. }
+  (* send_message gates itself: it registers only when config.json
+     declares named channels (a "channels" array of name/kind/target
+     entries), so there's no flag to thread through here. The model
+     can only post to operator-declared targets -- see
+     PasClaw.Tools.SendMessage. Paren-star delimiters because the
+     literal braces of a JSON object example inside curly-brace
+     comments terminate the comment early on dcc64; FPC tolerated
+     it but Delphi closes on the first '}'. *)
   RegisterSendMessageTool(Result);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(Result, Skills);

--- a/src/pkg/updater/PasClaw.Updater.pas
+++ b/src/pkg/updater/PasClaw.Updater.pas
@@ -53,24 +53,31 @@ implementation
 uses
   Classes,
   {$IFDEF FPC}{$IFDEF UNIX} BaseUnix, {$ENDIF}{$ENDIF}
+  {$IFNDEF FPC}{$IFDEF MSWINDOWS} Winapi.Windows, {$ENDIF}{$ENDIF}
   {$IFNDEF FPC}{$IFDEF POSIX} Posix.SysStat, Posix.UniStd, Posix.Errno, {$ENDIF}{$ENDIF}
   PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Providers.HTTP;
 
 function LastOSErrno: Integer;
-{ Cross-compiler errno read for the "rename failed" diagnostic.
-  GetLastOSError is in System.SysUtils on Delphi Windows (returns
-  GetLastError) and on FPC (returns fpgeterrno / errno), but dcc64
-  Linux doesn't expose it as of the version we target -- E2003 on
-  the call site. Read errno directly via Posix.Errno there. }
+(* Cross-compiler errno read for the "rename failed" diagnostic. Skips
+   System.SysUtils.GetLastOSError because dcc64 has refused it on the
+   builds we've hit: on Delphi Linux it isn't declared at all (E2003
+   was the original report -- PR #229), and on dcc64 Windows the
+   declaration's call-through to GetLastError won't resolve unless
+   Winapi.Windows is in scope, so leaning on the SysUtils wrapper
+   would still re-import the Windows API anyway. Going straight to the
+   per-platform primitive is one fewer indirection and one fewer
+   surprise. *)
 begin
-  {$IFNDEF FPC}{$IFDEF POSIX}
-  Result := errno;
+  {$IFDEF FPC}
+  Result := GetLastOSError;
   {$ELSE}
-  Result := GetLastOSError;
-  {$ENDIF}{$ELSE}
-  Result := GetLastOSError;
+  {$IFDEF MSWINDOWS}
+  Result := Integer(GetLastError);
+  {$ELSE}
+  Result := errno;
+  {$ENDIF}
   {$ENDIF}
 end;
 


### PR DESCRIPTION
Two dcc64 Windows errors from PR #230 / #229.

## Summary

### `PasClaw.Cmd.Agent.pas(209-211)` E2029/E2066/E2014/E2038

The curly-brace comment I added on PR #230 in front of `RegisterSendMessageTool` contained a literal `{name,kind,target}` JSON shape inside an outer `{...}` comment. Pascal `{...}` comments **don't nest**, so the first inner `}` (after `target`) closed the comment — and dcc64 then parsed the trailing `])` as code, producing the cascade of errors. FPC's lexer was more forgiving and the FPC build was clean.

Switched the comment to paren-star delimiters and reworded around the literal JSON example. (Same fix pattern I used for the `LocalVector.Sqlite3.pas` comment that contained a literal `{$ELSE}` token a few PRs back — Delphi's lexer is strict here, FPC's isn't.)

### `PasClaw.Updater.pas(71)` E2003 `GetLastOSError` undeclared (on Windows now too)

The `LastOSErrno` helper from PR #229 fell back to `System.SysUtils.GetLastOSError` for the non-POSIX branch. That works on FPC, but dcc64 has now refused it on both Delphi targets we've hit — Linux first (the original report), and now Windows.

Rather than keep chasing what `SysUtils` exports per-version, the helper now goes straight to the platform primitive:

| Target | Call |
|---|---|
| FPC (any) | `GetLastOSError` |
| dcc64 Windows | `Winapi.GetLastError` |
| dcc64 POSIX | `Posix.errno` |

Added `Winapi.Windows` to the Delphi-Windows uses gate alongside the existing `Posix.*` gate.

## Test plan

- [x] FPC `make smoke` clean.
- [x] Full `make test` green.
- [ ] dcc64 Windows: lines 209-211 of `Cmd.Agent.pas` and line 71 of `Updater.pas` should both clear.
- [ ] dcc64 Linux: `Updater.pas` line 71 still resolves (Posix.Errno branch unchanged).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_