### PR TITLE
gemini: keep contents valid after compaction (synthetic leading user turn)

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -445,16 +445,19 @@ begin
           a user turn or after a function response turn"), or
         - an orphaned tool functionResponse whose functionCall was
           summarised away -- a functionResponse with no matching call.
-      Skip leading orphaned tool results, then, if the first real turn is
-      the model's, synthesise a user turn so the call has a valid
-      predecessor. The summarised context lives in systemInstruction, so
-      nothing is lost. }
+      Skip leading orphaned tool results, then synthesise a user turn when
+      the first real turn is the model's -- OR when EVERY retained entry
+      was a skipped orphan (a tail that fell wholly inside a parallel
+      tool-result block), which would otherwise leave contents[] empty and
+      give Gemini no user turn to continue from. The summarised context
+      lives in systemInstruction, so nothing is lost. }
     StartIdx := 0;
     while (StartIdx <= High(Messages)) and
           ((Messages[StartIdx].Role = mrSystem) or
            (Messages[StartIdx].Role = mrTool)) do
       Inc(StartIdx);
-    if (StartIdx <= High(Messages)) and (Messages[StartIdx].Role = mrAssistant) then
+    if (StartIdx > High(Messages)) or
+       (Messages[StartIdx].Role = mrAssistant) then
     begin
       Content := TJsonObject.Create;
       Content.PutStr('role', 'user');

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -392,7 +392,7 @@ var
   i, j: Integer;
   Sys, ToolName, ArgsJSON: string;
   ToolIds, ToolNames: TStringList;   { id -> name map, parallel arrays }
-  Idx: Integer;
+  Idx, StartIdx: Integer;
   EmitGoogleSearch: Boolean;
 begin
   ToolIds   := TStringList.Create;
@@ -437,8 +437,37 @@ begin
             ToolNames.Add(Messages[i].ToolCalls[j].Func.Name);
           end;
 
+    { Gemini ordering guard for a compacted tail. After compaction folds
+      the summary into systemInstruction and keeps only the trailing
+      messages, the first turn we'd emit can be:
+        - a model functionCall whose originating user turn was summarised
+          away -- Gemini 400s ("function call turn comes immediately after
+          a user turn or after a function response turn"), or
+        - an orphaned tool functionResponse whose functionCall was
+          summarised away -- a functionResponse with no matching call.
+      Skip leading orphaned tool results, then, if the first real turn is
+      the model's, synthesise a user turn so the call has a valid
+      predecessor. The summarised context lives in systemInstruction, so
+      nothing is lost. }
+    StartIdx := 0;
+    while (StartIdx <= High(Messages)) and
+          ((Messages[StartIdx].Role = mrSystem) or
+           (Messages[StartIdx].Role = mrTool)) do
+      Inc(StartIdx);
+    if (StartIdx <= High(Messages)) and (Messages[StartIdx].Role = mrAssistant) then
+    begin
+      Content := TJsonObject.Create;
+      Content.PutStr('role', 'user');
+      Parts := TJsonArray.Create;
+      Part := TJsonObject.Create;
+      Part.PutStr('text', 'Continue.');
+      Parts.AddObject(Part);
+      Content.PutArray('parts', Parts);
+      Contents.AddObject(Content);
+    end;
+
     { Second pass: build contents[] in order. }
-    for i := 0 to High(Messages) do
+    for i := StartIdx to High(Messages) do
     begin
       if Messages[i].Role = mrSystem then Continue;
 

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -479,6 +479,24 @@ begin
   Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts);
   AssertMissing(Body, 'Continue.',
     'no synthetic user turn when the tail already starts with a user turn');
+
+  { Tail that is ENTIRELY orphaned tool results (a parallel tool batch
+    whose retained window fell wholly inside the result block). All get
+    skipped, so the synthetic user turn must still be emitted -- otherwise
+    contents[] is empty and Gemini has no user turn to continue from. }
+  SetLength(Msgs, 2);
+  Msgs[0].Role := mrTool; Msgs[0].ToolCallId := 'x0';
+  Msgs[0].Content := '[]'; Msgs[0].Name := 'fs_list';
+  Msgs[1].Role := mrTool; Msgs[1].ToolCallId := 'x1';
+  Msgs[1].Content := '[]'; Msgs[1].Name := 'fs_grep';
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts);
+  AssertContains(Body, '"contents"', 'contents array present');
+  AssertContains(Body, 'Continue.',
+    'synthetic user turn emitted when every retained entry is an orphaned tool');
+  AssertContains(Body, '"role" : "user"',
+    'the synthesised turn is a user turn');
+  AssertMissing(Body, 'functionResponse',
+    'orphaned tool results are dropped, not emitted as functionResponse');
 end;
 
 begin

