### PR TITLE
hashline: precise error + docs for the "echoed text on the anchor line" mistake

### DIFF
--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -489,6 +489,34 @@ begin
   Result := (RangeStart > 0) and (RangeEnd >= RangeStart);
 end;
 
+function IsAnchorWithTrailingText(const Line: string): Boolean;
+{ True for lines shaped like "10:  foo" or "7-10: foo" -- a line-number
+  anchor with text echoed after the colon. This is the single most common
+  malformed anchor: the model copies fs_read's "N:content" display onto
+  the anchor line instead of using a bare "N:" with the text on a |/↑/↓
+  payload line. TryParseAnchor rejects it (anchors take no trailing text),
+  and we use this to turn the generic "unrecognized content" into a
+  precise hint. NOT a parse path -- diagnostics only. }
+var
+  i, n: Integer;
+begin
+  Result := False;
+  n := Length(Line);
+  i := 1;
+  while (i <= n) and (Line[i] = ' ') do Inc(i);
+  if (i > n) or not ((Line[i] >= '1') and (Line[i] <= '9')) then Exit;
+  while (i <= n) and (Line[i] >= '0') and (Line[i] <= '9') do Inc(i);
+  if (i <= n) and (Line[i] = '-') then
+  begin
+    Inc(i);
+    while (i <= n) and (Line[i] >= '0') and (Line[i] <= '9') do Inc(i);
+  end;
+  if (i > n) or (Line[i] <> ':') then Exit;
+  Inc(i);
+  while (i <= n) and (Line[i] = ' ') do Inc(i);
+  Result := i <= n;   { non-space content remains after "N:" }
+end;
+
 function TryParsePayload(const Line: string; out Kind: THLPayloadKind;
                          out Body: string): Boolean;
 begin
@@ -682,15 +710,25 @@ begin
       end;
       if Trim(Lines[i]) = '' then Continue;
       if (Lines[i] <> '') and (Lines[i][1] = '#') then Continue;
