### PR TITLE
gateway: log bearer-token auth state at startup

### DIFF
--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -625,7 +625,7 @@ function GetEffectiveGatewayToken(const C: TConfig): string;
       gateway: bearer-token auth ENABLED (source=env, token len=64, prefix=ab12...)
       gateway: bearer-token auth ENABLED (source=config.json, token len=64, prefix=ab12...)
       gateway: bearer-token auth MISCONFIGURED -- token field is unresolved template '${PASCLAW_GATEWAY_TOKEN}'; env var not set, so no client token will match
-      gateway: bearer-token auth DISABLED -- no token configured (every /v1/* route open)
+      gateway: bearer-token auth DISABLED -- no token configured (every /v1/* and /mcp route open to any caller)
 
     The MISCONFIGURED case is the typo trap: an operator sets
     PASCAL_GATEWAY_TOKEN (no W) in the platform's env-var UI,
@@ -1717,8 +1717,15 @@ begin
   end
   else
   begin
+    (* Mention both /v1/* (main API surface) and /mcp (the dedicated
+       MCP companion listener at --mcp-port, plus the /v1/mcp/rpc
+       in-main-port path) so operators understand the full exposure
+       -- a token-less gateway leaves the MCP JSON-RPC endpoint open
+       to any reachable caller, not just the OpenAI-compatible
+       routes. Codex P2 on PR #255. *)
     Result := 'gateway: bearer-token auth DISABLED -- ' +
-              'no token configured (every /v1/* route open)';
+              'no token configured (every /v1/* and /mcp route ' +
+              'open to any caller)';
     Exit;
   end;
 

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -614,6 +614,37 @@ procedure SaveConfig(C: TConfig);
     serialise only C.Gateway.Token (never the env value). *)
 function GetEffectiveGatewayToken(const C: TConfig): string;
 
+(*  DescribeGatewayAuthState -- one-line summary of the gateway's
+    bearer-token auth state, intended for a single LogInfo at
+    gateway startup. Helps operators diagnose the typical
+    misconfigurations from the deploy logs without a console
+    exec into the container.
+
+    Possible outputs (always exactly one line, no token value):
+
+      gateway: bearer-token auth ENABLED (source=env, token len=64, prefix=ab12...)
+      gateway: bearer-token auth ENABLED (source=config.json, token len=64, prefix=ab12...)
+      gateway: bearer-token auth MISCONFIGURED -- token field is unresolved template '${PASCLAW_GATEWAY_TOKEN}'; env var not set, so no client token will match
+      gateway: bearer-token auth DISABLED -- no token configured (every /v1/* route open)
+
+    The MISCONFIGURED case is the typo trap: an operator sets
+    PASCAL_GATEWAY_TOKEN (no W) in the platform's env-var UI,
+    ExpandEnvVarsInJSON sees no PASCLAW_GATEWAY_TOKEN to substitute,
+    the literal `${PASCLAW_GATEWAY_TOKEN}` survives into
+    Cfg.Gateway.Token, GetEffectiveGatewayToken returns it, and
+    every bearer the web UI sends gets compared against the literal
+    template string -- guaranteed mismatch, infinite 401 loop.
+    This log line surfaces that case immediately at startup.
+
+    The prefix is the first 4 chars of the token + `...` -- enough
+    for the operator to visually match against the token they pasted
+    into their secret manager, not enough to enable a brute force
+    against the remaining bytes (16 bits of guessing for a hex
+    token, and the token is presumed long). Suppressed for tokens
+    shorter than 8 chars (we log `prefix=<short>` instead -- a 4-byte
+    prefix of a 6-byte token leaks too much). *)
+function DescribeGatewayAuthState(const C: TConfig): string;
+
 (*  ExpandEnvVarsInJSON -- raw-text ${VAR_NAME} substitution applied
     to the JSON config body BEFORE TConfig.FromJSON parses it.
     Matches openclaw's `${...}` template-substitution feature so an
@@ -1644,6 +1675,64 @@ begin
     Result := GEnvGatewayToken
   else
     Result := C.Gateway.Token;
+end;
+
+function LooksLikeUnresolvedTemplate(const S: string): Boolean;
+(* Heuristic: matches the literal `${...}` shape ExpandEnvVarsInJSON
+   leaves behind when an env var referenced by config.json isn't set.
+   No real bearer token would ever be generated in this shape (operators
+   pull from `openssl rand -hex 32` / a password manager / DO's secret
+   form), so the false-positive risk is zero in practice. *)
+var
+  n: Integer;
+begin
+  n := Length(S);
+  Result := (n >= 4) and (S[1] = '$') and (S[2] = '{') and (S[n] = '}');
+end;
+
+function GatewayTokenPrefix(const Tok: string): string;
+(* First 4 chars + `...` when long enough to keep the prefix from
+   leaking too much of a short token. Pure display helper; never
+   handed to the comparison path. *)
+begin
+  if Length(Tok) >= 8 then
+    Result := Copy(Tok, 1, 4) + '...'
+  else
+    Result := '<short>';
+end;
+
+function DescribeGatewayAuthState(const C: TConfig): string;
+var
+  Tok, Source: string;
+begin
+  if GEnvGatewayToken <> '' then
+  begin
+    Tok    := GEnvGatewayToken;
+    Source := 'env';
+  end
+  else if C.Gateway.Token <> '' then
+  begin
+    Tok    := C.Gateway.Token;
+    Source := 'config.json';
+  end
+  else
+  begin
+    Result := 'gateway: bearer-token auth DISABLED -- ' +
+              'no token configured (every /v1/* route open)';
+    Exit;
+  end;
+
+  if LooksLikeUnresolvedTemplate(Tok) then
+  begin
+    Result := Format('gateway: bearer-token auth MISCONFIGURED -- ' +
+                     'token field is unresolved template ''%s''; env var ' +
+                     'not set, so no client token will match', [Tok]);
+    Exit;
+  end;
+
+  Result := Format('gateway: bearer-token auth ENABLED ' +
+                   '(source=%s, token len=%d, prefix=%s)',
+                   [Source, Length(Tok), GatewayTokenPrefix(Tok)]);
 end;
 
 function EnvSubstJsonEscape(const S: string): string;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -483,6 +483,16 @@ begin
   FHTTP.Active := True;
   FStarted := True;
   LogInfo('gateway: listening on http://%s:%d', [BindAddr, Port]);
+  (* Auth-state summary at startup. Only the primary listener prints
+     it; the optional MCP companion listener shares the same FCfg, so
+     a second copy would be noise. The MISCONFIGURED branch in
+     particular is the typo trap that motivates the line -- operators
+     misspelling PASCLAW_GATEWAY_TOKEN as PASCAL_GATEWAY_TOKEN end up
+     with the literal "${PASCLAW_GATEWAY_TOKEN}" template stuck in
+     Cfg.Gateway.Token, and the gateway will reject every client
+     bearer until the env var is renamed. *)
+  if not FMCPOnly then
+    LogInfo('%s', [DescribeGatewayAuthState(FCfg)]);
 end;
 
 procedure TGatewayServer.Stop;


### PR DESCRIPTION
## Summary

Adds one `LogInfo` at the end of `TGatewayServer.Start` that summarises the bearer-token auth state, so the typical misconfigurations are visible in the deploy logs without needing to `exec` into the container. Surfaces four cases:

```
[info] gateway: bearer-token auth ENABLED (source=env, token len=64, prefix=ab12...)
[info] gateway: bearer-token auth ENABLED (source=config.json, token len=64, prefix=ab12...)
[info] gateway: bearer-token auth MISCONFIGURED -- token field is unresolved template '${PASCLAW_GATEWAY_TOKEN}'; env var not set, so no client token will match
[info] gateway: bearer-token auth DISABLED -- no token configured (every /v1/* route open)
```

## Motivation

The `MISCONFIGURED` branch is the case that motivated this PR. The typo trap:

1. Operator sets `PASCAL_GATEWAY_TOKEN` (no W) in the platform's env-var UI.
2. `ExpandEnvVarsInJSON` sees no `PASCLAW_GATEWAY_TOKEN`, so the literal `${PASCLAW_GATEWAY_TOKEN}` survives into `Cfg.Gateway.Token`.
3. `GetEffectiveGatewayToken` returns the literal template string.
4. Every bearer the web UI sends gets compared against `${PASCLAW_GATEWAY_TOKEN}` (the literal characters) — guaranteed mismatch, infinite 401 loop.

Without this log line you can only diagnose by `printenv`-ing inside the container or grepping the on-disk `config.json` for the unresolved marker. With it, one redeploy shows the operator exactly what's wrong on App Platform / Docker Hub / k8s — wherever the runtime logs are aggregated.

## Token-safety notes

- The log line never contains the token itself, only `prefix=<first 4 chars>...` for tokens >= 8 chars (~16 bits of brute-force surface against a hex token) and `prefix=<short>` for shorter tokens (a 4-byte prefix of a 6-byte token leaks too much).
- The `MISCONFIGURED` branch reveals the unresolved template string verbatim — that's a config marker, not a secret.

## Files

- `src/pkg/config/PasClaw.Config.pas` — new `DescribeGatewayAuthState(C: TConfig): string` helper next to `GetEffectiveGatewayToken`. Lives in `Config` so it can read `GEnvGatewayToken` without forcing a `Gateway -> Auth -> Config` dep cycle.
- `src/pkg/gateway/PasClaw.Gateway.Server.pas` — `TGatewayServer.Start` now calls `LogInfo('%s', [DescribeGatewayAuthState(FCfg)])` right after the existing "gateway: listening on" line. Suppressed when `FMCPOnly` is set so the optional `/mcp` companion listener doesn't double-log.

## Test plan

Verified each branch against a real gateway boot with a scratch `$PASCLAW_HOME`:

- [x] **DISABLED** — empty config, no env: `bearer-token auth DISABLED -- no token configured (every /v1/* route open)`
- [x] **ENABLED (config.json)** — `gateway.token: "abcdef0123456789ZZ"` (18 chars): `ENABLED (source=config.json, token len=18, prefix=abcd...)`
- [x] **ENABLED (env)** — `PASCLAW_GATEWAY_TOKEN=<64-char hex>`: `ENABLED (source=env, token len=64, prefix=cafe...)`
- [x] **MISCONFIGURED** — `gateway.token: "${PASCLAW_GATEWAY_TOKEN}"` with the env var unset: `MISCONFIGURED -- token field is unresolved template '${PASCLAW_GATEWAY_TOKEN}'; env var not set, so no client token will match`
- [x] **Short-token guard** — 5-char token: `prefix=<short>` (no leak of a token where 4 chars would reveal most of it)
- [x] `make` clean (FPC 3.2.2)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_