### PR TITLE
hashline: make fs_edit_hashline reliable (Delphi BOM fix + per-line payload guidance)

### DIFF
--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -682,7 +682,15 @@ begin
       end;
       if Trim(Lines[i]) = '' then Continue;
       if (Lines[i] <> '') and (Lines[i][1] = '#') then Continue;
-      ErrMsg := Format('line %d: unrecognized content %s', [i + 1, QuotedStr(Lines[i])]);
+      { Most common cause: a multi-line replacement that prefixed only its
+        first line. Every payload line needs its own marker, so a bare
+        line inside a block reads as unrecognized. Say so. }
+      ErrMsg := Format('line %d: unrecognized content %s -- every payload line ' +
+                       'must start with %s (replace), %s (insert above), or %s ' +
+                       '(insert below); a bare line usually means a multi-line ' +
+                       'replacement is missing its per-line %s prefix',
+                       [i + 1, QuotedStr(Lines[i]), HL_PAYLOAD_REPLACE,
+                        HL_PAYLOAD_ABOVE, HL_PAYLOAD_BELOW, HL_PAYLOAD_REPLACE]);
       Exit;
     end;
     if Started then

--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -85,13 +85,22 @@ const
   HL_OP_REPLACE      = ':';
   HL_PAYLOAD_REPLACE = '|';
   {$ELSE}
-  HL_FILE_PREFIX     = '¶';
+  { Delphi (UnicodeString = one WideChar per codepoint). Spell the
+    non-ASCII markers as explicit codepoint literals, NOT source
+    characters: this .pas is saved UTF-8 WITHOUT a BOM, and Delphi then
+    reads it via the system ANSI codepage -- so a source '¶' (UTF-8
+    bytes C2 B6) would compile to the TWO chars 'Â¶' (U+00C2 U+00B6) on
+    a CP1252 box, and HL_FILE_PREFIX would never match a real ¶. The
+    parser failed every patch at "line 1: content before any ¶ header".
+    #$00B6 etc. are unambiguous regardless of the file's on-disk
+    encoding -- the Delphi mirror of the FPC byte-literal trick above. }
+  HL_FILE_PREFIX     = #$00B6;   { ¶ U+00B6 }
   HL_FILE_HASH_SEP   = '#';
   HL_LINE_BODY_SEP   = ':';
   HL_OP_REPLACE      = ':';
   HL_PAYLOAD_REPLACE = '|';
-  HL_PAYLOAD_ABOVE   = '↑';
-  HL_PAYLOAD_BELOW   = '↓';
+  HL_PAYLOAD_ABOVE   = #$2191;   { ↑ U+2191 }
+  HL_PAYLOAD_BELOW   = #$2193;   { ↓ U+2193 }
   {$ENDIF}
 
   {$IFDEF FPC}

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -811,11 +811,15 @@ begin
   if UseHashline then
   begin
     T.Name        := 'fs_edit_hashline';
-    T.Description := 'Apply a hashline-format patch. Patch begins with ' + HL_FILE_PREFIX +
-                     'path#hash; each block is an anchor like 42: or 7-10: followed by ' +
-                     '| (replace), ' + HL_PAYLOAD_ABOVE + ' (insert above), or ' +
-                     HL_PAYLOAD_BELOW + ' (insert below). The header hash must match the file on disk; ' +
-                     'stale patches abort without writing.';
+    T.Description := 'Apply a hashline-format patch. Begins with a ' + HL_FILE_PREFIX +
+                     'path#hash header, then one or more blocks. Each block is an anchor line ' +
+                     '(42: for one line, 7-10: for a range) followed by payload lines. EVERY ' +
+                     'payload line must start with its own marker: ' + HL_PAYLOAD_REPLACE +
+                     ' to replace, ' + HL_PAYLOAD_ABOVE + ' to insert above the anchor, ' +
+                     HL_PAYLOAD_BELOW + ' to insert below. A multi-line replacement repeats ' +
+                     HL_PAYLOAD_REPLACE + ' on every line (a 3-line replacement has three ' +
+                     HL_PAYLOAD_REPLACE + ' lines) -- never a bare line. The header hash must ' +
+                     'match the file on disk; stale patches abort without writing.';
     T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
     T.Handler     := Tool_FSEditHashline;
     T.IsCore      := True;

