### PR TITLE
gateway: fix PR #246 — accept Bearer scheme via Indy's OnParseAuthentication

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -97,6 +97,23 @@ type
     procedure OnCommandGet(AContext: TIdContext;
                            ARequest: TIdHTTPRequestInfo;
                            AResponse: TIdHTTPResponseInfo);
+    (* OnParseAuth -- accept every Authorization scheme so Indy's
+       TIdCustomHTTPServer doesn't auto-401 with "Basic realm=..." on
+       Bearer (or any non-Basic) tokens before OnCommandGet runs.
+       Without this, Indy raises EIdHTTPUnsupportedAuthorisationScheme
+       on the FIRST byte of an `Authorization: Bearer <tok>` header,
+       which is converted to a 401 in its request-loop exception
+       handler -- so PasClaw's CheckGatewayAuth middleware never gets
+       a chance to validate. PR #246's bearer flow was silently broken
+       end-to-end; the web UI dodged it only because gwFetch suppresses
+       the Authorization header until a token is stored, and the
+       token-less default config never sent one either. The handler
+       just sets VHandled := True; real validation stays in
+       OnCommandGet via PasClaw.Gateway.Auth.CheckGatewayAuth. *)
+    procedure OnParseAuth(AContext: TIdContext;
+                          const AAuthType, AAuthData: string;
+                          var VUsername, VPassword: string;
+                          var VHandled: Boolean);
     procedure HandleHealth(AResp: TIdHTTPResponseInfo);
     procedure HandleVersion(AResp: TIdHTTPResponseInfo);
     procedure HandleStatus(AResp: TIdHTTPResponseInfo);
@@ -348,6 +365,7 @@ begin
   SetLength(FWebhookHandlers, 0);
   FHTTP := TIdHTTPServer.Create(nil);
   FHTTP.OnCommandGet := OnCommandGet;
+  FHTTP.OnParseAuthentication := OnParseAuth;
   FHTTP.KeepAlive    := True;
   FHTTP.ServerSoftware := 'PasClaw/' + FormatVersion;
   FMCPInbound       := nil;
@@ -596,6 +614,34 @@ end;
 
 { TGatewayServer.WriteSSE removed -- dead method, see class
   declaration. dcc64 H2219 cleanup. }
+
+procedure TGatewayServer.OnParseAuth(AContext: TIdContext;
+                                     const AAuthType, AAuthData: string;
+                                     var VUsername, VPassword: string;
+                                     var VHandled: Boolean);
+begin
+  (* Accept ALL schemes -- Bearer, plus anything an operator's
+     middleware might prepend later. Indy's default DoParseAuthentication
+     handles Basic itself before this fires; everything else falls
+     through to us. Setting VHandled := True keeps Indy from raising
+     EIdHTTPUnsupportedAuthorisationScheme (which it would auto-convert
+     to a 401 in the request-loop exception handler at
+     IdCustomHTTPServer.pas:1476, before OnCommandGet runs). PasClaw's
+     real bearer check lives in OnCommandGet via CheckGatewayAuth, so
+     leaving VUsername / VPassword empty is fine -- the AuthHeader is
+     still on ARequest.RawHeaders and CheckGatewayAuth pulls it from
+     there directly. PR #255 follow-up to fix PR #246's silent break.
+
+     AContext is not used here, but the parameter is part of Indy's
+     TIdHTTPParseAuthenticationEvent signature; we keep it named for
+     readability and reference it once to silence the "unused" hint. *)
+  if AContext = nil then ;       { silence unused-param hint }
+  if AAuthType = '' then ;       { likewise }
+  if AAuthData = '' then ;
+  VUsername := '';
+  VPassword := '';
+  VHandled  := True;
+end;
 
 procedure TGatewayServer.OnCommandGet(AContext: TIdContext;
                                      ARequest: TIdHTTPRequestInfo;


### PR DESCRIPTION
## Summary

PR #246 wired bearer-token auth into `OnCommandGet` but missed that Indy's `TIdCustomHTTPServer` natively recognizes only `Basic` as an auth scheme. Every `Authorization: Bearer <tok>` request is intercepted by Indy's built-in auth machinery and converted to a 401 with `WWW-Authenticate: Basic realm=""` **before** `OnCommandGet` runs — so `CheckGatewayAuth` never sees the bearer at all and rejects every authenticated request, even with the correct token.

## Repro

Set `PASCLAW_GATEWAY_TOKEN=awesome` in the container env, start the gateway, then:

```sh
$ curl -v -H "Authorization: Bearer $PASCLAW_GATEWAY_TOKEN" http://localhost:8088/v1/status
> Authorization: Bearer awesome
< HTTP/1.1 401 Unauthorized
< WWW-Authenticate: Basic           ← Indy emitted this, not PasClaw
< Server: PasClaw/dev               ← misleading — Indy uses ServerSoftware even in its own exception path
```

## Root cause

Indy walks the Authorization header inside `IdCustomHTTPServer.pas` at line 1454, calls `DoParseAuthentication` which only recognizes `Basic`, and raises `EIdHTTPUnsupportedAuthorisationScheme` on every other scheme:

```pascal
// vendor/Indy/Lib/Protocols/IdCustomHTTPServer.pas:1450-1458
s := LRequestInfo.RawHeaders.Values['Authorization'];
if Length(s) > 0 then begin
  LRequestInfo.FAuthType := Fetch(s, ' ');
  LRequestInfo.FAuthExists := DoParseAuthentication(...);
  if not LRequestInfo.FAuthExists then begin
    raise EIdHTTPUnsupportedAuthorisationScheme.Create(...);  // <-- here
  end;
end;
```

The exception handler at line 1476 converts it to a 401 with the canonical `WWW-Authenticate: Basic` header — all before `DoCommandGet` (where PasClaw's middleware lives) ever fires.

## Fix

Wire `FHTTP.OnParseAuthentication` to a handler that just sets `VHandled := True` for every non-Basic scheme. Indy's built-in `Basic` parsing path is unchanged; `Bearer` and any future scheme now fall through to `OnCommandGet`, where the existing `ExtractBearerToken` + constant-time comparison in `CheckGatewayAuth` does the real validation.

## Why this hid in PR #246

- Web UI's `gwFetch` (`webui.html`) doesn't attach an `Authorization` header until a token is stored in `localStorage`, so for a fresh / token-less deployment no Authorization header ever reaches the gateway.
- The default token-less config doesn't gate `/v1/*` at all — so every request was being routed through the no-token-needed path.
- The first time PR #246's auth feature actually got exercised on a real deployment (DO App Platform, `PASCLAW_GATEWAY_TOKEN` set), every request 401'd.

## Verified

Against a live gateway with `PASCLAW_GATEWAY_TOKEN=awesome`:

```
no auth header             → 401  (unchanged)
wrong bearer               → 401 with WWW-Authenticate: Bearer realm="pasclaw"
right bearer "awesome"     → 200  ← was 401 before this commit
exempt /v1/health, no auth → 200  (unchanged)
```

## Test plan

- [x] FPC 3.2.2 build clean
- [x] All four bearer/no-bearer cases above
- [x] 401 response now carries `WWW-Authenticate: Bearer realm="pasclaw"`, not `Basic`
- [ ] Confirm on the reporter's DO App Platform deployment after redeploy

## Stacked relationship

Independent of PR #255 (startup auth-state logging). #255 makes the misconfiguration visible in logs; this PR is the actual functional fix. Either can merge first.

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_