### PR TITLE
otel: OpenTelemetry traces (OTLP/HTTP+JSON) for agent loop + gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ UNIT_DIRS = \
 	src/pkg/hashline \
 	src/pkg/component \
 	src/pkg/markdown \
+	src/pkg/otel \
 	src/cmd
 
 # Indy unit + include dirs (only used when building under FPC).
@@ -497,6 +498,18 @@ test-fs-grep-tier1-4: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier1_4_tests.pas -o$(BUILDDIR)/fs_grep_tier1_4_tests
 	@$(BUILDDIR)/fs_grep_tier1_4_tests
 
+# OpenTelemetry traces (OTLP/HTTP+JSON). Pins span hierarchy,
+# attribute names (gen_ai.* semantic conventions), W3C traceparent
+# propagation in/out, sampling toggle, env-var override, JSON
+# escaping. Uses the test-export transport seam in PasClaw.Otel --
+# no real collector spun up, just captures the POST body and asserts
+# on its shape.
+test-otel: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/otel_tests.pas -o$(BUILDDIR)/otel_tests
+	@$(BUILDDIR)/otel_tests
+	@OTEL_EXPORTER_OTLP_ENDPOINT=http://env-host:4318 $(BUILDDIR)/otel_tests --env-mode
+
 # fs_grep ripgrep-tier5-6 optimisations: byte walker replacing the
 # TStringList/StringReplace/per-line LowerCase path (tier 5), and
 # Boyer-Moore-Horspool substring search replacing Pos() (tier 6).
@@ -508,4 +521,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -773,7 +773,7 @@ end;
 
 function TConfig.ToJSON: string;
 var
-  Root, Gw, Tmp: TJsonObject;
+  Root, Gw, Tmp, Diag, OtelHdrs: TJsonObject;
   Arr, FallbacksArr: TJsonArray;
   i: Integer;
 begin
@@ -794,6 +794,37 @@ begin
     Gw.PutStr ('bind_addr', Gateway.BindAddr);
     Gw.PutInt ('port',      Gateway.Port);
     Root.PutObject('gateway', Gw);
+
+    (* diagnostics.otel round-trip. Without this block, ANY command
+       that calls SaveConfig after a LoadConfig (auth, model, mcp,
+       skill updates) would rewrite config.json through ToJSON and
+       silently drop the whole diagnostics tree. The user re-runs
+       the agent expecting traces and gets nothing, with no error to
+       tell them why. The shape mirrors the FromJSON parse block
+       below 1-for-1 (same keys, same types, same headers nested
+       object). Symmetric with the gateway / sandbox blocks above:
+       always emitted, even at defaults, so a `pasclaw config show`
+       round-trip is stable. *)
+    Tmp := TJsonObject.Create;
+    Tmp.PutBool ('enabled',     Diagnostics.Otel.Enabled);
+    Tmp.PutStr  ('endpoint',    Diagnostics.Otel.Endpoint);
+    Tmp.PutStr  ('protocol',    Diagnostics.Otel.Protocol);
+    Tmp.PutStr  ('serviceName', Diagnostics.Otel.ServiceName);
+    Tmp.PutFloat('sampleRate',  Diagnostics.Otel.SampleRate);
+    Tmp.PutBool ('traces',      Diagnostics.Otel.Traces);
+    Tmp.PutBool ('metrics',     Diagnostics.Otel.Metrics);
+    Tmp.PutBool ('logs',        Diagnostics.Otel.Logs);
+    if Length(Diagnostics.Otel.Headers) > 0 then
+    begin
+      OtelHdrs := TJsonObject.Create;
+      for i := 0 to High(Diagnostics.Otel.Headers) do
+        OtelHdrs.PutStr(Diagnostics.Otel.Headers[i].Name,
+                        Diagnostics.Otel.Headers[i].Value);
+      Tmp.PutObject('headers', OtelHdrs);
+    end;
+    Diag := TJsonObject.Create;
+    Diag.PutObject('otel', Tmp);
+    Root.PutObject('diagnostics', Diag);
 
     Tmp := TJsonObject.Create;
     Tmp.PutBool('restrict_to_workspace',        Sandbox.RestrictToWorkspace);

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -45,6 +45,66 @@ type
     Port:     Integer;
   end;
 
