### PR TITLE
Revert PR #237's GetConsoleOutputCP fix; cmd pipes use OEM, not console CP

### DIFF
--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -203,23 +203,28 @@ begin
     CP := Codepage
   else
   begin
-    { Prefer the ACTIVE console output codepage over the system OEM
-      default. cmd.exe writes its stdout in whichever codepage is
-      currently set on the console (the OEM default initially, but
-      operators can switch it -- `chcp 65001` puts the console in
-      UTF-8, and PowerShell sessions inherit the host process's
-      OutputEncoding). Pinning to GetOEMCP would silently re-mojibake
-      output in those environments by decoding UTF-8 bytes as if they
-      were CP437. GetConsoleOutputCP returns the active output CP for
-      the console attached to this process; it returns 0 when the
-      process isn't attached to a console (gateway / serve daemons
-      launched from a service manager, headless CI), in which case
-      we fall back to GetOEMCP -- a long-running headless daemon
-      doesn't have a "currently active" console CP to consult, but
-      its spawned cmd.exe children still default to the OEM CP.
-      Codex P2 on PR #237. }
-    CP := GetConsoleOutputCP;
-    if CP = 0 then CP := GetOEMCP;
+    { Use the OEM codepage, NOT GetConsoleOutputCP. Reverting PR #237's
+      Codex P2 fix because real-world testing (Eli on a Windows Terminal
+      / Windows 7 box) showed it regresses the common case. The
+      reviewer's reasoning was: "what if the operator ran chcp 65001
+      first?" But `chcp` in cmd.exe is well-documented to NOT reliably
+      switch piped output encoding -- cmd.exe's redirected stdout uses
+      the OEM codepage regardless of the console's chcp setting (and
+      our spawned cmd.exe children don't inherit a parent shell's
+      chcp at all). Meanwhile pasclaw.exe launched from Windows
+      Terminal (CP_UTF8 by default on Win10+) makes GetConsoleOutputCP
+      return 65001 -- so we then ran MultiByteToWideChar(65001, ...)
+      over real CP437 bytes (the 0x82 byte for é). 65001 is strict
+      UTF-8: 0x82 is an invalid lead byte, gets replaced with U+FFFD,
+      and the model sees `r�sum�.txt` instead of `résumé.txt`.
+      Exactly the original bug, just routed through a different
+      mojibake. GetOEMCP returns the system default (CP437 on US
+      English Windows), which is what cmd.exe's piped output actually
+      uses. The chcp 65001 case can still be handled by the operator
+      running it inside their shell_exec command -- `cmd /c "chcp
+      65001 && dir /b > out.utf8 && type out.utf8"` -- but the
+      default decode path must match cmd.exe's pipe default. }
+    CP := GetOEMCP;
   end;
   { Pass 1: discover the wide-char buffer size we need. }
   WideLen := MultiByteToWideChar(CP, 0, PAnsiChar(@Bytes[0]), Len, nil, 0);

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -183,6 +183,11 @@ uses
 function DecodeShellOutputBytes(const Bytes: TBytes;
                                 ByteCount: Integer;
                                 Codepage: UInt32): string;
+{$IFDEF MSWINDOWS}
+const
+  CP_UTF8_LOCAL              = 65001;
+  MB_ERR_INVALID_CHARS_LOCAL = $00000008;
+{$ENDIF}
 var
   Len: Integer;
   {$IFDEF MSWINDOWS}
@@ -203,28 +208,38 @@ begin
     CP := Codepage
   else
   begin
