### PR TITLE
mcp: salvage streamed tools/list, 12h refresh TTL, non-blocking exit

### DIFF
--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -132,6 +132,9 @@ type
     FClient: TMCPBaseClient;
     FDone:   TEvent;   { signalled when Execute returns -- lets shutdown
                          bound its wait instead of a 30s-connect WaitFor }
+    FRegLock: TCriticalSection;  { held across the registry mutation so
+                                   shutdown can flush an in-progress
+                                   registration before freeing FReg }
   protected
     procedure Execute; override;
   public
@@ -139,6 +142,10 @@ type
                        State: TMCPServerState);
     destructor  Destroy; override;
     property DoneEvent: TEvent read FDone;
+    { Block until the loader is not mid-registration. After this returns,
+      with Terminated already set, the loader will not touch FReg again --
+      so the caller can free the registry and abandon the thread safely. }
+    procedure FlushPendingRegistration;
   end;
 
 const
@@ -328,6 +335,13 @@ begin
   FState  := State;
   FClient := nil;
   FDone   := TEvent.Create(nil, {ManualReset=}True, {InitialState=}False, '');
+  FRegLock := TCriticalSection.Create;
+end;
+
+procedure TMCPLoader.FlushPendingRegistration;
+begin
+  FRegLock.Acquire;
+  FRegLock.Release;
 end;
 
 destructor TMCPLoader.Destroy;
@@ -337,6 +351,7 @@ begin
     client is still ours to free. }
   if FClient <> nil then begin FClient.Free; FClient := nil; end;
   FDone.Free;
+  FRegLock.Free;
   inherited Destroy;
 end;
 
@@ -406,35 +421,49 @@ begin
     end;
     LogInfo('mcp[%s] live connect OK (%d tools)', [FCfg.Name, Length(Tools)]);
     SaveCachedTools(FCfg.Name, Tools);
-    { Shutting down -- don't mutate the registry/state past this point so
-      an abandoned loader can't use-after-free them (the cache is already
-      saved). }
+    { Cheap early-out before taking the lock -- the cache is already saved. }
     if Terminated then Exit;
 
-    { Always re-register every live tool. Reuse the existing
-      dispatch object (created in the cache pass) when one is
-      present so HandlerObj pointer stability holds -- only the
-      description and schema on the TTool entry change. Skipping
-      re-registration when a cached entry exists would leave the
-      registry stuck on yesterday's (possibly stale) description
-      and inputSchema while the model continued to dispatch via
-      the (live, working) dispatch object. Codex P2 on PR #141.
-      FindDispatchFor + Register are both O(N); for several
-      thousand tools that's an O(N²) one-time cost in the loader
-      thread -- acceptable, but if it ever becomes noticeable
-      promote FDispatches to a sorted TStringList. }
-    for i := 0 to High(Tools) do
-    begin
-      Dispatch := FState.FindDispatchFor(Tools[i].Name);
-      if Dispatch = nil then
-        Dispatch := FState.AddDispatch(Tools[i].Name);
-      RegisterToolViaDispatch(FReg, FCfg.Name, Tools[i], Dispatch);
-    end;
+    { Registry mutation is the one shutdown-sensitive step: it writes FReg,
+      which the caller frees right after FreeMCPClients returns. Hold
+      FRegLock across the whole re-register + SetReady so a concurrent
+      shutdown's FlushPendingRegistration blocks until we finish (bounded
+      by registration time -- CPU only, no network), then re-check
+      Terminated INSIDE the lock: if shutdown began before we acquired it,
+      skip touching FReg entirely. Together with FreeMCPClients setting
+      Terminated before the flush, this guarantees an abandoned loader
+      never writes a freed registry. }
+    FRegLock.Acquire;
+    try
+      if Terminated then Exit;
 
