### PR TITLE
tui: support the docker shell backend (one container per TUI process)

### DIFF
--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -223,9 +223,6 @@ begin
     try
       TUIInst.Run;
     finally
-      { Stop the TUI's container (no-op for local / when none was
-        started). --rm at spawn removes it on stop. }
-      if ShellSessionId <> '' then CloseShellSession(ShellSessionId);
       TUIInst.Free;
       FreeMCPClients(MCPClients);
       { Spawn owned here (same shape as Cmd.Agent); BgCoord is NOT
@@ -237,6 +234,12 @@ begin
     end;
     Result := 0;
   finally
+    { Tear down the TUI container here, not in the inner TUIInst.Run
+      finally: this covers every path after a successful StartShellSession
+      -- including a raise during provider/registry/MCP setup before
+      TTUI.Run -- so a --rm docker container can't be orphaned. No-op for
+      local / when none was started. }
+    if ShellSessionId <> '' then CloseShellSession(ShellSessionId);
     Cfg.Free;
   end;
 end;

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -42,6 +42,8 @@ uses
   PasClaw.Skills.Loader,
   PasClaw.Agent.Subagent,
   PasClaw.Agent.SubagentBg,
+  PasClaw.Session.Store,           { NewSessionId -- stable per-launch id for
+                                     the TUI's single shell container }
   PasClaw.TUI;
 
 type
@@ -95,26 +97,19 @@ var
   BgCoord: TBackgroundSpawnCoordinator;
   KindSelected: TShellBackendKind;
   BackendDesc: string;
+  ShellSessionId: string;
 begin
   if not ParseArgs(Argv, A) then Exit(1);
   Cfg := LoadConfig;
   ConfigureSandbox(Cfg.Sandbox, '');
-  { Phase 1 docker backend is wired for the agent + heartbeat
-    surfaces; TUI's in-process session switching (/new, /load) needs
-    a per-switch container handoff that's a Phase 1.5 follow-up.
-    Until then, install only the local backend on TUI and refuse a
-    docker selection loudly so the operator isn't silently running
-    on the host when they thought they had isolation. }
-  if (LowerCase(A.BackendOverride) = 'docker')
-     or ((A.BackendOverride = '') and (Cfg.ShellBackend = sbDocker)) then
-  begin
-    PrintLn(Ansi.Yellow + '!' + Ansi.Reset +
-            ' TUI does not yet support the docker shell backend.');
-    PrintLn('  Use ' + Ansi.Bold + 'pasclaw agent' + Ansi.Reset +
-            ' for an interactive docker-backed session, or pass ' +
-            Ansi.Bold + '--backend local' + Ansi.Reset + '.');
-    Exit(1);
-  end;
+  { Docker backend: the TUI runs ONE container for its whole process,
+    not one per chat session. The container is a workspace sandbox --
+    every TUI session shares the same bind-mounted workspace, and
+    shell_exec/execute_code pick their container via the process-wide
+    GetCurrentSessionId -- so there's nothing per-conversation to
+    isolate and no per-switch container handoff to get wrong. We spawn
+    it once below (before the full-screen UI, so a slow first-time image
+    pull doesn't freeze the alt-screen) and tear it down on exit. }
   try
     InstallShellBackend(Cfg, A.BackendOverride, KindSelected, BackendDesc);
   except
@@ -125,6 +120,30 @@ begin
     end;
   end;
   try
+    { Spawn the one TUI container up front (no-op for the local backend).
+      A docker spawn blocks while the image pulls on first use, which is
+      why it happens here -- before TTUI.Run enters the alt-screen -- and
+      surfaces failures as a clean console error rather than a frozen UI.
+      The id is unique per launch so a leaked container from a previous
+      run can't collide on the docker name. SetCurrentSessionId points
+      shell_exec/execute_code at this container for every turn. }
+    ShellSessionId := '';
+    if KindSelected = sbDocker then
+    begin
+      ShellSessionId := NewSessionId;
+      PrintLn(Ansi.Dim + 'starting docker container for this session...' + Ansi.Reset);
+      try
+        StartShellSession(ShellSessionId);
+      except
+        on E: Exception do
+        begin
+          PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
+          Exit(1);
+        end;
+      end;
+      SetCurrentSessionId(ShellSessionId);
+    end;
+
     if A.Provider <> '' then Name := A.Provider else Name := Cfg.DefaultProvider;
     Provider := nil;
     if Name <> '' then
@@ -204,6 +223,9 @@ begin
     try
       TUIInst.Run;
     finally
+      { Stop the TUI's container (no-op for local / when none was
+        started). --rm at spawn removes it on stop. }
+      if ShellSessionId <> '' then CloseShellSession(ShellSessionId);
       TUIInst.Free;
       FreeMCPClients(MCPClients);
       { Spawn owned here (same shape as Cmd.Agent); BgCoord is NOT


### PR DESCRIPTION
## Symptom

```
! TUI does not yet support the docker shell backend.
```

`pasclaw tui` refused to start when the docker shell backend was selected.

## Why it was deferred — and why the deferral was unnecessary

The refusal cited a "per-switch container handoff" that in-session `/new` and `/load` seemed to require. But that handoff isn't actually needed: the container is a **workspace sandbox, not per-conversation state**.

- Every TUI chat session shares the **same** bind-mounted workspace.
- `shell_exec` / `execute_code` select their container via the **process-wide** `GetCurrentSessionId`, not the chat-session id.

So one container for the whole TUI process is correct, and chat-session switches (`/new`, `/load`) never need to touch it — which also sidesteps the in-flight-loop hazard (the "current" container id never changes mid-loop).

## Change (entirely in `Cmd.TUI.pas`)

- Remove the refusal; let `InstallShellBackend` install docker.
- Spawn **one** container up front with a unique per-launch id, **before** `TTUI.Run` enters the alt-screen — so a slow first-time image pull doesn't freeze the full-screen UI, and a spawn failure surfaces as a clean console error + exit instead of a wedged screen (same place `pasclaw agent` spawns).
- `SetCurrentSessionId` points the shell tools at that container for every turn; `CloseShellSession` (with the spawn-time `--rm`) tears it down on exit.

## Scope / safety

- **Local backend unchanged**: `ShellSessionId` stays empty → no lifecycle calls, behavior identical to today.
- Lives entirely in `Cmd.TUI.pas`, so it covers **both** the Delphi rich TUI and the FPC line-based TUI without touching either.
- The unique-per-launch id avoids a docker name collision with a container leaked by a previous crashed run.

## Verification

- Build clean (rc=0); `shell_backend_tests` pass; binary runs.
- ⚠️ Docker isn't available in CI here, so the container spawn/teardown path is verified by construction; a `pasclaw tui` run on a Docker host (ideally the Windows box) is the final confirmation.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_