### PR TITLE
steering: demote benign drain-lock contention from warn to debug

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Steering.pas
+++ b/src/pkg/agent/PasClaw.Agent.Steering.pas
@@ -280,7 +280,14 @@ begin
   Lock := LockPath(SessionKey);
   if not AcquireLock(Lock) then
   begin
-    LogWarn('steering: drain lock timeout for %s', [SessionKey]);
+    { Benign and self-healing: we never renamed the queue file, so the
+      pending messages are still there and the next loop iteration's
+      drain picks them up. This only trips under lock contention (a
+      concurrent push/drain, or a stale lock not yet reclaimed) and fires
+      at the loop's per-iteration cadence -- warn-level spam for a
+      condition that needs no operator action. Debug keeps it diagnosable
+      without the noise. }
+    LogDebug('steering: drain lock contended for %s (retrying next turn)', [SessionKey]);
     Exit;
   end;
   try


### PR DESCRIPTION
## Symptom

```
[warn] steering: drain lock timeout for 20260614T064949-a5e3dfb5
```
appearing repeatedly during an agent session.

## Why it's noise, not a problem

`DrainSteering` has a single caller — the tool loop, once per **iteration** (each provider round-trip), at `ToolLoop.pas:724`. So the warning fires at the loop's cadence (≈ one model round-trip apart, which looks timer-like) whenever the per-session steering lock is contended for >2s (a concurrent push/drain, or a stale lock not yet reclaimed).

The condition is **benign and self-healing**: when the lock can't be taken, the queue file is left untouched (never renamed), so the pending steering messages stay put and the **next iteration's drain picks them up**. Nothing for the operator to act on.

## Fix

Demote the drain-lock-contention log from `LogWarn` to `LogDebug` (still diagnosable, no console spam). `PushSteering`'s lock-acquisition timeout — which represents a genuinely *dropped* steering push — stays at warn.

## Verification

Build clean (rc=0). Behavior unchanged except log level.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_