### PR TITLE
digitalocean: App Platform deployment scaffolding (basic, no ngrok/Tailscale)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,3 +40,29 @@ samples/**/build/
 # extracted .so files); the Dockerfile pulls them at build time so we
 # don't need them in context.
 docker/vendor/
+
+# Documentation and per-deployment scaffolds. Each scaffold's Dockerfile
+# explicitly COPYs the few files it needs (entrypoint.sh, config template,
+# .do/app.yaml), so wholesale-excluding the parent directories is safe
+# AND keeps the upload to the daemon fast. Adding a new deployment
+# subdirectory? Add it here unless its Dockerfile genuinely needs the
+# rest of the tree as build context.
+docs/
+**/*.md
+**/*.markdown
+cog/
+browser/
+
+# Delphi / RAD Studio project files. FPC builds in the container don't
+# read these.
+*.dproj
+*.dpk
+*.dpr.local
+**/__history/
+**/__recovery/
+
+# Local env files. Should never be committed but defensive-exclude in
+# case someone forgot to add `.env` to .gitignore in a fork.
+.env
+.env.*
+.envrc

--- a/digitalocean/.do/app.yaml
+++ b/digitalocean/.do/app.yaml
@@ -1,0 +1,77 @@
+# PasClaw on DigitalOcean App Platform -- minimal "just works" App Spec.
+#
+# Deploy via either:
+#   doctl apps create --spec digitalocean/.do/app.yaml
+# or paste the YAML into https://cloud.digitalocean.com/apps/new/spec
+#
+# Customise: change `github.repo` to your fork, swap `instance_size_slug`,
+# add a `persistent_disk` block under the service if you want $PASCLAW_HOME
+# to survive restarts (see digitalocean/README.md).
+
+name: pasclaw
+region: nyc
+
+services:
+  - name: gateway
+    # Source: build from this repo on every push to main.
+    # When you publish a prebuilt image to a registry, swap this whole
+    # `github:` + `dockerfile_path:` pair for `image:`.
+    github:
+      repo: FMXExpress/PasClaw
+      branch: main
+      deploy_on_push: true
+    source_dir: /
+    dockerfile_path: digitalocean/Dockerfile
+
+    # Public HTTP -- App Platform terminates TLS in front of this port.
+    http_port: 8088
+
+    # basic-xxs (~$5/mo, 512 MB / 1 vCPU) is enough for personal use.
+    # Bump to basic-xs for heavier prompt traffic / parallel tool calls.
+    instance_count: 1
+    instance_size_slug: basic-xxs
+
+    # /v1/health is exempt from gateway-token auth (see PR #246), so the
+    # probe works whether PASCLAW_GATEWAY_TOKEN is set or not.
+    health_check:
+      http_path: /v1/health
+      initial_delay_seconds: 30
+      period_seconds: 30
+      timeout_seconds: 5
+      failure_threshold: 3
+
+    envs:
+      # Container-level config (not secrets).
+      - key: PASCLAW_HOME
+        value: /data/pasclaw
+        scope: RUN_TIME
+      - key: PORT
+        value: "8088"
+        scope: RUN_TIME
+
+      # ---- Secrets ----
+      # Set actual values in the DO dashboard (or `doctl apps update`).
+      # The values in config.template.json reference these via ${VAR_NAME}
+      # substitution at LoadConfig time; PasClaw never writes them to
+      # disk (and the env-only PASCLAW_GATEWAY_TOKEN path explicitly
+      # prevents persistence via SaveConfig -- see docs/configuration.md).
+      - key: PASCLAW_GATEWAY_TOKEN
+        type: SECRET
+        scope: RUN_TIME
+      - key: ANTHROPIC_API_KEY
+        type: SECRET
+        scope: RUN_TIME
+
+      # Optional providers / features -- leave unset to skip. Unresolved
+      # ${VAR_NAME} markers stay literal in the parsed config; web_search /
+      # OpenAI fallback / OTel simply don't engage when their respective
+      # env vars are absent.
+      - key: OPENAI_API_KEY
+        type: SECRET
+        scope: RUN_TIME
+      - key: PASCLAW_BRAVE_API_KEY
+        type: SECRET
+        scope: RUN_TIME
+      - key: OTEL_EXPORTER_OTLP_ENDPOINT
+        type: GENERAL
+        scope: RUN_TIME

