### PR TITLE
shell_exec: tell the model commands run in a Linux container (docker on Windows)

### DIFF
--- a/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
@@ -261,19 +261,26 @@ end;
 
 function TDockerShellBackend.Describe: string;
 begin
-  { Spell out that commands run in a LINUX container via /bin/sh, with the
-    workspace at its container path -- otherwise, on a Windows host, the
-    model follows the host platform and emits cmd.exe (`dir /s /b`) with
-    C:\ paths, which fail inside the Linux container. ContainerPath gives
-    the in-container workspace dir (same-path on POSIX, /workspace on
-    Windows). }
+  {$IFDEF MSWINDOWS}
+  { Windows host only: without this the model follows the host platform and
+    emits cmd.exe (`dir /s /b`, C:\ paths) into the Linux container, which
+    fails. Spell out Linux/POSIX and the mapped container cwd (/workspace).
+    On POSIX hosts the container shares the host's conventions and the
+    workspace is same-path, so no such warning is needed -- see the ELSE
+    branch, which keeps the original wording verbatim. }
   Result := Format('runs each command inside a per-session Linux Docker container ' +
                    '(image=%s, network=%s) via /bin/sh, so use POSIX commands ' +
                    '(ls, find, grep, cat) and POSIX paths -- NOT Windows cmd ' +
-                   '(dir) or C:\ paths, even when the host is Windows. The ' +
+                   '(dir) or C:\ paths even though the host is Windows. The ' +
                    'workspace is mounted at %s, which is the working directory',
                    [FOpts.Image, FOpts.Network,
                     ContainerPath(JoinPath(GetHome, 'workspace'))]);
+  {$ELSE}
+  Result := Format('runs inside a per-session Docker container (image=%s, network=%s; ' +
+                   'workspace bind-mounted at the same path so the model sees the ' +
+                   'same files you do on the host)',
+                   [FOpts.Image, FOpts.Network]);
+  {$ENDIF}
 end;
 
 function TDockerShellBackend.ContainerName(const SessionId: string): string;

--- a/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
@@ -261,10 +261,19 @@ end;
 
 function TDockerShellBackend.Describe: string;
 begin
-  Result := Format('runs inside a per-session Docker container (image=%s, network=%s; ' +
-                   'workspace bind-mounted at the same path so the model sees the ' +
-                   'same files you do on the host)',
-                   [FOpts.Image, FOpts.Network]);
+  { Spell out that commands run in a LINUX container via /bin/sh, with the
+    workspace at its container path -- otherwise, on a Windows host, the
+    model follows the host platform and emits cmd.exe (`dir /s /b`) with
+    C:\ paths, which fail inside the Linux container. ContainerPath gives
+    the in-container workspace dir (same-path on POSIX, /workspace on
+    Windows). }
+  Result := Format('runs each command inside a per-session Linux Docker container ' +
+                   '(image=%s, network=%s) via /bin/sh, so use POSIX commands ' +
+                   '(ls, find, grep, cat) and POSIX paths -- NOT Windows cmd ' +
+                   '(dir) or C:\ paths, even when the host is Windows. The ' +
+                   'workspace is mounted at %s, which is the working directory',
+                   [FOpts.Image, FOpts.Network,
+                    ContainerPath(JoinPath(GetHome, 'workspace'))]);
 end;
 
 function TDockerShellBackend.ContainerName(const SessionId: string): string;

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -131,23 +131,20 @@ procedure RegisterShellTool(R: TToolRegistry);
 var
   T: TTool;
   Backend: IShellBackend;
+  BackendNote: string;
 begin
   Backend := GetActiveShellBackend;
   if (Backend <> nil) and (Backend.Name <> 'local') then
