### PR TITLE
docker: explicit host→/workspace path example to stop /workspace/workspace

### DIFF
--- a/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
@@ -264,16 +264,23 @@ begin
   {$IFDEF MSWINDOWS}
   { Windows host only: without this the model follows the host platform and
     emits cmd.exe (`dir /s /b`, C:\ paths) into the Linux container, which
-    fails. Spell out Linux/POSIX and the mapped container cwd (/workspace).
-    On POSIX hosts the container shares the host's conventions and the
-    workspace is same-path, so no such warning is needed -- see the ELSE
-    branch, which keeps the original wording verbatim. }
+    fails. Spell out Linux/POSIX, the mapped container cwd (/workspace),
+    AND a concrete host->container path example -- the model otherwise sees
+    host paths everywhere (fs_read/fs_list return them) and mistranslates,
+    e.g. C:\...\workspace\DelphiPalAI became /workspace/workspace/DelphiPalAI
+    (the 'workspace' segment counted twice). On POSIX hosts the container
+    shares the host's conventions and the workspace is same-path, so no
+    such warning is needed -- see the ELSE branch (original wording). }
   Result := Format('runs each command inside a per-session Linux Docker container ' +
-                   '(image=%s, network=%s) via /bin/sh, so use POSIX commands ' +
-                   '(ls, find, grep, cat) and POSIX paths -- NOT Windows cmd ' +
-                   '(dir) or C:\ paths even though the host is Windows. The ' +
-                   'workspace is mounted at %s, which is the working directory',
+                   '(image=%s, network=%s) via /bin/sh. Use POSIX commands (ls, find, ' +
+                   'grep, cat) and POSIX paths -- NOT Windows cmd (dir) or C:\ paths ' +
+                   'even though the host is Windows. The workspace is mounted at %s, ' +
+                   'which is the working directory: a host path %s\NAME appears here ' +
+                   'as %s/NAME (do not reuse the C:\ path or repeat "workspace"). ' +
+                   'Prefer paths relative to the working directory.',
                    [FOpts.Image, FOpts.Network,
+                    ContainerPath(JoinPath(GetHome, 'workspace')),
+                    JoinPath(GetHome, 'workspace'),
                     ContainerPath(JoinPath(GetHome, 'workspace'))]);
   {$ELSE}
   Result := Format('runs inside a per-session Docker container (image=%s, network=%s; ' +


### PR DESCRIPTION
## Symptom

With the docker backend on a **Windows host**, the model mistranslated a workspace path inside the Linux container:

```
find C:\Users\anony\.pasclaw\workspace\DelphiPalAI\src\llama_cpp ...   → No such file (host path; container is Linux)
find /workspace/workspace/DelphiPalAI/src/llama_cpp ...                → No such file (doubled "workspace")
```

The correct container path is `/workspace/DelphiPalAI/...` — *one* `workspace`.

## Cause

On Windows+docker the model sees **host** paths everywhere (`fs_read`/`fs_list` return `C:\...\.pasclaw\workspace\X`), but `shell_exec` runs in a Linux container where that tree is bind-mounted at `/workspace`. Translating, it counted the `workspace` segment twice: mount point `/workspace` + the `workspace` segment of the host path → `/workspace/workspace/...`.

(Nothing in `ContainerPath` doubles — it maps `…\.pasclaw\workspace → /workspace` exactly once. This is the model mis-constructing the path.)

## Fix (follow-up to merged #256, description text only)

#256 already told the model "the workspace is mounted at `/workspace` (the cwd)." This adds a **concrete mapping example** to the docker `Describe` (Windows branch):

> *"a host path `<home>\workspace\NAME` appears here as `/workspace/NAME` (do not reuse the `C:\` path or repeat 'workspace'); prefer paths relative to the working directory."*

with the real `<home>\workspace` and `/workspace` interpolated, so the model gets an exact `C:\…\workspace\X → /workspace/X` example. POSIX branch (same-path mounts) is unchanged.

## Verification

- Build clean (rc=0); `shell_backend_tests` pass.
- Description text only — no runtime behavior change. The Windows `{$IFDEF}` branch can't be compiled in CI here (no Delphi/Windows); verified by construction. A `shell_exec` run under docker on the Windows box is the end-to-end confirmation.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_