--- a/src/tests/gemini_schema_strip_tests.pas
+++ b/src/tests/gemini_schema_strip_tests.pas
@@ -437,8 +437,53 @@ begin
     'no functionDeclarations entry when caller has no tools');
 end;
 
+procedure TestCompactedTailOrdering;
+{ After compaction the retained tail can begin with a model functionCall
+  (its originating user turn was summarised into systemInstruction).
+  BuildRequest must synthesise a leading user turn so Gemini doesn't 400
+  with "function call turn comes immediately after a user turn or after a
+  function response turn". A tail that already starts with a real user
+  turn must NOT get the synthetic turn. }
+var
+  Msgs:  TMessageArray;
+  Tools: TToolDefinitionArray;
+  Opts:  TChatOptions;
+  Body:  string;
+begin
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+
+  { Compacted tail: leading model functionCall + its tool response. }
+  SetLength(Msgs, 2);
+  Msgs[0].Role    := mrAssistant;
+  Msgs[0].Content := '';
+  SetLength(Msgs[0].ToolCalls, 1);
+  Msgs[0].ToolCalls[0].Id            := 'c0';
+  Msgs[0].ToolCalls[0].Kind          := 'function';
+  Msgs[0].ToolCalls[0].Func.Name     := 'fs_list';
+  Msgs[0].ToolCalls[0].Func.Arguments := '{"path":"."}';
+  Msgs[1].Role       := mrTool;
+  Msgs[1].ToolCallId := 'c0';
+  Msgs[1].Content    := '[]';
+  Msgs[1].Name       := 'fs_list';
+
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts);
+  AssertContains(Body, 'Continue.',
+    'synthetic user turn added before a leading model functionCall');
+  if Pos('Continue.', Body) > Pos('"functionCall"', Body) then
+    Fail('synthetic user turn must precede the functionCall', Body);
+
+  { Normal tail already starting with a user turn -- no synthetic turn. }
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'hello there');
+  Body := BuildRequest(Msgs, Tools, 'gemini-3.5-flash', Opts);
+  AssertMissing(Body, 'Continue.',
+    'no synthetic user turn when the tail already starts with a user turn');
+end;
+
 begin
   TestRejectedFieldsScrubbed;
+  TestCompactedTailOrdering;
   TestUserPropertyNamedAdditionalPropertiesSurvives;
   TestEmptyAndMalformed;
   TestThoughtSignatureRoundTrip;


### PR DESCRIPTION
## Symptom

After a compaction, Gemini 400s:

```
[info] compact: 47 msgs (incl 0 system) → 0 system + 8 tail msgs; summary ~378 tokens folded into SystemPrompt
gemini error 400: "Please ensure that function call turn comes immediately after a user turn or after a function response turn."
```

## Cause

Compaction folds the summary into `systemInstruction` and keeps only the trailing messages. The Gemini `contents[]` builder emitted those messages in order with **no start-of-conversation guard**, so the first turn could be:

- a **model `functionCall`** whose originating user turn was summarized away → Gemini rejects a leading function call (it must follow a user / function-response turn), or
- an **orphaned tool `functionResponse`** whose `functionCall` was summarized away.

## Fix

`BuildRequest` now guards the start of `contents[]`:
- skip leading orphaned tool results, then
- if the first real turn is the model's, synthesize a `"Continue."` user turn so the function call has a valid predecessor.

The summarized context already lives in `systemInstruction`, so nothing is lost. **Normal histories are unaffected** — the synthetic turn is added only when the emitted sequence would otherwise start with a model turn (i.e. post-compaction), which I verified leaves the existing tests byte-equivalent.

## Verification

- `gemini_schema_strip_tests` pass, including a new `TestCompactedTailOrdering` that asserts:
  - a compacted tail starting with a model `functionCall` gets a synthetic user turn **before** the call, and
  - a normal tail starting with a real user turn gets **no** synthetic turn.
- Full build clean (rc=0).

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_