### PR TITLE
config: ${VAR_NAME} env-variable substitution inside config.json (openclaw-compat)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,6 +521,21 @@ test-gateway-token: | $(BUILDDIR)
 	@PASCLAW_GATEWAY_TOKEN=sk-pasclaw-env-test-aaaaaaaa $(BUILDDIR)/gateway_token_tests --env-mode
 	@OPENCLAW_GATEWAY_TOKEN=sk-openclaw-env-test-bbbbbb $(BUILDDIR)/gateway_token_tests --env-mode
 
+# ${VAR_NAME} env-substitution in config.json. Pins the pattern
+# (uppercase only, [A-Z_][A-Z0-9_]*), the splice + JSON-escape, the
+# unset-env "leave the literal in place" diagnostic behaviour, and
+# the round-trip through TConfig.FromJSON when a marker is
+# unresolved. --env-mode pass inherits fixture vars from this rule
+# to exercise the actual splicing path FPC's startup-snapshotted
+# envp would otherwise block.
+test-config-env-subst: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/config_env_subst_tests.pas -o$(BUILDDIR)/config_env_subst_tests
+	@$(BUILDDIR)/config_env_subst_tests
+	@PASCLAW_CONFIG_TEST_VAR_A4F9='hello-from-env-aaaaaaaa' \
+	 PASCLAW_CONFIG_TRICKY_VAR_A4F9='hello"world\backslash' \
+	 $(BUILDDIR)/config_env_subst_tests --env-mode
+
 # OpenTelemetry traces (OTLP/HTTP+JSON). Pins span hierarchy,
 # attribute names (gen_ai.* semantic conventions), W3C traceparent
 # propagation in/out, sampling toggle, env-var override, JSON