-      { Most common cause: a multi-line replacement that prefixed only its
-        first line. Every payload line needs its own marker, so a bare
-        line inside a block reads as unrecognized. Say so. }
-      ErrMsg := Format('line %d: unrecognized content %s -- every payload line ' +
-                       'must start with %s (replace), %s (insert above), or %s ' +
-                       '(insert below); a bare line usually means a multi-line ' +
-                       'replacement is missing its per-line %s prefix',
-                       [i + 1, QuotedStr(Lines[i]), HL_PAYLOAD_REPLACE,
-                        HL_PAYLOAD_ABOVE, HL_PAYLOAD_BELOW, HL_PAYLOAD_REPLACE]);
+      if IsAnchorWithTrailingText(Lines[i]) then
+        { The model echoed the current line text onto the anchor (copying
+          fs_read's "N:content" display). Anchors take no trailing text. }
+        ErrMsg := Format('line %d: anchor line must be JUST the line number(s) -- ' +
+                         '"%s" should be e.g. "10:" or "7-10:" with nothing after ' +
+                         'the colon. Do not copy the "N:content" form from fs_read ' +
+                         'onto the anchor; put the replacement text on the next ' +
+                         'line(s) prefixed with %s (replace).',
+                         [i + 1, Trim(Lines[i]), HL_PAYLOAD_REPLACE])
+      else
+        { Most common remaining cause: a multi-line replacement that
+          prefixed only its first line. Every payload line needs its own
+          marker, so a bare line inside a block reads as unrecognized. }
+        ErrMsg := Format('line %d: unrecognized content %s -- every payload line ' +
+                         'must start with %s (replace), %s (insert above), or %s ' +
+                         '(insert below); a bare line usually means a multi-line ' +
+                         'replacement is missing its per-line %s prefix',
+                         [i + 1, QuotedStr(Lines[i]), HL_PAYLOAD_REPLACE,
+                          HL_PAYLOAD_ABOVE, HL_PAYLOAD_BELOW, HL_PAYLOAD_REPLACE]);
       Exit;
     end;
     if Started then

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -813,13 +813,18 @@ begin
     T.Name        := 'fs_edit_hashline';
     T.Description := 'Apply a hashline-format patch. Begins with a ' + HL_FILE_PREFIX +
                      'path#hash header, then one or more blocks. Each block is an anchor line ' +
-                     '(42: for one line, 7-10: for a range) followed by payload lines. EVERY ' +
-                     'payload line must start with its own marker: ' + HL_PAYLOAD_REPLACE +
+                     'that is JUST the line number(s) -- "42:" for one line, "7-10:" for a ' +
+                     'range -- with NOTHING after the colon. Do NOT copy fs_read''s "N:content" ' +
+                     'display onto the anchor (write "42:", not "42:  the old text"). The ' +
+                     'anchor is followed by payload lines, and EVERY payload line must start ' +
+                     'with its own marker: ' + HL_PAYLOAD_REPLACE +
                      ' to replace, ' + HL_PAYLOAD_ABOVE + ' to insert above the anchor, ' +
                      HL_PAYLOAD_BELOW + ' to insert below. A multi-line replacement repeats ' +
                      HL_PAYLOAD_REPLACE + ' on every line (a 3-line replacement has three ' +
-                     HL_PAYLOAD_REPLACE + ' lines) -- never a bare line. The header hash must ' +
-                     'match the file on disk; stale patches abort without writing.';
+                     HL_PAYLOAD_REPLACE + ' lines) -- never a bare line. Example: "' +
+                     HL_FILE_PREFIX + 'foo.pas#ab12" / "10:" / "' + HL_PAYLOAD_REPLACE +
+                     '  new line 10 text". The header hash must match the file on disk; ' +
+                     'stale patches abort without writing.';
     T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
     T.Handler     := Tool_FSEditHashline;
     T.IsCore      := True;

--- a/src/tests/hashline_patch_tests.pas
+++ b/src/tests/hashline_patch_tests.pas
@@ -66,10 +66,39 @@ begin
              'error explains the per-line prefix requirement: ' + Err);
 end;
 
+procedure TestAnchorWithEchoedTextRejected;
+{ The recurring real-world mistake: the model copies fs_read's "N:content"
+  display onto the anchor line instead of a bare "N:". Must be rejected
+  (echoing the old text on the anchor is ambiguous in multi-line cases),
+  and the error must precisely name the anchor problem -- not the generic
+  missing-| hint -- so the model fixes it without flailing. The bare-"N:"
+  form must of course still parse. }
+var
+  P, Err: string;
+  Sections: THLSectionArray;
+begin
+  P := '¶e.txt#beef' + #10 +
+       '10:  FireDAC.FUI.Transit, FireDAC.Comp.UI;' + #10 +
+       '|  FireDAC.FMXUI.Wait, FireDAC.Comp.UI;';
+  AssertTrue(not ParseHashlinePatch(P, Sections, Err),
+             'anchor line with echoed text must be rejected');
+  AssertTrue(Pos('anchor', Err) > 0,
+             'error names the anchor as the problem: ' + Err);
+  AssertTrue((Pos('per-line', Err) = 0),
+             'error does NOT misfire the generic missing-| hint: ' + Err);
+
+  { The corrected form -- bare anchor + replace payload -- parses fine. }
+  P := '¶e.txt#beef' + #10 + '10:' + #10 +
+       '|  FireDAC.FMXUI.Wait, FireDAC.Comp.UI;';
+  AssertTrue(ParseHashlinePatch(P, Sections, Err),
+             'bare "N:" anchor + payload still parses: ' + Err);
+end;
+
 begin
   TestValidInsertion;
   TestValidMultilineReplacement;
   TestInvalidInlinePayload;
   TestBareContinuationLineRejected;
+  TestAnchorWithEchoedTextRejected;
   Writeln('PASS');
 end.


### PR DESCRIPTION
## What's going on

Sessions keep burning a wasted `fs_edit_hashline` call because the model copies `fs_read`'s display format (`N:content`) straight onto the **anchor** line:

```
¶…\DelphiPal.Database.pas#fff5
10:  FireDAC.FUI.Transit, FireDAC.Comp.UI, FireDAC.DApt, Data.DB;   ← anchor with echoed text
|  FireDAC.FMXUI.Wait, FireDAC.Comp.UI, FireDAC.DApt, Data.DB;
```

A hashline anchor must be a **bare** `10:` (or `7-10:`) — the line text belongs only on `|`/`↑`/`↓` payload lines. The parser rejected it, but with the *generic* message ("unrecognized content … a bare line usually means a missing per-line `|`"), which misdiagnoses the real problem. The model self-corrects to `10:\n|new`, but only after a failed call.

## Why I didn't just accept `N: content`

Tempting (ignore the echo), but unsafe. In the other logged case the model wrote three `N:content` "anchors" + one `|`:
```
415:    InitializeModelsList; // …
416:  end;
417:  else
|    …
```
Silently ignoring the echoes would apply a **wrong** edit (only line 417 replaced) instead of erroring. For a code-editing tool, a silent wrong edit is worse than one retry — so parsing stays strict.

## Fix

- **Precise diagnosis**: new `IsAnchorWithTrailingText` turns the generic error into "anchor line must be JUST the line number(s) … do not copy the `N:content` form from fs_read; put the replacement on the next `|`-line." The model now knows exactly what to fix.
- **Teach it upfront**: `fs_edit_hashline`'s description now states anchors are bare line numbers with nothing after the colon, explicitly warns against copying `fs_read`'s `N:content`, and shows a worked example — reducing the first-failure rate.

## Verification

- Build clean (rc=0); `hashline_patch_tests` pass, including a new case asserting the anchor-echo form is rejected with an *anchor*-named error (not the generic missing-`|` hint) and that the corrected bare-`N:` form parses.

This complements #254 (per-line `|` guidance) and #256 — same goal of making `fs_edit_hashline` get it right the first time.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_