--- a/src/tests/hashline_patch_tests.pas
+++ b/src/tests/hashline_patch_tests.pas
@@ -48,9 +48,28 @@ begin
   AssertTrue(Pos(':↓', Err) > 0, 'expected actionable token in validator error');
 end;
 
+procedure TestBareContinuationLineRejected;
+{ The exact shape that tripped a real session: a multi-line replacement
+  where only the first payload line carries the | marker and the rest are
+  bare. Must be rejected (not silently dropped), and the error must point
+  at the missing per-line prefix so the model can self-correct. }
+var
+  P, Err: string;
+  Sections: THLSectionArray;
+begin
+  P := '¶d.txt#dead' + #10 + '40-41:' + #10 +
+       '|procedure Foo;' + #10 + 'begin';   { 'begin' has no | prefix }
+  AssertTrue(not ParseHashlinePatch(P, Sections, Err),
+             'bare continuation line must be rejected, not dropped');
+  AssertTrue(Pos('begin', Err) > 0, 'error names the offending line: ' + Err);
+  AssertTrue(Pos('per-line', Err) > 0,
+             'error explains the per-line prefix requirement: ' + Err);
+end;
+
 begin
   TestValidInsertion;
   TestValidMultilineReplacement;
   TestInvalidInlinePayload;
+  TestBareContinuationLineRejected;
   Writeln('PASS');
 end.


### PR DESCRIPTION
Two fixes that together make `fs_edit_hashline` actually usable on Delphi/Windows and harder to misuse on any platform.

## Fix 1 — `¶`/`↑`/`↓` markers broken on Delphi (no BOM)

**Symptom:** `fs_edit_hashline` rejected **every** patch on Delphi/Windows — even well-formed ones — with `line 1: content before any ¶PATH header`.

**Cause:** `src/pkg/hashline/PasClaw.Hashline.pas` is saved UTF-8 **without a BOM**. The FPC branch defends against this with explicit byte literals (`#$C2#$B6`) + `{$CODEPAGE UTF8}`, but the Delphi branch used raw source characters:

```pascal
HL_FILE_PREFIX = '¶';   HL_PAYLOAD_ABOVE = '↑';   HL_PAYLOAD_BELOW = '↓';
```

With no BOM, Delphi reads the source through the system ANSI codepage, so `'¶'` (UTF-8 `C2 B6`) compiles to the **two** chars `'Â¶'` (U+00C2 U+00B6) on a CP1252 box. `HL_FILE_PREFIX` then never matches a real `¶`. FPC-on-Linux reads source as UTF-8, which is why tests never caught it.

**Fix:** encoding-independent codepoint literals for the Delphi branch — the mirror of the FPC byte-literal trick:

```pascal
HL_FILE_PREFIX = #$00B6;   HL_PAYLOAD_ABOVE = #$2191;   HL_PAYLOAD_BELOW = #$2193;
```

## Fix 2 — per-line payload prefix guidance (all platforms)

A real session produced a multi-line replacement that prefixed only its first line and left the rest bare:

```
¶...pas#43e8
40-53:
|procedure ...Load(...);
begin            ← no | marker
{$IF...          ← no | marker
```

No PasClaw code drops the marker — the **model** omitted it, and the tool description invited the mistake: *"an anchor like 42: or 7-10: followed by `|` (replace)"* reads as a one-time marker, not a per-line prefix.

- `fs_edit_hashline` description now states **every** payload line needs its own marker, and that a multi-line replacement repeats `|` on every line (never a bare line).
- The parser already *rejects* a bare line (it does not silently drop it); the error now explains the per-line requirement so the model can self-correct on retry.
- Added a regression test for the exact bare-continuation-line shape.

## Verification

- FPC branch untouched; `hashline_patch_tests` (incl. the new case) pass; full build clean (rc=0).
- Audited all `.pas` with `¶`/`↑`/`↓`: the other runtime units using raw literals (`Gateway.ToolView`, `Tools.FS`, `Tools.ToolLoop`) carry a BOM, so Delphi reads them correctly; `JSON.pas`'s only occurrence is a comment. `Hashline.pas` was the lone functional offender.
- ⚠️ Verified by analysis + FPC tests; the Delphi/Windows path needs a confirmation run on a Windows box (I can't compile Delphi here).

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6