### PR TITLE
build-delphi.bat + build-fpc.bat: add src\pkg\shell to UNIT_PATH

### DIFF
--- a/build-delphi.bat
+++ b/build-delphi.bat
@@ -42,7 +42,7 @@ if errorlevel 1 (
 if not exist "build\delphi\%PLATFORM%\%CONFIG%" mkdir "build\delphi\%PLATFORM%\%CONFIG%" || exit /b 1
 if not exist "build\delphi\%PLATFORM%\%CONFIG%\dcu" mkdir "build\delphi\%PLATFORM%\%CONFIG%\dcu" || exit /b 1
 
-set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\stream;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\crypto;src\pkg\net;src\pkg\search;src\pkg\cron;src\pkg\skills;src\pkg\checkpoints;src\pkg\condense;src\pkg\session;src\pkg\identity;src\pkg\agent;src\pkg\memory;src\pkg\memory\localvector;src\pkg\kb;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\markdown;src\pkg\vendor\dmvcframework"
+set "UNIT_PATH=src\cmd;src\pkg\cliui;src\pkg\utils;src\pkg\logger;src\pkg\config;src\pkg\json;src\pkg\providers;src\pkg\stream;src\pkg\tokenizer;src\pkg\tools;src\pkg\mcp;src\pkg\gateway;src\pkg\channels;src\pkg\crypto;src\pkg\net;src\pkg\search;src\pkg\cron;src\pkg\skills;src\pkg\checkpoints;src\pkg\condense;src\pkg\session;src\pkg\identity;src\pkg\agent;src\pkg\memory;src\pkg\memory\localvector;src\pkg\kb;src\pkg\updater;src\pkg\membench;src\pkg\tui;src\pkg\platform;src\pkg\hashline;src\pkg\component;src\pkg\markdown;src\pkg\shell;src\pkg\vendor\dmvcframework"
 
 echo Building %DPR% with dcc64.exe...
 rem -DPASCLAW_NETHTTP routes outbound HTTP through System.Net.HttpClient

--- a/build-fpc.bat
+++ b/build-fpc.bat
@@ -52,7 +52,7 @@ if errorlevel 1 (
 popd
 
 set "FPCFLAGS=-MDelphi -Sh -O2 -Xs -XX"
-set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\stream -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\crypto -Fusrc\pkg\net -Fusrc\pkg\search -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\checkpoints -Fusrc\pkg\condense -Fusrc\pkg\session -Fusrc\pkg\identity -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\memory\localvector -Fusrc\pkg\kb -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\pkg\markdown -Fusrc\cmd"
+set "FPCFLAGS=%FPCFLAGS% -Fusrc\pkg\cliui -Fusrc\pkg\utils -Fusrc\pkg\logger -Fusrc\pkg\config -Fusrc\pkg\json -Fusrc\pkg\providers -Fusrc\pkg\stream -Fusrc\pkg\tokenizer -Fusrc\pkg\tools -Fusrc\pkg\mcp -Fusrc\pkg\gateway -Fusrc\pkg\channels -Fusrc\pkg\crypto -Fusrc\pkg\net -Fusrc\pkg\search -Fusrc\pkg\cron -Fusrc\pkg\skills -Fusrc\pkg\checkpoints -Fusrc\pkg\condense -Fusrc\pkg\session -Fusrc\pkg\identity -Fusrc\pkg\agent -Fusrc\pkg\memory -Fusrc\pkg\memory\localvector -Fusrc\pkg\kb -Fusrc\pkg\updater -Fusrc\pkg\membench -Fusrc\pkg\tui -Fusrc\pkg\platform -Fusrc\pkg\hashline -Fusrc\pkg\component -Fusrc\pkg\markdown -Fusrc\pkg\shell -Fusrc\cmd"
 set "FPCFLAGS=%FPCFLAGS% -Fu%INDY_DIR%\Lib\Core -Fu%INDY_DIR%\Lib\Protocols -Fu%INDY_DIR%\Lib\System -Fi%INDY_DIR%\Lib\Core -Fi%INDY_DIR%\Lib\Protocols -Fi%INDY_DIR%\Lib\System"
 if not "%ICONVENC_DIR%"=="" set "FPCFLAGS=%FPCFLAGS% -Fu%ICONVENC_DIR%"
 set "FPCFLAGS=%FPCFLAGS% -FE%BUILDDIR% -FU%BUILDDIR%\lib"


### PR DESCRIPTION
Codex P2 on PR #234, legit. PR #234 fixed the IDE/msbuild path via `PasClaw.dproj`'s `DCC_UnitSearchPath` but missed the `dcc64.exe` fallback in `build-delphi.bat` — its hard-coded `UNIT_PATH` at line 45 still lacked `src\pkg\shell`, so the documented "msbuild.exe not on PATH" fallback continued to F2613 on `PasClaw.Shell.Backend` through `PasClaw.Config`'s new uses-line.

Added `src\pkg\shell` to:
- `build-delphi.bat` (the actual review target)
- `build-fpc.bat` (same class of bug, same root cause — PR #233 added the directory and only some build paths got updated; worth fixing in the same PR since it's the obvious sibling)

Position matches the existing ordering (after `pkg\markdown`, before `pkg\vendor\dmvcframework`) so a future audit can `diff` the path lists across all the build helpers cleanly.

## Test plan

- [x] FPC `make smoke` clean.
- [ ] dcc64 Windows: run `build-delphi.bat` with msbuild absent from PATH; the F2613 on `PasClaw.Shell.Backend` should clear.
- [ ] FPC Windows: run `build-fpc.bat`; no regression.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_