-    FState.SetReady(FClient);
-    { Ownership transferred to FState; clear ours so Destroy doesn't
-      double-free. }
-    FClient := nil;
+      { Always re-register every live tool. Reuse the existing
+        dispatch object (created in the cache pass) when one is
+        present so HandlerObj pointer stability holds -- only the
+        description and schema on the TTool entry change. Skipping
+        re-registration when a cached entry exists would leave the
+        registry stuck on yesterday's (possibly stale) description
+        and inputSchema while the model continued to dispatch via
+        the (live, working) dispatch object. Codex P2 on PR #141.
+        FindDispatchFor + Register are both O(N); for several
+        thousand tools that's an O(N²) one-time cost in the loader
+        thread -- acceptable, but if it ever becomes noticeable
+        promote FDispatches to a sorted TStringList. }
+      for i := 0 to High(Tools) do
+      begin
+        Dispatch := FState.FindDispatchFor(Tools[i].Name);
+        if Dispatch = nil then
+          Dispatch := FState.AddDispatch(Tools[i].Name);
+        RegisterToolViaDispatch(FReg, FCfg.Name, Tools[i], Dispatch);
+      end;
+
+      FState.SetReady(FClient);
+      { Ownership transferred to FState; clear ours so Destroy doesn't
+        double-free. }
+      FClient := nil;
+    finally
+      FRegLock.Release;
+    end;
   except
     on E: Exception do
     begin
@@ -519,7 +548,15 @@ begin
     if Clients[i] <> nil then
     begin
       Loader := TMCPLoader(Clients[i]);
+      { Order matters: set Terminated, THEN flush. After the flush returns,
+        any registration that was in flight has finished and -- because
+        Terminated is now set and the registration block re-checks it under
+        FRegLock -- the loader will never write FReg again. Only then is it
+        safe for the abandon branch to let the caller free the registry.
+        The flush blocks at most for a registration pass (CPU only); it
+        never waits on the network. }
       Loader.Terminate;
+      Loader.FlushPendingRegistration;
       if Loader.DoneEvent.WaitFor(ShutdownWaitMs) = wrSignaled then
       begin
         Loader.WaitFor;
@@ -527,10 +564,11 @@ begin
       end
       else
       begin
-        { Still blocked in a network call. Don't hang the app on exit:
-          hand the thread to the OS (FreeOnTerminate) and abandon it. Its
-          Terminated checks keep it from touching the registry/state after
-          this point, so it self-frees cleanly when the call returns. }
+        { Still blocked in a network call (Connect/ListTools -- neither
+          touches FReg). Don't hang the app on exit: hand the thread to the
+          OS (FreeOnTerminate) and abandon it. The flush above + the
+          Terminated re-check guarantee it can't write the about-to-be-freed
+          registry; it self-frees when the call returns. }
         Loader.FreeOnTerminate := True;
         Abandoned := True;
       end;

--- a/src/pkg/mcp/PasClaw.MCP.Bridge.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Bridge.pas
@@ -32,9 +32,16 @@
   no per-slot handler boilerplate, no MaxBindings cap. Replicate's
   catalog can be as big as it wants.
 
-  FreeMCPClients waits for every loader thread to finish before freeing
-  its client, so a fast `^C` doesn't race the thread that's still inside
-  Connect.
+  FreeMCPClients gives each loader a bounded wait to finish (so the
+  common case frees cleanly), but a loader still blocked inside a network
+  Connect/ListTools is abandoned to the OS (FreeOnTerminate) rather than
+  hanging the app's exit -- its Terminated checks keep it from touching
+  the registry/state after teardown begins.
+
+  Refresh TTL: a tools/list cache younger than MCPRefreshTTLSeconds is
+  reused as-is. The loader still connects (so tool calls work) but skips
+  the expensive tools/list; only a stale/absent cache pays the full
+  refresh. This is what keeps a quick start+exit cheap.
 }
 unit PasClaw.MCP.Bridge;
 
@@ -123,13 +130,22 @@ type
     FReg:    TToolRegistry;
     FState:  TMCPServerState;
     FClient: TMCPBaseClient;
+    FDone:   TEvent;   { signalled when Execute returns -- lets shutdown
+                         bound its wait instead of a 30s-connect WaitFor }
   protected
     procedure Execute; override;
   public
     constructor Create(const ServerCfg: TMCPServer; Reg: TToolRegistry;
                        State: TMCPServerState);
     destructor  Destroy; override;
+    property DoneEvent: TEvent read FDone;
   end;