-    { Use the OEM codepage, NOT GetConsoleOutputCP. Reverting PR #237's
-      Codex P2 fix because real-world testing (Eli on a Windows Terminal
-      / Windows 7 box) showed it regresses the common case. The
-      reviewer's reasoning was: "what if the operator ran chcp 65001
-      first?" But `chcp` in cmd.exe is well-documented to NOT reliably
-      switch piped output encoding -- cmd.exe's redirected stdout uses
-      the OEM codepage regardless of the console's chcp setting (and
-      our spawned cmd.exe children don't inherit a parent shell's
-      chcp at all). Meanwhile pasclaw.exe launched from Windows
-      Terminal (CP_UTF8 by default on Win10+) makes GetConsoleOutputCP
-      return 65001 -- so we then ran MultiByteToWideChar(65001, ...)
-      over real CP437 bytes (the 0x82 byte for é). 65001 is strict
-      UTF-8: 0x82 is an invalid lead byte, gets replaced with U+FFFD,
-      and the model sees `r�sum�.txt` instead of `résumé.txt`.
-      Exactly the original bug, just routed through a different
-      mojibake. GetOEMCP returns the system default (CP437 on US
-      English Windows), which is what cmd.exe's piped output actually
-      uses. The chcp 65001 case can still be handled by the operator
-      running it inside their shell_exec command -- `cmd /c "chcp
-      65001 && dir /b > out.utf8 && type out.utf8"` -- but the
-      default decode path must match cmd.exe's pipe default. }
-    CP := GetOEMCP;
+    { Auto-detect between UTF-8 and OEM. PR #237's first attempt
+      pinned GetConsoleOutputCP (wrong: returns OUR console's CP,
+      not the spawned cmd.exe's piped-output CP). The revert to
+      unconditional GetOEMCP was right for cmd.exe (which pipes
+      OEM regardless of chcp) but wrong for pwsh -- PowerShell 6+
+      defaults to UTF-8 stdout, so a `Write-Output 'résumé'` from
+      execute_code's pwsh branch produces UTF-8 bytes that GetOEMCP
+      would mojibake as CP437. Codex P2 on PR #239.
+
+      Heuristic: try strict UTF-8 (MB_ERR_INVALID_CHARS) first.
+      Valid UTF-8 -> use it (pwsh / chcp 65001 / Linux on Wine).
+      Invalid sequence anywhere -> fall back to OEM (cmd.exe's
+      piped output).
+
+      This is robust because:
+        - Pure ASCII (most output) is valid UTF-8 -> taken either way.
+        - cmd's CP437 non-ASCII bytes (0x80-0xFF) are typically
+          invalid UTF-8 lead bytes -- e.g. 0x82 (é in CP437) has
+          binary 10000010 which is a UTF-8 continuation marker, not
+          a lead byte, so it fails MB_ERR_INVALID_CHARS.
+        - pwsh UTF-8 output (multi-byte sequences for é/résumé/etc.)
+          parses cleanly.
+
+      Edge case: OEM bytes that happen to coincide with a valid
+      UTF-8 sequence (e.g. exactly a 2-byte CP437 pair that maps
+      to a real Unicode codepoint via UTF-8 decoding). This is
+      vanishingly unlikely for filename / dir output. }
+    if MultiByteToWideChar(CP_UTF8_LOCAL, MB_ERR_INVALID_CHARS_LOCAL,
+                            PAnsiChar(@Bytes[0]), Len, nil, 0) > 0 then
+      CP := CP_UTF8_LOCAL
+    else
+      CP := GetOEMCP;
   end;
   { Pass 1: discover the wide-char buffer size we need. }
   WideLen := MultiByteToWideChar(CP, 0, PAnsiChar(@Bytes[0]), Len, nil, 0);

--- a/src/tests/shell_output_decode_tests.pas
+++ b/src/tests/shell_output_decode_tests.pas
@@ -241,6 +241,33 @@ begin
               'UTF-8 input round-trips through codepage 65001');
 end;
 
