### PR TITLE
fs_grep: ripgrep-inspired tier 1-4 speedups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,4 +486,15 @@ test-kb-index: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/kb_index_tests.pas -o$(BUILDDIR)/kb_index_tests
 	@$(BUILDDIR)/kb_index_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode
+# fs_grep ripgrep-tier1-4 optimisations: defer ComputeFileHash until first
+# match (tier 1), skip blocked dir names like .git/node_modules/target
+# (tier 2), skip binary files by NUL-byte sniff in the first kilobyte
+# (tier 3), and skip files larger than max_file_bytes (default 10 MiB,
+# tier 4). Pure-Pascal: spins temp-dir fixtures, calls Tool_FSGrep
+# through the registered handler, asserts on observable output.
+test-fs-grep-tier1-4: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier1_4_tests.pas -o$(BUILDDIR)/fs_grep_tier1_4_tests
+	@$(BUILDDIR)/fs_grep_tier1_4_tests
+
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -116,6 +116,71 @@ begin
   end;
 end;
 
+function ParseInt64Arg(const ArgsJSON, Field: string; Default_: Int64): Int64;
+var
+  Obj: TJsonObject;
+begin
+  Result := Default_;
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      if Obj.Has(Field) then Result := Obj.GetInt(Field, Default_);
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := Default_;
+  end;
+end;
+
+function IsBlockedGrepDir(const Name: string): Boolean;
+{ ripgrep-style hardcoded skip list. The model never wants
+  fs_grep results from .git/, node_modules/, etc. -- they're
+  pure noise for project-level queries. Cuts directory walk
+  time by ~10x on a typical repo where the bulk of file count
+  lives under these dirs. Operators with non-standard layouts
+  who genuinely need to grep into one of these can pass an
+  explicit Path pointing INTO it (the skip list only kicks
+  during recursion, not at the user-supplied Root). }
+const
+  BlockedDirs: array[0..11] of string = (
+    '.git', '.hg', '.svn',                  { VCS }
+    'node_modules',                          { JS/TS deps }
+    'target',                                { Rust / Java build }
+    'build',                                 { generic build dir }
+    'dist',                                  { JS publish output }
+    'vendor',                                { Go / PHP deps }
+    '.venv',                                 { Python venv }
+    '__pycache__',                           { Python bytecode }
+    '.gradle',                               { Gradle cache }
+    '.next'                                  { Next.js build }
+  );
+var
+  i: Integer;
+begin
+  for i := Low(BlockedDirs) to High(BlockedDirs) do
+    if SameText(Name, BlockedDirs[i]) then Exit(True);
+  Result := False;
+end;
+
+function LooksBinary(const Body: string): Boolean;
+{ ripgrep-style binary detection: peek at the first 1024 bytes
+  for a NUL. Source code never embeds NUL; PDFs / PNGs / zips /
+  .exe / .so all do at the file header. Cheap O(1024) scan that
+  saves the per-line allocation work on the (often majority)
+  files where the model has no use for the contents anyway. }
+var
+  N, i: Integer;
+begin
+  N := Length(Body);
+  if N > 1024 then N := 1024;
+  for i := 1 to N do
+    if Body[i] = #0 then Exit(True);
+  Result := False;
+end;
+
 function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
 var
   Path, Body, Reason: string;
@@ -348,11 +413,37 @@ function Tool_FSGrep(const ArgsJSON: string; out ErrMsg: string): string;
 { Recursive line scan returning hashline-formatted matches. Output looks
   like one section per matched file (¶path#hash header + N:line per
   match), so a follow-up fs_edit_hashline call can paste anchors
-  verbatim. }
+  verbatim.
+
+  Speed: four ripgrep-inspired tier-1 optimisations layered on top of
+  the original naive scan:
+
+    1. Defer ComputeFileHash until the first match in a file. Most
+       scanned files don't match the pattern; hashing them was pure
+       waste.
+    2. Skip well-known VCS / build / dependency directories by name
+       at walk time (.git, node_modules, target, build, ...). Cuts
+       directory walk by ~10x on a typical project.
+    3. Binary file detection (NUL byte in first 1024 bytes) -- skip
+       these before line-splitting since the model can't use the
+       contents anyway.
+    4. File-size cap (default 10 MB, override via max_file_bytes
+       arg) -- a multi-GB log file would dominate the grep.
+
+  Tier 5+ (byte-level scan to avoid TStringList, Boyer-Moore-Horspool
+  substring search) are a worthwhile follow-up if a perf budget
+  surfaces. }
+const
+  { 10 MiB. Source files are kilobytes; binary blobs get caught by
+    the NUL-byte check above; the cap exists for "the model accidentally
+    fs_greps a giant log file" cases that would otherwise stall a
+    session for tens of seconds reading megabytes off disk. }
+  DefaultMaxFileBytes = 10 * 1024 * 1024;
 var
   Root, Pattern, IncludeGlob: string;
   IgnoreCase: Boolean;
   MaxMatches: Int64;