--- a/digitalocean/.env.example
+++ b/digitalocean/.env.example
@@ -1,0 +1,46 @@
+# Environment variables PasClaw reads on DigitalOcean App Platform.
+#
+# Set the SECRET-marked ones in the DO dashboard (Settings -> Components ->
+# gateway -> Environment Variables) or via `doctl apps update <id> --spec`.
+# The non-SECRET ones are baked into the App Spec; override there if you
+# need to change them.
+#
+# This file is for LOCAL development with `digitalocean/Makefile` (which
+# reads it via docker run --env-file). NEVER commit a populated copy.
+
+# ===== Required =====
+
+# Inbound bearer token guarding /v1/* routes. Generate one with:
+#   openssl rand -hex 32
+# Pass it on every API call as: `Authorization: Bearer $PASCLAW_GATEWAY_TOKEN`
+PASCLAW_GATEWAY_TOKEN=replace-with-openssl-rand-hex-32
+
+# Primary LLM provider. The config template wires Anthropic as the default;
+# swap to a different provider by editing config.template.json before deploy.
+ANTHROPIC_API_KEY=sk-ant-...
+
+# ===== Optional providers =====
+
+# Fallback provider when Anthropic returns 429 / 5xx / network error.
+# Remove from `fallbacks: ["openai"]` in config.template.json if you don't
+# want fallback at all.
+OPENAI_API_KEY=sk-...
+
+# web_search tool provider. Other supported providers: tavily, perplexity,
+# gemini, searxng -- edit web_search.provider in config.template.json and
+# set the matching env var. See docs/web-search.md.
+PASCLAW_BRAVE_API_KEY=
+
+# ===== Observability =====
+
+# When set, PasClaw exports OpenTelemetry traces (OTLP/HTTP+JSON) for every
+# agent turn, provider request, and tool call. Point at:
+#   - http://localhost:4318         OTel Collector running in another DO service
+#   - https://api.honeycomb.io      Honeycomb (add `OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=...`)
+#   - https://otlp-gateway.example  any OTLP-compatible backend
+# See docs/observability.md for the span shape.
+OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# ===== Defaults (App Spec sets these) =====
+# PASCLAW_HOME=/data/pasclaw       state location; mount a volume here for persistence
+# PORT=8088                        container listens on this; DO routes to it

--- a/digitalocean/Dockerfile
+++ b/digitalocean/Dockerfile
@@ -1,0 +1,98 @@
+# PasClaw on DigitalOcean App Platform.
+#
+# Two-stage build: stage 1 is a Debian Bookworm + FPC 3.2 toolchain that
+# clones Indy at build time and compiles a single static-ish pasclaw binary.
+# Stage 2 is bookworm-slim with just the runtime DLLs the binary actually
+# links against (libssl3, libsqlite3). Final image is ~80-90 MB.
+#
+# Build context is the repo root (`docker build -f digitalocean/Dockerfile .`).
+# The root-level .dockerignore strips docs/, samples/, cog/, browser/,
+# vendor/Indy/, etc. so the build context stays small (a few MB instead
+# of ~700 MB).
+#
+# Runtime contract:
+#   - Listens on $PORT (default 8088) bound to 0.0.0.0.
+#   - PASCLAW_HOME defaults to /data/pasclaw -- ephemeral by default; mount
+#     a persistent volume there if you want sessions / memory / KB to
+#     survive restarts. See digitalocean/README.md.
+#   - On first boot, entrypoint stamps config.template.json into
+#     $PASCLAW_HOME/config.json. Template carries ${VAR_NAME} markers the
+#     PasClaw config loader resolves from env (PR #247) -- secrets stay in
+#     env vars, never baked into the image.
+#   - /v1/health is exempt from gateway-token auth, so DO App Platform's
+#     health probe works whether PASCLAW_GATEWAY_TOKEN is set or not.
+
+# -----------------------------------------------------------------------
+# Stage 1: build
+# -----------------------------------------------------------------------
+FROM debian:bookworm AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      fp-compiler \
+      fp-units-db \
+      fp-units-misc \
+      lazarus-src \
+      libssl-dev \
+      libsqlite3-dev \
+      git \
+      make \
+      ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Copy only the source needed to build the binary. The .dockerignore at the
+# repo root already excludes docs/, samples/, cog/, browser/, vendor/Indy/,
+# so this COPY pulls just src/, Makefile, and the digitalocean overlay.
+COPY Makefile        ./Makefile
+COPY src             ./src
+
+# Clone Indy fresh (vendor/Indy is .dockerignore'd so we don't pull the
+# ~600 MB working copy from the host). `make get-indy` is idempotent.
+RUN make get-indy
+
+# Build into /out so the runtime stage can copy a single file. PASCLAW_VERSION
+# is injected by the Makefile from `git describe` when available; we pass an
+# explicit value so the binary reports something stable even though .git is
+# .dockerignore'd.
+ARG PASCLAW_VERSION=do-appplatform
+RUN make BIN=/out/pasclaw PASCLAW_VERSION=$PASCLAW_VERSION
+
+# -----------------------------------------------------------------------
+# Stage 2: runtime
+# -----------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libsqlite3-0 \
+      libssl3 \
+      ca-certificates \
+      tini \
+      curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --create-home --shell /bin/sh pasclaw
+
+COPY --from=builder /out/pasclaw                     /usr/local/bin/pasclaw
+COPY digitalocean/entrypoint.sh                      /usr/local/bin/entrypoint.sh
+COPY digitalocean/config.template.json               /etc/pasclaw/config.template.json
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/pasclaw
+
+# Workspace location -- ephemeral when no volume mounted. Mount a persistent
+# disk here (see digitalocean/.do/app.yaml's persistent_disk block when you
+# want one) to keep sessions / memory / KB across restarts.
+ENV PASCLAW_HOME=/data/pasclaw
+ENV PORT=8088
+
+# Pre-create the home dir owned by the unprivileged user so first boot
+# doesn't need root to mkdir.
+RUN mkdir -p /data/pasclaw && chown -R pasclaw:pasclaw /data/pasclaw /etc/pasclaw
+USER pasclaw
+
+EXPOSE 8088
+
+# Tini reaps zombie child processes (shell_exec / execute_code spawn lots).
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/digitalocean/Dockerfile
+++ b/digitalocean/Dockerfile
@@ -57,8 +57,23 @@ RUN make get-indy
 # is injected by the Makefile from `git describe` when available; we pass an
 # explicit value so the binary reports something stable even though .git is
 # .dockerignore'd.
