### PR TITLE
Windows shell output: decode via OEM codepage (closes mojibake on non-ASCII paths)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,6 +448,14 @@ test-shell-backend: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/shell_backend_tests.pas -o$(BUILDDIR)/shell_backend_tests
 	@$(BUILDDIR)/shell_backend_tests
 
+# Shell output decode (PasClaw.Platform.DecodeShellOutputBytes) -- the OEM
+# codepage fix for cmd.exe stdout. Exercises the explicit-codepage path so
+# tests pin Windows behaviour without needing Windows itself.
+test-shell-output-decode: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/shell_output_decode_tests.pas -o$(BUILDDIR)/shell_output_decode_tests
+	@$(BUILDDIR)/shell_output_decode_tests
+
 # Goals runner: the auto-continue Ralph loop. Scripted fake provider
 # returns MET / CONTINUE / FAILED verdicts; pins parser + budget +
 # abort + judge-outage semantics. No real model.
@@ -478,4 +486,4 @@ test-kb-index: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/kb_index_tests.pas -o$(BUILDDIR)/kb_index_tests
 	@$(BUILDDIR)/kb_index_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -29,6 +29,21 @@ unit PasClaw.Platform;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}            { Tag this unit's AnsiStrings as UTF-8 so
+                                the UTF-8 bytes DecodeShellOutputBytes
+                                builds survive the function return on
+                                Windows. Without this, FPC implicitly
+                                transcodes UTF-8 -> system ANSI
+                                codepage (CP1252 on English Windows,
+                                CP932 on Japanese, etc.) at the result
+                                assignment, dropping characters that
+                                aren't representable in the system CP
+                                -- exactly the round-trip loss this
+                                whole patch is trying to prevent. }
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -125,11 +125,37 @@ function RunOneShotWithEnv(const Cmd, WorkingDir: string;
                             ExtraEnv: TStringList;
                             out Output: string): Integer;
 
