### PR TITLE
dcc64: add otel/ to Delphi search path; add `pasclaw agent --quiet`

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -94,15 +94,31 @@ type
     { --backend local|docker. Empty = use Cfg.ShellBackend. Override
       is per-invocation; we don't persist it to config. }
     BackendOverride: string;
+    (* --quiet / -q: machine-friendly output. RunSingleTurn drops the
+       `assistant (provider/model):` header, every tool-call /
+       tool-result preview line, and the trailing dim
+       [tokens in=... out=... iters=...] line, leaving only the
+       assistant's final reply on stdout (followed by a single
+       newline). PrintBanner is also skipped at the dpr level via
+       IsQuietInvocation. Designed for Replicate / Lambda / curl
+       pipelines where the caller wants the model's answer as the
+       sole stdout payload. Interactive mode ignores this; quiet
+       only makes sense for one-shot -m. *)
+    Quiet: Boolean;
   end;
 
   TLoopHandlers = class
+    Quiet: Boolean;  { when True, OnToolCall / OnToolResult emit nothing.
+                       Set by Cmd_Agent_Run before passing to BuildLoopConfig
+                       so machine-friendly callers (-q / --quiet) get the
+                       assistant reply on stdout with no per-tool decoration. }
     procedure OnToolCall(const Name, ArgsJSON: string);
     procedure OnToolResult(const Name, ResultText, Err: string);
   end;
 
 procedure TLoopHandlers.OnToolCall(const Name, ArgsJSON: string);
 begin
+  if Quiet then Exit;
   PrintLn(Ansi.Magenta + '› tool ' + Name + Ansi.Reset + ' ' + Copy(ArgsJSON, 1, 200));
 end;
 
@@ -110,6 +126,7 @@ procedure TLoopHandlers.OnToolResult(const Name, ResultText, Err: string);
 var
   Preview: string;
 begin
+  if Quiet then Exit;
   if Err <> '' then
     PrintLn(Ansi.Red + '  ✗ ' + Err + Ansi.Reset)
   else
@@ -132,6 +149,7 @@ begin
   Result.NoTools       := False;
   Result.NoMCP         := False;
   Result.NoHashline    := False;
+  Result.Quiet         := False;
 end;
 
 function ParseArgs(const Argv: array of string; var A: TAgentArgs): Boolean;
@@ -157,6 +175,7 @@ begin
     if Argv[i] = '--no-tools'    then begin A.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-mcp'      then begin A.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline' then begin A.NoHashline := True; Inc(i); Continue; end;
+    if (Argv[i] = '--quiet') or (Argv[i] = '-q') then begin A.Quiet := True; Inc(i); Continue; end;
     if Argv[i] = '--session'     then begin if i = High(Argv) then Exit(False); A.Session := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--backend'     then begin if i = High(Argv) then Exit(False); A.BackendOverride := Argv[i + 1]; Inc(i, 2); Continue; end;
     Inc(i);
@@ -403,9 +422,18 @@ var
 begin
   if not PickProvider(Cfg, A, Provider, Err) then
   begin
-    PrintLn(Ansi.Yellow + '(offline preview -- ' + Err + ')' + Ansi.Reset);
-    PrintLn('You: ' + Prompt);
-    PrintLn('Assistant: <provider not configured; run `pasclaw onboard`>');
+    if A.Quiet then
+      { Quiet mode: a single undecorated line so scripts have
+        SOMETHING on stdout to surface, without the banner-y "(offline
+        preview)" / "You: ..." mock-conversation rendering. Callers
+        relying on exit code still see this as a failure path. }
+      PrintLn('pasclaw error: provider not configured (' + Err + ')')
+    else
+    begin
+      PrintLn(Ansi.Yellow + '(offline preview -- ' + Err + ')' + Ansi.Reset);
+      PrintLn('You: ' + Prompt);
+      PrintLn('Assistant: <provider not configured; run `pasclaw onboard`>');
+    end;
     Exit;
   end;
 
@@ -428,6 +456,12 @@ begin
   Spawn := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   BgCoord := MaybeRegisterBackgroundSpawnTools(Cfg, Provider, Reg, Model);
   Handlers := TLoopHandlers.Create;
+  { Propagate --quiet so the per-tool decoration the loop fires
+    through the OnToolCall / OnToolResult callbacks no-ops. Combined
+    with the header + token-line skips below, the only thing
+    RunSingleTurn writes to stdout in quiet mode is the assistant's
+    final reply (plus a single trailing newline). }
+  Handlers.Quiet := A.Quiet;
   { Allocate a one-shot session id so the active shell backend
     (docker, ssh, ...) actually isolates this turn. Codex P1 on
     PR #233: without StartShellSession the docker backend's empty-
@@ -446,12 +480,31 @@ begin
 
     LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers, Prompt);
 
-    PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset + ' (' + Provider.GetName + '/' + Model + '):');
+    if not A.Quiet then
+      PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset +
+              ' (' + Provider.GetName + '/' + Model + '):');
     if RunToolLoop(LoopCfg, Msgs, Loop) then