+  (*  TOtelHeader -- one header pair for OTLP exports. The
+      OpenTelemetry collector spec uses these for auth (Authorization:
+      Bearer ..., x-honeycomb-team, etc). Mirrors openclaw's
+      diagnostics.otel.headers shape so a config block copy-pastes. *)
+  TOtelHeader = record
+    Name:  string;
+    Value: string;
+  end;
+
+  (*  TOtelDiagnosticsConfig -- OTLP/HTTP traces exporter. Off by
+      default; turn on by setting diagnostics.otel.enabled=true and
+      a valid endpoint, OR by setting OTEL_EXPORTER_OTLP_ENDPOINT in
+      the environment (the standard OTel SDK contract -- the env var
+      flips Enabled=true on its own).
+
+      Endpoint
+        Collector URL. http://localhost:4318 is the OTel Collector
+        default. We append /v1/traces when the path is missing.
+
+      Protocol
+        Always "http/json" in this release. Reserved for "http/protobuf"
+        once we ship a protobuf encoder.
+
+      ServiceName
+        resource.service.name attribute on every span. Defaults to
+        "pasclaw" -- override per-deployment to distinguish CLI
+        sessions from gateway deployments.
+
+      SampleRate
+        Bernoulli sampling on trace start, 0.0..1.0. 1.0 = trace
+        every turn, 0.0 = trace nothing (effectively off), 0.1 =
+        trace ~10%. Sampling is decided at the root span (agent.turn
+        or http.server.request); children inherit the parent's
+        decision. Default 1.0.
+
+      Headers
+        Extra HTTP headers on every OTLP POST. Typically Authorization,
+        x-honeycomb-team, etc. The OTEL_EXPORTER_OTLP_HEADERS env var
+        ("k1=v1,k2=v2") overrides this when set.
+
+      Traces / Metrics / Logs
+        Reserved booleans. Only Traces is wired in this release;
+        Metrics and Logs are a follow-up PR. Defaults: traces=true,
+        metrics=false, logs=false. *)
+  TOtelDiagnosticsConfig = record
+    Enabled:     Boolean;
+    Endpoint:    string;
+    Protocol:    string;
+    ServiceName: string;
+    SampleRate:  Double;
+    Headers:     array of TOtelHeader;
+    Traces:      Boolean;
+    Metrics:     Boolean;
+    Logs:        Boolean;
+  end;
+
+  TDiagnosticsConfig = record
+    Otel: TOtelDiagnosticsConfig;
+  end;
+
   (*  TSandboxPolicy - opt-in workspace + shell hardening.
 
       RestrictToWorkspace
@@ -376,6 +436,7 @@ type
       or by editing config.json's "fallbacks": ["openai","gemini"]. }
     Fallbacks:  array of string;
     Gateway:    TGatewayConfig;
+    Diagnostics: TDiagnosticsConfig;  { OpenTelemetry traces -- see TOtelDiagnosticsConfig }
     Sandbox:    TSandboxPolicy;
     Providers:  array of TProviderConfig;
     MCPServers: array of TMCPServer;
@@ -545,8 +606,13 @@ uses
   PasClaw.JSON,
   PasClaw.Promptware,         { LoadConfig propagates promptware_enabled --
                                 see the comment inside LoadConfig }
-  PasClaw.Tools.OutputCache;  { LoadConfig propagates condense_reversible
+  PasClaw.Tools.OutputCache,  { LoadConfig propagates condense_reversible
                                 via SetCondenseReversible -- same pattern }
+  PasClaw.Otel;               { LoadConfig calls InitOtelFromConfig so
+                                env-var overrides (OTEL_EXPORTER_OTLP_ENDPOINT)
+                                + the diagnostics.otel.* block in config.json
+                                both take effect at the same single chokepoint
+                                every entry point already passes through. }
 
 procedure ApplyPromptCacheConfig(var Opts: TChatOptions; const PC: TPromptCacheConfig);
 begin
@@ -562,6 +628,19 @@ begin
   Gateway.LogLevel := 'info';
   Gateway.BindAddr := '127.0.0.1';
   Gateway.Port     := 8088;
+  { OpenTelemetry diagnostics defaults: off, but pre-populated with
+    the OTel Collector localhost address so flipping enabled=true is
+    a one-key change. Sampling at 1.0 (trace every turn) is the right
+    default for the small-scale deployments PasClaw targets; turn
+    down for high-volume gateways. }
+  Diagnostics.Otel.Enabled     := False;
+  Diagnostics.Otel.Endpoint    := 'http://localhost:4318';
+  Diagnostics.Otel.Protocol    := 'http/json';
+  Diagnostics.Otel.ServiceName := 'pasclaw';
+  Diagnostics.Otel.SampleRate  := 1.0;
+  Diagnostics.Otel.Traces      := True;
+  Diagnostics.Otel.Metrics     := False;
+  Diagnostics.Otel.Logs        := False;
   { Sandbox defaults: workspace boundary OFF for backwards compat
     (existing configs do not have a sandbox section), shell denylist
     ON because it's a strict safety upgrade over the previous
@@ -975,8 +1054,9 @@ end;
 
 procedure TConfig.FromJSON(const S: string);
 var
-  Root, Obj, Item: TJsonObject;
+  Root, Obj, Item, Sub, SubHdrs: TJsonObject;
   Arr, ToolsArr: TJsonArray;
+  HdrKeys: TStringList;
   i, j: Integer;
 begin
   if Trim(S) = '' then Exit;
@@ -1004,6 +1084,50 @@ begin
       Gateway.LogLevel := Obj.GetStr('log_level', Gateway.LogLevel);
       Gateway.BindAddr := Obj.GetStr('bind_addr', Gateway.BindAddr);
       Gateway.Port     := Obj.GetInt('port',      Gateway.Port);
+    finally
+      Obj.Free;
+    end;
+
+    { diagnostics.otel.* -- mirrors openclaw v2026.2+ keys so a
+      config block ports cleanly. The env vars
+      OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS take
+      effect later in PasClaw.Otel.InitOtelFromConfig; we don't
+      mutate the parsed values here so the round-trip toString stays
+      faithful to what's in config.json. }
+    Obj := Root.ChildObject('diagnostics');
+    if Obj <> nil then
+    try
+      Sub := Obj.ChildObject('otel');
+      if Sub <> nil then
+      try
+        Diagnostics.Otel.Enabled     := Sub.GetBool('enabled',     Diagnostics.Otel.Enabled);
+        Diagnostics.Otel.Endpoint    := Sub.GetStr ('endpoint',    Diagnostics.Otel.Endpoint);
+        Diagnostics.Otel.Protocol    := Sub.GetStr ('protocol',    Diagnostics.Otel.Protocol);
+        Diagnostics.Otel.ServiceName := Sub.GetStr ('serviceName', Diagnostics.Otel.ServiceName);
+        Diagnostics.Otel.SampleRate  := Sub.GetFloat('sampleRate', Diagnostics.Otel.SampleRate);
+        Diagnostics.Otel.Traces      := Sub.GetBool('traces',      Diagnostics.Otel.Traces);
+        Diagnostics.Otel.Metrics     := Sub.GetBool('metrics',     Diagnostics.Otel.Metrics);
+        Diagnostics.Otel.Logs        := Sub.GetBool('logs',        Diagnostics.Otel.Logs);
+        SubHdrs := Sub.ChildObject('headers');
+        if SubHdrs <> nil then
+        try
+          HdrKeys := SubHdrs.Keys;
+          try
+            SetLength(Diagnostics.Otel.Headers, HdrKeys.Count);
+            for i := 0 to HdrKeys.Count - 1 do
+            begin
+              Diagnostics.Otel.Headers[i].Name  := HdrKeys[i];
+              Diagnostics.Otel.Headers[i].Value := SubHdrs.GetStr(HdrKeys[i], '');
+            end;
+          finally
+            HdrKeys.Free;
+          end;
+        finally
+          SubHdrs.Free;
+        end;
+      finally
+        Sub.Free;
+      end;
     finally
       Obj.Free;
     end;
@@ -1379,6 +1503,11 @@ begin
     { Symmetric propagation of the reversible-condensation flag --
       OutputCache holds the same process-global mirror. }
     SetCondenseReversible(Result.CondenseReversible);
+    { OpenTelemetry traces. No-op when diagnostics.otel.enabled is
+      False AND the OTEL_EXPORTER_OTLP_ENDPOINT env var is unset --
+      so single-shot CLI commands like `pasclaw status` pay nothing
+      for the wiring. }
+    InitOtelFromConfig(Result);
   end;
 end;
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -201,7 +201,13 @@ uses
   PasClaw.Identity,
   PasClaw.Session.Store,
   PasClaw.Gateway.ToolView,
-  PasClaw.Gateway.WebUI;
+  PasClaw.Gateway.WebUI,
+  PasClaw.Otel;             { http.server.request span wrapping every
+                              inbound /v1/* call. Parent context comes
+                              from the incoming traceparent header (W3C
+                              Trace Context) when present, so an upstream
+                              caller's trace stays connected to the agent
+                              turn that gets kicked off by this request. }
 
 var
   { Process-wide cache for the /v1/stats response. Walking the
@@ -592,11 +598,29 @@ var
   Doc: string;
   IsChatCompletionsStream: Boolean;
   ResponseStarted: Boolean;
+  HttpSpan: TOtelSpan;
+  ParentTP: string;
 begin
   Doc := ARequest.Document;
   IsChatCompletionsStream := False;
   ResponseStarted := False;
   LogDebug('gateway: %s %s', [ARequest.Command, Doc]);
+
+  { Tier-4 instrumentation: wrap the whole inbound request in an
+    http.server span. ParentTP is the incoming W3C Trace Context
+    header (typically set by an OTel-instrumented client upstream);
+    when absent we start a new trace right here. Each Indy worker
+    thread runs OnCommandGet on its own thread, and Otel's
+    threadvar current-span stack scopes child agent.turn /
+    chat / execute_tool spans to this request without cross-thread
+    bleed. }
+  ParentTP := ARequest.RawHeaders.Values['traceparent'];
+  HttpSpan := StartSpan('HTTP ' + ARequest.Command + ' ' + Doc,
+                        oskServer, ParentTP);
+  try
+    SetAttrStr(HttpSpan, 'http.request.method', ARequest.Command);
+    SetAttrStr(HttpSpan, 'url.path',            Doc);
+    SetAttrStr(HttpSpan, 'http.route',          Doc);
 
   { MCP-only listener: when this gateway was spun up as the
     --mcp-port companion, the only routes it honours are the
@@ -660,6 +684,7 @@ begin
     on E: Exception do
     begin
       LogError('gateway: handler crashed: %s', [E.Message]);
+      SetStatus(HttpSpan, oscError, E.ClassName + ': ' + E.Message);
       if IsChatCompletionsStream and (ResponseStarted or AResponse.HeaderHasBeenWritten) then
       begin
         LogWarn('gateway: streaming response already started; closing connection');
@@ -678,6 +703,15 @@ begin
       else if (AContext <> nil) and (AContext.Connection <> nil) then
         AContext.Connection.Disconnect;
     end;
+  end;
+  finally
+    SetAttrInt(HttpSpan, 'http.response.status_code', AResponse.ResponseNo);
+    if (AResponse.ResponseNo >= 200) and (AResponse.ResponseNo < 400) then
+      SetStatus(HttpSpan, oscOk, '')
+    else if HttpSpan <> nil then
+      SetStatus(HttpSpan, oscError,
+                'HTTP ' + IntToStr(AResponse.ResponseNo));
+    FinishSpan(HttpSpan);
   end;
 end;
 

--- a/src/pkg/otel/PasClaw.Otel.pas
+++ b/src/pkg/otel/PasClaw.Otel.pas
@@ -1,0 +1,703 @@
+(*
+  PasClaw.Otel - OpenTelemetry traces (OTLP/HTTP+JSON) for the agent loop
+  and gateway HTTP server. Off by default; enable via the
+  diagnostics.otel block in config.json, or the standard
+  OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS env vars
+  (env vars win when both are set).
+
+  Span shape mirrors openclaw v2026.2+ so dashboards and exporters
+  built for the openclaw ecosystem (Langfuse, Tempo, Jaeger,
+  Honeycomb, Datadog) groks our spans without remapping:
+
+    HTTP <method> <route>     (gateway server span, parent of agent.turn
+                               when triggered via /v1/chat)
+      └── openclaw.agent.turn (one tool-loop iteration)
+          ├── chat {model}    (provider request -- gen_ai.* attrs)
+          └── execute_tool {name}
+              (one per tool dispatch)
+
+  Attribute names follow OpenTelemetry GenAI semantic conventions
+  (gen_ai.request.model, gen_ai.usage.input_tokens / output_tokens,
+  gen_ai.provider.name, gen_ai.operation.name) plus W3C Trace Context
+  for cross-service propagation (traceparent header in/out).
+
+  Transport: OTLP/HTTP with application/json body. We don't ship
+  protobuf encoding in this first cut -- the OTLP spec mandates
+  both JSON and protobuf on the http path and every collector groks
+  both, so JSON is the realistic Pascal choice.
+
+  Threading: the agent loop is single-threaded; the gateway runs
+  one OnCommandGet per Indy worker thread. The "current span" is a
+  threadvar so per-request gateway traces don't bleed into each
+  other. The export buffer is module-level guarded by a critical
+  section.
+*)
+unit PasClaw.Otel;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs, DateUtils,
+  PasClaw.Config;
+
+type
+  TOtelSpanKind = (oskInternal, oskServer, oskClient);
+  TOtelStatusCode = (oscUnset, oscOk, oscError);
+
+  TOtelAttrKind = (oakStr, oakInt, oakBool);
+  TOtelAttr = record
+    Key:    string;
+    Kind:   TOtelAttrKind;
+    SValue: string;
+    IValue: Int64;
+    BValue: Boolean;
+  end;
+
+  TOtelSpan = class
+  public
+    TraceId:      string;   { 32 lowercase hex chars (16 bytes) }
+    SpanId:       string;   { 16 lowercase hex chars (8 bytes) }
+    ParentSpanId: string;   { 16 hex; '' for root spans }
+    Name:         string;
+    Kind:         TOtelSpanKind;
+    StartNanos:   Int64;
+    EndNanos:     Int64;
+    Attrs:        array of TOtelAttr;
+    StatusCode:   TOtelStatusCode;
+    StatusMsg:    string;
+    PrevCurrent:  TOtelSpan;   { restored on Finish }
+    Finished:     Boolean;
+  end;
+
+{ Lifecycle. Init is safe to call multiple times -- last config wins.
+  Shutdown flushes any buffered spans synchronously; safe at process
+  exit. }
+procedure InitOtelFromConfig(const Cfg: TConfig);
+procedure ShutdownOtel;
+
+{ StartSpan returns nil when OTel is disabled OR when the trace was
+  not sampled. All other helpers (SetAttr*, SetStatus, Finish) tolerate
+  nil and become no-ops, so call sites stay clean:
+
+    Span := StartSpan('chat ' + Model, oskClient, '');
+    try
+      ...
+    finally
+      Finish(Span);
+    end;
+
+  ParentTraceparent is the W3C Trace Context header value when this
+  span starts as a child of a remote trace (gateway request inbound).
+  Empty string means "use the threadvar current span as parent if
+  any, else start a new trace". }
+function StartSpan(const Name: string;
+                   Kind: TOtelSpanKind;
+                   const ParentTraceparent: string = ''): TOtelSpan;
+
+procedure SetAttrStr(Span: TOtelSpan; const Key, Value: string);
+procedure SetAttrInt(Span: TOtelSpan; const Key: string; Value: Int64);
+procedure SetAttrBool(Span: TOtelSpan; const Key: string; Value: Boolean);
+
+procedure SetStatus(Span: TOtelSpan;
+                    Code: TOtelStatusCode;
+                    const Msg: string = '');
+
+procedure FinishSpan(Span: TOtelSpan);
+
+{ Returns the W3C traceparent string for the current span, or '' when
+  OTel is disabled / no current span. Hand this to outbound HTTP
+  clients (provider requests, MCP calls) to propagate the trace. }
+function CurrentTraceparent: string;
+
+{ True when OTel emits traces (config enabled + endpoint set). Call
+  sites can branch around expensive attribute-building when off. }
+function OtelEnabled: Boolean;
+
+{ Test seam: swap the export transport for a callback. The test
+  passes a closure that captures the POST body so we can assert on
+  it without spinning up real HTTP. Pass nil to restore the default
+  OTLP/HTTP transport. Not part of the public contract; here so
+  src/tests/otel_tests.pas can pin behaviour without a TCP listener. }
+type
+  TOtelExportFunc = procedure(const Endpoint, JSONBody: string;
+                              const Headers: array of string);
+
+procedure SetExportTransport(F: TOtelExportFunc);
+
+implementation
+
+uses
+  PasClaw.Logger,
+  PasClaw.Crypto.Random,
+  PasClaw.Providers.HTTP;
+
+var
+  GEnabled:      Boolean = False;
+  GEndpoint:     string  = '';   { e.g. http://localhost:4318/v1/traces }
+  GServiceName:  string  = 'pasclaw';
+  GHeaders:      THeaderPairs;
+  GSampleRate:   Double  = 1.0;
+  GLock:         TCriticalSection = nil;
+  GBuffer:       TList = nil;   { TList of TOtelSpan; flushed when root finishes }
+  GFlushThreshold: Integer = 64;  { hard cap so an unbounded trace doesn't grow forever }
+  GExportFunc:   TOtelExportFunc = nil;
+
+threadvar
+  GCurrent: TOtelSpan;
+
+{ ---------- ID / hex helpers ---------- }
+
+function BytesToHexLower(const B: TBytes): string;
+const
+  Hex: array[0..15] of Char = '0123456789abcdef';
+var
+  i: Integer;
+begin
+  SetLength(Result, Length(B) * 2);
+  for i := 0 to High(B) do
+  begin
+    Result[i * 2 + 1] := Hex[(B[i] shr 4) and $0F];
+    Result[i * 2 + 2] := Hex[ B[i]        and $0F];
+  end;
+end;
+
+function NewTraceId: string;
+begin
+  Result := BytesToHexLower(GetRandomBytes(16));
+end;
+
+function NewSpanId: string;
+begin
+  Result := BytesToHexLower(GetRandomBytes(8));
+end;
+
+{ ---------- Time ---------- }
+
+function UnixNanosNow: Int64;
+var
+  T: TDateTime;
+  Sec: Int64;
+  MSec: Word;
+begin
+  T := Now;
+  Sec := DateTimeToUnix(T, True);
+  MSec := MilliSecondOf(T);
+  Result := Sec * Int64(1000000000) + Int64(MSec) * Int64(1000000);
+end;
+
+(* ---------- W3C traceparent ----------
+  Format: 00-<32 hex trace id>-<16 hex span id>-<2 hex flags>
+  Flags: 01 = sampled. We always emit 01 (we sampled or we wouldn't
+  be propagating). Inbound: tolerate any version-00 traceparent;
+  on parse failure, start a new trace silently (do not throw). *)
+
+procedure ParseTraceparent(const H: string;
+                           out TraceId, SpanId: string;
+                           out OK: Boolean);
+var
+  Parts: TStringList;
+begin
+  TraceId := '';
+  SpanId  := '';
+  OK := False;
+  if H = '' then Exit;
+  Parts := TStringList.Create;
+  try
+    Parts.Delimiter := '-';
+    Parts.StrictDelimiter := True;
+    Parts.DelimitedText := H;
+    if Parts.Count < 4 then Exit;
+    if Length(Parts[1]) <> 32 then Exit;
+    if Length(Parts[2]) <> 16 then Exit;
+    { Don't validate hex character-by-character; the worst that
+      happens is the collector rejects this span and we move on. }
+    TraceId := LowerCase(Parts[1]);
+    SpanId  := LowerCase(Parts[2]);
+    OK := True;
+  finally
+    Parts.Free;
+  end;
+end;
+
+function FormatTraceparent(const TraceId, SpanId: string): string;
+begin
+  Result := '00-' + TraceId + '-' + SpanId + '-01';
+end;
+
+{ ---------- JSON escape ----------
+  Cheap escaper for the attribute payload. We control the keys (all
+  ASCII), but values come from user-ish strings (tool names, model
+  ids, error messages) so escape what JSON requires. }
+
+function JsonEscape(const S: string): string;
+var
+  i: Integer;
+  c: Char;
+  Sb: TStringBuilder;
+begin
+  Sb := TStringBuilder.Create;
+  try
+    for i := 1 to Length(S) do
+    begin
+      c := S[i];
+      case c of
+        '"':  Sb.Append('\"');
+        '\':  Sb.Append('\\');
+        #8:   Sb.Append('\b');
+        #9:   Sb.Append('\t');
+        #10:  Sb.Append('\n');
+        #12:  Sb.Append('\f');
+        #13:  Sb.Append('\r');
+      else
+        if Ord(c) < $20 then
+          Sb.Append('\u00' + IntToHex(Ord(c), 2))
+        else
+          Sb.Append(c);
+      end;
+    end;
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
+end;
+
+{ ---------- Span helpers ---------- }
+
+procedure ResetSpanState(Span: TOtelSpan);
+begin
+  if Span <> nil then
+  begin
+    SetLength(Span.Attrs, 0);
+    Span.Finished := False;
+  end;
+end;
+
+function KindToOTLP(K: TOtelSpanKind): Integer;
+begin
+  { OTLP span kind enum:
+      0 SPAN_KIND_UNSPECIFIED
+      1 SPAN_KIND_INTERNAL
+      2 SPAN_KIND_SERVER
+      3 SPAN_KIND_CLIENT
+      (we don't emit PRODUCER / CONSUMER) }
+  case K of
+    oskServer: Result := 2;
+    oskClient: Result := 3;
+  else
+    Result := 1;
+  end;
+end;
+
+function StatusToOTLP(S: TOtelStatusCode): Integer;
+begin
+  case S of
+    oscOk:    Result := 1;
+    oscError: Result := 2;
+  else
+    Result := 0;
+  end;
+end;
+
+(* ---------- OTLP/HTTP+JSON encoding ----------
+  Body shape (per OTLP spec, ExportTraceServiceRequest):
+    resourceSpans[].resource.attributes  <- service.name, telemetry.sdk.name
+    resourceSpans[].scopeSpans[].scope   <- {name: "pasclaw"}
+    resourceSpans[].scopeSpans[].spans[] <- one entry per finished span
+
+  Per-span keys: traceId, spanId, parentSpanId (omitted on root),
+  name, kind (1=internal/2=server/3=client),
+  startTimeUnixNano + endTimeUnixNano (string-encoded Int64 per
+  OTLP convention -- JSON only safely represents 53-bit ints),
+  attributes[] (each {key,value:{stringValue|intValue|boolValue}}),
+  status{code:0|1|2, optional message}. *)
+
+procedure AppendAttr(Sb: TStringBuilder; const A: TOtelAttr; First: Boolean);
+begin
+  if not First then Sb.Append(',');
+  Sb.Append('{"key":"').Append(JsonEscape(A.Key)).Append('","value":{');
+  case A.Kind of
+    oakStr:
+      Sb.Append('"stringValue":"').Append(JsonEscape(A.SValue)).Append('"');
+    oakInt:
+      Sb.Append('"intValue":"').Append(IntToStr(A.IValue)).Append('"');
+    oakBool:
+      if A.BValue then
+        Sb.Append('"boolValue":true')
+      else
+        Sb.Append('"boolValue":false');
+  end;
+  Sb.Append('}}');
+end;
+
+function EncodeSpan(Span: TOtelSpan): string;
+var
+  Sb: TStringBuilder;
+  k: Integer;
+begin
+  Sb := TStringBuilder.Create;
+  try
+    Sb.Append('{"traceId":"').Append(Span.TraceId).Append('",');
+    Sb.Append('"spanId":"').Append(Span.SpanId).Append('",');
+    if Span.ParentSpanId <> '' then
+      Sb.Append('"parentSpanId":"').Append(Span.ParentSpanId).Append('",');
+    Sb.Append('"name":"').Append(JsonEscape(Span.Name)).Append('",');
+    Sb.Append('"kind":').Append(IntToStr(KindToOTLP(Span.Kind))).Append(',');
+    Sb.Append('"startTimeUnixNano":"').Append(IntToStr(Span.StartNanos)).Append('",');
+    Sb.Append('"endTimeUnixNano":"').Append(IntToStr(Span.EndNanos)).Append('",');
+    Sb.Append('"attributes":[');
+    for k := 0 to High(Span.Attrs) do
+      AppendAttr(Sb, Span.Attrs[k], k = 0);
+    Sb.Append('],');
+    Sb.Append('"status":{"code":').Append(IntToStr(StatusToOTLP(Span.StatusCode)));
+    if Span.StatusMsg <> '' then
+      Sb.Append(',"message":"').Append(JsonEscape(Span.StatusMsg)).Append('"');
+    Sb.Append('}}');
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
+end;
+
+function EncodeBuffer(const Spans: array of TOtelSpan): string;
+var
+  Sb: TStringBuilder;
+  i: Integer;
+begin
+  Sb := TStringBuilder.Create;
+  try
+    Sb.Append('{"resourceSpans":[{"resource":{"attributes":[');
+    Sb.Append('{"key":"service.name","value":{"stringValue":"')
+      .Append(JsonEscape(GServiceName)).Append('"}},');
+    Sb.Append('{"key":"telemetry.sdk.name","value":{"stringValue":"pasclaw-otel"}},');
+    Sb.Append('{"key":"telemetry.sdk.language","value":{"stringValue":"pascal"}}');
+    Sb.Append(']},"scopeSpans":[{"scope":{"name":"pasclaw"},"spans":[');
+    for i := 0 to High(Spans) do
+    begin
+      if i > 0 then Sb.Append(',');
+      Sb.Append(EncodeSpan(Spans[i]));
+    end;
+    Sb.Append(']}]}]}');
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
+end;
+
+{ ---------- Default OTLP/HTTP exporter ----------
+  Single synchronous POST. Failures are logged at warn -- we never
+  want OTel export to crash the agent or block a tool result on a
+  flaky collector. PostJSON already has a hard timeout. }
+
+procedure DefaultExport(const Endpoint, JSONBody: string;
+                        const ExtraHeadersIgnored: array of string);
+var
+  AllHeaders: THeaderPairs;
+  i, BaseLen: Integer;
+  Resp: THTTPResult;
+begin
+  BaseLen := Length(GHeaders);
+  SetLength(AllHeaders, BaseLen + 1);
+  for i := 0 to BaseLen - 1 do AllHeaders[i] := GHeaders[i];
+  AllHeaders[BaseLen].Name  := 'Content-Type';
+  AllHeaders[BaseLen].Value := 'application/json';
+  try
+    Resp := PostJSON(Endpoint, JSONBody, AllHeaders, 10);
+    if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+      LogWarn('otel: export %s -> %d: %s',
+              [Endpoint, Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
+  except
+    on E: Exception do
+      LogWarn('otel: export %s raised %s: %s',
+              [Endpoint, E.ClassName, E.Message]);
+  end;
+end;
+
+procedure FlushBufferLocked;
+var
+  Spans: array of TOtelSpan;
+  i: Integer;
+  Body: string;
+begin
+  if (GBuffer = nil) or (GBuffer.Count = 0) then Exit;
+  SetLength(Spans, GBuffer.Count);
+  for i := 0 to GBuffer.Count - 1 do
+    Spans[i] := TOtelSpan(GBuffer[i]);
+  Body := EncodeBuffer(Spans);
+  if Assigned(GExportFunc) then
+    GExportFunc(GEndpoint, Body, [])
+  else
+    DefaultExport(GEndpoint, Body, []);
+  for i := 0 to High(Spans) do
+    Spans[i].Free;
+  GBuffer.Clear;
+end;
+
+{ ---------- Public API ---------- }
+
+function OtelEnabled: Boolean;
+begin
+  Result := GEnabled and (GEndpoint <> '');
+end;
+
+procedure SetExportTransport(F: TOtelExportFunc);
+begin
+  GExportFunc := F;
+end;
+
+function EnsureTracesPath(const Ep: string): string;
+{ Standard collectors expose POST /v1/traces. If the configured
+  endpoint is just a host:port (the openclaw convention), append
+  the path; if it already ends in /v1/traces, leave it alone. }
+begin
+  if Ep = '' then Exit('');
+  if (Length(Ep) >= 10) and (Copy(Ep, Length(Ep) - 9, 10) = '/v1/traces') then
+    Exit(Ep);
+  Result := Ep;
+  while (Result <> '') and (Result[Length(Result)] = '/') do
+    SetLength(Result, Length(Result) - 1);
+  Result := Result + '/v1/traces';
+end;
+
+procedure ParseHeaderEnv(const S: string; var H: THeaderPairs);
+{ OTEL_EXPORTER_OTLP_HEADERS = "k1=v1,k2=v2" (W3C Baggage style).
+  Commas and equals inside values aren't escaped per the OTel spec
+  -- the common case is API tokens which are URL-safe. We split on
+  the first comma / equals; anything weirder needs config.json. }
+var
+  Parts, KV: TStringList;
+  i: Integer;
+begin
+  SetLength(H, 0);
+  if S = '' then Exit;
+  Parts := TStringList.Create;
+  try
+    Parts.Delimiter := ',';
+    Parts.StrictDelimiter := True;
+    Parts.DelimitedText := S;
+    SetLength(H, Parts.Count);
+    KV := TStringList.Create;
+    try
+      KV.Delimiter := '=';
+      KV.StrictDelimiter := True;
+      for i := 0 to Parts.Count - 1 do
+      begin
+        KV.DelimitedText := Parts[i];
+        if KV.Count >= 2 then
+        begin
+          H[i].Name  := Trim(KV[0]);
+          H[i].Value := Trim(KV[1]);
+        end;
+      end;
+    finally
+      KV.Free;
+    end;
+  finally
+    Parts.Free;
+  end;
+end;
+
+procedure InitOtelFromConfig(const Cfg: TConfig);
+var
+  EnvEp, EnvHdr: string;
+  i: Integer;
+begin
+  if GLock = nil then GLock := TCriticalSection.Create;
+  if GBuffer = nil then GBuffer := TList.Create;
+
+  GEnabled     := Cfg.Diagnostics.Otel.Enabled;
+  GEndpoint    := Cfg.Diagnostics.Otel.Endpoint;
+  GServiceName := Cfg.Diagnostics.Otel.ServiceName;
+  GSampleRate  := Cfg.Diagnostics.Otel.SampleRate;
+
+  SetLength(GHeaders, Length(Cfg.Diagnostics.Otel.Headers));
+  for i := 0 to High(Cfg.Diagnostics.Otel.Headers) do
+  begin
+    GHeaders[i].Name  := Cfg.Diagnostics.Otel.Headers[i].Name;
+    GHeaders[i].Value := Cfg.Diagnostics.Otel.Headers[i].Value;
+  end;
+
+  { Env vars override config -- standard OTel SDK contract. The
+    presence of OTEL_EXPORTER_OTLP_ENDPOINT also flips enabled=on
+    even when config.json has it off, matching what openclaw does. }
+  EnvEp := GetEnvironmentVariable('OTEL_EXPORTER_OTLP_ENDPOINT');
+  if EnvEp <> '' then
+  begin
+    GEndpoint := EnvEp;
+    GEnabled  := True;
+  end;
+  EnvHdr := GetEnvironmentVariable('OTEL_EXPORTER_OTLP_HEADERS');
+  if EnvHdr <> '' then ParseHeaderEnv(EnvHdr, GHeaders);
+
+  if GEndpoint <> '' then
+    GEndpoint := EnsureTracesPath(GEndpoint);
+
+  if GServiceName = '' then GServiceName := 'pasclaw';
+
+  if GEnabled and (GEndpoint <> '') then
+    LogInfo('otel: traces enabled, endpoint=%s service=%s sampleRate=%.2f',
+            [GEndpoint, GServiceName, GSampleRate])
+  else
+    LogDebug('otel: disabled (set diagnostics.otel.enabled=true or OTEL_EXPORTER_OTLP_ENDPOINT)');
+end;
+
+procedure ShutdownOtel;
+begin
+  if GLock = nil then Exit;
+  GLock.Enter;
+  try
+    FlushBufferLocked;
+  finally
+    GLock.Leave;
+  end;
+end;
+
+function Sampled: Boolean;
+begin
+  if GSampleRate >= 1.0 then Exit(True);
+  if GSampleRate <= 0.0 then Exit(False);
+  { Trivial Bernoulli. Random() returns [0,1). }
+  Result := Random < GSampleRate;
+end;
+
+function StartSpan(const Name: string;
+                   Kind: TOtelSpanKind;
+                   const ParentTraceparent: string): TOtelSpan;
+var
+  PTrace, PSpan: string;
+  POK: Boolean;
+begin
+  Result := nil;
+  if not OtelEnabled then Exit;
+
+  { Sampling decision: only roll for ROOT spans (no current and no
+    parent traceparent). Child spans inherit the trace's decision
+    by simple virtue of having a parent already. }
+  if (GCurrent = nil) and (ParentTraceparent = '') then
+    if not Sampled then Exit;
+
+  Result := TOtelSpan.Create;
+  Result.Name := Name;
+  Result.Kind := Kind;
+  Result.StartNanos := UnixNanosNow;
+  Result.EndNanos := 0;
+  Result.StatusCode := oscUnset;
+  Result.SpanId := NewSpanId;
+
+  if GCurrent <> nil then
+  begin
+    Result.TraceId := GCurrent.TraceId;
+    Result.ParentSpanId := GCurrent.SpanId;
+  end
+  else if ParentTraceparent <> '' then
+  begin
+    ParseTraceparent(ParentTraceparent, PTrace, PSpan, POK);
+    if POK then
+    begin
+      Result.TraceId := PTrace;
+      Result.ParentSpanId := PSpan;
+    end
+    else
+      Result.TraceId := NewTraceId;
+  end
+  else
+    Result.TraceId := NewTraceId;
+
+  Result.PrevCurrent := GCurrent;
+  GCurrent := Result;
+end;
+
+procedure SetAttrStr(Span: TOtelSpan; const Key, Value: string);
+var
+  n: Integer;
+begin
+  if Span = nil then Exit;
+  n := Length(Span.Attrs);
+  SetLength(Span.Attrs, n + 1);
+  Span.Attrs[n].Key    := Key;
+  Span.Attrs[n].Kind   := oakStr;
+  Span.Attrs[n].SValue := Value;
+end;
+
+procedure SetAttrInt(Span: TOtelSpan; const Key: string; Value: Int64);
+var
+  n: Integer;
+begin
+  if Span = nil then Exit;
+  n := Length(Span.Attrs);
+  SetLength(Span.Attrs, n + 1);
+  Span.Attrs[n].Key    := Key;
+  Span.Attrs[n].Kind   := oakInt;
+  Span.Attrs[n].IValue := Value;
+end;
+
+procedure SetAttrBool(Span: TOtelSpan; const Key: string; Value: Boolean);
+var
+  n: Integer;
+begin
+  if Span = nil then Exit;
+  n := Length(Span.Attrs);
+  SetLength(Span.Attrs, n + 1);
+  Span.Attrs[n].Key    := Key;
+  Span.Attrs[n].Kind   := oakBool;
+  Span.Attrs[n].BValue := Value;
+end;
+
+procedure SetStatus(Span: TOtelSpan;
+                    Code: TOtelStatusCode;
+                    const Msg: string);
+begin
+  if Span = nil then Exit;
+  Span.StatusCode := Code;
+  if Msg <> '' then Span.StatusMsg := Msg;
+end;
+
+procedure FinishSpan(Span: TOtelSpan);
+var
+  ShouldFlush: Boolean;
+begin
+  if Span = nil then Exit;
+  if Span.Finished then Exit;
+  Span.Finished := True;
+  Span.EndNanos := UnixNanosNow;
+
+  { Restore the threadvar to whatever was current before this span
+    started. Out-of-order Finish (children that outlive their parent)
+    is a caller bug; we tolerate it by just restoring our recorded
+    PrevCurrent regardless of whether GCurrent matches us right now. }
+  if GCurrent = Span then
+    GCurrent := Span.PrevCurrent;
+
+  GLock.Enter;
+  try
+    GBuffer.Add(Span);
+    { Flush when the trace root finishes (typical case) OR when the
+      buffer grows past the cap (defensive against pathologically
+      deep traces). PrevCurrent = nil means "this span has no parent
+      span in our process" -- exactly the trace boundary. }
+    ShouldFlush := (Span.PrevCurrent = nil) or (GBuffer.Count >= GFlushThreshold);
+    if ShouldFlush then
+      FlushBufferLocked;
+  finally
+    GLock.Leave;
+  end;
+end;
+
+function CurrentTraceparent: string;
+begin
+  if (GCurrent = nil) or not OtelEnabled then Exit('');
+  Result := FormatTraceparent(GCurrent.TraceId, GCurrent.SpanId);
+end;
+
+initialization
+  Randomize;
+
+finalization
+  try ShutdownOtel except end;
+  if GBuffer <> nil then FreeAndNil(GBuffer);
+  if GLock <> nil then FreeAndNil(GLock);
+
+end.

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -195,7 +195,11 @@ uses
   PasClaw.Tools.Types,
   PasClaw.Tools.OutputCache,
   PasClaw.Condense.JSON,
-  PasClaw.Promptware;       { injection scan on tool results -- chokepoint 1 }
+  PasClaw.Promptware,       { injection scan on tool results -- chokepoint 1 }
+  PasClaw.Otel;             (* agent.turn / chat / execute_tool spans.
+                               All helpers are no-ops when OTel is
+                               disabled, so the wiring costs ~5 ns per
+                               call in the default-off shape. *)
 
 type
   { Per-call work unit. The same record is filled in by a worker thread
@@ -580,6 +584,7 @@ var
                              can be stashed for tool_output_get }
   OrigLen:   Integer;
   Truncated: Boolean;
+  TurnSpan, ChatSpan, ToolSpan: TOtelSpan;
 begin
   Loop.Content    := '';
   Loop.Iterations := 0;
@@ -589,6 +594,21 @@ begin
   Loop.ToolCallsDispatched := 0;
 
   if Cfg.Provider = nil then Exit(False);
+
+  { openclaw.agent.turn span (tier-1 instrumentation point). Wraps
+    the whole tool loop -- everything below up to the final
+    Result := True / Result := False flows through this span.
+    Pascal's Exit cleanly traverses try/finally, so every
+    Exit(True) / Exit(False) deeper in the loop still finishes
+    the span. TurnSpan is nil when OTel is off; all Set/Finish
+    helpers tolerate nil. }
+  TurnSpan := StartSpan('openclaw.agent.turn', oskInternal, '');
+  try
+    SetAttrStr(TurnSpan, 'gen_ai.request.model',  Cfg.Model);
+    SetAttrStr(TurnSpan, 'gen_ai.operation.name', 'chat');
+    SetAttrInt(TurnSpan, 'openclaw.max_iterations', Cfg.MaxIterations);
+    if Cfg.Provider <> nil then
+      SetAttrStr(TurnSpan, 'gen_ai.provider.name', Cfg.Provider.GetName);
 
   { Annotate the log stream once per turn with the canonical sender
     id (picoclaw parity -- pkg/identity). Hooks and post-hoc audit
@@ -750,26 +770,46 @@ begin
       details through to the caller. Hook embedders that want the
       diagnostic still get it via OnError. (Codex P2 on PR #114.) }
     LastProviderErrText := '';
+    { gen_ai chat span (tier-2 instrumentation). Wraps the actual
+      provider request -- naming follows openclaw / Langfuse so
+      backend dashboards recognise the span shape. Token counts
+      are stamped on success; status flips to error on a non-2xx
+      StatusCode or an exception. }
+    ChatSpan := StartSpan('chat ' + Cfg.Model, oskClient, '');
     try
-      { Empty-turn auto-retry. When StreamReliability.EmptyRetryAttempts
-        is 0 (default record zero, the legacy shape) ChatWithEmptyRetry
-        is a one-shot call -- identical to the pre-PR behaviour.
-        Callers (Cmd.Agent BuildLoopConfig, gateway HandleChat, etc.)
-        populate StreamReliability from Cfg.StreamReliability to
-        opt this loop into the retry path. The fallback walk below
-        still runs unchanged on retryable HTTP failures; empty-turn
-        is a separate, pre-fallback recovery. }
-      Resp := ChatWithEmptyRetry(Cfg.Provider, Hist, Tools, Cfg.Model,
-                                  LiveOptions, Cfg.StreamReliability);
-    except
-      on E: Exception do
-      begin
-        LogWarn('provider Chat raised: %s: %s', [E.ClassName, E.Message]);
-        Resp := Default(TLLMResponse);
-        Resp.StatusCode := -1;
-        LastProviderErrText := Cfg.Provider.GetName + ': '
-                               + E.ClassName + ': ' + E.Message;
+      SetAttrStr(ChatSpan, 'gen_ai.operation.name', 'chat');
+      SetAttrStr(ChatSpan, 'gen_ai.request.model',  Cfg.Model);
+      SetAttrStr(ChatSpan, 'gen_ai.provider.name',  Cfg.Provider.GetName);
+      SetAttrInt(ChatSpan, 'openclaw.turn.iteration', Iter);
+      try
+        { Empty-turn auto-retry. When StreamReliability.EmptyRetryAttempts
+          is 0 (default record zero, the legacy shape) ChatWithEmptyRetry
+          is a one-shot call -- identical to the pre-PR behaviour. }
+        Resp := ChatWithEmptyRetry(Cfg.Provider, Hist, Tools, Cfg.Model,
+                                    LiveOptions, Cfg.StreamReliability);
+      except
+        on E: Exception do
+        begin
+          LogWarn('provider Chat raised: %s: %s', [E.ClassName, E.Message]);
+          Resp := Default(TLLMResponse);
+          Resp.StatusCode := -1;
+          LastProviderErrText := Cfg.Provider.GetName + ': '
+                                 + E.ClassName + ': ' + E.Message;
+          SetStatus(ChatSpan, oscError, E.ClassName + ': ' + E.Message);
+        end;
       end;
+    finally
+      SetAttrInt(ChatSpan, 'http.response.status_code',  Resp.StatusCode);
+      SetAttrInt(ChatSpan, 'gen_ai.usage.input_tokens',  Resp.Usage.InputTokens);
+      SetAttrInt(ChatSpan, 'gen_ai.usage.output_tokens', Resp.Usage.OutputTokens);
+      if Resp.FinishReason <> '' then
+        SetAttrStr(ChatSpan, 'gen_ai.response.finish_reason', Resp.FinishReason);
+      if (Resp.StatusCode >= 200) and (Resp.StatusCode < 300) then
+        SetStatus(ChatSpan, oscOk, '')
+      else if ChatSpan <> nil then
+        SetStatus(ChatSpan, oscError,
+                  'provider status ' + IntToStr(Resp.StatusCode));
+      FinishSpan(ChatSpan);
     end;
     { Provider fallback. Retryable conditions: HTTP 408 / 429 / 5xx,
       and StatusCode <= 0 (network / TLS / pre-HTTP failure that the
@@ -959,10 +999,35 @@ begin
         { Serial batch (or Parallel disabled): just run inline on the
           main thread. Same DispatchOneToolCall the workers use, so
           fs_edit_hashline retry semantics are identical. Skip
-          cancelled slots -- synthetic result already in ResultText. }
+          cancelled slots -- synthetic result already in ResultText.
+
+          execute_tool span (tier-3 instrumentation). Parent is the
+          enclosing agent.turn span via the threadvar stack. Tool
+          spans only emit on the serial path -- parallel-worker
+          dispatch doesn't share the parent's threadvar context yet;
+          a follow-up PR threads the W3C traceparent through workers. }
         for j := 0 to High(Batch) do
           if not Dispatches[Batch[j]].Cancelled then
-            DispatchOneToolCall(Cfg, Dispatches[Batch[j]]);
+          begin
+            ToolSpan := StartSpan('execute_tool ' +
+                                  Dispatches[Batch[j]].Call.Func.Name,
+                                  oskInternal, '');
+            try
+              SetAttrStr(ToolSpan, 'openclaw.tool.name',
+                         Dispatches[Batch[j]].Call.Func.Name);
+              SetAttrStr(ToolSpan, 'openclaw.tool.call_id',
+                         Dispatches[Batch[j]].Call.Id);
+              DispatchOneToolCall(Cfg, Dispatches[Batch[j]]);
+              if Dispatches[Batch[j]].Err <> '' then
+                SetStatus(ToolSpan, oscError, Dispatches[Batch[j]].Err)
+              else
+                SetStatus(ToolSpan, oscOk, '');
+              SetAttrInt(ToolSpan, 'openclaw.tool.result_bytes',
+                         Length(Dispatches[Batch[j]].ResultText));
+            finally
+              FinishSpan(ToolSpan);
+            end;
+          end;
       end;
 
       { Phase 2: fire AfterToolResult hooks + OnToolResult event +
@@ -1134,6 +1199,17 @@ begin
   Loop.FinalMessages    := Hist;
   Loop.FinalSystemPrompt := LiveOptions.SystemPrompt;
   Result := True;
+  finally
+    { Roll the final per-turn telemetry into the span before
+      flushing. Iterations + total token usage are the two
+      numbers anyone looking at a trace will want first; the
+      provider already has per-call counters on each chat span. }
+    SetAttrInt(TurnSpan, 'openclaw.iterations', Loop.Iterations);
+    SetAttrInt(TurnSpan, 'gen_ai.usage.input_tokens',  Loop.TotalUsage.InputTokens);
+    SetAttrInt(TurnSpan, 'gen_ai.usage.output_tokens', Loop.TotalUsage.OutputTokens);
+    if not Result then SetStatus(TurnSpan, oscError, 'agent turn returned false');
+    FinishSpan(TurnSpan);
+  end;
 end;
 
 end.

--- a/src/tests/otel_tests.pas
+++ b/src/tests/otel_tests.pas
@@ -355,6 +355,81 @@ begin
   end;
 end;
 
+procedure TestConfigRoundTripPreservesOtelBlock;
+(* PR #242 P2 regression: TConfig.ToJSON had no diagnostics emission
+   block, so any command that called SaveConfig after LoadConfig
+   (auth, model, mcp, skill updates) rewrote config.json through
+   ToJSON and silently dropped the whole diagnostics tree. The user
+   re-ran the agent expecting traces and got nothing. Pin every
+   otel field through a ToJSON / FromJSON round-trip so a future
+   refactor that touches the emitter can't regress this silently
+   again. *)
+var
+  Src, Dst: TConfig;
+  Roundtripped: string;
+begin
+  Src := TConfig.Create;
+  Dst := TConfig.Create;
+  try
+    { Mutate every field away from defaults so a missing emission
+      shows up as a value drop, not a "happens to match default". }
+    Src.Diagnostics.Otel.Enabled     := True;
+    Src.Diagnostics.Otel.Endpoint    := 'https://collector.example.com:4318';
+    Src.Diagnostics.Otel.Protocol    := 'http/json';
+    Src.Diagnostics.Otel.ServiceName := 'pasclaw-prod';
+    Src.Diagnostics.Otel.SampleRate  := 0.25;
+    Src.Diagnostics.Otel.Traces      := True;
+    Src.Diagnostics.Otel.Metrics     := True;
+    Src.Diagnostics.Otel.Logs        := True;
+    SetLength(Src.Diagnostics.Otel.Headers, 2);
+    Src.Diagnostics.Otel.Headers[0].Name  := 'Authorization';
+    Src.Diagnostics.Otel.Headers[0].Value := 'Bearer test-token';
+    Src.Diagnostics.Otel.Headers[1].Name  := 'x-honeycomb-team';
+    Src.Diagnostics.Otel.Headers[1].Value := 'hc-key-123';
+
+    Roundtripped := Src.ToJSON;
+
+    { The emission must produce a diagnostics.otel block at all --
+      catch the regression directly so a future change that breaks
+      emitting any block shows up as an actionable failure, not just
+      "all the field assertions trivially pass because default ==
+      default". }
+    AssertContains(Roundtripped, '"diagnostics"',
+                   'ToJSON emits the diagnostics block');
+    AssertContains(Roundtripped, '"otel"',
+                   'ToJSON emits the diagnostics.otel block');
+
+    Dst.FromJSON(Roundtripped);
+    AssertTrue(Dst.Diagnostics.Otel.Enabled,
+               'enabled preserved');
+    AssertEq(Dst.Diagnostics.Otel.Endpoint,
+             'https://collector.example.com:4318',
+             'endpoint preserved');
+    AssertEq(Dst.Diagnostics.Otel.Protocol,    'http/json',
+             'protocol preserved');
+    AssertEq(Dst.Diagnostics.Otel.ServiceName, 'pasclaw-prod',
+             'serviceName preserved');
+    AssertTrue(Abs(Dst.Diagnostics.Otel.SampleRate - 0.25) < 0.0001,
+               'sampleRate preserved');
+    AssertTrue(Dst.Diagnostics.Otel.Traces,  'traces preserved');
+    AssertTrue(Dst.Diagnostics.Otel.Metrics, 'metrics preserved');
+    AssertTrue(Dst.Diagnostics.Otel.Logs,    'logs preserved');
+    AssertEqInt(Length(Dst.Diagnostics.Otel.Headers), 2,
+                'two headers preserved');
+    { Header order is not guaranteed across the JSON object dance;
+      check each by name. }
+    AssertTrue((Dst.Diagnostics.Otel.Headers[0].Name = 'Authorization') or
+               (Dst.Diagnostics.Otel.Headers[1].Name = 'Authorization'),
+               'Authorization header survived');
+    AssertTrue((Dst.Diagnostics.Otel.Headers[0].Name = 'x-honeycomb-team') or
+               (Dst.Diagnostics.Otel.Headers[1].Name = 'x-honeycomb-team'),
+               'x-honeycomb-team header survived');
+  finally
+    Src.Free;
+    Dst.Free;
+  end;
+end;
+
 procedure TestSampleRateZeroDropsTrace;
 { sampleRate=0 means "trace nothing". StartSpan must return nil for
   ROOT spans, so the rest of the call graph stays in no-op mode and
@@ -483,6 +558,8 @@ begin
   WriteLn('  ok: malformed traceparent does not break span creation');
   TestCurrentTraceparentForOutbound;
   WriteLn('  ok: CurrentTraceparent formats W3C header for outbound HTTP');
+  TestConfigRoundTripPreservesOtelBlock;
+  WriteLn('  ok: TConfig.ToJSON / FromJSON round-trip preserves diagnostics.otel (PR #242 P2)');
   TestSampleRateZeroDropsTrace;
   WriteLn('  ok: sampleRate=0.0 drops root spans (no buffer, no export)');
   TestErrorStatusEncoded;

--- a/src/tests/otel_tests.pas
+++ b/src/tests/otel_tests.pas
@@ -1,0 +1,495 @@
+program otel_tests;
+(*
+  Pin the OpenTelemetry exporter shape: span hierarchy, attribute
+  names, W3C trace context propagation, sampling toggle, env-var
+  override. No real OTel collector is spun up -- we install a
+  test-only export transport that captures the JSON body so we can
+  parse it and assert on the structure. Same JSON the real OTLP
+  exporter would POST to /v1/traces.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.JSON,
+  PasClaw.Otel;
+
+var
+  GCapturedEndpoint: string;
+  GCapturedBody: string;
+  GCaptureCount: Integer = 0;
+
+procedure CaptureExport(const Endpoint, JSONBody: string;
+                        const Headers: array of string);
+begin
+  GCapturedEndpoint := Endpoint;
+  GCapturedBody := JSONBody;
+  Inc(GCaptureCount);
+end;
+
+procedure ResetCapture;
+begin
+  GCapturedEndpoint := '';
+  GCapturedBody := '';
+  GCaptureCount := 0;
+end;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertEq(const A, B, Msg: string);
+begin
+  if A <> B then
+    Fail_(Msg + ' (expected "' + B + '" got "' + A + '")');
+end;
+
+procedure AssertEqInt(A, B: Integer; const Msg: string);
+begin
+  if A <> B then
+    Fail_(Msg + ' (expected ' + IntToStr(B) + ' got ' + IntToStr(A) + ')');
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' +
+          Copy(Haystack, 1, 400) + '")');
+end;
+
+procedure AssertNotContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) > 0 then
+    Fail_(Msg + ' (unwanted needle "' + Needle + '" present in "' +
+          Copy(Haystack, 1, 400) + '")');
+end;
+
+function MakeEnabledConfig: TConfig;
+begin
+  Result := TConfig.Create;
+  Result.Diagnostics.Otel.Enabled     := True;
+  Result.Diagnostics.Otel.Endpoint    := 'http://127.0.0.1:65535';
+  Result.Diagnostics.Otel.ServiceName := 'otel-test';
+  Result.Diagnostics.Otel.SampleRate  := 1.0;
+end;
+
+procedure TestDisabledByDefault;
+{ Out of the box (TConfig.Create defaults) OTel must NOT export
+  anything. The whole point of "off by default" is that running
+  `pasclaw status` doesn't fire a stray POST to localhost:4318. }
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := TConfig.Create;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    AssertTrue(not OtelEnabled, 'OtelEnabled is False on default config');
+    Span := StartSpan('whatever', oskInternal, '');
+    AssertTrue(Span = nil, 'StartSpan returns nil when disabled');
+    FinishSpan(Span);  { must tolerate nil }
+    AssertTrue(GCaptureCount = 0, 'no exports happened');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestSingleSpanShape;
+{ One root span emits the canonical OTLP/HTTP+JSON envelope:
+  resourceSpans -> resource.attributes -> scopeSpans -> spans.
+  Resource attrs must include service.name (matches openclaw's
+  diagnostics.otel.serviceName setting). }
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    Span := StartSpan('test-root', oskInternal, '');
+    AssertTrue(Span <> nil, 'span created when enabled');
+    SetAttrStr(Span, 'foo', 'bar');
+    SetAttrInt(Span, 'count', 42);
+    SetAttrBool(Span, 'is_test', True);
+    SetStatus(Span, oscOk, '');
+    FinishSpan(Span);
+
+    AssertTrue(GCaptureCount = 1, 'exactly one export fired on root finish');
+    AssertContains(GCapturedEndpoint, '/v1/traces',
+                   'endpoint path includes /v1/traces');
+    AssertContains(GCapturedBody, '"resourceSpans"', 'envelope is resourceSpans');
+    AssertContains(GCapturedBody, '"service.name"', 'service.name in resource attrs');
+    AssertContains(GCapturedBody, '"otel-test"',     'service name value present');
+    AssertContains(GCapturedBody, '"telemetry.sdk.name"',
+                   'telemetry.sdk.name in resource attrs');
+    AssertContains(GCapturedBody, '"scopeSpans"',    'scopeSpans wrapper');
+    AssertContains(GCapturedBody, '"name":"test-root"', 'span name preserved');
+    AssertContains(GCapturedBody, '"foo"', 'string attr key');
+    AssertContains(GCapturedBody, '"bar"', 'string attr value');
+    AssertContains(GCapturedBody, '"count"',         'int attr key');
+    AssertContains(GCapturedBody, '"intValue":"42"', 'int attr value as OTLP intValue');
+    AssertContains(GCapturedBody, '"is_test"',       'bool attr key');
+    AssertContains(GCapturedBody, '"boolValue":true','bool attr value');
+    AssertContains(GCapturedBody, '"status":{"code":1', 'status OK');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+function ExtractSubstring(const Body, StartTag, EndTag: string): string;
+var
+  i, j: Integer;
+begin
+  Result := '';
+  i := Pos(StartTag, Body);
+  if i <= 0 then Exit;
+  Inc(i, Length(StartTag));
+  j := Pos(EndTag, Copy(Body, i, Length(Body)));
+  if j <= 0 then Exit;
+  Result := Copy(Body, i, j - 1);
+end;
+
+procedure TestParentChildHierarchy;
+{ Nested StartSpan / FinishSpan produces parent-child structure: the
+  child carries the parent's traceId AND its spanId as parentSpanId.
+  This is the openclaw.agent.turn -> chat -> execute_tool shape that
+  Langfuse / Tempo dashboards depend on. }
+var
+  Cfg: TConfig;
+  Parent, Child: TOtelSpan;
+  ParentTraceId, ParentSpanId: string;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+
+    Parent := StartSpan('parent-span', oskInternal, '');
+    AssertTrue(Parent <> nil, 'parent created');
+    ParentTraceId := Parent.TraceId;
+    ParentSpanId  := Parent.SpanId;
+    AssertEqInt(Length(ParentTraceId), 32, 'trace id is 32 hex chars (16 bytes)');
+    AssertEqInt(Length(ParentSpanId),  16, 'span id is 16 hex chars (8 bytes)');
+
+    Child := StartSpan('child-span', oskClient, '');
+    AssertTrue(Child <> nil, 'child created');
+    AssertEq(Child.TraceId, ParentTraceId,
+             'child inherits parent traceId (same trace)');
+    AssertEq(Child.ParentSpanId, ParentSpanId,
+             'child.parentSpanId points at parent.spanId');
+
+    { Child finishes first; no export yet because parent still open. }
+    FinishSpan(Child);
+    AssertTrue(GCaptureCount = 0, 'no export until root finishes');
+
+    FinishSpan(Parent);
+    AssertTrue(GCaptureCount = 1, 'export fires when root finishes');
+
+    { Both spans in the same envelope, parent referenced by child. }
+    AssertContains(GCapturedBody, ParentTraceId,
+                   'trace id in body');
+    AssertContains(GCapturedBody, '"parentSpanId":"' + ParentSpanId + '"',
+                   'child.parentSpanId points at parent');
+    AssertContains(GCapturedBody, '"name":"parent-span"', 'parent name');
+    AssertContains(GCapturedBody, '"name":"child-span"',  'child name');
+    AssertContains(GCapturedBody, '"kind":3',
+                   'client kind = 3 (OTLP SPAN_KIND_CLIENT)');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestTraceparentInbound;
+{ The gateway path passes an incoming traceparent header to
+  StartSpan. The parsed trace id and parent span id must drive the
+  new span's TraceId / ParentSpanId so the upstream caller's trace
+  stays connected. }
+const
+  IncomingTP =
+    '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+  ExpectedTrace = '0af7651916cd43dd8448eb211c80319c';
+  ExpectedParent = 'b7ad6b7169203331';
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    Span := StartSpan('HTTP POST /v1/chat', oskServer, IncomingTP);
+    AssertTrue(Span <> nil, 'span created from inbound traceparent');
+    AssertEq(Span.TraceId, ExpectedTrace,
+             'trace id from traceparent header');
+    AssertEq(Span.ParentSpanId, ExpectedParent,
+             'parent span id from traceparent header');
+    FinishSpan(Span);
+    AssertContains(GCapturedBody, ExpectedTrace,
+                   'inbound trace id in exported body');
+    AssertContains(GCapturedBody, '"parentSpanId":"' + ExpectedParent + '"',
+                   'inbound parent span id in exported body');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestTraceparentMalformedTolerated;
+{ A garbage traceparent header must not break the request: we silently
+  start a new trace instead. Real-world gateways see broken
+  propagation all the time -- crashing the request handler over a bad
+  header would be the wrong tradeoff. }
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    Span := StartSpan('HTTP POST /v1/chat', oskServer,
+                      'this-is-not-a-traceparent');
+    AssertTrue(Span <> nil, 'span still created with bad traceparent');
+    AssertTrue(Span.TraceId <> '', 'fresh trace id generated');
+    AssertTrue(Span.ParentSpanId = '',
+               'no parent set (treated as root)');
+    AssertEqInt(Length(Span.TraceId), 32, 'fresh trace id is 32 hex');
+    FinishSpan(Span);
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestCurrentTraceparentForOutbound;
+(* While a span is current, CurrentTraceparent returns the W3C header
+   string an outbound HTTP client should send. Format:
+   00-<trace>-<span>-01. Empty when no current span. *)
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+  TP: string;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    AssertEq(CurrentTraceparent, '',
+             'no current span = empty traceparent');
+    Span := StartSpan('parent', oskInternal, '');
+    TP := CurrentTraceparent;
+    AssertTrue(Pos('00-', TP) = 1, 'traceparent starts with version 00-');
+    AssertTrue(Pos(Span.TraceId, TP) > 0,
+               'traceparent contains current trace id');
+    AssertTrue(Pos(Span.SpanId, TP) > 0,
+               'traceparent contains current span id');
+    AssertTrue(Copy(TP, Length(TP) - 2, 3) = '-01',
+               'traceparent ends with -01 (sampled flag)');
+    FinishSpan(Span);
+    AssertEq(CurrentTraceparent, '',
+             'after finish, no current = empty traceparent');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestEnvVarOverridesEndpoint;
+(* OTEL_EXPORTER_OTLP_ENDPOINT env var must override the config
+   endpoint AND flip enabled=true on its own (standard OTel SDK
+   contract -- ops sets the var, deploy reads it).
+
+   This test runs only when invoked with --env-mode AND
+   OTEL_EXPORTER_OTLP_ENDPOINT is set. FPC's RTL
+   GetEnvironmentVariable snapshots envp at process start, so a
+   mid-process mutation via libc setenv() isn't visible to the
+   PasClaw.Otel reader. The Makefile invokes this binary twice:
+   first plain (default tests, env var unset), then with
+   OTEL_EXPORTER_OTLP_ENDPOINT=http://env-host:4318 and --env-mode
+   to exercise the env-var override path under the env we ACTUALLY
+   inherited at process start. *)
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := TConfig.Create;
+  try
+    { Note: Diagnostics.Otel.Enabled stays default-False here -- so any
+      "enabled" we observe MUST have come from the env var. }
+    AssertTrue(not Cfg.Diagnostics.Otel.Enabled,
+               'config has otel.enabled=false as a control');
+    AssertContains(GetEnvironmentVariable('OTEL_EXPORTER_OTLP_ENDPOINT'),
+                   'env-host',
+                   'precondition: OTEL_EXPORTER_OTLP_ENDPOINT inherited from Makefile');
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    AssertTrue(OtelEnabled,
+               'env var alone is enough to enable OTel (openclaw parity)');
+    Span := StartSpan('env-test', oskInternal, '');
+    AssertTrue(Span <> nil, 'env-var-enabled OTel emits spans');
+    FinishSpan(Span);
+    AssertContains(GCapturedEndpoint, 'env-host',
+                   'env var endpoint reached the exporter');
+    AssertContains(GCapturedEndpoint, '/v1/traces',
+                   '/v1/traces path appended when env URL has no path');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestSampleRateZeroDropsTrace;
+{ sampleRate=0 means "trace nothing". StartSpan must return nil for
+  ROOT spans, so the rest of the call graph stays in no-op mode and
+  nothing exports. Real high-volume gateways would set this low
+  (0.01) to keep collector cost bounded. }
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  Cfg.Diagnostics.Otel.SampleRate := 0.0;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    Span := StartSpan('would-be-root', oskInternal, '');
+    AssertTrue(Span = nil,
+               'sampleRate=0 drops root spans (no allocation)');
+    FinishSpan(Span);
+    AssertTrue(GCaptureCount = 0, 'no export, no buffer');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestErrorStatusEncoded;
+{ SetStatus(oscError) writes status.code=2 and the optional message
+  into the span. Backends use this for "show errors in red" /
+  alerting filters. }
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    Span := StartSpan('failing', oskClient, '');
+    SetStatus(Span, oscError, 'simulated provider 503');
+    FinishSpan(Span);
+    AssertContains(GCapturedBody, '"status":{"code":2',
+                   'error status code = 2');
+    AssertContains(GCapturedBody, 'simulated provider 503',
+                   'error message preserved');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestNilTolerance;
+{ All helpers must tolerate nil so call sites stay clean -- you can
+  write the instrumentation once and let the StartSpan-returns-nil
+  path silently no-op the whole block when OTel is off. }
+var
+  Cfg: TConfig;
+begin
+  Cfg := TConfig.Create;
+  try
+    InitOtelFromConfig(Cfg);  { stays disabled }
+    SetExportTransport(@CaptureExport);
+    SetAttrStr(nil, 'k', 'v');
+    SetAttrInt(nil, 'n', 7);
+    SetAttrBool(nil, 'b', True);
+    SetStatus(nil, oscError, 'wat');
+    FinishSpan(nil);
+    AssertTrue(True, 'no crash on nil helpers');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestJsonEscapeOnAttrs;
+{ Attribute values that include JSON-control bytes must be escaped
+  so the OTLP payload stays valid JSON. Tool names like "fs_grep"
+  are fine; agent error messages that include " or backslash are
+  the real risk. }
+var
+  Cfg: TConfig;
+  Span: TOtelSpan;
+begin
+  ResetCapture;
+  Cfg := MakeEnabledConfig;
+  try
+    InitOtelFromConfig(Cfg);
+    SetExportTransport(@CaptureExport);
+    Span := StartSpan('escape-test', oskInternal, '');
+    SetAttrStr(Span, 'error.message',
+               'unexpected " character and ' + #10 + 'newline + \backslash');
+    SetStatus(Span, oscError, 'bad "quote" and \slash');
+    FinishSpan(Span);
+    AssertContains(GCapturedBody, '\" character',
+                   'embedded quote got escaped');
+    AssertContains(GCapturedBody, '\n',
+                   'newline got escaped');
+    AssertContains(GCapturedBody, '\\backslash',
+                   'backslash got escaped (doubled)');
+    AssertContains(GCapturedBody, '\"quote\"',
+                   'status message quotes escaped');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+begin
+  if (ParamCount >= 1) and (ParamStr(1) = '--env-mode') then
+  begin
+    { Second pass: invoked from the Makefile with
+      OTEL_EXPORTER_OTLP_ENDPOINT set. Only run the env-var override
+      test (the rest already ran in the first pass with a clean env). }
+    TestEnvVarOverridesEndpoint;
+    WriteLn('  ok: OTEL_EXPORTER_OTLP_ENDPOINT enables OTel and overrides endpoint');
+    WriteLn('PASS');
+    Exit;
+  end;
+
+  TestDisabledByDefault;
+  WriteLn('  ok: disabled-by-default emits nothing');
+  TestSingleSpanShape;
+  WriteLn('  ok: single root span emits canonical OTLP/HTTP+JSON envelope');
+  TestParentChildHierarchy;
+  WriteLn('  ok: parent/child spans share trace id, child carries parentSpanId');
+  TestTraceparentInbound;
+  WriteLn('  ok: W3C traceparent header parsed for cross-service propagation');
+  TestTraceparentMalformedTolerated;
+  WriteLn('  ok: malformed traceparent does not break span creation');
+  TestCurrentTraceparentForOutbound;
+  WriteLn('  ok: CurrentTraceparent formats W3C header for outbound HTTP');
+  TestSampleRateZeroDropsTrace;
+  WriteLn('  ok: sampleRate=0.0 drops root spans (no buffer, no export)');
+  TestErrorStatusEncoded;
+  WriteLn('  ok: SetStatus(oscError) writes code=2 + message into span');
+  TestNilTolerance;
+  WriteLn('  ok: all helpers tolerate nil so disabled call sites stay clean');
+  TestJsonEscapeOnAttrs;
+  WriteLn('  ok: JSON-control bytes in attribute values are escaped');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## Summary

Adds OpenTelemetry traces to PasClaw, mirroring openclaw v2026.2+'s span shape so existing OTel-aware backends (Langfuse, Tempo, Jaeger, Honeycomb, Datadog) recognise our spans without remapping.

**Span hierarchy:**
```
HTTP <method> <route>            (gateway: every inbound /v1/* call,
                                  W3C traceparent parsed for parent ctx)
└── openclaw.agent.turn          (one tool loop iteration set)
    ├── chat <model>             (provider request, gen_ai.* attrs)
    └── execute_tool <name>      (serial tool dispatch)
```

**Configuration** mirrors openclaw's `diagnostics.otel.*` block so configs copy/paste cleanly:

```json
{"diagnostics":{"otel":{
  "enabled": true,
  "endpoint": "http://localhost:4318",
  "serviceName": "pasclaw",
  "sampleRate": 1.0,
  "headers": {"Authorization": "Bearer ..."}
}}}
```

**Off by default.** Flips on when EITHER `diagnostics.otel.enabled=true` in `config.json` OR `OTEL_EXPORTER_OTLP_ENDPOINT` is set in the environment — matching the standard OTel SDK contract (ops sets the env var at deploy time, the agent picks it up).

## Design choices

- **OTLP/HTTP+JSON only.** Spec mandates both JSON and protobuf on the http path; every collector groks both, so JSON avoids protobuf vendoring in Pascal.
- **Synchronous-per-trace export.** Spans buffer until the root finishes, then ship in one POST. Avoids 5-POSTs-per-turn waste without a background batcher thread.
- **`threadvar` current-span stack.** Per-request gateway spans stay isolated across Indy worker threads.
- **W3C Trace Context** (traceparent header) parsed inbound, formatted outbound via `CurrentTraceparent`.
- **JSON-control-byte escaping** on all attribute string values — error messages with embedded quotes won't break the envelope.
- **Test seam.** `SetExportTransport(@CaptureFn)` swaps the OTLP/HTTP transport for a callback, so `otel_tests` captures the POST body without standing up a real collector.

## Known limitations (follow-up PRs)

- **Metrics + logs** scoped out. The `diagnostics.otel.metrics`/`logs` booleans are reserved fields; only traces are wired.
- **Parallel tool workers** don't yet propagate the parent span's `threadvar` context across the worker boundary; tool dispatches under `Cfg.Parallel=True` won't appear in traces. Serial dispatch (the default) is fully traced.

## Test plan

- [x] `make smoke` — green
- [x] `make test` — full aggregate green (19 PASS markers)
- [x] `make test-otel` — 10 inline assertions + 1 env-mode pass, all green:
  - disabled-by-default emits nothing
  - single root span → canonical OTLP/HTTP+JSON envelope (resourceSpans, scopeSpans, service.name, telemetry.sdk.*)
  - parent/child relationship: same trace id, child.parentSpanId points at parent.spanId; export deferred until root finishes
  - W3C traceparent parsed inbound
  - malformed traceparent tolerated (start fresh trace silently)
  - `CurrentTraceparent` formats outbound header
  - `sampleRate=0.0` drops root spans (no allocation, no export)
  - `SetStatus(oscError)` → status.code=2 + message preserved
  - All helpers tolerate nil so disabled call sites stay clean
  - JSON-control bytes escaped in attribute values
  - Env-mode pass: Makefile invokes the binary with `OTEL_EXPORTER_OTLP_ENDPOINT=http://env-host:4318 --env-mode` to exercise the env-var-flips-enabled path (FPC RTL snapshots envp at startup, so we can't mutate mid-process)

## Scope check

~1500 LOC (target ~500 + tests). The unit ended up larger than estimated because the OTLP/JSON envelope encoding + W3C traceparent + sampling + threadvar context stack + nil-tolerant helpers all needed inline documentation to be useful. Test file came in at ~500 LOC to cover the corner cases (escaping, malformed headers, sampling edge cases) — happy to split out into a leaner v2 if you'd prefer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_