+
+const
+  { TTL for the live tools/list refresh. A cache younger than this is
+    reused as-is (the loader still connects, so tool calls work, but skips
+    the expensive tools/list -- Replicate returns thousands of tools). }
+  MCPRefreshTTLSeconds = 12 * 60 * 60;
 
 var
   GStates: TList;  { TList of TMCPServerState -- owned; freed in FreeMCPClients }
@@ -311,6 +327,7 @@ begin
   FReg    := Reg;
   FState  := State;
   FClient := nil;
+  FDone   := TEvent.Create(nil, {ManualReset=}True, {InitialState=}False, '');
 end;
 
 destructor TMCPLoader.Destroy;
@@ -319,6 +336,7 @@ begin
     here) or failed before reaching that point -- in which case the
     client is still ours to free. }
   if FClient <> nil then begin FClient.Free; FClient := nil; end;
+  FDone.Free;
   inherited Destroy;
 end;
 
@@ -345,7 +363,9 @@ var
   Err: string;
   Dispatch: TMCPToolDispatch;
   i: Integer;
+  Age: Int64;
 begin
+  try
   {$IFDEF MSWINDOWS}
   CoInitializeEx(nil, COINIT_MULTITHREADED);
   try
@@ -355,12 +375,29 @@ begin
       FClient := TMCPHttpClient.Create(FCfg.Name, FCfg.Cmd, FCfg.Args)
     else
       FClient := TMCPStdioClient.Create(FCfg.Name, FCfg.Cmd, FCfg.Args);
+    if Terminated then Exit;
     if not FClient.Connect(30 * 1000, Err) then
     begin
       LogWarn('mcp[%s] connect failed: %s', [FCfg.Name, Err]);
       FState.SetFailed(Err);
       Exit;
     end;