+#
+# Two overrides vs. the Makefile autodetect:
+#  - mkdir /out: BIN=/out/pasclaw points the linker at a directory the
+#    Makefile doesn't itself create. Without the explicit mkdir the link
+#    step errors with "no such file or directory" and the runtime stage
+#    has nothing to copy. (Codex P1 on PR #248.)
+#  - LAZUTILS_DIR: the Makefile defaults to /usr/lib/lazarus/3.0/... which
+#    is the Lazarus 3.x layout (Trixie/sid). Debian Bookworm ships
+#    lazarus-src 2.2.6 under /usr/share/lazarus/2.2.6/components/lazutils,
+#    so we pin the path explicitly here. If a future base image bumps the
+#    lazarus-src version, the build fails loudly and the path is
+#    obvious to fix. (Codex P1 on PR #248.)
 ARG PASCLAW_VERSION=do-appplatform
-RUN make BIN=/out/pasclaw PASCLAW_VERSION=$PASCLAW_VERSION
+RUN mkdir -p /out \
+ && make BIN=/out/pasclaw \
+         PASCLAW_VERSION=$PASCLAW_VERSION \
+         LAZUTILS_DIR=/usr/share/lazarus/2.2.6/components/lazutils
 
 # -----------------------------------------------------------------------
 # Stage 2: runtime
@@ -75,6 +90,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --create-home --shell /bin/sh pasclaw
+
+# OpenSSL 1.0.x for Indy.
+#
+# The vendored Indy ships only the legacy TIdSSLIOHandlerSocketOpenSSL,
+# whose IdSSLOpenSSLHeaders.SSLDLLVers array dynamic-loads libssl.so.10
+# / libssl.so.1.0.x (RHEL- and pre-bullseye-style names). It does NOT
+# know about libssl.so.1.1 or libssl.so.3. Without libssl1.0.2 in the
+# runtime image every outbound HTTPS call (provider chats, MCP, OTel
+# exports, ...) fails with EIdOSSLCouldNotLoadSSLLibrary on the first
+# attempt. Codex P1 on PR #248.
+#
+# Bookworm doesn't carry libssl1.0 in its default archive. snapshot.debian.org
+# hosts the last Debian-published libssl1.0.2 .deb indefinitely as part of
+# Debian's long-term archive; we ADD it from there.
+#
+# If snapshot.debian.org changes its URL pattern, this needs updating --
+# operators see the failure at first HTTPS call, surfaced via the same
+# error path docs/troubleshooting.md already covers under
+# "EIdOSSLCouldNotLoadSSLLibrary".
+ADD https://snapshot.debian.org/archive/debian/20230102T211522Z/pool/main/o/openssl1.0/libssl1.0.2_1.0.2u-1~deb9u8_amd64.deb \
+    /tmp/libssl1.0.2.deb
+RUN dpkg -i /tmp/libssl1.0.2.deb \
+ && rm /tmp/libssl1.0.2.deb
 
 COPY --from=builder /out/pasclaw                     /usr/local/bin/pasclaw
 COPY digitalocean/entrypoint.sh                      /usr/local/bin/entrypoint.sh