-      PrintLn(MaybeRender(Cfg, Loop.Content))
+    begin
+      { In quiet mode skip MaybeRender -- the markdown renderer adds
+        ANSI styling that defeats the "machine-readable plain text"
+        contract --quiet promises. The model's raw reply text goes
+        straight to stdout, no decoration. }
+      if A.Quiet then
+        PrintLn(Loop.Content)
+      else
+        PrintLn(MaybeRender(Cfg, Loop.Content));
+    end
+    else if not A.Quiet then
+      PrintLn('(loop failed)')
     else
+      { In quiet mode, a failed loop still needs SOMETHING on stdout
+        so the caller doesn't silently get an empty body and assume
+        the model said nothing. Match the non-quiet sentinel verbatim
+        so scripts can grep for it; exit code is the authoritative
+        success signal anyway. }
       PrintLn('(loop failed)');
-    if Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0 then
+    if (not A.Quiet) and
+       (Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0) then
       PrintLn(Ansi.Dim + FormatTokenLine(Loop.TotalUsage, Loop.Iterations) + Ansi.Reset);
   finally
     CloseShellSession(OneShotSessionId);
@@ -1258,7 +1311,7 @@ begin
   begin
     PrintLnErr('usage: pasclaw agent [-m "msg"] [--model M] [--provider P] [--system S]');
     PrintLnErr('                     [--thinking low|medium|high] [--max-tokens N]');
-    PrintLnErr('                     [--max-iterations N] [--no-tools]');
+    PrintLnErr('                     [--max-iterations N] [--no-tools] [-q|--quiet]');
     Exit(1);
   end;
 

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -405,7 +405,16 @@ begin
   else                       Result := S;
 end;
 
-procedure RunSingleTurn(const Cfg: TConfig; const A: TAgentArgs; const Prompt: string);
+function RunSingleTurn(const Cfg: TConfig; const A: TAgentArgs;
+                       const Prompt: string): Boolean;
+(* Returns True on a clean turn (provider resolved, RunToolLoop
+   returned True) and False on either failure mode. Cmd_Agent_Run
+   maps False -> process exit code 1 so scripts using --quiet (or
+   anything else parsing $?) treat a missing provider or a failed
+   tool loop as a failed invocation. PR #243 P2: prior behaviour
+   always exited 0 even when the assistant produced no reply,
+   which silently masked provider-config errors in machine-readable
+   pipelines. *)
 var
   Provider: ILLMProvider;
   Err: string;
@@ -420,13 +429,20 @@ var
   BgCoord: TBackgroundSpawnCoordinator;
   OneShotSessionId: string;
 begin
+  { Default to True; only flip to False on a known failure path.
+    Any code path that hits Exit before producing a real assistant
+    reply MUST set Result := False first so Cmd_Agent_Run can map
+    it to a non-zero process exit. }
+  Result := True;
   if not PickProvider(Cfg, A, Provider, Err) then
   begin
+    Result := False;
     if A.Quiet then
       { Quiet mode: a single undecorated line so scripts have
         SOMETHING on stdout to surface, without the banner-y "(offline
-        preview)" / "You: ..." mock-conversation rendering. Callers
-        relying on exit code still see this as a failure path. }
+        preview)" / "You: ..." mock-conversation rendering. Exit
+        code (non-zero, via Cmd_Agent_Run) is the authoritative
+        success signal. }
       PrintLn('pasclaw error: provider not configured (' + Err + ')')
     else
     begin
@@ -494,15 +510,15 @@ begin
       else
         PrintLn(MaybeRender(Cfg, Loop.Content));
     end
-    else if not A.Quiet then
-      PrintLn('(loop failed)')
     else