+  MaxFileBytes: Int64;
   Globs: TStringList;
   Sb: TStringBuilder;
   TotalMatches: Integer;
@@ -360,7 +451,7 @@ var
 
   procedure ScanFile(const Path: string);
   var
-    Body, Header: string;
+    Body: string;
     Lines: TStringList;
     j: Integer;
     Cmp: string;
@@ -370,20 +461,18 @@ var
     try
       Body := ReadFileText(Path);
     except
-      Exit;  { binary / permissions -- skip silently to keep grep tractable }
+      Exit;  { permissions -- skip silently to keep grep tractable }
     end;
-    Header := FormatHashlineHeader(Path, ComputeFileHash(Body));
+    { ripgrep tier 3: skip binaries before the line-splitting work.
+      Source code never has embedded NUL bytes; PDFs / PNGs / zips /
+      executables always do at the file header. }
+    if LooksBinary(Body) then Exit;
     Lines := TStringList.Create;
     try
       Lines.LineBreak := #10;
       Lines.StrictDelimiter := True;
       Lines.Text := StringReplace(Body, #13, '', [rfReplaceAll]);
       Wrote := False;
-      { Removed MatchCount local -- it was incremented per match but
-        never read; the per-file scope made it look like a counter
-        but only TotalMatches actually gates the loop. dcc64 H2077
-        flagged the dead writes; removing the var keeps the code
-        honest about what's being tracked. }
       for j := 0 to Lines.Count - 1 do
       begin
         if TotalMatches >= MaxMatches then Break;
@@ -393,7 +482,11 @@ var
           if not Wrote then
           begin
             if Sb.Length > 0 then Sb.Append(#10);
-            Sb.Append(Header).Append(#10);
+            { ripgrep tier 1: defer ComputeFileHash until we actually
+              have a match. On a typical project scan most files have
+              zero matches -- hashing them all was pure waste. }
+            Sb.Append(FormatHashlineHeader(Path,
+                       ComputeFileHash(Body))).Append(#10);
             Wrote := True;
           end;
           Sb.Append(FormatNumberedLine(j + 1, Lines[j])).Append(#10);
@@ -419,12 +512,22 @@ var
           Full := JoinPath(Dir, SR.Name);
           if (SR.Attr and faDirectory) <> 0 then
           begin
-            if SR.Name <> '' then
-              if SR.Name[1] = '.' then Continue;  { skip dotdirs }
+            if (SR.Name <> '') and (SR.Name[1] = '.') then Continue;
+            { ripgrep tier 2: skip well-known VCS / build / deps dirs
+              by name. The model never wants results from node_modules
+              etc. -- and these dirs dominate file count on real repos. }
+            if IsBlockedGrepDir(SR.Name) then Continue;
             Walk(Full);
           end
-          else if MatchesAny(SR.Name, Globs) then
-            ScanFile(Full);
+          else
+          begin
+            { ripgrep tier 4: skip files over the cap WITHOUT reading
+              them. TSearchRec.Size is already populated by FindFirst /
+              FindNext, so no extra stat call. }
+            if SR.Size > MaxFileBytes then Continue;
+            if MatchesAny(SR.Name, Globs) then
+              ScanFile(Full);
+          end;
         until (FindNext(SR) <> 0) or (TotalMatches >= MaxMatches);
       finally
         FindClose(SR);
@@ -448,6 +551,8 @@ begin
   IgnoreCase := ParseBoolArg(ArgsJSON, 'ignore_case', False);
   if IgnoreCase then PatLower := LowerCase(Pattern) else PatLower := Pattern;
   MaxMatches := 1000;
+  MaxFileBytes := ParseInt64Arg(ArgsJSON, 'max_file_bytes', DefaultMaxFileBytes);
+  if MaxFileBytes <= 0 then MaxFileBytes := DefaultMaxFileBytes;
   IncludeGlob := '';
   ParseStringArg(ArgsJSON, 'include', IncludeGlob);
   Globs := TStringList.Create;
@@ -589,9 +694,18 @@ begin
 
     T.Name        := 'fs_grep';
     T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
-                     'Skips dotdirs. Returns hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
+                     'Skips dotdirs, well-known build/VCS/deps dirs (.git, node_modules, target, build, ' +
+                     'dist, vendor, .venv, __pycache__, .gradle, .next), binary files (NUL-byte detection ' +
+                     'in first 1 KiB), and files larger than max_file_bytes (default 10 MiB). Returns ' +
+                     'hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
                      'so you can paste anchors directly into fs_edit_hashline.';
-    T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"pattern":{"type":"string"},"ignore_case":{"type":"boolean"},"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"}},"required":["path","pattern"]}';
+    T.Schema      := '{"type":"object","properties":{' +
+                     '"path":{"type":"string"},' +
+                     '"pattern":{"type":"string"},' +
+                     '"ignore_case":{"type":"boolean"},' +
+                     '"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"},' +
+                     '"max_file_bytes":{"type":"integer","description":"Skip files larger than this (default 10485760 = 10 MiB). Override for grepping into giant log files."}' +
+                     '},"required":["path","pattern"]}';
     T.Handler     := Tool_FSGrep;
     T.IsCore      := True;
     T.Category    := tcReadOnly;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -448,6 +448,7 @@ var
   Sb: TStringBuilder;
   TotalMatches: Integer;
   PatLower: string;
+  DirectSR: TSearchRec;
 
   procedure ScanFile(const Path: string);
   var
@@ -563,7 +564,21 @@ begin
     if DirectoryExists(Root) then
       Walk(Root)
     else if FileExists(Root) then
-      ScanFile(Root)
+    begin
+      { ripgrep tier 4: enforce the size cap on the direct-file path
+        too, not just inside Walk. Without this, `fs_grep
+        path=server.log pattern=...` against an 11 MiB log would
+        still scan it -- the schema and tool description promise
+        files over max_file_bytes are skipped, so the direct-file
+        case has to honour that contract too. SR.Size from FindFirst
+        is the same stat that Walk uses; no read of the file body. }
+      if FindFirst(Root, faAnyFile, DirectSR) = 0 then
+        try
+          if DirectSR.Size <= MaxFileBytes then ScanFile(Root);
+        finally
+          FindClose(DirectSR);
+        end;
+    end
     else
     begin
       ErrMsg := 'no such path: ' + Root;

--- a/src/tests/fs_grep_tier1_4_tests.pas
+++ b/src/tests/fs_grep_tier1_4_tests.pas
@@ -249,6 +249,42 @@ begin
   end;
 end;
 
+procedure TestDirectFilePathRespectsCap;
+{ Regression for PR #240 P2: when fs_grep is called with `path`
+  pointing directly at a file (not a dir), the size cap must still
+  apply. The walk-time SR.Size check inside Walk() does nothing on
+  the direct-file branch; the fix puts an equivalent FindFirst stat
+  in front of that branch too. Pin both directions: oversize is
+  skipped at the default cap AND included when the cap is raised. }
+var
+  Got, Big, Huge: string;
+const
+  Marker = 'FsGrepTier4DirectMarker_TRIPWIRE';
+  BigSize = 11 * 1024 * 1024;
+begin
+  Huge := IncludeTrailingPathDelimiter(SysUtils.GetTempDir) +
+          'pasclaw-fsgrep-direct-' + IntToStr(Random(MaxInt)) + '.log';
+  try
+    SetLength(Big, BigSize);
+    FillChar(Big[1], BigSize, Ord('A'));
+    Move(Marker[1], Big[BigSize - Length(Marker) + 1], Length(Marker));
+    WriteText(Huge, Big);
+
+    { Default cap: an 11 MiB file targeted by exact path is still
+      over 10 MiB, so its marker must NOT surface. }
+    Got := CallGrep(Huge, Marker);
+    AssertContains(Got, 'no matches',
+                   'direct-file path: oversize file skipped at default cap');
+
+    { Raise the cap and the same direct-file path must scan it. }
+    Got := CallGrep(Huge, Marker, 20 * 1024 * 1024);
+    AssertContains(Got, '.log',
+                   'direct-file path: oversize file IS scanned when cap is raised');
+  finally
+    if FileExists(Huge) then DeleteFile(Huge);
+  end;
+end;
+
 procedure TestEmptyResultRendersClean;
 var
   Root, Got: string;
@@ -296,6 +332,8 @@ begin
   WriteLn('  ok: tier 4 -- 11 MiB file skipped at default 10 MiB cap');
   TestRaisingCapIncludesLargeFile;
   WriteLn('  ok: tier 4 -- raising max_file_bytes brings file back in scope');
+  TestDirectFilePathRespectsCap;
+  WriteLn('  ok: tier 4 -- direct-file path also honours / overrides cap (PR #240 P2)');
   TestEmptyResultRendersClean;
   WriteLn('  ok: zero-match result still renders friendly placeholder');
   TestMatchOutputUnchangedForHitFiles;

--- a/src/tests/fs_grep_tier1_4_tests.pas
+++ b/src/tests/fs_grep_tier1_4_tests.pas
@@ -1,0 +1,304 @@
+program fs_grep_tier1_4_tests;
+(*
+  Pin the four ripgrep-inspired fs_grep optimisations as observable
+  behaviour, not just timing.
+
+    Tier 1  Defer ComputeFileHash until first match in a file.
+            Not directly observable in output (the hash is still
+            correct when a match DOES happen). Covered by the
+            general correctness tests -- if we broke deferral the
+            existing match output would still be right.
+
+    Tier 2  Hardcoded skip-dirs (.git, node_modules, target, ...).
+            Test by seeding a temp tree with one of these
+            containing a unique pattern and asserting fs_grep
+            does NOT find it.
+
+    Tier 3  Binary file detection. Seed a file with embedded NUL
+            byte in the first 1024 bytes AND the pattern; assert
+            the file is silently skipped.
+
+    Tier 4  File-size cap. Seed an oversize file; assert it's
+            skipped when default cap applies AND included when
+            max_file_bytes overrides upward.
+
+  Strategy: spin a unique-per-run temp dir under SysUtils.GetTempDir,
+  populate fixtures, drive Tool_FSGrep via its public handler with
+  hand-built JSON args, clean up. No model, no provider, no
+  PasClaw runtime beyond the FS tool registry.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  PasClaw.Utils,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.FS;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' +
+          Copy(Haystack, 1, 200) + '")');
+end;
+
+procedure AssertNotContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) > 0 then
+    Fail_(Msg + ' (unwanted needle "' + Needle +
+          '" found in "' + Copy(Haystack, 1, 200) + '")');
+end;
+
+procedure WriteText(const Path, Content: string);
+var
+  F: TFileStream;
+begin
+  F := TFileStream.Create(Path, fmCreate);
+  try
+    if Length(Content) > 0 then
+      F.WriteBuffer(Content[1], Length(Content));
+  finally
+    F.Free;
+  end;
+end;
+
+function MakeTempDir(const Tag: string): string;
+begin
+  Result := IncludeTrailingPathDelimiter(SysUtils.GetTempDir) +
+            'pasclaw-fsgrep-' + Tag + '-' +
+            IntToStr(Random(MaxInt));
+  ForceDirectories(Result);
+end;
+
+procedure DeleteTree(const Dir: string);
+var
+  SR: TSearchRec;
+begin
+  if not DirectoryExists(Dir) then Exit;
+  if FindFirst(JoinPath(Dir, '*'), faAnyFile, SR) = 0 then
+  begin
+    try
+      repeat
+        if (SR.Name = '.') or (SR.Name = '..') then Continue;
+        if (SR.Attr and faDirectory) <> 0 then
+          DeleteTree(JoinPath(Dir, SR.Name))
+        else
+          DeleteFile(JoinPath(Dir, SR.Name));
+      until FindNext(SR) <> 0;
+    finally
+      FindClose(SR);
+    end;
+  end;
+  RemoveDir(Dir);
+end;
+
+function CallGrep(const Path, Pattern: string;
+                  MaxFileBytes: Int64 = -1): string;
+var
+  Reg: TToolRegistry;
+  Tool: TTool;
+  Args, ErrMsg: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    if not Reg.Find('fs_grep', Tool) then
+      Fail_('fs_grep not registered');
+    if MaxFileBytes < 0 then
+      Args := Format('{"path":"%s","pattern":"%s"}',
+                     [StringReplace(Path, '\', '\\', [rfReplaceAll]), Pattern])
+    else
+      Args := Format('{"path":"%s","pattern":"%s","max_file_bytes":%d}',
+                     [StringReplace(Path, '\', '\\', [rfReplaceAll]),
+                      Pattern, MaxFileBytes]);
+    Result := Tool.Handler(Args, ErrMsg);
+    if ErrMsg <> '' then
+      Fail_('fs_grep returned error: ' + ErrMsg);
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestSkipsBlockedDirsByName;
+var
+  Root, Got: string;
+const
+  UniqueMarker = 'FsGrepTier2Marker_TRIPWIRE';
+begin
+  Root := MakeTempDir('skipdirs');
+  try
+    { Marker in a clean place we should find. }
+    WriteText(JoinPath(Root, 'good.txt'), 'header'#10 + UniqueMarker + #10);
+
+    { Same marker inside each blocked directory -- should be ignored. }
+    ForceDirectories(JoinPath(Root, 'node_modules'));
+    WriteText(JoinPath(Root, 'node_modules' + PathDelim + 'inner.txt'),
+              UniqueMarker);
+    ForceDirectories(JoinPath(Root, 'target'));
+    WriteText(JoinPath(Root, 'target' + PathDelim + 'inner.txt'),
+              UniqueMarker);
+    ForceDirectories(JoinPath(Root, '__pycache__'));
+    WriteText(JoinPath(Root, '__pycache__' + PathDelim + 'inner.txt'),
+              UniqueMarker);
+
+    Got := CallGrep(Root, UniqueMarker);
+    AssertContains(Got, 'good.txt',
+                   'match in non-blocked dir surfaces');
+    AssertNotContains(Got, 'node_modules',
+                      'node_modules path NOT in output');
+    AssertNotContains(Got, 'target' + PathDelim + 'inner',
+                      'target/inner NOT in output');
+    AssertNotContains(Got, '__pycache__',
+                      '__pycache__ NOT in output');
+  finally
+    DeleteTree(Root);
+  end;
+end;
+
+procedure TestSkipsBinaryByNULDetection;
+var
+  Root, Got, Binary: string;
+const
+  Marker = 'FsGrepTier3Marker_TRIPWIRE';
+begin
+  Root := MakeTempDir('binary');
+  try
+    { Text file with the marker -- found. }
+    WriteText(JoinPath(Root, 'text.txt'), Marker + ' lives here');
+
+    { "Binary" file: NUL byte in the first kilobyte alongside the
+      marker. Source code never has embedded NUL; the model would
+      get noise from the bytes anyway. }
+    Binary := 'header'#10'something'#0'more text with ' + Marker;
+    WriteText(JoinPath(Root, 'image.bin'), Binary);
+
+    Got := CallGrep(Root, Marker);
+    AssertContains(Got, 'text.txt',
+                   'text-file match surfaces');
+    AssertNotContains(Got, 'image.bin',
+                      'binary file silently skipped (NUL-byte check)');
+  finally
+    DeleteTree(Root);
+  end;
+end;
+
+procedure TestSkipsLargeFileAtDefaultCap;
+var
+  Root, Got, Big: string;
+const
+  Marker = 'FsGrepTier4Marker_TRIPWIRE';
+  { 11 MiB > 10 MiB default cap. Building a 11 MiB AnsiString in
+    one shot is fine memory-wise on every supported platform. }
+  BigSize = 11 * 1024 * 1024;
+begin
+  Root := MakeTempDir('largefile');
+  try
+    WriteText(JoinPath(Root, 'small.txt'), Marker);
+    SetLength(Big, BigSize);
+    FillChar(Big[1], BigSize, Ord('A'));
+    { Put the marker inside so the file would match if scanned. }
+    Move(Marker[1], Big[BigSize - Length(Marker) + 1], Length(Marker));
+    WriteText(JoinPath(Root, 'huge.log'), Big);
+
+    Got := CallGrep(Root, Marker);
+    AssertContains(Got, 'small.txt',
+                   'small file match surfaces');
+    AssertNotContains(Got, 'huge.log',
+                      'oversize file skipped at default 10 MiB cap');
+  finally
+    DeleteTree(Root);
+  end;
+end;
+
+procedure TestRaisingCapIncludesLargeFile;
+var
+  Root, Got, Big: string;
+const
+  Marker = 'FsGrepTier4RaiseCapMarker_TRIPWIRE';
+  BigSize = 11 * 1024 * 1024;
+begin
+  Root := MakeTempDir('largefile-raised');
+  try
+    SetLength(Big, BigSize);
+    FillChar(Big[1], BigSize, Ord('A'));
+    Move(Marker[1], Big[BigSize - Length(Marker) + 1], Length(Marker));
+    WriteText(JoinPath(Root, 'huge.log'), Big);
+
+    { Override the cap so the same file is now in scope. }
+    Got := CallGrep(Root, Marker, 20 * 1024 * 1024);
+    AssertContains(Got, 'huge.log',
+                   'oversize file IS scanned when max_file_bytes is raised');
+  finally
+    DeleteTree(Root);
+  end;
+end;
+
+procedure TestEmptyResultRendersClean;
+var
+  Root, Got: string;
+begin
+  Root := MakeTempDir('empty');
+  try
+    WriteText(JoinPath(Root, 'a.txt'), 'no match here');
+    Got := CallGrep(Root, 'absent_pattern_xyz');
+    AssertContains(Got, 'no matches',
+                   'zero-match result has friendly placeholder');
+  finally
+    DeleteTree(Root);
+  end;
+end;
+
+procedure TestMatchOutputUnchangedForHitFiles;
+{ Sanity that tier-1 (deferred hash) still emits the correct
+  hashline header when a file actually matches. The header is what
+  fs_edit_hashline parses for the file-hash check; getting it wrong
+  would silently break the edit path even if grep "ran fast". }
+var
+  Root, Got: string;
+begin
+  Root := MakeTempDir('hashok');
+  try
+    WriteText(JoinPath(Root, 'src.pas'),
+              'line one'#10'line with NEEDLE'#10'line three');
+    Got := CallGrep(Root, 'NEEDLE');
+    AssertContains(Got, '¶', 'hashline ¶ prefix present');
+    AssertContains(Got, 'src.pas#', 'path + # separator present');
+    AssertContains(Got, '2:line with NEEDLE',
+                   'matching line surfaces with correct line number');
+  finally
+    DeleteTree(Root);
+  end;
+end;
+
+begin
+  Randomize;
+  TestSkipsBlockedDirsByName;
+  WriteLn('  ok: tier 2 -- blocked dirs (.git/node_modules/target/...) skipped');
+  TestSkipsBinaryByNULDetection;
+  WriteLn('  ok: tier 3 -- binary files (NUL byte) skipped');
+  TestSkipsLargeFileAtDefaultCap;
+  WriteLn('  ok: tier 4 -- 11 MiB file skipped at default 10 MiB cap');
+  TestRaisingCapIncludesLargeFile;
+  WriteLn('  ok: tier 4 -- raising max_file_bytes brings file back in scope');
+  TestEmptyResultRendersClean;
+  WriteLn('  ok: zero-match result still renders friendly placeholder');
+  TestMatchOutputUnchangedForHitFiles;
+  WriteLn('  ok: tier 1 -- deferred-hash header still correct for matched files');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
Four cheap wins for fs_grep, modelled after ripgrep's tier-1 filters:

  1. Defer ComputeFileHash until first match in a file. Most scanned files have zero matches and were being hashed for nothing.
  2. Skip well-known VCS / build / deps directories by name at walk time (.git, .hg, .svn, node_modules, target, build, dist, vendor, .venv, __pycache__, .gradle, .next). The model never wants results from these and they dominate file count on real repos.
  3. Binary file detection: NUL byte in first 1 KiB -> skip. Source code never embeds NUL; PDFs / PNGs / archives / executables always do at the file header.
  4. File-size cap (default 10 MiB, override via max_file_bytes arg). Prevents one accidental fs_grep over a giant log file from stalling a session.

The walk-time skips (2, 4) avoid the read entirely; the body-time skips (1, 3) avoid line-splitting and hashing on files that wouldn't contribute to output anyway.

Observable behaviour pinned by src/tests/fs_grep_tier1_4_tests.pas: seeds a temp tree with marker tripwires inside each blocked dir, a binary file, and a 11 MiB file, then asserts the markers do NOT surface in fs_grep output -- and that raising max_file_bytes brings the large file back in scope. Tier 1 is covered indirectly by the hashline-header assertion (the deferred hash still has to be correct on the match path).