+(* Decode a byte buffer captured from a child shell's stdout/stderr
+   into a UTF-8-encoded Pascal string suitable for tool output. On
+   Windows, cmd.exe writes its stdout in the SYSTEM OEM CODEPAGE
+   (CP437 on US English, CP866 on Cyrillic, CP932 on Japanese,
+   etc.) -- NOT UTF-8. Decoding those bytes as UTF-8 produces
+   mojibake on any non-ASCII byte and was the documented cause of
+   the "directory exists?" failures on D:/E:/F: drives with
+   non-ASCII path components. We detect the OEM codepage via
+   GetOEMCP and route through MultiByteToWideChar to UTF-16, then
+   UTF-8 encode. POSIX shells already output UTF-8 so the POSIX
+   path is a plain UTF-8 decode -- unchanged from the previous
+   behaviour, just routed through one helper.
+
+   Codepage parameter: 0 (default) means "auto-detect per platform"
+   -- Windows uses GetOEMCP, POSIX is fixed UTF-8. Explicit
+   non-zero values pin the codepage and are used by tests so a
+   known CP437 byte sequence decodes the same way on Linux as it
+   would on a Windows operator's box. ByteCount lets the caller
+   pass only the prefix of a larger buffer; pass -1 for "all of
+   Bytes". *)
+function DecodeShellOutputBytes(const Bytes: TBytes;
+                                ByteCount: Integer = -1;
+                                Codepage: UInt32 = 0): string;
+
 implementation
 
 uses
   {$IFDEF FPC}
     Process
+    {$IFDEF MSWINDOWS}, Windows {$ENDIF}   { GetOEMCP + MultiByteToWideChar
+                                             for cmd.exe output decode }
   {$ELSE}{$IFDEF MSWINDOWS}
     Winapi.Windows
   {$ELSE}
@@ -138,6 +164,68 @@ uses
     Posix.SysTime                  { timeval / Ptimeval for select() --
                                      NOT re-exported by Posix.SysSelect }
   {$ENDIF}{$ENDIF};
+
+function DecodeShellOutputBytes(const Bytes: TBytes;
+                                ByteCount: Integer;
+                                Codepage: UInt32): string;
+var
+  Len: Integer;
+  {$IFDEF MSWINDOWS}
+  WideLen: Integer;
+  Wide: UnicodeString;
+  CP: UInt32;
+  {$ELSE}
+  Enc: TEncoding;
+  {$ENDIF}
+begin
+  Result := '';
+  if ByteCount < 0 then Len := Length(Bytes) else Len := ByteCount;
+  if Len <= 0 then Exit;
+  if Len > Length(Bytes) then Len := Length(Bytes);
+
+  {$IFDEF MSWINDOWS}
+  if Codepage = 0 then CP := GetOEMCP else CP := Codepage;
+  { Pass 1: discover the wide-char buffer size we need. }
+  WideLen := MultiByteToWideChar(CP, 0, PAnsiChar(@Bytes[0]), Len, nil, 0);
+  if WideLen <= 0 then
+  begin
+    { Fall back to UTF-8 if the OEM decode failed -- better than
+      returning empty. Catches the case where GetOEMCP returned an
+      unsupported codepage on a weird locale. }
+    Result := UTF8Encode(TEncoding.UTF8.GetString(Bytes, 0, Len));
+    Exit;
+  end;
+  SetLength(Wide, WideLen);
+  MultiByteToWideChar(CP, 0, PAnsiChar(@Bytes[0]), Len, PWideChar(Wide), WideLen);
+  { Wide -> UTF-8. UTF8Encode is the cross-compiler explicit form;
+    implicit assignment would go via DefaultSystemCodepage which on
+    Windows is the ANSI codepage, not UTF-8 -- exactly the bug we're
+    avoiding. }
+  Result := UTF8Encode(Wide);
+  {$ELSE}
+  { POSIX shells (bash, sh, zsh) output UTF-8 -- just decode as such.
+    Codepage param is honoured for tests so a fixture exercising the
+    Windows OEM path can call from Linux with an explicit CP. The
+    runtime always passes 0 on POSIX so the test-only branch never
+    fires in production. 65001 = CP_UTF8 (named constant lives in
+    Windows.pas which isn't imported on POSIX). }
+  if (Codepage = 0) or (Codepage = 65001) then
+  begin
+    Result := UTF8Encode(TEncoding.UTF8.GetString(Bytes, 0, Len));
+    Exit;
+  end;
+  { TEncoding.GetEncoding hands back a freshly-allocated instance the
+    caller must Free; route through UTF8Encode for the implicit
+    UnicodeString -> string conversion so the bytes land as UTF-8
+    regardless of DefaultSystemCodepage. }
+  Enc := TEncoding.GetEncoding(Codepage);
+  try
+    Result := UTF8Encode(Enc.GetString(Bytes, 0, Len));
+  finally
+    Enc.Free;
+  end;
+  {$ENDIF}
+end;
 
 {$IFDEF FPC}
 (* ----- FPC backend (fcl-process) ----- *)
@@ -251,6 +339,7 @@ var
   P: TInternalProcess;
   M: TMemoryStream;
   Buf: array[0..ReadBufferSize - 1] of Byte;
+  Bytes: TBytes;
   N, Total: Integer;
 begin
   Result := -1;
@@ -280,8 +369,19 @@ begin
       Sleep(20);
     end;
     Result := P.ExitStatus;
-    SetLength(Output, M.Size);
-    if M.Size > 0 then begin M.Position := 0; M.ReadBuffer(Output[1], M.Size); end;
+    if M.Size > 0 then
+    begin
+      { Hand the captured bytes to the shared decoder rather than
+        copying them straight into the Pascal string. On Windows
+        cmd.exe writes its stdout in the system OEM codepage, not
+        UTF-8 or the system ANSI codepage -- without a proper
+        decode any non-ASCII path or filename surfaces as mojibake.
+        See DecodeShellOutputBytes for the full rationale. }
+      SetLength(Bytes, M.Size);
+      M.Position := 0;
+      M.ReadBuffer(Bytes[0], M.Size);
+      Output := DecodeShellOutputBytes(Bytes, Length(Bytes));
+    end;
   finally
     M.Free;
     P.Free;
@@ -301,6 +401,7 @@ var
   P: TInternalProcess;
   M: TMemoryStream;
   Buf: array[0..ReadBufferSize - 1] of Byte;
+  Bytes: TBytes;
   N, Total, i, EqPos: Integer;
   EnvList: TStringList;
   Name, Existing: string;
@@ -358,8 +459,15 @@ begin
       Sleep(20);
     end;
     Result := P.ExitStatus;
-    SetLength(Output, M.Size);
-    if M.Size > 0 then begin M.Position := 0; M.ReadBuffer(Output[1], M.Size); end;
+    if M.Size > 0 then
+    begin
+      { Same OEM-decode trick as RunOneShot above -- see the
+        comment there and DecodeShellOutputBytes for the rationale. }
+      SetLength(Bytes, M.Size);
+      M.Position := 0;
+      M.ReadBuffer(Bytes[0], M.Size);
+      Output := DecodeShellOutputBytes(Bytes, Length(Bytes));
+    end;
   finally
     EnvList.Free;
     M.Free;
@@ -577,7 +685,11 @@ begin
       SetLength(Bytes, Acc.Size);
       Acc.Position := 0;
       Acc.ReadBuffer(Bytes[0], Acc.Size);
-      Output := TEncoding.UTF8.GetString(Bytes);
+      { OEM-aware decode on Windows; plain UTF-8 on POSIX. The
+        helper makes both branches go through one place so the
+        bug-fix history -- "cmd.exe is in OEM not UTF-8" -- lives
+        in one comment block (see DecodeShellOutputBytes). }
+      Output := DecodeShellOutputBytes(Bytes, Length(Bytes));
     end;
   finally
     Acc.Free;
@@ -828,7 +940,11 @@ begin
       SetLength(Bytes, Acc.Size);
       Acc.Position := 0;
       Acc.ReadBuffer(Bytes[0], Acc.Size);
-      Output := TEncoding.UTF8.GetString(Bytes);
+      { OEM-aware decode on Windows; plain UTF-8 on POSIX. The
+        helper makes both branches go through one place so the
+        bug-fix history -- "cmd.exe is in OEM not UTF-8" -- lives
+        in one comment block (see DecodeShellOutputBytes). }
+      Output := DecodeShellOutputBytes(Bytes, Length(Bytes));
     end;
   finally
     Acc.Free;

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -199,7 +199,28 @@ begin
   if Len > Length(Bytes) then Len := Length(Bytes);
 
   {$IFDEF MSWINDOWS}
-  if Codepage = 0 then CP := GetOEMCP else CP := Codepage;
+  if Codepage <> 0 then
+    CP := Codepage
+  else
+  begin
+    { Prefer the ACTIVE console output codepage over the system OEM
+      default. cmd.exe writes its stdout in whichever codepage is
+      currently set on the console (the OEM default initially, but
+      operators can switch it -- `chcp 65001` puts the console in
+      UTF-8, and PowerShell sessions inherit the host process's
+      OutputEncoding). Pinning to GetOEMCP would silently re-mojibake
+      output in those environments by decoding UTF-8 bytes as if they
+      were CP437. GetConsoleOutputCP returns the active output CP for
+      the console attached to this process; it returns 0 when the
+      process isn't attached to a console (gateway / serve daemons
+      launched from a service manager, headless CI), in which case
+      we fall back to GetOEMCP -- a long-running headless daemon
+      doesn't have a "currently active" console CP to consult, but
+      its spawned cmd.exe children still default to the OEM CP.
+      Codex P2 on PR #237. }
+    CP := GetConsoleOutputCP;
+    if CP = 0 then CP := GetOEMCP;
+  end;
   { Pass 1: discover the wide-char buffer size we need. }
   WideLen := MultiByteToWideChar(CP, 0, PAnsiChar(@Bytes[0]), Len, nil, 0);
   if WideLen <= 0 then

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -15,6 +15,16 @@ unit PasClaw.Tools.Shell;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}            { Match PasClaw.Platform: keep shell
+                                output bytes UTF-8-tagged through the
+                                Format(...) string-building in
+                                Tool_Shell so they survive into JSON
+                                serialization without ANSI-codepage
+                                transcoding. }
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 

--- a/src/tests/shell_output_decode_tests.pas
+++ b/src/tests/shell_output_decode_tests.pas
@@ -28,6 +28,16 @@ program shell_output_decode_tests;
 {$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
 
 uses
+  {$IFDEF UNIX}cwstring,{$ENDIF}    { Bridges TEncoding.GetEncoding to
+                                      iconv for non-default codepages.
+                                      Production POSIX paths only ever
+                                      decode UTF-8, which works without
+                                      this; the explicit-codepage tests
+                                      below need it to actually resolve
+                                      CP437 (otherwise FPC falls back
+                                      to Latin-1 sign-extension and
+                                      0x82 round-trips as U+0082 instead
+                                      of U+00E9). }
   SysUtils,
   PasClaw.Platform;
 
@@ -139,6 +149,98 @@ begin
               'oversized ByteCount clamps to actual array length');
 end;
 
+procedure TestCP437SingleNonAsciiByte;
+(* The actual point of the whole patch: prove the codepage table is
+   hit correctly, not just that the byte-counting math works. Byte
+   0x82 in CP437 is 'é' (U+00E9); UTF-8 encodes 'é' as the two-byte
+   sequence 0xC3 0xA9. This is the exact mojibake the bug reporter
+   hit -- under naive UTF-8 decoding 0x82 is an invalid lead byte
+   and shows up as a replacement character. Through GetOEMCP +
+   MultiByteToWideChar (Windows) or TEncoding.GetEncoding(437)
+   (Linux via iconv's IBM437) the byte resolves to the right
+   character.
+
+   The CODEPAGE UTF8 directive at the top of this file means 'é'
+   as a source literal is encoded as bytes 0xC3 0xA9 too, so
+   AssertEqStr is meaningful -- otherwise we'd be comparing
+   different encodings. Paren-star delimiters because the directive
+   token would close a curly-brace comment early on dcc64. *)
+var
+  B: TBytes;
+  Got: string;
+begin
+  SetLength(B, 1);
+  B[0] := $82;
+  Got := DecodeShellOutputBytes(B, 1, 437);
+  AssertEqInt(Length(Got), 2,
+              'é UTF-8-encodes to exactly 2 bytes');
+  AssertEqInt(Byte(Got[1]), $C3, 'first UTF-8 byte of é is 0xC3');
+  AssertEqInt(Byte(Got[2]), $A9, 'second UTF-8 byte of é is 0xA9');
+  AssertEqStr(Got, 'é',
+              'CP437 byte 0x82 decodes to é (and round-trips as UTF-8)');
+end;
+
+procedure TestCP437MultiByteString;
+{ A string with multiple non-ASCII CP437 bytes mixed with ASCII --
+  like a real `dir` listing of a directory whose name contains
+  accents. Pins that the conversion handles a mixed run, not just
+  one byte in isolation. }
+var
+  B: TBytes;
+  Got: string;
+begin
+  { "résumé" in CP437:
+      r=0x72, é=0x82, s=0x73, u=0x75, m=0x6D, é=0x82 }
+  SetLength(B, 6);
+  B[0] := $72;
+  B[1] := $82;
+  B[2] := $73;
+  B[3] := $75;
+  B[4] := $6D;
+  B[5] := $82;
+  Got := DecodeShellOutputBytes(B, 6, 437);
+  AssertEqStr(Got, 'résumé',
+              'CP437 multibyte sequence round-trips through the helper');
+end;
+
+procedure TestCP437BoxDrawing;
+{ `dir`'s table output uses CP437 box-drawing characters by
+  default. Byte 0xC4 in CP437 is U+2500 (─, light horizontal),
+  which UTF-8 encodes as 3 bytes 0xE2 0x94 0x80. Pins the
+  three-byte UTF-8 case in addition to the two-byte one above. }
+var
+  B: TBytes;
+  Got: string;
+begin
+  SetLength(B, 1);
+  B[0] := $C4;
+  Got := DecodeShellOutputBytes(B, 1, 437);
+  AssertEqInt(Length(Got), 3,
+              'U+2500 UTF-8-encodes to exactly 3 bytes');
+  AssertEqInt(Byte(Got[1]), $E2, 'first UTF-8 byte of ─ is 0xE2');
+  AssertEqInt(Byte(Got[2]), $94, 'second UTF-8 byte of ─ is 0x94');
+  AssertEqInt(Byte(Got[3]), $80, 'third UTF-8 byte of ─ is 0x80');
+end;
+
+procedure TestUTF8InputThroughExplicitCP65001;
+{ Codepage 65001 is the magic "this is UTF-8" CP on Windows. When
+  the input is already UTF-8 bytes (which is what cmd.exe writes
+  on Windows 10/11 when the operator has the "Use Unicode UTF-8"
+  region option enabled), we must round-trip verbatim. Pins both
+  the Windows-UTF-8-locale branch and the POSIX default. }
+var
+  B: TBytes;
+  Got: string;
+begin
+  { 'é' in UTF-8 = 0xC3 0xA9 }
+  SetLength(B, 2);
+  B[0] := $C3;
+  B[1] := $A9;
+  Got := DecodeShellOutputBytes(B, 2, 65001);
+  AssertEqStr(Got, 'é',
+              'UTF-8 input round-trips through codepage 65001');
+end;
+
 begin
   TestEmptyInputEmptyOutput;
   WriteLn('  ok: empty input -> empty output');
@@ -152,5 +254,13 @@ begin
   WriteLn('  ok: dir-shaped output survives intact');
   TestLengthExceedsBytes;
   WriteLn('  ok: oversized ByteCount clamps safely');
+  TestCP437SingleNonAsciiByte;
+  WriteLn('  ok: CP437 0x82 -> é (the actual codepage table is hit)');
+  TestCP437MultiByteString;
+  WriteLn('  ok: CP437 multibyte sequence round-trips');
+  TestCP437BoxDrawing;
+  WriteLn('  ok: CP437 0xC4 -> ─ (3-byte UTF-8)');
+  TestUTF8InputThroughExplicitCP65001;
+  WriteLn('  ok: codepage 65001 = pass-through UTF-8');
   WriteLn('PASS');
 end.

--- a/src/tests/shell_output_decode_tests.pas
+++ b/src/tests/shell_output_decode_tests.pas
@@ -1,0 +1,156 @@
+program shell_output_decode_tests;
+(*
+  Covers PasClaw.Platform.DecodeShellOutputBytes -- the helper that
+  decodes captured shell-process bytes (cmd.exe / /bin/sh stdout) into
+  a UTF-8 Pascal string. The core bug it fixes: cmd.exe on Windows
+  writes its stdout in the system OEM codepage (CP437 / CP866 / CP932 /
+  ...) NOT UTF-8, and naive `TEncoding.UTF8.GetString` produces
+  mojibake on any non-ASCII byte. That was the root cause of the "is
+  this D:\non-ascii-folder there?" failures the bug reporter hit.
+
+  Tests run on every platform (Linux CI is fine -- the helper accepts
+  an explicit codepage argument so we can pin Windows OEM behaviour
+  without needing Windows itself). On POSIX the codepage table for 437
+  is the same one Windows ships, so the conversion math works.
+
+  Contracts pinned:
+    - Empty input -> empty output (no decode attempted)
+    - ASCII-only bytes round-trip identically regardless of codepage
+      (every codepage agrees on the lower 128)
+    - ByteCount = -1 means "all of Bytes"
+    - ByteCount cap respected
+    - On POSIX, codepage=0 routes to UTF-8 (the default and the
+      historical behaviour we're preserving)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Platform;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")');
+end;
+
+procedure AssertEqInt(Got, Want: Integer; const Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got ' + IntToStr(Got) + ', want ' + IntToStr(Want) + ')');
+end;
+
+function MakeBytes(const S: string): TBytes;
+{ Pack ASCII characters into a TBytes the same way a freshly-captured
+  child stdout buffer would arrive -- one byte per character. }
+var
+  i: Integer;
+begin
+  SetLength(Result, Length(S));
+  for i := 1 to Length(S) do
+    Result[i - 1] := Byte(S[i]);
+end;
+
+procedure TestEmptyInputEmptyOutput;
+var
+  B: TBytes;
+begin
+  SetLength(B, 0);
+  AssertEqStr(DecodeShellOutputBytes(B), '', 'empty TBytes -> empty');
+  AssertEqStr(DecodeShellOutputBytes(B, 0), '', 'ByteCount=0 -> empty');
+  AssertEqStr(DecodeShellOutputBytes(B, -1), '', 'ByteCount=-1 on empty -> empty');
+end;
+
+procedure TestAsciiRoundTripDefault;
+begin
+  AssertEqStr(DecodeShellOutputBytes(MakeBytes('hello world')),
+              'hello world', 'plain ASCII round-trips on default codepage');
+end;
+
+procedure TestAsciiRoundTripExplicit437;
+{ The lower 128 of CP437 == ASCII, so explicit codepage=437 must round
+  trip ASCII verbatim. Exercises the OEM-decode path on Windows; on
+  POSIX exercises the explicit-codepage fallback. }
+begin
+  AssertEqStr(DecodeShellOutputBytes(MakeBytes('Volume in drive C is OS'),
+                                     -1, 437),
+              'Volume in drive C is OS',
+              'ASCII bytes decoded via CP437 are byte-identical');
+end;
+
+procedure TestByteCountCap;
+var
+  B: TBytes;
+begin
+  B := MakeBytes('abcdefghij');
+  AssertEqStr(DecodeShellOutputBytes(B, 5),
+              'abcde', 'ByteCount = 5 takes the first 5 bytes only');
+  AssertEqStr(DecodeShellOutputBytes(B, 0),
+              '', 'ByteCount = 0 returns empty');
+  AssertEqStr(DecodeShellOutputBytes(B, -1),
+              'abcdefghij', 'ByteCount = -1 takes all bytes');
+  AssertEqStr(DecodeShellOutputBytes(B, 1000),
+              'abcdefghij',
+              'ByteCount > Length clamps to Length (no buffer overrun)');
+end;
+
+procedure TestNewlineAndPunctSurvive;
+{ Real `dir` output has CR/LF + spaces + slashes. Pin that none of
+  those are mangled by the decode path regardless of codepage. }
+var
+  Raw: string;
+  i: Integer;
+begin
+  Raw := '12/24/2026  10:15 AM    <DIR>          Documents' + sLineBreak +
+         '                       Total bytes:   123,456';
+  AssertEqStr(DecodeShellOutputBytes(MakeBytes(Raw), -1, 437),
+              Raw, 'dir-shaped ASCII survives CP437 decode intact');
+  AssertEqStr(DecodeShellOutputBytes(MakeBytes(Raw)),
+              Raw, 'dir-shaped ASCII survives default decode intact');
+  { sanity: the input itself has non-zero length so the test isn't
+    vacuous }
+  AssertTrue(Length(Raw) > 0, 'fixture is non-empty');
+  for i := 1 to Length(Raw) do
+    AssertTrue(Ord(Raw[i]) < 128,
+               'fixture must stay pure ASCII so the test runs ' +
+               'identically across CI platforms');
+end;
+
+procedure TestLengthExceedsBytes;
+var
+  B: TBytes;
+begin
+  B := MakeBytes('abc');
+  AssertEqInt(Length(DecodeShellOutputBytes(B, 999)), 3,
+              'oversized ByteCount clamps to actual array length');
+end;
+
+begin
+  TestEmptyInputEmptyOutput;
+  WriteLn('  ok: empty input -> empty output');
+  TestAsciiRoundTripDefault;
+  WriteLn('  ok: ASCII round-trips on default codepage');
+  TestAsciiRoundTripExplicit437;
+  WriteLn('  ok: ASCII round-trips on explicit CP437 (OEM path)');
+  TestByteCountCap;
+  WriteLn('  ok: ByteCount cap respected, -1 = all');
+  TestNewlineAndPunctSurvive;
+  WriteLn('  ok: dir-shaped output survives intact');
+  TestLengthExceedsBytes;
+  WriteLn('  ok: oversized ByteCount clamps safely');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
Closes the real bug behind the "is `D:\non-ASCII-folder` there?" report on Windows. `cmd.exe` writes its stdout in the system OEM codepage (CP437 on US English, CP866 on Cyrillic, CP932 on Japanese, ...), **not** UTF-8. `PasClaw.Platform`'s four `RunOneShot*` sites unconditionally decoded captured bytes as UTF-8, producing mojibake on any non-ASCII byte. That's why the reporter saw `dir /b /a` fail while `fs_list` worked: `shell_exec`'s `dir` came back mangled and the model couldn't recognise the path.

The reporter's later "it appears fixed in the new version" was almost certainly them either preferring `fs_list` going forward or enabling Windows 10/11's "Beta: Use Unicode UTF-8 for worldwide language support" region option — nothing in our code had changed.

## What's new

**`PasClaw.Platform.DecodeShellOutputBytes`** funnels every post-spawn byte-to-string conversion through one place:
- **Windows**: `GetOEMCP` → `MultiByteToWideChar` → `UTF8Encode`. Falls back to UTF-8 if the OEM codepage lookup returns an invalid CP (safer than empty output).
- **POSIX**: `TEncoding.UTF8.GetString` wrapped through `UTF8Encode` for explicit `UnicodeString` → `AnsiString-CP_UTF8` conversion. Behaviourally identical to before, just routed through one helper.
- **Optional `Codepage` parameter** lets tests pin the Windows OEM path from Linux CI with a known CP437 fixture.

Wired into:
- FPC `RunOneShot` (line 359 site)
- FPC `RunOneShotWithEnv` (line 449 site)
- Delphi Windows `RunOneShot` (line 655 site)
- Delphi POSIX `RunOneShot` (line 906 site)

The two Delphi non-shell stubs (`RunOneShotWithEnv` on Windows / POSIX — `ExtraEnv` currently ignored) don't capture output and weren't affected.

## Tests

`shell_output_decode_tests` (6 cases):
- empty → empty
- ASCII round-trip on default + explicit CP437
- `ByteCount` cap (5 / 0 / -1 / oversized)
- dir-shaped output survives intact (CR/LF/spaces/slashes)
- oversized `ByteCount` clamps safely

Tests run on Linux — the explicit-codepage path lets us pin Windows behaviour without needing Windows itself. The actual mojibake fix needs manual verification on a Windows box with non-ASCII paths, since the helper depends on Windows' `MultiByteToWideChar` codepage tables.

## Test plan

- [x] FPC `make smoke` clean.
- [x] Full `make test` green (36 targets, +1 new: `test-shell-output-decode`).
- [ ] **Manual Windows**: create `D:\テスト\foo.txt`, run `pasclaw agent -m "does D:\\テスト exist?"`. Before this PR: model says "no". After: model says "yes" (`shell_exec dir` no longer mangles).

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_