+    if Terminated then Exit;
+
+    { TTL gate: a cache younger than MCPRefreshTTLSeconds is still good.
+      Connect above established the live session so tool calls work --
+      reuse the tools we already registered at startup and skip the
+      expensive tools/list (Replicate's catalog is thousands of tools). }
+    Age := CacheAgeSeconds(FCfg.Name);
+    if (Age >= 0) and (Age < MCPRefreshTTLSeconds) then
+    begin
+      LogInfo('mcp[%s] cache fresh (%ds old < %ds TTL) -- reusing cached tools, skipping live tools/list',
+              [FCfg.Name, Age, Int64(MCPRefreshTTLSeconds)]);
+      FState.SetReady(FClient);
+      FClient := nil;
+      Exit;
+    end;
+
     if not FClient.ListTools(Tools, Err) then
     begin
       LogWarn('mcp[%s] tools/list failed: %s', [FCfg.Name, Err]);
@@ -369,6 +406,10 @@ begin
     end;
     LogInfo('mcp[%s] live connect OK (%d tools)', [FCfg.Name, Length(Tools)]);
     SaveCachedTools(FCfg.Name, Tools);
+    { Shutting down -- don't mutate the registry/state past this point so
+      an abandoned loader can't use-after-free them (the cache is already
+      saved). }
+    if Terminated then Exit;
 
     { Always re-register every live tool. Reuse the existing
       dispatch object (created in the cache pass) when one is
@@ -406,6 +447,10 @@ begin
     CoUninitialize;
   end;
   {$ENDIF}
+  finally
+    { Always signal completion so a bounded shutdown wait can proceed. }
+    FDone.SetEvent;
+  end;
 end;
 
 { ============================================================
@@ -442,7 +487,7 @@ begin
         Inc(CachedCount);
       end;
       if CachedCount > 0 then
-        LogInfo('mcp[%s] cache hit: %d tool(s) registered, live refresh started',
+        LogInfo('mcp[%s] cache hit: %d tool(s) registered (connecting in background)',
                 [Cfg.MCPServers[i].Name, CachedCount]);
       Inc(CachedRegistered, CachedCount);
     end;
@@ -458,24 +503,54 @@ begin
 end;
 
 procedure FreeMCPClients(var Clients: TMCPClientList);
+const
+  { Per-loader budget. A finished or fresh-cache loader signals DoneEvent
+    almost immediately; only one still blocked in a network call waits the
+    full budget before being abandoned. Bounds exit instead of a 30s
+    connect WaitFor. }
+  ShutdownWaitMs = 1000;
 var
   i: Integer;
+  Loader: TMCPLoader;
+  Abandoned: Boolean;
 begin
+  Abandoned := False;
   for i := 0 to High(Clients) do
     if Clients[i] <> nil then
     begin
-      try Clients[i].WaitFor; except end;
-      Clients[i].Free;
+      Loader := TMCPLoader(Clients[i]);
+      Loader.Terminate;
+      if Loader.DoneEvent.WaitFor(ShutdownWaitMs) = wrSignaled then
+      begin
+        Loader.WaitFor;
+        Loader.Free;
+      end
+      else
+      begin
+        { Still blocked in a network call. Don't hang the app on exit:
+          hand the thread to the OS (FreeOnTerminate) and abandon it. Its
+          Terminated checks keep it from touching the registry/state after
+          this point, so it self-frees cleanly when the call returns. }
+        Loader.FreeOnTerminate := True;
+        Abandoned := True;
+      end;
     end;
   SetLength(Clients, 0);
 
   { Server states (and their owned dispatch objects + clients) are
     referenced from the registry via HandlerObj pointers; freeing them
     here invalidates those entries, but the caller is tearing the whole
-    agent down so the registry is going too. }
-  for i := 0 to GStates.Count - 1 do
-    TMCPServerState(GStates[i]).Free;
-  GStates.Clear;
+    agent down so the registry is going too.
+
+    When a loader was abandoned, skip this: that loader still references
+    its TMCPServerState, so freeing it would risk a use-after-free. The
+    process is exiting, so the leak is reclaimed by the OS momentarily. }
+  if not Abandoned then
+  begin
+    for i := 0 to GStates.Count - 1 do
+      TMCPServerState(GStates[i]).Free;
+    GStates.Clear;
+  end;
 end;
 
 initialization

--- a/src/pkg/mcp/PasClaw.MCP.Cache.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Cache.pas
@@ -49,6 +49,13 @@ procedure SaveCachedTools(const ServerName: string;
 function CachePath(const ServerName: string): string;
 function HasCachedTools(const ServerName: string): Boolean;
 
+{ Seconds since the cache for ServerName was written (its `cached_at`).
+  -1 when there is no cache, it can't be read, or it predates the
+  cached_at field. Clock skew (cached_at in the future) clamps to 0 so a
+  fresh cache is never treated as stale. Used to gate the live tools/list
+  refresh on a TTL. }
+function CacheAgeSeconds(const ServerName: string): Int64;
+
 implementation
 
 uses
@@ -80,6 +87,38 @@ begin
   T := Now;
   {$ENDIF}
   Result := Round((T - UnixDelta) * 86400);
+end;
+
+function CacheAgeSeconds(const ServerName: string): Int64;
+var
+  Path: string;
+  L: TStringList;
+  Root: TJsonObject;
+  CachedAt: Int64;
+begin
+  Result := -1;
+  Path := CachePath(ServerName);
+  if not FileExists(Path) then Exit;
+  L := TStringList.Create;
+  try
+    try
+      L.LoadFromFile(Path);
+    except
+      Exit;
+    end;
+    Root := TJsonObject.Parse(L.Text);
+    if Root = nil then Exit;
+    try
+      CachedAt := Root.GetInt('cached_at', 0);
+    finally
+      Root.Free;
+    end;
+  finally
+    L.Free;
+  end;
+  if CachedAt <= 0 then Exit;
+  Result := NowUnix - CachedAt;
+  if Result < 0 then Result := 0;   { clock skew -> treat as fresh }
 end;
 
 function LoadCachedTools(const ServerName: string;

--- a/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
+++ b/src/pkg/mcp/PasClaw.MCP.HttpClient.pas
@@ -97,6 +97,24 @@ begin
   end;
 end;
 
+function LooksLikeJsonRpcReply(const S: string): Boolean;
+{ True when S parses as a JSON object carrying a JSON-RPC reply shape
+  (result / error / jsonrpc). Used to salvage a streamed reply when the
+  HTTP layer reports a bad/zero status but the body actually arrived. }
+var
+  O: TJsonObject;
+begin
+  Result := False;
+  if Trim(S) = '' then Exit;
+  O := TJsonObject.Parse(S);
+  if O = nil then Exit;
+  try
+    Result := O.Has('result') or O.Has('error') or O.Has('jsonrpc');
+  finally
+    O.Free;
+  end;
+end;
+
 function LookupHeader(const Headers: THeaderPairs; const Name: string): string;
 { Case-insensitive header lookup. HTTP header names are
   case-insensitive per RFC 7230 §3.2, and Indy + TNetHTTPClient
@@ -160,7 +178,7 @@ function TMCPHttpClient.RoundTrip(const Method, ParamsJSON: string;
 
 var
   Req: TJsonObject;
-  Body, EffectiveAuth, RefreshErr: string;
+  Body, EffectiveAuth, RefreshErr, Salvaged: string;
   Headers: TArray<THeaderPair>;
   Resp: THTTPResult;
 begin
@@ -203,6 +221,20 @@ begin
 
   if (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
   begin
+    { Salvage a streamed reply. Streamable-HTTP servers (Replicate among
+      them) send the JSON-RPC response as a single text/event-stream event
+      and then hold or abruptly close the connection; System.Net raises on
+      that, so we see StatusCode=0 even though the logical response landed
+      in the body intact. If the collapsed body is a well-formed JSON-RPC
+      envelope, treat it as success rather than discarding it. }
+    Salvaged := CollapseSSE(Resp.Body);
+    if LooksLikeJsonRpcReply(Salvaged) then
+    begin
+      if FSessionId = '' then
+        FSessionId := LookupHeader(Resp.RespHeaders, 'Mcp-Session-Id');
+      RespJSON := Salvaged;
+      Exit(True);
+    end;
     LogWarn('mcp-http[%s] status=%d body=%s',
             [FName, Resp.StatusCode, Copy(Resp.Body, 1, 200)]);
     Exit(False);


### PR DESCRIPTION
Three related fixes for HTTP MCP servers (Replicate in particular), from a live session log.

## 1. Salvage streamed `tools/list` replies (the reported `tools/list failed`)

```
[warn] mcp-http[replicate] status=0 body=event: message
data: {"jsonrpc":"2.0","id":2,"result":{"tools":[...]}}
[warn] mcp[replicate] tools/list failed: tools/list failed
```

Streamable-HTTP servers send the JSON-RPC reply as a single `text/event-stream` event and then hold/close the connection; `System.Net.HttpClient` raises on that, so `RoundTrip` saw `StatusCode=0` even though the full response was already buffered in the body. `RoundTrip` now collapses the SSE body on a non-2xx status and, when it's a well-formed JSON-RPC envelope, accepts it instead of discarding it. Restores Replicate's tools.

## 2. 12-hour refresh TTL

The loader re-fetched `tools/list` on **every** launch. New `CacheAgeSeconds` + `MCPRefreshTTLSeconds` (12h): when the cache is fresh, the loader still **connects** (so tool calls work — the cached dispatches need a live client) but **reuses the cached tools and skips the expensive `tools/list`** (Replicate returns thousands). A stale or absent cache still does the full refresh. Global TTL — applies to any MCP server, not just Replicate.

## 3. Non-blocking exit

`FreeMCPClients` used an unbounded `WaitFor`, so exiting an agent/TUI mid-connect blocked until the 30s connect returned. It now:
- waits a **bounded** time per loader (via a new `DoneEvent`), and
- **abandons** a still-connecting loader to the OS (`FreeOnTerminate`) rather than hanging exit.

The loader gained `Terminated` checks before it mutates the registry/state, and abandoned loaders skip the `GStates` free to avoid a use-after-free (the process is exiting, so the small leak is reclaimed immediately). This matches the bounded-wait + `FreeOnTerminate` handoff the TUI already uses for its loop thread.

## Interaction
Fix 1 makes the refresh actually succeed → it updates `cached_at` → Fix 2's TTL then suppresses refresh for 12h → Fix 3 means even the occasional stale-cache refresh never blocks exit.

## Verification
- Build clean (rc=0); `mcp_server_tests` + `mcp_hub_projection_tests` pass.
- ⚠️ Threading (bounded-exit/abandon) and the HTTP-transport salvage can't be unit-tested in CI (no Docker / Windows / live MCP here) — verified by construction. A Replicate-backed `pasclaw agent` start + quick-exit on your box is the end-to-end confirmation.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_