-  begin
-    { A non-local backend (docker/ssh) runs commands somewhere other than
-      the host shell, so the host-oriented "/bin/sh -c or cmd.exe on
-      Windows" line is misleading -- on a Windows host it nudges the model
-      toward cmd syntax that fails in a Linux container. Lead with the
-      backend's own description of where (and how) commands run. }
-    T.Description := 'Run a shell command in the ' + Backend.Name +
-                     ' shell backend: ' + Backend.Describe +
-                     '. Captures stdout+stderr, caps output at 1 MiB.';
-  end
+    { Tell the model where commands actually run so it doesn't
+      `apt install` something expecting host-persistence. Same
+      trick send_message uses to enumerate configured channels. }
+    BackendNote := ' Runs via the ' + Backend.Name + ' shell backend: ' +
+                   Backend.Describe + '.'
   else
-    T.Description := 'Run a shell command via /bin/sh -c (or cmd.exe on Windows). ' +
-                     'Captures stdout+stderr, caps output at 1 MiB.';
+    BackendNote := '';
   T.Name        := 'shell_exec';
+  T.Description := 'Run a shell command via /bin/sh -c (or cmd.exe on Windows). ' +
+                   'Captures stdout+stderr, caps output at 1 MiB.' + BackendNote;
   T.Schema      := '{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute."}},"required":["command"]}';
   T.Handler     := Tool_Shell;
   T.IsCore      := True;

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -131,20 +131,23 @@ procedure RegisterShellTool(R: TToolRegistry);
 var
   T: TTool;
   Backend: IShellBackend;
-  BackendNote: string;
 begin
   Backend := GetActiveShellBackend;
   if (Backend <> nil) and (Backend.Name <> 'local') then
-    { Tell the model where commands actually run so it doesn't
-      `apt install` something expecting host-persistence. Same
-      trick send_message uses to enumerate configured channels. }
-    BackendNote := ' Runs via the ' + Backend.Name + ' shell backend: ' +
-                   Backend.Describe + '.'
+  begin
+    { A non-local backend (docker/ssh) runs commands somewhere other than
+      the host shell, so the host-oriented "/bin/sh -c or cmd.exe on
+      Windows" line is misleading -- on a Windows host it nudges the model
+      toward cmd syntax that fails in a Linux container. Lead with the
+      backend's own description of where (and how) commands run. }
+    T.Description := 'Run a shell command in the ' + Backend.Name +
+                     ' shell backend: ' + Backend.Describe +
+                     '. Captures stdout+stderr, caps output at 1 MiB.';
+  end
   else
-    BackendNote := '';
+    T.Description := 'Run a shell command via /bin/sh -c (or cmd.exe on Windows). ' +
+                     'Captures stdout+stderr, caps output at 1 MiB.';
   T.Name        := 'shell_exec';
-  T.Description := 'Run a shell command via /bin/sh -c (or cmd.exe on Windows). ' +
-                   'Captures stdout+stderr, caps output at 1 MiB.' + BackendNote;
   T.Schema      := '{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute."}},"required":["command"]}';
   T.Handler     := Tool_Shell;
   T.IsCore      := True;


### PR DESCRIPTION
## Symptom

With the docker backend active on a **Windows host**, the model followed the host platform and emitted Windows `cmd` syntax *inside the Linux container*:

```
shell_exec {"command":"dir /s /b C:\Users\anony\.pasclaw\workspace\*.dpr ..."}
✓ exit=2
dir: cannot access '/s': No such file or directory
```

The container is Linux (`debian:bookworm-slim`), so `dir`/`/s`/`/b` and `C:\` paths are meaningless there.

## Fix (description text only — scoped to Windows + docker)

The docker backend's `Describe()` is now `{$IFDEF MSWINDOWS}`:
- **Windows branch:** states commands run in a **Linux** container via `/bin/sh`; use **POSIX** commands (`ls`/`find`/`grep`) and POSIX paths — *not* `dir`/`C:\` even though the host is Windows — and reports the in-container cwd (`/workspace`) via `ContainerPath`.
- **POSIX branch:** the **original wording, verbatim** (no change for Linux/macOS docker users).

`shell_exec` itself (`Tools.Shell.pas`) is a **zero diff vs main** — the host-specific guidance lives solely in the OS-gated `Describe`, surfaced through the existing backend note.

## Gating (the point of the latest revision)

| Backend | Host | Behavior |
|---|---|---|
| local | any | unchanged |
| docker | Linux/macOS | unchanged (original `Describe` text) |
| docker | **Windows** | **new POSIX guidance** |

So the change manifests **only** for (Windows AND docker).

## Notes

- Builds on merged #253 (`ContainerPath` lives in the docker backend).
- Full build clean (rc=0); `shell_backend_tests` pass.
- Description text only — no runtime behavior change; an on-device Windows run confirms the model now uses POSIX.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6