@@ -544,4 +559,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-config-env-subst

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,63 @@ pasclaw config path   # print the resolved path
 pasclaw config reset  # write a default config
 ```
 
+## `${VAR_NAME}` environment-variable substitution
+
+`config.json` string values can reference environment variables with the openclaw `${VAR_NAME}` syntax. At `LoadConfig` time PasClaw resolves every marker in the raw JSON body before parsing, so the rest of the codebase sees the substituted value.
+
+```json
+{
+  "providers": [
+    { "name": "anthropic",
+      "kind": "anthropic",
+      "api_key": "${ANTHROPIC_API_KEY}",
+      "model":   "claude-opus-4-7" }
+  ],
+  "gateway": {
+    "token": "${PASCLAW_GATEWAY_TOKEN}"
+  },
+  "channels": [
+    { "name":   "ops",
+      "kind":   "discord",
+      "target": "${OPS_DISCORD_WEBHOOK}" }
+  ]
+}
+```
+
+### Pattern
+
+`${[A-Z_][A-Z0-9_]*}` — matches openclaw exactly:
+
+- Uppercase only. Lowercase names don't match: `${api_key}` is left in place verbatim.
+- First character must be `A-Z` or `_`. Digit-first names don't match: `${1FOO}` is left in place.
+- Subsequent characters allow digits: `${FOO_42}` matches if `FOO_42` is set.
+- No dashes: `${WITH-DASH}` is left in place.
+
+### Behaviour on unset env
+
+When the named env var is unset (or set to empty), the literal `${VAR_NAME}` is left in the config string. This is deliberate — `pasclaw config show` then prints the unresolved marker so an operator can see exactly which variable didn't resolve. No error, no abort, no silent substitution to empty.
+
+### JSON safety
+
+Substituted values are JSON-escaped on the fly: `"`, `\`, and control bytes get the standard `\"` / `\\` / `\u00xx` treatment. An `ANTHROPIC_API_KEY=foo"bar` env value yields valid `{"api_key":"foo\"bar"}` JSON, not a broken parse.
+
+### Round-trip with `SaveConfig`
+
+Substitution is **not preserved** through `SaveConfig`. Any config-mutating CLI command (`pasclaw auth login`, `pasclaw model set`, `pasclaw skills install`, ...) round-trips through `TConfig.FromJSON` → memory → `TConfig.ToJSON`, and by that point the marker has already resolved to its literal value. The next `SaveConfig` writes the resolved value, not the marker.
+
+If you want a secret to live **only** in the environment and never get persisted, prefer the dedicated env-var path:
+
+- `PASCLAW_GATEWAY_TOKEN` (or `OPENCLAW_GATEWAY_TOKEN`) for the gateway bearer — see [Gateway § Authentication](./gateway.md#authentication).
+- Other dedicated env-only paths are documented per-feature.
+
+### No literal `${UPPER}` value
+
+There is no escape sequence for a literal `${UPPER}` string in a config value. Workarounds:
+
+- Use the dedicated env-var path mentioned above (doesn't go through substitution at all).
+- Downcase one letter so the pattern doesn't match: `${UPPER}` → `${Upper}`.
+- Wrap with extra chars: `${{UPPER}}` resolves the outer `{UPPER}` (not a match — no opening `$`), so the literal stays. Note this only works because `${UPPER}` requires the leading `$` directly before `{`.
+
 ## Defaults
 
 ```json

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -209,6 +209,14 @@ PASCLAW_GATEWAY_TOKEN=sk-pasclaw-<secret> pasclaw gateway --addr 0.0.0.0
 
 `OPENCLAW_GATEWAY_TOKEN` is honoured as an alias for openclaw-compat — an operator pointing PasClaw at an existing openclaw `.env` file doesn't have to rename anything. `PASCLAW_GATEWAY_TOKEN` wins when both env vars are set.
 
+A third path: reference any env var inline via openclaw-style `${VAR_NAME}` substitution in `config.json` (see [Configuration § `${VAR_NAME}` environment-variable substitution](./configuration.md#var_name-environment-variable-substitution)):
+
+```json
+"gateway": { "token": "${MY_CORP_PASCLAW_TOKEN}" }
+```
+
+This pattern persists the resolved value through `SaveConfig`; for env-only secrets that should never end up in `config.json`, prefer the dedicated `PASCLAW_GATEWAY_TOKEN` env path above.
+
 Env overrides config when both are set. An env-only token does **not** leak into `config.json` — any config-mutating command (`pasclaw auth login`, `pasclaw model set`, `pasclaw skills install`, ...) round-trips through `SaveConfig` and `TConfig.ToJSON` emits only the in-config `gateway.token` field, never the env override. The middleware reads the effective value via `PasClaw.Config.GetEffectiveGatewayToken`.
 
 The `/v1/config` route masks `gateway.token` to `•••` for any authenticated caller — same shape `providers[].api_key` and `mcp_servers[].env` already use.

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -613,6 +613,34 @@ procedure SaveConfig(C: TConfig);
     The gateway middleware uses this getter; ToJSON / SaveConfig
     serialise only C.Gateway.Token (never the env value). *)
 function GetEffectiveGatewayToken(const C: TConfig): string;
+
+(*  ExpandEnvVarsInJSON -- raw-text ${VAR_NAME} substitution applied
+    to the JSON config body BEFORE TConfig.FromJSON parses it.
+    Matches openclaw's `${...}` template-substitution feature so an
+    operator can keep secrets out of `config.json` without using
+    the dedicated `PASCLAW_GATEWAY_TOKEN` env var:
+
+      "providers": [
+        { "name": "anthropic", "api_key": "${ANTHROPIC_API_KEY}" }
+      ]
+
+    Pattern: `${[A-Z_][A-Z0-9_]*}` (uppercase only, matching openclaw).
+    On a match we GetEnvironmentVariable the name and splice the value
+    in -- JSON-escaping any `"`, `\`, or control byte so the result
+    stays valid JSON regardless of the env value's contents. When the
+    env var is unset (or set but empty), the literal `${VAR_NAME}` is
+    left in place so an operator reading config back can diagnose by
+    seeing the unresolved marker. No escape sequence for a literal
+    `${UPPER}` value in v1; the workaround is downcasing one letter
+    so the pattern doesn't match, or use the dedicated PASCLAW_* env
+    var path that doesn't go through string substitution at all.
+
+    Applied at LoadConfig only -- embedders constructing TConfig from
+    a hand-crafted JSON string and calling FromJSON directly do their
+    own env wiring. Exposed in the interface so the test can pin
+    the expansion contract without driving LoadConfig itself. *)
+function ExpandEnvVarsInJSON(const Body: string): string;
+
 function FormatVersion: string;
 function FormatBuildInfo: string;
 
@@ -1561,6 +1589,13 @@ begin
     if FileExists(Path) then
     begin
       S := ReadFileText(Path);
+      (* Resolve ${VAR_NAME} markers BEFORE FromJSON parses. Lets
+         operators keep API keys / bearer tokens / webhook URLs in
+         the environment and reference them by name from config.json
+         the same way openclaw's templates work. Unset env vars
+         leave the literal marker in place so config-back-from-disk
+         diagnostics still show which variable didn't resolve. *)
+      S := ExpandEnvVarsInJSON(S);
       try
         Result.FromJSON(S);
       except
@@ -1609,6 +1644,105 @@ begin
     Result := GEnvGatewayToken
   else
     Result := C.Gateway.Token;
+end;
+
+function EnvSubstJsonEscape(const S: string): string;
+(* Escape a substituted env value so the resulting JSON stays valid
+   no matter what bytes the operator's env happens to contain. Same
+   control-byte handling as PasClaw.Otel's JsonEscape (intentionally
+   duplicated -- making PasClaw.Config depend on PasClaw.Otel for
+   one helper would be backwards: Config is downstream of Otel).
+   Used only for ${VAR_NAME} expansion below. *)
+var
+  i: Integer;
+  c: Char;
+  Sb: TStringBuilder;
+begin
+  Sb := TStringBuilder.Create;
+  try
+    for i := 1 to Length(S) do
+    begin
+      c := S[i];
+      case c of
+        '"':  Sb.Append('\"');
+        '\':  Sb.Append('\\');
+        #8:   Sb.Append('\b');
+        #9:   Sb.Append('\t');
+        #10:  Sb.Append('\n');
+        #12:  Sb.Append('\f');
+        #13:  Sb.Append('\r');
+      else
+        if Ord(c) < $20 then
+          Sb.Append('\u00' + IntToHex(Ord(c), 2))
+        else
+          Sb.Append(c);
+      end;
+    end;
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
+end;
+
+function ExpandEnvVarsInJSON(const Body: string): string;
+var
+  i, j, n, NameStart: Integer;
+  Sb: TStringBuilder;
+  Name, Value: string;
+
+  function IsFirstNameChar(c: Char): Boolean;
+  begin
+    Result := ((c >= 'A') and (c <= 'Z')) or (c = '_');
+  end;
+
+  function IsNameChar(c: Char): Boolean;
+  begin
+    Result := ((c >= 'A') and (c <= 'Z'))
+           or ((c >= '0') and (c <= '9'))
+           or (c = '_');
+  end;
+
+begin
+  n := Length(Body);
+  Sb := TStringBuilder.Create;
+  try
+    i := 1;
+    while i <= n do
+    begin
+      if (Body[i] = '$') and (i + 1 <= n) and (Body[i + 1] = '{') then
+      begin
+        NameStart := i + 2;
+        if (NameStart <= n) and IsFirstNameChar(Body[NameStart]) then
+        begin
+          j := NameStart + 1;
+          while (j <= n) and IsNameChar(Body[j]) do Inc(j);
+          if (j <= n) and (Body[j] = '}') then
+          begin
+            Name := Copy(Body, NameStart, j - NameStart);
+            Value := GetEnvironmentVariable(Name);
+            if Value <> '' then
+              Sb.Append(EnvSubstJsonEscape(Value))
+            else
+              (* Unset / empty env: keep the literal ${VAR_NAME} in
+                 the JSON so the operator can read config back and
+                 see exactly which marker didn't resolve. FromJSON
+                 accepts it as a normal string value. *)
+              Sb.Append(Copy(Body, i, j + 1 - i));
+            i := j + 1;
+            Continue;
+          end;
+        end;
+        (* Falls through: malformed ${...} -- missing closing brace,
+           empty name, lowercase first char. Preserve verbatim so an
+           accidental `$` in a value like a regex doesn't get eaten. *)
+      end;
+      Sb.Append(Body[i]);
+      Inc(i);
+    end;
+    Result := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
 end;
 
 procedure SaveConfig(C: TConfig);

--- a/src/tests/config_env_subst_tests.pas
+++ b/src/tests/config_env_subst_tests.pas
@@ -1,0 +1,190 @@
+program config_env_subst_tests;
+(*
+  Pins PasClaw.Config.ExpandEnvVarsInJSON contract:
+
+    - Pattern matches openclaw's ${[A-Z_][A-Z0-9_]*} exactly.
+    - Set env var: spliced in, JSON-escaping any "/\\/control bytes
+      so the result stays valid JSON regardless of value contents.
+    - Unset (or set-but-empty) env: literal ${VAR_NAME} left in
+      place so an operator reading config back can SEE which marker
+      didn't resolve.
+    - Lowercase names DON'T match (case-sensitive per openclaw).
+    - First char must be A-Z or _; subsequent allow 0-9 too.
+    - Malformed markers (missing }, empty name, dollar without {)
+      preserved verbatim -- a regex pattern in some config value
+      that happens to contain `$` doesn't get eaten.
+    - Substitution is positional (raw text), so anywhere the marker
+      appears it expands; inside string values is the canonical
+      use case but the function doesn't enforce that itself.
+
+  Some assertions require the env var to actually be set in the
+  parent process (FPC's RTL snapshots envp at startup). The
+  Makefile invokes this binary in two passes: clean env for the
+  in-process control assertions, and a second pass with a fixture
+  env var for the actual expansion path -- same shape otel_tests
+  and gateway_token_tests use.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  PasClaw.Config;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure AssertEq(const A, B, Msg: string);
+begin
+  if A <> B then
+    Fail_(Msg + ' (expected "' + B + '" got "' + A + '")');
+end;
+
+procedure TestUnsetEnvLeavesLiteral;
+const
+  Name = 'PASCLAW_TEST_DEFINITELY_UNSET_VAR_a4f9';
+begin
+  AssertEq(GetEnvironmentVariable(Name), '',
+           'precondition: this env var is genuinely unset');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${' + Name + '}"}'),
+           '{"k":"${' + Name + '}"}',
+           'unset env: literal ${VAR_NAME} preserved so operator can diagnose');
+end;
+
+procedure TestNoMarkersIsIdentity;
+begin
+  AssertEq(ExpandEnvVarsInJSON(''), '',
+           'empty input -> empty output');
+  AssertEq(ExpandEnvVarsInJSON('{"key":"plain string"}'),
+           '{"key":"plain string"}',
+           'no markers -> identity');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"contains $ literal"}'),
+           '{"k":"contains $ literal"}',
+           'lone $ not followed by { -> identity');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${ }"}'),
+           '{"k":"${ }"}',
+           'malformed marker (space inside) -> preserved');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${UNCLOSED_VAR"}'),
+           '{"k":"${UNCLOSED_VAR"}',
+           'missing closing brace -> preserved');
+end;
+
+procedure TestCaseSensitiveAndCharsetRules;
+const
+  Lower = 'pasclaw_lower_should_not_match_a4f9';
+  Mixed = 'PasClaw_Mixed_Case_Should_Not_Match_a4f9';
+begin
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${' + Lower + '}"}'),
+           '{"k":"${' + Lower + '}"}',
+           'lowercase name does NOT match (uppercase-only per openclaw)');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${' + Mixed + '}"}'),
+           '{"k":"${' + Mixed + '}"}',
+           'mixed-case name does NOT match (first char lowercase fails the rule)');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${1STARTS_WITH_DIGIT}"}'),
+           '{"k":"${1STARTS_WITH_DIGIT}"}',
+           'name starting with digit does NOT match (first char must be A-Z or _)');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${WITH-DASH}"}'),
+           '{"k":"${WITH-DASH}"}',
+           'name containing - does NOT match (- not in [A-Z0-9_])');
+end;
+
+procedure TestEnvModeSubstitution;
+(* --env-mode pass. Makefile sets PASCLAW_CONFIG_TEST_VAR_A4F9 to a
+   known value before launch so we can observe the actual splicing
+   behaviour through GetEnvironmentVariable (which sees envp the
+   process started with). *)
+const
+  Name     = 'PASCLAW_CONFIG_TEST_VAR_A4F9';
+  Expected = 'hello-from-env-aaaaaaaa';
+begin
+  AssertEq(GetEnvironmentVariable(Name), Expected,
+           'precondition: Makefile set the fixture env var to the expected value');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"${' + Name + '}"}'),
+           '{"k":"hello-from-env-aaaaaaaa"}',
+           'simple substitution: ${VAR} -> value');
+  AssertEq(ExpandEnvVarsInJSON('{"k":"prefix-${' + Name + '}-suffix"}'),
+           '{"k":"prefix-hello-from-env-aaaaaaaa-suffix"}',
+           'mid-string substitution: prefix-${VAR}-suffix');
+  AssertEq(ExpandEnvVarsInJSON('{"a":"${' + Name + '}","b":"${' + Name + '}"}'),
+           '{"a":"hello-from-env-aaaaaaaa","b":"hello-from-env-aaaaaaaa"}',
+           'multiple occurrences in same body each expand');
+  AssertEq(ExpandEnvVarsInJSON('{"deep":{"nested":{"k":"${' + Name + '}"}}}'),
+           '{"deep":{"nested":{"k":"hello-from-env-aaaaaaaa"}}}',
+           'works inside nested objects (raw-text substitution doesn''t care about depth)');
+end;
+
+procedure TestEnvModeJsonEscaping;
+(* --env-mode pass continued. Makefile sets
+   PASCLAW_CONFIG_TRICKY_VAR_A4F9 to `hello"world\backslash` (single-
+   quoted in the shell so the " and \ stay literal). After splicing
+   we expect the JSON body to be `{"k":"hello\"world\\backslash"}`
+   -- the `"` escapes to `\"` and the `\` escapes to `\\`. *)
+const
+  Name = 'PASCLAW_CONFIG_TRICKY_VAR_A4F9';
+  { Pascal string literals do NOT interpret backslash sequences, so
+    every \ below is a literal backslash byte and every " inside
+    the single-quoted string is a literal quote. }
+  ExpectedEscaped = 'hello\"world\\backslash';
+var
+  Got: string;
+begin
+  AssertTrue(GetEnvironmentVariable(Name) <> '',
+             'precondition: tricky env var inherited from Makefile');
+  Got := ExpandEnvVarsInJSON('{"k":"${' + Name + '}"}');
+  AssertEq(Got, '{"k":"' + ExpectedEscaped + '"}',
+           'JSON-special bytes in env value get escaped (\" and \\)');
+end;
+
+procedure TestRoundTripWithEmptyConfig;
+(* TConfig.FromJSON(ExpandEnvVarsInJSON(empty-with-markers)) must
+   not crash. An unset marker leaves the literal ${VAR} in the
+   string field, which FromJSON treats as a normal string. *)
+var
+  Cfg: TConfig;
+begin
+  Cfg := TConfig.Create;
+  try
+    Cfg.FromJSON(ExpandEnvVarsInJSON(
+      '{"providers":[{"name":"anthropic","api_key":"${UNRELATED_UNSET_VAR_a4f9}"}]}'));
+    AssertTrue(Length(Cfg.Providers) = 1,
+               'unresolved marker still parses as a string field; providers[0] exists');
+    AssertEq(Cfg.Providers[0].APIKey,
+             '${UNRELATED_UNSET_VAR_a4f9}',
+             'unresolved marker stays in the string verbatim');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+begin
+  if (ParamCount >= 1) and (ParamStr(1) = '--env-mode') then
+  begin
+    TestEnvModeSubstitution;
+    WriteLn('  ok: env-mode -- ${VAR} expands inside string values (simple, mid-string, multiple, nested)');
+    TestEnvModeJsonEscaping;
+    WriteLn('  ok: env-mode -- JSON-special bytes in env values get escaped so the body stays valid JSON');
+    WriteLn('PASS');
+    Exit;
+  end;
+
+  TestUnsetEnvLeavesLiteral;
+  WriteLn('  ok: unset env: literal ${VAR_NAME} preserved (operator can diagnose by reading config back)');
+  TestNoMarkersIsIdentity;
+  WriteLn('  ok: no markers / malformed markers: input passes through verbatim');
+  TestCaseSensitiveAndCharsetRules;
+  WriteLn('  ok: pattern is ${[A-Z_][A-Z0-9_]*} (case-sensitive, no -, no digit-first)');
+  TestRoundTripWithEmptyConfig;
+  WriteLn('  ok: TConfig.FromJSON tolerates unresolved markers as plain string values');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## Summary

Adds openclaw-style `${VAR_NAME}` environment-variable substitution inside `config.json` string values. Any uppercase env var name wrapped in `${...}` resolves at `LoadConfig` time to the env value (JSON-escaped on the fly). Lets operators keep API keys, bearer tokens, and webhook URLs in the environment and reference them by name from `config.json` the same way openclaw does.

```json
{
  "providers": [
    { "name": "anthropic",
      "kind": "anthropic",
      "api_key": "${ANTHROPIC_API_KEY}",
      "model":   "claude-opus-4-7" }
  ],
  "gateway": { "token": "${PASCLAW_GATEWAY_TOKEN}" },
  "channels": [
    { "name":   "ops",
      "kind":   "discord",
      "target": "${OPS_DISCORD_WEBHOOK}" }
  ]
}
```

## Pattern

`${[A-Z_][A-Z0-9_]*}` — matches openclaw exactly:

- Uppercase only. `${api_key}` does NOT match.
- First character must be `A-Z` or `_`. `${1FOO}` does NOT match.
- Subsequent allow digits. `${FOO_42}` does match if `FOO_42` is set.
- No dashes. `${WITH-DASH}` does NOT match.

## Behaviour

- **Set env var** → spliced in, JSON-escaping any `"`, `\`, or control byte so the body stays valid JSON regardless of what the operator put in the env.
- **Unset (or set-but-empty) env var** → literal `${VAR_NAME}` left in place in the parsed string field. Deliberate diagnostic — `pasclaw config show` then prints the unresolved marker so the operator can see exactly which variable didn't resolve. No abort, no error.
- **Round-trip caveat** — substitution is NOT preserved through `SaveConfig`. A config-mutating command (`pasclaw auth login`, `pasclaw model set`, `pasclaw skills install`, ...) writes the resolved value back. For env-only secrets that should never end up in `config.json`, prefer the dedicated env-var paths (`PASCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_TOKEN`) which don't go through string substitution at all. Documented in `docs/configuration.md`.

## Test plan

- [x] `make smoke` — green
- [x] `make test` — full aggregate green (25 PASS markers, was 23)
- [x] `make test-config-env-subst` — 6 cases across two passes:
  - **Clean env pass**: unset env preserves literal; no-marker / malformed-marker input passes through; lowercase / mixed-case / digit-first / dash-containing names rejected; `TConfig.FromJSON` round-trips unresolved markers as plain string values without crashing.
  - **`--env-mode` pass** (fixture vars set by Makefile): simple `${VAR}` substitution; mid-string `prefix-${VAR}-suffix`; multiple occurrences in same body; nested-object substitution; JSON-special bytes (`"` and `\`) in env values get escaped to `\"` and `\\` so the body stays parseable.

## Docs

- `docs/configuration.md` — new `## ${VAR_NAME} environment-variable substitution` section: pattern, examples, behaviour-on-unset, JSON safety, round-trip caveat, the no-escape workaround.
- `docs/gateway.md` — adds a paragraph to the Authentication section pointing operators at the `${...}` path for the gateway token, with the persist-through-SaveConfig caveat.

## Scope

~400 LOC. ~130 in `PasClaw.Config` (helper functions + `LoadConfig` integration), ~190 in tests, ~60 in docs. The implementation deliberately doesn't touch `PasClaw.JSON` — substitution runs as raw text on the JSON body before parsing, keeping the JSON unit a leaf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_