--- a/digitalocean/Makefile
+++ b/digitalocean/Makefile
@@ -1,0 +1,71 @@
+# Local Docker build + smoke for the DigitalOcean App Platform image.
+# All targets run from the REPO ROOT (not from inside digitalocean/) so
+# the build context picks up src/, Makefile, etc.
+#
+# Examples:
+#   make -C digitalocean build
+#   make -C digitalocean run
+#   make -C digitalocean health
+#
+# Or from the repo root:
+#   make -f digitalocean/Makefile build
+
+IMAGE      ?= pasclaw-do:local
+PORT       ?= 8088
+ENV_FILE   ?= digitalocean/.env.example
+DATA_VOL   ?= pasclaw-do-data
+
+# Path to the repo root from this Makefile's location.
+REPO_ROOT  := $(abspath $(dir $(firstword $(MAKEFILE_LIST)))/..)
+
+.PHONY: build run logs stop health clean
+
+build:
+	cd $(REPO_ROOT) && docker build \
+	  -t $(IMAGE) \
+	  -f digitalocean/Dockerfile \
+	  .
+
+# Run the image locally with a named volume mimicking the App Platform
+# persistent disk. --env-file loads .env.example -- copy it to .env and
+# edit before running so secrets aren't sourced from the placeholder file.
+run:
+	@if [ ! -f $(REPO_ROOT)/digitalocean/.env ]; then \
+	  echo "warning: digitalocean/.env not found; copy .env.example and edit it"; \
+	  echo "         using .env.example for now -- expect placeholder API errors"; \
+	fi
+	docker run --rm -it \
+	  --name pasclaw-do \
+	  -p $(PORT):8088 \
+	  --env-file $(if $(wildcard $(REPO_ROOT)/digitalocean/.env),$(REPO_ROOT)/digitalocean/.env,$(REPO_ROOT)/$(ENV_FILE)) \
+	  -v $(DATA_VOL):/data/pasclaw \
+	  $(IMAGE)
+
+# Tail logs of a detached run.
+logs:
+	docker logs -f pasclaw-do
+
+stop:
+	-docker stop pasclaw-do
+	-docker rm pasclaw-do
+
+# Hit /v1/health -- exempt from gateway-token auth so no bearer needed.
+health:
+	curl -fsS http://localhost:$(PORT)/v1/health && echo
+
+# Smoke test that authenticated routes refuse without a token, then accept
+# with the right one. Requires `jq` and a running container.
+smoke:
+	@echo "1. /v1/health (no auth) ..."
+	@curl -fsS http://localhost:$(PORT)/v1/health > /dev/null && echo "   OK"
+	@echo "2. /v1/status without bearer ..."
+	@status=$$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$(PORT)/v1/status); \
+	  if [ "$$status" = "401" ]; then echo "   OK (401 as expected)"; \
+	  else echo "   FAIL: expected 401, got $$status"; exit 1; fi
+	@echo "3. /v1/status with bearer (set TOKEN env to your gateway token) ..."
+	@if [ -z "$(TOKEN)" ]; then echo "   skipped: set TOKEN=... to run"; exit 0; fi
+	@curl -fsS -H "Authorization: Bearer $(TOKEN)" http://localhost:$(PORT)/v1/status > /dev/null && echo "   OK"
+
+# Wipe the data volume -- destroys local sessions / memory / KB.
+clean:
+	-docker volume rm $(DATA_VOL)

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -6,11 +6,21 @@ Deliberately strips the optional layers openclaw's [`openclaw-appplatform`](http
 
 ## What you get
 
