### PR TITLE
digitalocean: move Dockerfile to repo root so DO auto-detect works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-# PasClaw on DigitalOcean App Platform.
+# PasClaw on DigitalOcean App Platform (and any docker-build-aware host).
 #
 # Two-stage build: stage 1 is a Debian Bookworm + FPC 3.2 toolchain that
 # clones Indy at build time and compiles a single static-ish pasclaw binary.
 # Stage 2 is bookworm-slim with just the runtime DLLs the binary actually
-# links against (libssl3, libsqlite3). Final image is ~80-90 MB.
+# links against (libssl1.0 via snapshot.debian.org, libsqlite3). Final
+# image is ~80-90 MB.
 #
-# Build context is the repo root (`docker build -f digitalocean/Dockerfile .`).
-# The root-level .dockerignore strips docs/, samples/, cog/, browser/,
-# vendor/Indy/, etc. so the build context stays small (a few MB instead
-# of ~700 MB).
+# Lives at the repo root (rather than under digitalocean/) so DO App
+# Platform's UI auto-detect picks it up without the operator having to
+# touch the "Source Directory" / "Dockerfile Path" fields. Build context
+# is the repo root; the root-level .dockerignore strips docs/, samples/,
+# cog/, browser/, vendor/Indy/, etc. so the upload to the daemon stays
+# small (a few MB instead of ~700 MB).
 #
 # Runtime contract:
 #   - Listens on $PORT (default 8088) bound to 0.0.0.0.

--- a/digitalocean/.do/app.yaml
+++ b/digitalocean/.do/app.yaml
@@ -21,7 +21,7 @@ services:
       branch: main
       deploy_on_push: true
     source_dir: /
-    dockerfile_path: digitalocean/Dockerfile
+    dockerfile_path: Dockerfile
 
     # Public HTTP -- App Platform terminates TLS in front of this port.
     http_port: 8088

--- a/digitalocean/Makefile
+++ b/digitalocean/Makefile
@@ -23,7 +23,7 @@ REPO_ROOT  := $(abspath $(dir $(firstword $(MAKEFILE_LIST)))/..)
 build:
 	cd $(REPO_ROOT) && docker build \
 	  -t $(IMAGE) \
-	  -f digitalocean/Dockerfile \
+	  -f Dockerfile \
 	  .
 
 # Run the image locally with a named volume mimicking the App Platform

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -34,35 +34,43 @@ DO App Platform terminates TLS in front of the container's port 8088; **publicly
 ## Files
 
 ```
+/                              ← repo root
+└── Dockerfile                 ← lives here (not under digitalocean/) so DO's
+                                  UI auto-detect picks it up with no source-
+                                  directory edits. Build context = repo root,
+                                  COPY paths resolve to src/ / Makefile /
+                                  digitalocean/entrypoint.sh / etc.
+
 digitalocean/
 ├── README.md                  ← this file
-├── Dockerfile                 ← two-stage FPC build → ~80 MB runtime image
 ├── entrypoint.sh              ← stamps config.json from template on first boot, execs pasclaw gateway
 ├── config.template.json       ← config.json with ${VAR_NAME} markers (resolved at LoadConfig)
 ├── .env.example               ← every env var the App Spec references, with comments
 ├── Makefile                   ← local `docker build` + `docker run` smoke
 └── .do/
-    └── app.yaml               ← App Spec
+    └── app.yaml               ← App Spec (source_dir: /, dockerfile_path: Dockerfile)
 ```
 
 ## Deploy
 
-### Option A: paste the spec (no `doctl` required)
+### Option A: DigitalOcean dashboard "Create App" flow (recommended)
 
