### PR TITLE
Dockerfile: install fp-units-fcl (SyncObjs) + adjacent unit packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,27 @@ FROM debian:bookworm AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Why each fp-units-* package is here (an unhinted `fp-compiler` install
+# misses several units the build needs, with the failure surfacing as a
+# generic "Can't find unit X" -- the apt-units mapping below is the part
+# you can't grep for from the FPC error):
+#   fp-units-base  -- classic Classes / SysUtils / StrUtils / DateUtils
+#   fp-units-fcl   -- SyncObjs (TCriticalSection used by PasClaw.Otel,
+#                     PasClaw.Logger, PasClaw.Tools.OutputCache, MCP, etc.)
+#   fp-units-db    -- fcl-db / SQLite3Connection (memory_search, kb_*,
+#                     session_search)
+#   fp-units-misc  -- iconvenc (web_fetch HTML-to-text decoder)
+#   fp-units-rtl   -- belt-and-suspenders; fp-compiler usually pulls it,
+#                     but Debian's dependency chain has flexed before.
+#   lazarus-src    -- Masks unit (PasClaw.Tools.FS's fs_grep `include`
+#                     glob filter) -- see LAZUTILS_DIR override below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       fp-compiler \
+      fp-units-base \
+      fp-units-fcl \
       fp-units-db \
       fp-units-misc \
+      fp-units-rtl \
       lazarus-src \
       libssl-dev \
       libsqlite3-dev \


### PR DESCRIPTION
## Summary

DO App Platform build fails at the FPC link step:

```
PasClaw.Logger.pas(54,3) Fatal: Can't find unit SyncObjs used by PasClaw.Logger
Fatal: Compilation aborted
make: *** [Makefile:176: /out/pasclaw] Error 1
```

`SyncObjs` (FPC's `TCriticalSection` home) ships in Debian's `fp-units-fcl` package, which `fp-compiler` does NOT pull as a hard dependency on Bookworm. The PR #248 Dockerfile only requested `fp-compiler + fp-units-db + fp-units-misc`, so `SyncObjs` (and several other adjacent units) silently weren't present.

## Fix

Add `fp-units-fcl`, `fp-units-base`, `fp-units-rtl` to the apt install. Comment block above the apt line maps each package to the PasClaw unit / feature that needs it so the next person hit by `"Can't find unit X"` can grep that block and know exactly which `fp-units-*` package to add (the FPC error itself doesn't give you the package name — you have to reverse-map by trial-and-error without this comment).

| Package | What's in it (PasClaw-relevant) |
|---|---|
| `fp-units-base` | Classes / SysUtils / StrUtils / DateUtils |
| **`fp-units-fcl`** | **`SyncObjs` — `TCriticalSection` used by PasClaw.Logger, PasClaw.Otel, PasClaw.Tools.OutputCache, MCP**, etc. (the actual fix) |
| `fp-units-db` | fcl-db / `SQLite3Connection` (memory_search, kb_*, session_search) |
| `fp-units-misc` | iconvenc (web_fetch HTML→text decoder) |
| `fp-units-rtl` | Belt-and-suspenders; `fp-compiler` usually pulls it but Debian's dep chain has flexed before |
| `lazarus-src` | `Masks` unit (fs_grep's `include` glob filter) |

## Why this slipped past local smoke

`make smoke` runs on a host that uses `apt install fpc` — the meta-package that pulls everything. The Dockerfile uses `apt install fp-compiler` for a leaner build image, which means each unit dependency has to be requested explicitly. Lesson learned; the comment block now documents the mapping so future Dockerfile edits stay aware.

## Test plan

- [x] `make smoke` — green
- [ ] DO build retried after this PR merges (operator validation; the symptom from the issue was the exact error this fixes).

## Scope

1 file changed, +17 lines (3 apt package additions + the explanatory comment block). No other code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_