+procedure TestAutoDetectPrefersUTF8ForValidSequences;
+(* Codex P2 on PR #239: PowerShell 6+ (pwsh) defaults to UTF-8 stdout,
+   so when execute_code or shell_exec captures pwsh output the bytes
+   are valid UTF-8 sequences -- decoding via GetOEMCP would mojibake
+   them. With Codepage = 0 the helper should detect "this is valid
+   UTF-8" and pass through verbatim, NOT route through CP437. POSIX
+   side: Codepage=0 already goes through TEncoding.UTF8.GetString
+   so the same input is handled the same way on Linux CI. *)
+var
+  B: TBytes;
+  Got: string;
+begin
+  { "résumé" as UTF-8: r(0x72), é(0xC3 0xA9), s(0x73), u(0x75),
+    m(0x6D), é(0xC3 0xA9) -- 8 bytes total. }
+  SetLength(B, 8);
+  B[0] := $72;
+  B[1] := $C3; B[2] := $A9;
+  B[3] := $73;
+  B[4] := $75;
+  B[5] := $6D;
+  B[6] := $C3; B[7] := $A9;
+  Got := DecodeShellOutputBytes(B);   { Codepage = 0 -> auto-detect }
+  AssertEqStr(Got, 'résumé',
+              'auto-detect: valid UTF-8 input passes through verbatim ' +
+              '(would be mojibake "rA©sumA©" or similar if CP437 was forced)');
+end;
+
 begin
   TestEmptyInputEmptyOutput;
   WriteLn('  ok: empty input -> empty output');
@@ -262,5 +289,7 @@ begin
   WriteLn('  ok: CP437 0xC4 -> ─ (3-byte UTF-8)');
   TestUTF8InputThroughExplicitCP65001;
   WriteLn('  ok: codepage 65001 = pass-through UTF-8');
+  TestAutoDetectPrefersUTF8ForValidSequences;
+  WriteLn('  ok: auto-detect picks UTF-8 for valid UTF-8 input (pwsh case)');
   WriteLn('PASS');
 end.


### PR DESCRIPTION
Revert PR #237's review fix. Real-world Windows testing on Eli's box showed the `GetConsoleOutputCP` change actively regressed the bug it was supposed to address.

## What went wrong

Trace from Eli's session:
- His cmd console: `chcp` confirms CP437
- His pasclaw.exe: launched from Windows Terminal which defaults to CP65001 (Win10+) → our process's `GetConsoleOutputCP()` returns **65001**
- `DecodeShellOutputBytes` runs `MultiByteToWideChar(65001, [..., 0x82, ...], ...)`
- 0x82 is an invalid UTF-8 lead byte → Windows replaces with U+FFFD
- `UTF8Encode` produces the bytes 0xEF 0xBF 0xBD for each
- Model sees `r�sum�.txt` (where `�` = U+FFFD) instead of `résumé.txt`

Same mojibake as before, just routed through a different codepage mismatch.

## Why the Codex P2 reasoning was wrong

The review argued "what if the operator ran `chcp 65001` first?" The flaw: **`chcp` doesn't reliably switch cmd.exe's piped output encoding.** cmd.exe writes redirected stdout in the OEM codepage regardless of the console's chcp setting (a documented Windows behavior). Our spawned cmd.exe children also don't inherit a parent shell's chcp — they're new processes attached to the same console.

So `GetConsoleOutputCP` returns the parent shell's console CP (our pasclaw.exe's terminal — 65001 from Windows Terminal), but cmd.exe's piped output uses the OEM CP (CP437). Decoding 437 bytes as 65001 is the mojibake we just observed.

`GetOEMCP` returns the system OEM default — which is what cmd.exe's pipe output **actually** uses. The legitimate "I want UTF-8 cmd output" case can still be handled by the operator running `chcp 65001 &&` inside their `shell_exec` command (that affects the spawned cmd.exe's own internal codepage handling for that specific invocation).

## Test plan

- [x] FPC `make smoke` clean.
- [x] Full `make test` green (36 targets).
- [ ] **Manual Windows**: rebuild, run `pasclaw agent -m "Run shell_exec to: cd %USERPROFILE%\.pasclaw && dir /b. Do you see résumé.txt?"`. Model should now see `résumé.txt` clean, not `r�sum�.txt`.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_