-      { In quiet mode, a failed loop still needs SOMETHING on stdout
-        so the caller doesn't silently get an empty body and assume
-        the model said nothing. Match the non-quiet sentinel verbatim
-        so scripts can grep for it; exit code is the authoritative
-        success signal anyway. }
+    begin
+      Result := False;
+      { Failed loop: a "(loop failed)" sentinel still goes to stdout
+        in both modes so a caller eyeballing the output sees what
+        happened, but Result := False bubbles up so Cmd_Agent_Run
+        exits non-zero (PR #243 P2 fix). }
       PrintLn('(loop failed)');
+    end;
     if (not A.Quiet) and
        (Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0) then
       PrintLn(Ansi.Dim + FormatTokenLine(Loop.TotalUsage, Loop.Iterations) + Ansi.Reset);
@@ -1332,9 +1348,24 @@ begin
     end;
   end;
   try
-    if A.Message <> '' then RunSingleTurn(Cfg, A, A.Message)
-    else                    RunInteractive(Cfg, A);
-    Result := 0;
+    if A.Message <> '' then
+    begin
+      { One-shot path: RunSingleTurn returns False on (a) no provider
+        configured or (b) a failed tool loop. Map either to exit 1 so
+        `pasclaw agent --quiet -m "..."` callers checking $? see real
+        failures instead of a silently-zero exit code that lies about
+        success. PR #243 P2. Interactive mode has no equivalent
+        return -- session lifecycle is the user's signal there. }
+      if RunSingleTurn(Cfg, A, A.Message) then
+        Result := 0
+      else
+        Result := 1;
+    end
+    else
+    begin
+      RunInteractive(Cfg, A);
+      Result := 0;
+    end;
   finally
     Cfg.Free;
   end;

--- a/src/pasclaw/PasClaw.dpr
+++ b/src/pasclaw/PasClaw.dpr
@@ -69,13 +69,33 @@ begin
   end;
 end;
 
+function IsQuietInvocation: Boolean;
+{ Suppress the banner whenever the user passed --quiet or -q on the
+  command line. The actual semantic suppression (tool decoration,
+  token line, assistant header) lives inside Cmd.Agent's RunSingleTurn,
+  but the banner is printed BEFORE arg parsing in this file, so we
+  need an early scan here -- same shape IsStdioMCPInvocation uses
+  for the mcp-stdio case. Flag form matches what Cmd.Agent.ParseArgs
+  accepts, so users only have to type --quiet once. }
+var
+  i: Integer;
+  Arg: string;
+begin
+  Result := False;
+  for i := 1 to ParamCount do
+  begin
+    Arg := ParamStr(i);
+    if (Arg = '--quiet') or (Arg = '-q') then Exit(True);
+  end;
+end;
+
 var
   ExitCode_: Integer;
 begin
   { Detect color support before any output so the banner respects NO_COLOR. }
   CliUI_Init(EarlyColorDisabled);
 
-  if not IsStdioMCPInvocation then
+  if not (IsStdioMCPInvocation or IsQuietInvocation) then
     PrintBanner;
   ApplyTimezoneFromEnv;
 

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names


### PR DESCRIPTION
## Summary

Two unrelated-but-grouped fixes the user hit running PasClaw on Replicate after PR #242 merged.

### 1. `dcc64` fix: add `src/pkg/otel` to `DCC_UnitSearchPath`

PR #242 added `src/pkg/otel/PasClaw.Otel.pas` and wired it into `PasClaw.Config`'s implementation `uses` clause, but only the FPC Makefile's `UNIT_DIRS` got updated. `src/pasclaw/PasClaw.dproj` kept the pre-#242 search path, so the next `dcc64` build of `PasClaw.dpr` errored:

```
PasClaw.Config.pas(611): F2613 Unit 'PasClaw.Otel' not found.
```

Fix: append `..\pkg\otel` to `DCC_UnitSearchPath`, slotted right before `..\pkg\vendor\dmvcframework` to match the order the Makefile lists it. No behavioural change; FPC build is already green.

### 2. `pasclaw agent --quiet` / `-q` for machine-readable output

Replicate / Lambda / curl callers running `pasclaw agent -m "..."` want JUST the assistant's reply on stdout — not the ASCII banner, the `assistant (provider/model):` header, every per-tool `› tool fs_read { ... }` / `✓ ...` decoration line, or the trailing `[tokens in=X out=Y, iters=Z]` footer.

**Before:**
```
██████╗  █████╗ ███████╗ ██████╗██╗      █████╗ ██╗    ██╗
██╔══██╗██╔══██╗██╔════╝██╔════╝██║     ██╔══██╗██║    ██║
...
assistant (gemini/gemini-3.5-flash):
› tool fs_list { "path" : "/tmp/tmpreb5necq" }
  ✓ - config.json  675
› tool fs_read ...
  ✓ ...
Hello! I am PasClaw, your 10x developer assistant. ...
  [tokens in=9572 out=128, iters=4]
```

**After `--quiet`:**
```
Hello! I am PasClaw, your 10x developer assistant. ...
```

Wiring (one new bool propagated through 3 sites):

- `TAgentArgs.Quiet`, set by `ParseArgs` on `--quiet` or `-q`.
- `TLoopHandlers.Quiet` causes `OnToolCall` / `OnToolResult` to no-op, so the loop's per-tool preview lines stay off stdout.
- `RunSingleTurn` skips the cyan assistant header, skips `MaybeRender` (which would re-introduce ANSI styling), and skips the dim token line. The offline-preview branch collapses to a single `pasclaw error: ...` line so callers still get something on stdout.
- `PasClaw.dpr`'s `IsQuietInvocation` scans argv for `--quiet` / `-q` before the banner fires, same pattern `IsStdioMCPInvocation` already uses for `pasclaw mcp stdio`.

Interactive mode silently ignores `Quiet` (only makes sense for one-shot `-m`).

## Test plan

- [x] `make smoke` — green
- [x] `make test` — 19 PASS markers, no failures
- [x] Manual: `PASCLAW_HOME=/tmp/quiet-test ./build/pasclaw agent --quiet -m "test"` → single line `pasclaw error: provider not configured (...)` (no banner, no decorations)
- [x] Manual: `PASCLAW_HOME=/tmp/quiet-test ./build/pasclaw agent -q -m "test"` → identical (short flag works)
- [x] Manual: `PASCLAW_HOME=/tmp/quiet-test ./build/pasclaw agent -m "test"` (no `--quiet`) → full banner + offline preview scaffold (control)
- [ ] Operator with real provider: `pasclaw agent --quiet --provider anthropic -m "say hi"` should print only the assistant text — happy to run if the merge needs validation, just need an API key on the runner

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_