### PR TITLE
Hashline: fix fs_read header mojibake on Windows (Â¶ → ¶)

### DIFF
--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -328,6 +328,16 @@ begin
       Sb.Append(FormatNumberedLine(StartLine + i, Lines[i]));
     end;
     Result := Sb.ToString;
+    {$IFDEF FPC}
+    { TStringBuilder.ToString returns a string with no codepage set
+      regardless of what the appended pieces were tagged with. Stamp
+      it CP_UTF8 so callers concatenating this result (Tool_FSGrep's
+      multi-section TStringBuilder, the patch-apply summary) carry
+      the right tag through to JSON serialisation. The bytes are
+      already correct -- Text comes in as whatever the caller passes
+      (file bytes are UTF-8 in practice) and we don't transcode. }
+    SetCodePage(RawByteString(Result), CP_UTF8, False);
+    {$ENDIF}
   finally
     Sb.Free;
     Lines.Free;
@@ -338,6 +348,17 @@ function FormatHashlineRead(const FilePath, Content: string): string;
 begin
   Result := FormatHashlineHeader(FilePath, ComputeFileHash(Content)) + #10 +
             FormatNumberedLines(Content, 1);
+  {$IFDEF FPC}
+  { Concat of a CP_UTF8 header with default-codepage operands resets
+    the result's tag to CP=0 ("use DefaultSystemCodepage"). On Windows
+    that's the system ANSI CP (CP1252 on English), so the JSON
+    serialiser downstream would still mojibake the UTF-8 bytes the
+    way it would have before the FormatHashlineHeader fix. Stamp
+    the final concatenation here too -- this is the actual string
+    Tool_FSRead returns, the same one PasClaw.JSON.PutStr serialises
+    to the model. Codex P2 on PR #238. }
+  SetCodePage(RawByteString(Result), CP_UTF8, False);
+  {$ENDIF}
 end;
 
 { ====================== Prefix stripping (defensive) ====================== }

--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -36,6 +36,24 @@ unit PasClaw.Hashline;
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
 {$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}            { Tag this unit's AnsiStrings as CP_UTF8
+                                so concatenation results
+                                (FormatHashlineHeader's `HL_FILE_PREFIX
+                                + FilePath + ...`) carry CP_UTF8 instead
+                                of defaulting to the system ANSI codepage.
+                                Without this, on Windows the JSON
+                                serialiser downstream treats the bytes
+                                as CP1252 and re-encodes them to UTF-8 --
+                                that's how the bytes for `¶` (0xC2 0xB6)
+                                turned into `Â¶` (0xC3 0x82 0xC2 0xB6) in
+                                fs_read tool results. The special-char
+                                constants below sidestep the
+                                directive's literal-promotion gotcha by
+                                being spelled as raw byte sequences. }
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
 
 interface
 
@@ -47,7 +65,26 @@ const
      native string form: Delphi UnicodeString = one WideChar per
      codepoint, FPC mode-delphi UTF-8 AnsiString = multi-byte encoding.
      Length() and Copy() are unit-consistent per compiler (chars in
-     Delphi, bytes in FPC), so the same parsing code works in both. *)
+     Delphi, bytes in FPC), so the same parsing code works in both.
+
+     FPC-side: byte literals (#$NN sequences) avoid any source
+     codepage interpretation. The .pas file is saved as UTF-8 on
+     disk, but FPC's default source codepage on Windows is CP1252
+     (or other system ANSI), which would read the UTF-8 bytes of
+     '¶' (0xC2 0xB6) as two separate Latin-1 chars and tag the
+     AnsiString as CP1252. When that string later flowed through
+     fs_read into the model's tool result, downstream UTF-8
+     re-encoding turned `¶` into `Â¶`. Spelling the bytes explicitly
+     bypasses the source-codepage step entirely and we additionally
+     tag the resulting AnsiString as CP_UTF8 via SetCodePage at
+     unit initialization, so the bytes round-trip through the JSON
+     serialiser as proper UTF-8. *)
+  {$IFDEF FPC}
+  HL_FILE_HASH_SEP   = '#';
+  HL_LINE_BODY_SEP   = ':';
+  HL_OP_REPLACE      = ':';
+  HL_PAYLOAD_REPLACE = '|';
+  {$ELSE}
   HL_FILE_PREFIX     = '¶';
   HL_FILE_HASH_SEP   = '#';
   HL_LINE_BODY_SEP   = ':';
@@ -55,6 +92,19 @@ const
   HL_PAYLOAD_REPLACE = '|';
   HL_PAYLOAD_ABOVE   = '↑';
   HL_PAYLOAD_BELOW   = '↓';
+  {$ENDIF}
+
+  {$IFDEF FPC}
+  { UTF-8 byte sequences spelled out to bypass source-codepage
+    interpretation. ¶ U+00B6 = 0xC2 0xB6. ↑ U+2191 = 0xE2 0x86 0x91.
+    ↓ U+2193 = 0xE2 0x86 0x93. Constants are AnsiString here; the
+    initialization section below SetCodePages each to CP_UTF8 so
+    downstream code (JSON serialisation, etc.) treats the bytes as
+    UTF-8 instead of re-encoding via the system ANSI codepage. }
+  HL_FILE_PREFIX:     AnsiString = #$C2#$B6;
+  HL_PAYLOAD_ABOVE:   AnsiString = #$E2#$86#$91;
+  HL_PAYLOAD_BELOW:   AnsiString = #$E2#$86#$93;
+  {$ENDIF}
   HL_FILE_HASH_LEN   = 4;
 
 type
@@ -241,6 +291,18 @@ end;
 function FormatHashlineHeader(const FilePath, FileHash: string): string;
 begin
   Result := HL_FILE_PREFIX + FilePath + HL_FILE_HASH_SEP + FileHash;
+  {$IFDEF FPC}
+  { Concatenating an AnsiString(CP_UTF8) with strings tagged at the
+    system's default codepage produces a Result tagged CP=0 ("use
+    DefaultSystemCodepage") even though the bytes are valid UTF-8.
+    On Windows that DefaultSystemCodepage is the system ANSI CP
+    (CP1252 on English, etc.), so downstream JSON serialisation
+    transcodes our UTF-8 bytes as if they were CP1252 chars --
+    that's how `¶` (0xC2 0xB6) flips to `Â¶` (0xC3 0x82 0xC2 0xB6)
+    in fs_read output. Stamp the result as CP_UTF8 so the
+    downstream serialiser passes the bytes through verbatim. }
+  SetCodePage(RawByteString(Result), CP_UTF8, False);
+  {$ENDIF}
 end;
 
 function FormatNumberedLine(LineNumber: Integer; const LineText: string): string;
@@ -819,5 +881,17 @@ begin
     Src.Free;
   end;
 end;
+
+{$IFDEF FPC}
+initialization
+  { Tag the byte-literal AnsiString constants as CP_UTF8 so when
+    they reach the JSON serialiser (via hashline headers in fs_read
+    output, etc.) the bytes are treated as the UTF-8 sequences they
+    are -- not re-encoded as if they were the system ANSI codepage,
+    which is what produced "Â¶..." instead of "¶..." on Windows. }
+  SetCodePage(RawByteString(HL_FILE_PREFIX),   CP_UTF8, False);
+  SetCodePage(RawByteString(HL_PAYLOAD_ABOVE), CP_UTF8, False);
+  SetCodePage(RawByteString(HL_PAYLOAD_BELOW), CP_UTF8, False);
+{$ENDIF}
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -467,7 +467,20 @@ begin
     if TotalMatches = 0 then
       Result := '(no matches)'
     else
+    begin
       Result := Sb.ToString;
+      {$IFDEF FPC}
+      { fs_grep's TStringBuilder concatenates hashline-formatted
+        per-file sections (each CP_UTF8) with #10 separators. The
+        builder's ToString resets the codepage tag back to 0 ("use
+        DefaultSystemCodepage"), which on Windows means CP1252 and
+        the JSON serialiser would re-encode our valid UTF-8 bytes
+        as if they were CP1252 chars -- the same root mojibake the
+        hashline fix is undoing in FormatHashlineRead. Stamp the
+        final fs_grep result CP_UTF8 too. Codex P2 on PR #238. }
+      SetCodePage(RawByteString(Result), CP_UTF8, False);
+      {$ENDIF}
+    end;
   finally
     Sb.Free;
     Globs.Free;


### PR DESCRIPTION
Fixes the `Â¶C:\...` mojibake Eli hit in `fs_read` output on Windows. Three-part fix:

## Root cause

`PasClaw.Hashline.pas` had `HL_FILE_PREFIX = '¶'` (and similar for `'↑'/'↓'`) as bare character literals in the const block. Without `{$CODEPAGE UTF8}` on the unit:
- **Linux** (FPC default reads source as UTF-8): bytes interpreted correctly, tests passed.
- **Windows** (FPC default reads source as CP1252): UTF-8 bytes `0xC2 0xB6` got read as **two** Latin-1 chars. Even when the byte values were preserved correctly, the resulting `AnsiString` carried no codepage tag — when `FormatHashlineHeader`'s result hit the JSON serialiser, the bytes got re-encoded as if they were CP1252 characters, producing `Â¶` (UTF-8 `0xC3 0x82 0xC2 0xB6`).

## Why the naive fix didn't work

Adding `{$CODEPAGE UTF8}` alone broke the parser: FPC under that directive promotes a bare `const X = 'literal'` to a single-codepoint UnicodeString-flavoured value. `Length()` returns 1 codepoint instead of 3 UTF-8 bytes, and the validator's byte-arithmetic `Copy(L, p+1, Length(HL_PAYLOAD_BELOW))` captures only the first byte. The validator silently stopped flagging `60:↓bad inline payload` as invalid.

## Three-part fix

1. **`{$CODEPAGE UTF8}` on the unit** so concatenation results in `FormatHashlineHeader` carry CP_UTF8 instead of defaulting to system ANSI when reaching the JSON serialiser.
2. **Byte-literal constants on the FPC side** to sidestep the directive's literal-promotion gotcha:
   ```pascal
   HL_FILE_PREFIX:   AnsiString = #$C2#$B6;
   HL_PAYLOAD_ABOVE: AnsiString = #$E2#$86#$91;
   HL_PAYLOAD_BELOW: AnsiString = #$E2#$86#$93;
   ```
   Unit initialization `SetCodePage`s each to CP_UTF8 so they identify as UTF-8 to downstream code.
3. **Explicit `SetCodePage(RawByteString(Result), CP_UTF8, False)` in `FormatHashlineHeader`** because concatenation across mixed-CP operands produces CP=0 ("use default") even when the bytes are valid UTF-8 — explicitly stamping the tag is the only way to make the JSON serialiser pass bytes through verbatim on Windows.

Delphi build untouched (Delphi reads source as UTF-16 already; everything's `{$IFDEF FPC}`-guarded).

## Test plan

- [x] FPC `make smoke` clean.
- [x] Full `make test` green (36 targets).
- [x] Probe shows `FormatHashlineHeader` now returns CP=65001 with bytes `0xC2 0xB6 ...` (was CP=0 before fix).
- [ ] **Windows manual**: rebuild, run any `fs_read` — header should show `¶C:\path` not `Â¶C:\path`.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_