-1. Go to https://cloud.digitalocean.com/apps/new/spec.
-2. Paste the contents of [`.do/app.yaml`](./.do/app.yaml). Edit `github.repo` if you forked.
-3. On the **Environment Variables** screen, fill in the SECRET-marked vars:
+1. Go to https://cloud.digitalocean.com/apps/new.
+2. **Source:** select GitHub → pick your fork of this repo (or `FMXExpress/PasClaw` if you have access) → branch `main`.
+3. **Resource detection:** leave **Source Directory** blank (or `/`). DO auto-detects the root `Dockerfile`. **Do NOT set Source Directory to `digitalocean`** — that would break the build because the Dockerfile's `COPY Makefile` / `COPY src` lines reference the repo root.
+4. On the **Environment Variables** screen, fill in the SECRET-marked vars:
    - `PASCLAW_GATEWAY_TOKEN` — generate with `openssl rand -hex 32`.
    - `ANTHROPIC_API_KEY` — your Anthropic key (`sk-ant-...`).
    - Optional: `OPENAI_API_KEY`, `PASCLAW_BRAVE_API_KEY`, `OTEL_EXPORTER_OTLP_ENDPOINT`.
-4. Click **Create Resources**. First build takes ~5 minutes.
-5. Wait for the deploy. The dashboard shows a green health badge once `/v1/health` returns 200.
-6. Smoke test:
+   - Also set `PASCLAW_HOME=/data/pasclaw` and `PORT=8088` (non-secret) so the runtime matches the App Spec defaults.
+5. Click **Create Resources**. First build takes ~5 minutes.
+6. Wait for the deploy. The dashboard shows a green health badge once `/v1/health` returns 200.
+7. Smoke test:
    ```sh
    curl https://your-app.ondigitalocean.app/v1/health
    ```
 
-### Option B: `doctl` CLI
+### Option B: `doctl` CLI (uses the bundled App Spec)
 
 ```sh
 # Fork the repo and edit digitalocean/.do/app.yaml's github.repo if you


### PR DESCRIPTION
## Summary

Moves the DigitalOcean Dockerfile from `digitalocean/Dockerfile` to the repo root so DO App Platform's dashboard "Create App" flow auto-detects it without operator config.

## Why

The current `digitalocean/Dockerfile` doesn't work with DO's UI deploy:

- **Source Directory empty** → DO scans the repo root for a Dockerfile, doesn't find one → `"No components detected"`.
- **Source Directory = `digitalocean`** → DO finds the Dockerfile there but the build context becomes `/digitalocean/`. The Dockerfile's `COPY Makefile` and `COPY src` reference paths at the repo root, which don't exist relative to `/digitalocean/` → `docker build` fails on the first `COPY`.
- **YAML-paste at `/apps/new/spec`** → DO appears to have deprecated that page; operators report it errors out.

The only reliable UI flow is to put the Dockerfile at the repo root. The build context stays at `/` (repo root), every `COPY` in the Dockerfile continues to resolve relative to that (`src/`, `Makefile`, `digitalocean/entrypoint.sh`, `digitalocean/config.template.json`), and `.dockerignore` already wholesale-excludes the noise (`docs/`, `cog/`, `browser/`, `vendor/Indy/`, etc.).

## Operator flow now

1. `cloud.digitalocean.com/apps/new`
2. GitHub source → pick the repo → pick branch
3. **Source Directory: leave blank (root)** — `do NOT` change to `digitalocean`
4. Resource type auto-detects Dockerfile
5. Set the SECRET env vars (`PASCLAW_GATEWAY_TOKEN`, `ANTHROPIC_API_KEY`, ...) plus `PASCLAW_HOME=/data/pasclaw` and `PORT=8088`
6. Deploy

## Files

- `Dockerfile` (NEW location) — moved from `digitalocean/Dockerfile`. Comment block updated to explain why it lives at the root.
- `digitalocean/.do/app.yaml` — `dockerfile_path: digitalocean/Dockerfile` → `dockerfile_path: Dockerfile`.
- `digitalocean/Makefile` — `docker build -f digitalocean/Dockerfile` → `-f Dockerfile`.
- `digitalocean/README.md` — file tree updated; deploy flow rewritten as dashboard-driven (Option A) with an explicit "do NOT set Source Directory to `digitalocean`" warning; `doctl` path stays as Option B.

## Test plan

- [x] `make smoke` — green
- [x] `git mv` preserves history (the file rename is detected as 90% similarity in `git diff`).
- [ ] Manual: dashboard "Create App" flow against the rebased repo (operator validation; the PR description has the step-by-step).

## Scope

4 files, no PasClaw core changes. The Dockerfile content is unchanged except for the comment block at the top.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_