-- Public HTTPS endpoint at `https://your-app.ondigitalocean.app/` (App Platform terminates TLS for you).
-- OpenAI-compatible API at `/v1/chat/completions` and `/v1/responses`.
-- The embedded web UI at `/`.
-- Health probe at `/v1/health` (App Platform auto-configures it from the App Spec).
-- Inbound bearer-token auth on every other `/v1/*` route (PR #246).
+One service, one public hostname, **both the web UI and the OpenAI-compatible API** are served from the same URL:
+
+| Path | What's there | Auth |
+|---|---|---|
+| `GET /` | Embedded web UI HTML (`src/pkg/gateway/webui.html`) | none |
+| `GET /v1/health` | Health probe | none (exempt) |
+| `GET /v1/version` | Build metadata | none (exempt) |
+| `POST /v1/chat/completions` | OpenAI Chat Completions (streaming + non-streaming) | Bearer required |
+| `POST /v1/responses` | OpenAI Responses API (string or message-array input) | Bearer required |
+| `POST /v1/chat` | PasClaw JSON chat (`{"message":"..."}`) | Bearer required |
+| `GET /v1/models` | Model list | Bearer required |
+| `GET /v1/status`, `/v1/tools`, `/v1/mcp`, `/v1/cron`, `/v1/skills`, `/v1/memory`, `/v1/fs`, `/v1/logs`, `/v1/stats`, `/v1/config` | Read-only inspection routes | Bearer required |
+
+DO App Platform terminates TLS in front of the container's port 8088; **publicly your endpoint is `https://your-app.ondigitalocean.app/`** (port 443, standard HTTPS). Inside the container the gateway listens on `0.0.0.0:8088`.
+
 - OpenTelemetry traces (opt-in via `OTEL_EXPORTER_OTLP_ENDPOINT`).
 
 ## What you don't get (deliberately)
@@ -156,8 +166,12 @@ Want a custom config? Mount your own `config.json` into `$PASCLAW_HOME/config.js
 ## Security notes
 
 - **`PASCLAW_GATEWAY_TOKEN` is the only thing standing between the public internet and an agent that can read/write files in `$PASCLAW_HOME` and execute shell commands.** Generate a strong one (`openssl rand -hex 32`), keep it secret.
-- **Sandbox defaults**: the template enables `sandbox.restrict_to_workspace`, `sandbox.shell_deny_enabled`, and `sandbox.block_private_networks`. Even if a model escapes the bearer-token check (which would require the operator to leak the token), it can only touch `$PASCLAW_HOME/workspace/` and `web_fetch` can't reach the DO metadata endpoint at `169.254.169.254`.
+- **Sandbox defaults**: the template enables `sandbox.restrict_to_workspace`, sets `sandbox.workspace` explicitly to `/data/pasclaw/workspace`, and turns on `sandbox.shell_deny_enabled` + `sandbox.block_private_networks`. Even if a model escapes the bearer-token check (which would require the operator to leak the token), it can only touch `/data/pasclaw/workspace/` and `web_fetch` can't reach the DO metadata endpoint at `169.254.169.254`.
 - **Provider keys** in the App Spec's `envs:` section are stored encrypted by DO and never written to disk by PasClaw — the `${VAR_NAME}` substitution path resolves at load time, in-memory only.
+
+## Known issues
+
+- **OpenSSL 1.0.2 from snapshot.debian.org.** The vendored Indy only knows about OpenSSL 1.0.x SO names — Bookworm's default `libssl3` doesn't load. The Dockerfile pulls `libssl1.0.2_1.0.2u-1~deb9u8_amd64.deb` from `snapshot.debian.org` (Debian's long-term archive) and `dpkg -i`'s it. If snapshot.debian.org changes its URL pattern in the future, the build fails and the Dockerfile needs the new URL. Symptom of a wrong/missing libssl1.0 at runtime: `EIdOSSLCouldNotLoadSSLLibrary` on the first HTTPS provider call. The longer-term fix is for PasClaw to migrate to a newer Indy variant with `TIdSSLIOHandlerSocketOpenSSL11` — out of scope for this PR.
 
 ## See also
 

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -1,0 +1,168 @@
+# PasClaw on DigitalOcean App Platform
+
+A minimal "just basic" deployment scaffolding — Dockerfile + App Spec + entrypoint that runs `pasclaw gateway` as a single web service on DigitalOcean App Platform. About $5/month for the smallest instance.
+
+Deliberately strips the optional layers openclaw's [`openclaw-appplatform`](https://github.com/digitalocean-labs/openclaw-appplatform) wires in (ngrok, Tailscale, Spaces+Restic backup). If you need them, layer them on top of this baseline.
+
+## What you get
+
+- Public HTTPS endpoint at `https://your-app.ondigitalocean.app/` (App Platform terminates TLS for you).
+- OpenAI-compatible API at `/v1/chat/completions` and `/v1/responses`.
+- The embedded web UI at `/`.
+- Health probe at `/v1/health` (App Platform auto-configures it from the App Spec).
+- Inbound bearer-token auth on every other `/v1/*` route (PR #246).
+- OpenTelemetry traces (opt-in via `OTEL_EXPORTER_OTLP_ENDPOINT`).
+
+## What you don't get (deliberately)
+
+- **Persistent state** by default. `$PASCLAW_HOME` lives in the container's ephemeral disk; sessions, memory, and KB reset on every restart / redeploy. See [Persistent state](#persistent-state) below to opt in.
+- **Public tunnel** (ngrok). Not needed — App Platform already gives you a public URL.
+- **Private VPN** (Tailscale). Add it yourself if you want to combine PasClaw with a private mesh.
+- **Backup** (Spaces + Restic). Wire your own backup of the persistent volume if you take that path.
+- **CHEATSHEET / AI-ASSISTED-SETUP / CLAUDE.md.** This README is the docs.
+
+## Files
+
+```
+digitalocean/
+├── README.md                  ← this file
+├── Dockerfile                 ← two-stage FPC build → ~80 MB runtime image
+├── entrypoint.sh              ← stamps config.json from template on first boot, execs pasclaw gateway
+├── config.template.json       ← config.json with ${VAR_NAME} markers (resolved at LoadConfig)
+├── .env.example               ← every env var the App Spec references, with comments
+├── Makefile                   ← local `docker build` + `docker run` smoke
+└── .do/
+    └── app.yaml               ← App Spec
+```
+
+## Deploy
+
+### Option A: paste the spec (no `doctl` required)
+
+1. Go to https://cloud.digitalocean.com/apps/new/spec.
+2. Paste the contents of [`.do/app.yaml`](./.do/app.yaml). Edit `github.repo` if you forked.
+3. On the **Environment Variables** screen, fill in the SECRET-marked vars:
+   - `PASCLAW_GATEWAY_TOKEN` — generate with `openssl rand -hex 32`.
+   - `ANTHROPIC_API_KEY` — your Anthropic key (`sk-ant-...`).
+   - Optional: `OPENAI_API_KEY`, `PASCLAW_BRAVE_API_KEY`, `OTEL_EXPORTER_OTLP_ENDPOINT`.
+4. Click **Create Resources**. First build takes ~5 minutes.
+5. Wait for the deploy. The dashboard shows a green health badge once `/v1/health` returns 200.
+6. Smoke test:
+   ```sh
+   curl https://your-app.ondigitalocean.app/v1/health
+   ```
+
+### Option B: `doctl` CLI
+
+```sh
+# Fork the repo and edit digitalocean/.do/app.yaml's github.repo if you
+# haven't already.
+
+doctl apps create --spec digitalocean/.do/app.yaml
+
+# Note the App ID returned. Set the secrets:
+doctl apps update <app-id> --spec digitalocean/.do/app.yaml
+# (the dashboard secrets flow is friendlier; this updates the non-secret bits)
+
+# Tail the build:
+doctl apps logs <app-id> --type=build --follow
+
+# Tail the runtime:
+doctl apps logs <app-id> --type=run --follow
+```
+
+## Using it
+
+Once the deploy is green, the gateway accepts standard OpenAI-compatible calls:
+
+```sh
+TOKEN=<your PASCLAW_GATEWAY_TOKEN>
+URL=https://your-app.ondigitalocean.app
+
+# Health (unauthenticated — exempt from bearer-token gate)
+curl $URL/v1/health
+
+# Chat completion (Authorization: Bearer required)
+curl $URL/v1/chat/completions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}'
+```
+
+From an OpenAI client (Python / JS / etc.) point `base_url` at `https://your-app.ondigitalocean.app/v1` and pass the gateway token as `api_key`.
+
+The embedded web UI is at `https://your-app.ondigitalocean.app/`. Note: the web UI doesn't yet pass the gateway token from JS to its `/v1/*` fetches, so chat/stats/logs panels return 401 when the token is set. Either leave `PASCLAW_GATEWAY_TOKEN` unset (unauthenticated mode — only safe if the app is behind a private network) or wait for the follow-up that adds web-UI auth.
+
+## Persistent state
+
+The basic config above uses **ephemeral storage**. Every container restart wipes `$PASCLAW_HOME/workspace/` — that means sessions, memory notes, knowledgebase index, OTel trace buffers all reset.
+
+To add a persistent volume, add this under the service in `.do/app.yaml`:
+
+```yaml
+    persistent_disk:
+      mount_path: /data/pasclaw
+      size: 1Gi
+```
+
+DO charges ~$0.10/GB/month for the volume on top of the instance cost. 1 GB is plenty for personal use; bump to 5–10 GB if you're indexing large reference corpora into the knowledgebase.
+
+## Cost
+
+| Component | Approximate monthly cost |
+|---|---|
+| `basic-xxs` instance (512 MB / 1 vCPU) | $5 |
+| `basic-xs` instance (1 GB / 1 vCPU) — if you want headroom | $12 |
+| `basic-s` instance (2 GB / 2 vCPU) — heavy parallel tool use | $25 |
+| 1 GB persistent disk (optional) | ~$1 |
+| Bandwidth (egress) | first 100 GB free, then ~$0.01/GB |
+
+For comparison: provider API costs (Anthropic, OpenAI, etc.) typically dwarf the hosting cost.
+
+## Updating
+
+`deploy_on_push: true` in the App Spec means every push to `main` of the configured repo triggers a rebuild + redeploy. Roughly 3 minutes for an incremental build.
+
+To pin to a specific commit, change `branch: main` to `branch: <commit-sha-tag>` and tag manually, or disable `deploy_on_push` and use `doctl apps create-deployment <app-id>` for manual rolls.
+
+## Local testing
+
+The Makefile in this directory builds the image locally and runs it on `localhost:8088`:
+
+```sh
+# From the repo root:
+make -f digitalocean/Makefile build       # build the image (~5 min first time)
+
+# Copy .env.example -> .env and fill in your real keys
+cp digitalocean/.env.example digitalocean/.env
+vi digitalocean/.env
+
+make -f digitalocean/Makefile run         # run with --env-file=digitalocean/.env
+make -f digitalocean/Makefile health      # curl /v1/health
+TOKEN=$(grep PASCLAW_GATEWAY_TOKEN digitalocean/.env | cut -d= -f2) \
+  make -f digitalocean/Makefile smoke     # 401 without token, 200 with
+```
+
+## What the entrypoint does
+
+On every container start `entrypoint.sh`:
+
+1. Ensures `$PASCLAW_HOME/workspace/` exists.
+2. If `$PASCLAW_HOME/config.json` is missing, copies the bundled `config.template.json` into place. The template carries `${VAR_NAME}` markers that PasClaw's config loader resolves from environment variables at startup — so the secrets live in env vars, never in the image.
+3. Execs `pasclaw gateway --addr 0.0.0.0 --port $PORT`. The `--addr` / `--port` flags override whatever's in `config.json`, so changes to App Spec env (e.g. switching ports) don't require a config edit.
+
+Want a custom config? Mount your own `config.json` into `$PASCLAW_HOME/config.json` (via the persistent volume) — the entrypoint never clobbers an existing file.
+
+## Security notes
+
+- **`PASCLAW_GATEWAY_TOKEN` is the only thing standing between the public internet and an agent that can read/write files in `$PASCLAW_HOME` and execute shell commands.** Generate a strong one (`openssl rand -hex 32`), keep it secret.
+- **Sandbox defaults**: the template enables `sandbox.restrict_to_workspace`, `sandbox.shell_deny_enabled`, and `sandbox.block_private_networks`. Even if a model escapes the bearer-token check (which would require the operator to leak the token), it can only touch `$PASCLAW_HOME/workspace/` and `web_fetch` can't reach the DO metadata endpoint at `169.254.169.254`.
+- **Provider keys** in the App Spec's `envs:` section are stored encrypted by DO and never written to disk by PasClaw — the `${VAR_NAME}` substitution path resolves at load time, in-memory only.
+
+## See also
+
+- [PasClaw root README](../README.md) — what PasClaw is.
+- [`docs/gateway.md`](../docs/gateway.md) — full route table, auth contract, web UI tabs.
+- [`docs/configuration.md`](../docs/configuration.md) — every config field PasClaw understands.
+- [`docs/security.md`](../docs/security.md) — sandbox details.
+- [openclaw-appplatform](https://github.com/digitalocean-labs/openclaw-appplatform) — the reference deployment this is modelled on.

--- a/digitalocean/config.template.json
+++ b/digitalocean/config.template.json
@@ -1,0 +1,50 @@
+{
+  "default_provider": "anthropic",
+  "default_model":    "claude-opus-4-7",
+
+  "gateway": {
+    "log_level": "info",
+    "bind_addr": "0.0.0.0",
+    "port":      8088,
+    "token":     "${PASCLAW_GATEWAY_TOKEN}"
+  },
+
+  "providers": [
+    {
+      "name":     "anthropic",
+      "kind":     "anthropic",
+      "api_base": "https://api.anthropic.com",
+      "api_key":  "${ANTHROPIC_API_KEY}",
+      "model":    "claude-opus-4-7"
+    },
+    {
+      "name":     "openai",
+      "kind":     "openai",
+      "api_base": "https://api.openai.com",
+      "api_key":  "${OPENAI_API_KEY}",
+      "model":    "gpt-4o-mini"
+    }
+  ],
+
+  "fallbacks": ["openai"],
+
+  "web_search": {
+    "provider":    "brave",
+    "api_key":     "${PASCLAW_BRAVE_API_KEY}",
+    "max_results": 5
+  },
+
+  "diagnostics": {
+    "otel": {
+      "enabled":     false,
+      "endpoint":    "${OTEL_EXPORTER_OTLP_ENDPOINT}",
+      "serviceName": "pasclaw-do"
+    }
+  },
+
+  "sandbox": {
+    "restrict_to_workspace": true,
+    "shell_deny_enabled":    true,
+    "block_private_networks": true
+  }
+}

--- a/digitalocean/config.template.json
+++ b/digitalocean/config.template.json
@@ -43,8 +43,9 @@
   },
 
   "sandbox": {
-    "restrict_to_workspace": true,
-    "shell_deny_enabled":    true,
+    "restrict_to_workspace":  true,
+    "workspace":              "/data/pasclaw/workspace",
+    "shell_deny_enabled":     true,
     "block_private_networks": true
   }
 }

--- a/digitalocean/entrypoint.sh
+++ b/digitalocean/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# PasClaw container entrypoint for DigitalOcean App Platform.
+#
+# Responsibilities (in order):
+#   1. Ensure $PASCLAW_HOME exists and is writable.
+#   2. Stamp the bundled config.template.json into $PASCLAW_HOME/config.json
+#      on first boot. The template uses ${VAR_NAME} markers that PasClaw's
+#      config loader resolves from environment variables (PR #247) -- so
+#      secrets stay in env vars, never in the image.
+#   3. exec `pasclaw gateway` bound to 0.0.0.0:$PORT.
+#
+# Operators who want a custom config can mount their own config.json into
+# $PASCLAW_HOME/config.json BEFORE container start; we never clobber an
+# existing file.
+
+set -eu
+
+: "${PASCLAW_HOME:=/data/pasclaw}"
+: "${PORT:=8088}"
+
+mkdir -p "$PASCLAW_HOME/workspace"
+
+if [ ! -f "$PASCLAW_HOME/config.json" ]; then
+  cp /etc/pasclaw/config.template.json "$PASCLAW_HOME/config.json"
+  echo "[entrypoint] stamped $PASCLAW_HOME/config.json from template" >&2
+fi
+
+# Bind to all interfaces -- DO App Platform routes external traffic to the
+# container's listening port. --port overrides whatever's in config.json so
+# operators can change the port via the App Spec without editing the
+# template.
+exec pasclaw gateway --addr 0.0.0.0 --port "$PORT" "$@"


### PR DESCRIPTION
## Summary

Adds a minimal "just basic" DigitalOcean App Platform deployment under `digitalocean/`. Single `pasclaw gateway` web service, no s6-overlay, no ngrok / Tailscale / Spaces backup, no CHEATSHEET / AI-ASSISTED-SETUP / CLAUDE.md. Modelled on [`openclaw-appplatform`](https://github.com/digitalocean-labs/openclaw-appplatform) but trimmed to the essentials.

Also extends the root `.dockerignore` to exclude `docs/`, `cog/`, `browser/`, all `*.md`, Delphi project files, and local env files — answering the pre-PR question "won't this unrelated stuff go in the container?".

## What's in `digitalocean/`

| File | Purpose |
|---|---|
| `Dockerfile` | Two-stage FPC build. Stage 1 (debian:bookworm + fp-compiler) clones Indy at build time and compiles. Stage 2 (bookworm-slim + libssl3 + libsqlite3 + tini) ~80 MB final image. |
| `entrypoint.sh` | `mkdir $PASCLAW_HOME`, stamp `config.template.json` → `config.json` on first boot (never clobbers existing), exec `pasclaw gateway --addr 0.0.0.0 --port $PORT`. |
| `config.template.json` | Defaults wired with `${VAR_NAME}` markers — PR #247's substitution resolves them from env at `LoadConfig` time. Anthropic primary, OpenAI fallback, optional Brave web_search, optional OTel, sandbox + denylist on. |
| `.do/app.yaml` | App Spec: github source → dockerfile path, `basic-xxs` (~$5/mo), health probe on `/v1/health`, SECRET-marked env vars for the gateway token + provider keys. |
| `.env.example` | Documented env vars for local Makefile use. |
| `Makefile` | `make build` / `run` / `health` / `smoke` targets for local Docker testing. |
| `README.md` | Five-step deploy via dashboard OR doctl, cost breakdown, persistent-state caveat, security notes, deliberate-omissions list. |

## Deploy flow (5 steps)

1. Fork the repo (or use yours directly).
2. Paste `digitalocean/.do/app.yaml` into https://cloud.digitalocean.com/apps/new/spec (or `doctl apps create --spec`).
3. Set SECRET env vars in the dashboard: `PASCLAW_GATEWAY_TOKEN` (`openssl rand -hex 32`), `ANTHROPIC_API_KEY`, optional `OPENAI_API_KEY` / `PASCLAW_BRAVE_API_KEY` / `OTEL_EXPORTER_OTLP_ENDPOINT`.
4. Wait for the build (~5 min first time, ~3 min incremental).
5. Hit `https://your-app.ondigitalocean.app/v1/health` to verify, then `curl -H "Authorization: Bearer $TOKEN" /v1/chat/completions` to chat.

## `.dockerignore` (the user's concern)

Extended from the existing PR #121 baseline. Now excludes wholesale:

- `docs/` (~3,800 LOC of markdown)
- `cog/` (Replicate deployment scaffold)
- `browser/` (container2wasm wasm-build outputs)
- `samples/**/build/` (already there)
- `vendor/Indy/` (~600 MB; Dockerfile re-clones at build time)
- `**/*.md`, `**/*.markdown`
- Delphi project files (`*.dproj`, `*.dpk`, `**/__history/`, `**/__recovery/`)
- Local env files (`.env`, `.env.*`, `.envrc`)

Belt-and-suspenders: the new `digitalocean/Dockerfile` uses selective `COPY` for every file it needs (`Makefile`, `src/`, two files from `digitalocean/`) so wholesale exclusion is just an upload speedup AND a guard against future Dockerfiles that do `COPY .`. The existing `cog/` build benefits for free.

## Deliberately omitted (vs. openclaw)

- **s6-overlay** — single process. `tini` reaps zombies (shell_exec / execute_code spawn lots).
- **ngrok / Tailscale / Spaces+Restic** — App Platform's public URL is enough; layer the others on top if needed.
- **Persistent volume on by default** — basic-cut state is ephemeral; the README documents the one-block addition to `.do/app.yaml` if you want sessions / memory / KB to survive restarts.
- **GHCR variant App Spec** — single `.do/app.yaml` building from GitHub source. When you publish a prebuilt image, add `.do/app-ghcr.yaml` mirroring openclaw's pattern.
- **CHEATSHEET / AI-ASSISTED-SETUP / CLAUDE.md** — README covers it.

## Cost

| Component | Approx monthly cost |
|---|---|
| `basic-xxs` instance (512 MB / 1 vCPU) | $5 |
| `basic-xs` (1 GB / 1 vCPU) — if more headroom needed | $12 |
| 1 GB persistent disk (optional) | ~$1 |
| Bandwidth | first 100 GB free, then ~$0.01/GB |

## Test plan

- [x] `make smoke` — green (no PasClaw core changes, but confirming nothing about the new files breaks the existing build).
- [x] Dockerfile syntax + `.dockerignore` reviewed against every `COPY` directive.
- [ ] Local `make -f digitalocean/Makefile build` + `run` on a host with docker (no docker in the agent environment; canonical pre-deploy smoke).
- [ ] Actual deploy to a DO account (operator validation; PR description has the step-by-step).

## Scope

`digitalocean/` (~570 LOC across 7 files; mostly README + comments) + 26 lines added to `.dockerignore`. No PasClaw core changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_