### PR TITLE
tools: add delphi_build — host-side Delphi compile for docker-on-Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -449,6 +449,11 @@ test-shell-backend: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/shell_backend_tests.pas -o$(BUILDDIR)/shell_backend_tests
 	@$(BUILDDIR)/shell_backend_tests
 
+test-delphi-build: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/delphi_build_tests.pas -o$(BUILDDIR)/delphi_build_tests
+	@$(BUILDDIR)/delphi_build_tests
+
 # Shell output decode (PasClaw.Platform.DecodeShellOutputBytes) -- the OEM
 # codepage fix for cmd.exe stdout. Exercises the explicit-codepage path so
 # tests pin Windows behaviour without needing Windows itself.
@@ -559,4 +564,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-config-env-subst
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -35,6 +35,7 @@ uses
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
   PasClaw.Tools.KB,
+  PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
   PasClaw.Tools.WebSearch,
@@ -210,6 +211,11 @@ begin
   RegisterExecuteCodeTool(Result);
   RegisterMemoryTools(Result);
   RegisterKBTools(Result);
+  { delphi_build self-gates: registers only when a RAD Studio install is
+    found (so it's invisible on non-Delphi hosts). Runs host-side, which is
+    the point -- the compiler lives on the host even when shell_exec is in
+    a docker container. }
+  RegisterDelphiBuildTool(Result);
   RegisterSessionSearchTool(Result);
   { web_search registers only when a real provider is configured
     (Brave / Tavily / Perplexity / Gemini key, or SearXNG base URL).

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -34,6 +34,7 @@ uses
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
   PasClaw.Tools.KB,
+  PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
   PasClaw.Tools.WebSearch,
@@ -216,6 +217,7 @@ begin
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);
       RegisterKBTools(Reg);
+      RegisterDelphiBuildTool(Reg);   { self-gates on a discovered RAD Studio }
       RegisterSessionSearchTool(Reg);
       if HasConfiguredWebSearchProvider(Cfg) then
         RegisterWebSearchTool(Reg)

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -56,6 +56,7 @@ uses
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
   PasClaw.Tools.KB,
+  PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
   PasClaw.Tools.WebSearch,
@@ -188,6 +189,7 @@ begin
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);
       RegisterKBTools(Reg);
+      RegisterDelphiBuildTool(Reg);   { self-gates on a discovered RAD Studio }
       RegisterSessionSearchTool(Reg);
       if HasConfiguredWebSearchProvider(Cfg) then
         RegisterWebSearchTool(Reg)

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -27,6 +27,7 @@ uses
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
   PasClaw.Tools.KB,
+  PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
   PasClaw.Tools.WebSearch,
@@ -159,6 +160,7 @@ begin
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);
       RegisterKBTools(Reg);
+      RegisterDelphiBuildTool(Reg);   { self-gates on a discovered RAD Studio }
       RegisterSessionSearchTool(Reg);
       if HasConfiguredWebSearchProvider(Cfg) then
         RegisterWebSearchTool(Reg)

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -199,6 +199,7 @@
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.ExecuteCode.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.RPC.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.Memory.pas"/>
+        <DCCReference Include="..\pkg\tools\PasClaw.Tools.DelphiBuild.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.SessionSearch.pas"/>
         <DCCReference Include="..\pkg\tools\PasClaw.Tools.SendMessage.pas"/>
         <DCCReference Include="..\pkg\shell\PasClaw.Shell.Backend.pas"/>

--- a/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
+++ b/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
@@ -102,20 +102,37 @@ begin
 end;
 
 {$IFDEF MSWINDOWS}
+function VersionKey(const S: string): Int64;
+{ "23.0" -> 23*1000+0, "9.0" -> 9*1000+0, so a numeric compare orders
+   versions correctly. TStringList.Sort would put "9.0" AFTER "23.0"
+   lexicographically ('9' > '2') and pick the older compiler. }
+var
+  p: Integer;
+begin
+  p := Pos('.', S);
+  if p > 0 then
+    Result := Int64(StrToIntDef(Copy(S, 1, p - 1), 0)) * 1000 +
+              StrToIntDef(Copy(S, p + 1, MaxInt), 0)
+  else
+    Result := Int64(StrToIntDef(S, 0)) * 1000;
+end;
+
 function RegFindBin(Root: HKEY): string;
 { RAD Studio records its install dir at
   <Root>\SOFTWARE\Embarcadero\BDS\<ver>\RootDir -- the canonical way to
   find a compiler installed anywhere (custom drive/path), which the
   Program-Files probe below would miss. HKCU is where a normal per-user
   install writes it and isn't WOW64-redirected; HKLM is the fallback.
-  Enumerate versions and prefer the newest. }
+  Enumerate versions and pick the highest NUMERIC one that has a dcc. }
 var
   Reg: TRegistry;
   Keys: TStringList;
   i: Integer;
   RootDir, Bin: string;
+  V, BestV: Int64;
 begin
   Result := '';
+  BestV  := -1;
   Reg := TRegistry.Create;
   Keys := TStringList.Create;
   try
@@ -123,8 +140,7 @@ begin
     if not Reg.OpenKeyReadOnly('SOFTWARE\Embarcadero\BDS') then Exit;
     Reg.GetKeyNames(Keys);
     Reg.CloseKey;
-    Keys.Sort;   { ascending -> walk descending for newest-first }
-    for i := Keys.Count - 1 downto 0 do
+    for i := 0 to Keys.Count - 1 do
     begin
       if Reg.OpenKeyReadOnly('SOFTWARE\Embarcadero\BDS\' + Keys[i]) then
       begin
@@ -137,7 +153,12 @@ begin
         if RootDir <> '' then
         begin
           Bin := JoinPath(RootDir, 'bin');
-          if HasDcc(Bin) then Exit(Bin);
+          V := VersionKey(Keys[i]);
+          if HasDcc(Bin) and (V > BestV) then
+          begin
+            BestV  := V;
+            Result := Bin;
+          end;
         end;
       end;
     end;
@@ -379,12 +400,15 @@ begin
     Exit;
   end;
 
-  { Sandbox: only build a project inside the workspace. CanReadPath honours
-    restrict_to_workspace; building writes outputs next to the project, but
-    the gate we care about is "is this a workspace project, not some
-    arbitrary host path the model dreamed up". }
+  { Sandbox: gate on the WRITE boundary, not the read one. delphi_build is
+    a mutating tool -- it runs the compiler with the project dir as cwd and
+    drops .exe/.dcu next to the project. CanReadPath would accept a
+    read-only out-of-workspace location (allow_read_paths /
+    allow_read_outside_workspace), letting the build write outside the
+    sandbox. CanWritePath enforces restrict_to_workspace + allow_write_paths
+    -- the boundary that actually matches what we do. Codex P1 on PR #266. }
   ProjAbs := ExpandFileName(ExpandHome(Project));
-  if not CanReadPath(ProjAbs, Reason) then
+  if not CanWritePath(ProjAbs, Reason) then
   begin
     ErrMsg := Reason;
     Exit;

--- a/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
+++ b/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
@@ -1,0 +1,474 @@
+(*
+  PasClaw.Tools.DelphiBuild -- delphi_build tool.
+
+  Why this exists: with the docker shell backend on a Windows host, the
+  agent's shell_exec/execute_code run inside a Linux container, but the
+  Delphi compiler (dcc32/dcc64) lives on the Windows HOST. The model
+  could not reach it ("dcc32: command not found" / "No such file"). Like
+  fs_read/fs_write, this tool runs on the HOST (via PasClaw.Platform's
+  RunOneShot, NOT the shell backend), against the same workspace that is
+  bind-mounted into the container -- so the model's edit -> build ->
+  read-errors loop works regardless of the shell backend.
+
+  Two build mechanisms (operator picks the security/fidelity trade-off):
+
+    * dcc-direct (DEFAULT). Invokes dcc32.exe / dcc64.exe on the project's
+      .dpr with best-effort RAD-Studio library paths + namespaces. The
+      compiler does not execute arbitrary host code, so this is the
+      sandbox-friendly default. Non-trivial projects may need extra unit
+      paths -- supply them via PASCLAW_DELPHI_SEARCH.
+
+    * MSBuild (OPT-IN). Builds the .dproj via rsvars.bat + MSBuild, which
+      is IDE-identical (honours the project's own library paths/defines).
+      BUT MSBuild runs the .dproj's pre/post-build events -- arbitrary
+      host commands -- which defeats the docker sandbox. Gated behind
+      PASCLAW_DELPHI_ALLOW_MSBUILD=1 so a model can't turn on host
+      execution just by passing an argument.
+
+  Operator configuration (env vars; no config.json schema change):
+    PASCLAW_DELPHI_BIN          override the RAD Studio \bin directory
+    PASCLAW_DELPHI_SEARCH       extra ';'-separated unit search paths (dcc -U)
+    PASCLAW_DELPHI_NAMESPACES   override the default unit-scope namespaces
+    PASCLAW_DELPHI_ALLOW_MSBUILD  '1'/'true'/'yes' to allow MSBuild mode
+
+  Registration self-gates: RegisterDelphiBuildTool is a no-op unless a
+  Delphi \bin is discoverable, so it stays invisible on Linux/macOS and
+  on Windows boxes without RAD Studio.
+*)
+unit PasClaw.Tools.DelphiBuild;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+{ Registers delphi_build iff a RAD Studio \bin is discoverable. }
+procedure RegisterDelphiBuildTool(R: TToolRegistry);
+
+{ Absolute path of the RAD Studio \bin dir (with dcc32.exe), or '' if not
+  found. Exposed for status output / tests. }
+function DiscoverDelphiBin: string;
+
+{ Tolerant parse of dcc/MSBuild output into a compact diagnostic summary.
+  Classifies each line carrying a Delphi code token (E#### / W#### / H####
+  / F####) and returns the kept diagnostic lines; counts come back via the
+  out params. Format-agnostic across raw dcc and MSBuild's "[dcc32 Error]"
+  bracket form -- both embed the code. Exposed for tests. }
+function ParseDelphiOutput(const Raw: string;
+                           out NErrors, NWarnings, NHints: Integer): string;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Platform,
+  PasClaw.Tools.Sandbox,
+  PasClaw.Logger
+  {$IFDEF MSWINDOWS}
+  {$IFDEF FPC}, Windows, Registry{$ELSE}, Winapi.Windows, System.Win.Registry{$ENDIF}
+  {$ENDIF}
+  ;
+
+{$IFDEF MSWINDOWS}
+const
+  { Searched newest-first; first install with dcc32.exe wins. Athens=23,
+    Alexandria=22, Sydney=21, ... }
+  KnownStudioVersions: array[0..7] of string =
+    ('23.0', '22.0', '21.0', '20.0', '19.0', '18.0', '17.0', '36.0');
+{$ENDIF}
+
+const
+  DefaultNamespaces =
+    'System;System.Win;Winapi;Data;Data.Win;Xml;Web;Soap;Vcl;Vcl.Imaging;' +
+    'Vcl.Touch;Vcl.Samples;Vcl.Shell;FMX;System.Json;Data.Bind;' +
+    'System.Actions;System.ImageList;System.Bluetooth';
+
+function HasDcc(const BinDir: string): Boolean;
+begin
+  Result := (BinDir <> '') and
+            (FileExists(JoinPath(BinDir, 'dcc32.exe')) or
+             FileExists(JoinPath(BinDir, 'dcc64.exe')));
+end;
+
+{$IFDEF MSWINDOWS}
+function RegFindBin(Root: HKEY): string;
+{ RAD Studio records its install dir at
+  <Root>\SOFTWARE\Embarcadero\BDS\<ver>\RootDir -- the canonical way to
+  find a compiler installed anywhere (custom drive/path), which the
+  Program-Files probe below would miss. HKCU is where a normal per-user
+  install writes it and isn't WOW64-redirected; HKLM is the fallback.
+  Enumerate versions and prefer the newest. }
+var
+  Reg: TRegistry;
+  Keys: TStringList;
+  i: Integer;
+  RootDir, Bin: string;
+begin
+  Result := '';
+  Reg := TRegistry.Create;
+  Keys := TStringList.Create;
+  try
+    Reg.RootKey := Root;
+    if not Reg.OpenKeyReadOnly('SOFTWARE\Embarcadero\BDS') then Exit;
+    Reg.GetKeyNames(Keys);
+    Reg.CloseKey;
+    Keys.Sort;   { ascending -> walk descending for newest-first }
+    for i := Keys.Count - 1 downto 0 do
+    begin
+      if Reg.OpenKeyReadOnly('SOFTWARE\Embarcadero\BDS\' + Keys[i]) then
+      begin
+        try
+          RootDir := Reg.ReadString('RootDir');
+        except
+          RootDir := '';
+        end;
+        Reg.CloseKey;
+        if RootDir <> '' then
+        begin
+          Bin := JoinPath(RootDir, 'bin');
+          if HasDcc(Bin) then Exit(Bin);
+        end;
+      end;
+    end;
+  finally
+    Keys.Free;
+    Reg.Free;
+  end;
+end;
+{$ENDIF}
+
+function DiscoverDelphiBin: string;
+var
+  Cand: string;
+  {$IFDEF MSWINDOWS}
+  PF, PFx86: string;
+
+  function ProbeRoots(const ProgFiles: string): string;
+  var
+    v: Integer;
+    B: string;
+  begin
+    Result := '';
+    if ProgFiles = '' then Exit;
+    for v := Low(KnownStudioVersions) to High(KnownStudioVersions) do
+    begin
+      B := JoinPath(JoinPath(JoinPath(ProgFiles, 'Embarcadero'), 'Studio'),
+                    KnownStudioVersions[v]);
+      B := JoinPath(B, 'bin');
+      if HasDcc(B) then Exit(B);
+    end;
+  end;
+  {$ENDIF}
+begin
+  Result := '';
+  { 1. Explicit operator override -- works on any OS (e.g. a cross-mounted
+       toolchain), and lets tests point at a fixture. }
+  Cand := GetEnvironmentVariable('PASCLAW_DELPHI_BIN');
+  if (Cand <> '') and HasDcc(Cand) then Exit(Cand);
+
+  {$IFDEF MSWINDOWS}
+  { 2. Registry (canonical -- finds installs on any drive/path). }
+  Cand := RegFindBin(HKEY_CURRENT_USER);
+  if Cand <> '' then Exit(Cand);
+  Cand := RegFindBin(HKEY_LOCAL_MACHINE);
+  if Cand <> '' then Exit(Cand);
+  { 3. Default Program Files roots as a last resort. }
+  PFx86 := GetEnvironmentVariable('ProgramFiles(x86)');
+  PF    := GetEnvironmentVariable('ProgramFiles');
+  Cand := ProbeRoots(PFx86);
+  if Cand <> '' then Exit(Cand);
+  Cand := ProbeRoots(PF);
+  if Cand <> '' then Exit(Cand);
+  {$ENDIF}
+end;
+
+function FindDelphiCode(const Line: string; out Letter: Char): Boolean;
+{ True when Line contains a Delphi diagnostic code token: one of E/W/H/F
+  followed by exactly four digits, at a word boundary (so "FIRE2003" or a
+  hex blob doesn't false-positive). }
+var
+  i, n: Integer;
+begin
+  Result := False;
+  Letter := ' ';
+  n := Length(Line);
+  for i := 1 to n - 4 do
+    if CharInSet(Line[i], ['E', 'W', 'H', 'F']) and
+       CharInSet(Line[i + 1], ['0'..'9']) and
+       CharInSet(Line[i + 2], ['0'..'9']) and
+       CharInSet(Line[i + 3], ['0'..'9']) and
+       CharInSet(Line[i + 4], ['0'..'9']) and
+       ((i = 1) or not CharInSet(Line[i - 1], ['A'..'Z', 'a'..'z', '0'..'9', '_'])) and
+       ((i + 5 > n) or not CharInSet(Line[i + 5], ['0'..'9'])) then
+    begin
+      Letter := Line[i];
+      Exit(True);
+    end;
+end;
+
+function ParseDelphiOutput(const Raw: string;
+                           out NErrors, NWarnings, NHints: Integer): string;
+const
+  MaxKept = 200;   { cap so a runaway build can't blow the tool-result budget }
+var
+  Lines: TStringList;
+  Sb: TStringBuilder;
+  i, Kept: Integer;
+  Letter: Char;
+  Ln: string;
+begin
+  NErrors := 0; NWarnings := 0; NHints := 0;
+  Kept := 0;
+  Lines := TStringList.Create;
+  Sb := TStringBuilder.Create;
+  try
+    Lines.Text := StringReplace(Raw, #13, '', [rfReplaceAll]);
+    for i := 0 to Lines.Count - 1 do
+    begin
+      Ln := Lines[i];
+      if not FindDelphiCode(Ln, Letter) then Continue;
+      case Letter of
+        'F': Inc(NErrors);   { fatal counts as an error for the model }
+        'E': Inc(NErrors);
+        'W': Inc(NWarnings);
+        'H': Inc(NHints);
+      end;
+      if Kept < MaxKept then
+      begin
+        if Sb.Length > 0 then Sb.Append(#10);
+        Sb.Append(Trim(Ln));
+        Inc(Kept);
+      end;
+    end;
+    Result := Sb.ToString;
+    {$IFDEF FPC}
+    SetCodePage(RawByteString(Result), CP_UTF8, False);
+    {$ENDIF}
+  finally
+    Sb.Free;
+    Lines.Free;
+  end;
+end;
+
+function MsbuildAllowed: Boolean;
+var
+  V: string;
+begin
+  V := LowerCase(Trim(GetEnvironmentVariable('PASCLAW_DELPHI_ALLOW_MSBUILD')));
+  Result := (V = '1') or (V = 'true') or (V = 'yes') or (V = 'on');
+end;
+
+function DQuote(const S: string): string;
+{ Double-quote a path/arg for the cmd.exe / dcc command line we hand to
+  RunOneShot (which wraps in cmd /C on Windows). }
+begin
+  Result := '"' + S + '"';
+end;
+
+function BuildViaDcc(const BinDir, ProjDpr, Platform_, Config: string;
+                     out Output: string): Integer;
+var
+  Bds, Dcc, LibBase, Cmd, NS, Extra, DbgDcu, RelDcu: string;
+begin
+  Bds := ExtractFileDir(ExcludeTrailingPathDelimiter(BinDir));   { ...\Studio\NN.0 }
+
+  if SameText(Platform_, 'Win64') then
+    Dcc := JoinPath(BinDir, 'dcc64.exe')
+  else
+    Dcc := JoinPath(BinDir, 'dcc32.exe');
+
+  { Standard precompiled-DCU library dirs for this platform. release holds
+    the RTL/FMX/VCL .dcu the project links against; debug too for Debug. }
+  LibBase := JoinPath(JoinPath(Bds, 'lib'), Platform_);
+  RelDcu  := JoinPath(LibBase, 'release');
+  DbgDcu  := JoinPath(LibBase, 'debug');
+
+  NS := GetEnvironmentVariable('PASCLAW_DELPHI_NAMESPACES');
+  if NS = '' then NS := DefaultNamespaces;
+
+  Extra := GetEnvironmentVariable('PASCLAW_DELPHI_SEARCH');
+
+  { -B build all; -NS namespaces; -U unit search; -$D+/- debug info.
+    Output (exe/dcu) lands in the project dir (the cwd we run from). }
+  Cmd := DQuote(Dcc) + ' -B -NS' + NS;
+  if DirectoryExists(RelDcu) then Cmd := Cmd + ' -U' + DQuote(RelDcu);
+  if SameText(Config, 'Debug') and DirectoryExists(DbgDcu) then
+    Cmd := Cmd + ' -U' + DQuote(DbgDcu);
+  if Extra <> '' then Cmd := Cmd + ' -U' + DQuote(Extra);
+  if SameText(Config, 'Release') then
+    Cmd := Cmd + ' -$D- -$L- -$O+'
+  else
+    Cmd := Cmd + ' -$D+ -$L+ -$O-';
+  Cmd := Cmd + ' ' + DQuote(ProjDpr) + ' 2>&1';
+
+  Result := RunOneShot(Cmd, ExtractFileDir(ProjDpr), Output);
+end;
+
+function BuildViaMsbuild(const BinDir, Proj, Platform_, Config: string;
+                         out Output: string): Integer;
+var
+  Rsvars, Cmd: string;
+begin
+  Rsvars := JoinPath(BinDir, 'rsvars.bat');
+  if not FileExists(Rsvars) then
+  begin
+    Output := 'rsvars.bat not found in ' + BinDir;
+    Exit(-1);
+  end;
+  { call rsvars to set up the MSBuild + compiler environment, then build. }
+  Cmd := 'call ' + DQuote(Rsvars) + ' && msbuild ' + DQuote(Proj) +
+         ' /t:Build /p:Config=' + Config + ';Platform=' + Platform_ +
+         ' /nologo /v:minimal 2>&1';
+  Result := RunOneShot(Cmd, ExtractFileDir(Proj), Output);
+end;
+
+function Tool_DelphiBuild(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Obj: TJsonObject;
+  Project, Platform_, Config, ProjAbs, ProjDpr, BinDir, Out_, Diags, Reason: string;
+  WantMsbuild: Boolean;
+  ExitCode, NErr, NWarn, NHint: Integer;
+begin
+  Result := '';
+  ErrMsg := '';
+
+  Project := ''; Platform_ := 'Win32'; Config := 'Debug'; WantMsbuild := False;
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj <> nil then
+  try
+    Project := Trim(Obj.GetStr('project', ''));
+    if Obj.GetStr('platform', '') <> '' then Platform_ := Obj.GetStr('platform', 'Win32');
+    if Obj.GetStr('config', '')   <> '' then Config    := Obj.GetStr('config', 'Debug');
+    WantMsbuild := Obj.GetBool('msbuild', False);
+  finally
+    Obj.Free;
+  end;
+
+  if Project = '' then
+  begin
+    ErrMsg := 'missing required argument: project (path to a .dpr or .dproj)';
+    Exit;
+  end;
+  if not (SameText(Platform_, 'Win32') or SameText(Platform_, 'Win64')) then
+  begin
+    ErrMsg := 'platform must be Win32 or Win64 (got "' + Platform_ + '")';
+    Exit;
+  end;
+  if not (SameText(Config, 'Debug') or SameText(Config, 'Release')) then
+  begin
+    ErrMsg := 'config must be Debug or Release (got "' + Config + '")';
+    Exit;
+  end;
+
+  BinDir := DiscoverDelphiBin;
+  if BinDir = '' then
+  begin
+    ErrMsg := 'no RAD Studio install found. Set PASCLAW_DELPHI_BIN to the \bin ' +
+              'directory containing dcc32.exe.';
+    Exit;
+  end;
+
+  { Sandbox: only build a project inside the workspace. CanReadPath honours
+    restrict_to_workspace; building writes outputs next to the project, but
+    the gate we care about is "is this a workspace project, not some
+    arbitrary host path the model dreamed up". }
+  ProjAbs := ExpandFileName(ExpandHome(Project));
+  if not CanReadPath(ProjAbs, Reason) then
+  begin
+    ErrMsg := Reason;
+    Exit;
+  end;
+  if not FileExists(ProjAbs) then
+  begin
+    ErrMsg := 'no such project file: ' + ProjAbs;
+    Exit;
+  end;
+
+  if WantMsbuild then
+  begin
+    if not MsbuildAllowed then
+    begin
+      ErrMsg := 'MSBuild mode is disabled. It runs the .dproj''s pre/post-build ' +
+                'events on the host (a sandbox escape), so it must be enabled by ' +
+                'the operator via PASCLAW_DELPHI_ALLOW_MSBUILD=1. Omit "msbuild" ' +
+                'to use the dcc-direct compiler instead.';
+      Exit;
+    end;
+    LogInfo('delphi_build: msbuild %s (%s/%s)', [ProjAbs, Config, Platform_]);
+    ExitCode := BuildViaMsbuild(BinDir, ProjAbs, Platform_, Config, Out_);
+  end
+  else
+  begin
+    { dcc compiles a .dpr. If handed a .dproj, fall back to the sibling
+      .dpr; if that's missing, point the model at MSBuild mode. }
+    if SameText(ExtractFileExt(ProjAbs), '.dproj') then
+    begin
+      ProjDpr := ChangeFileExt(ProjAbs, '.dpr');
+      if not FileExists(ProjDpr) then
+      begin
+        ErrMsg := 'dcc-direct needs a .dpr; none found next to ' + ProjAbs +
+                  '. Pass the .dpr, or enable MSBuild mode ' +
+                  '(PASCLAW_DELPHI_ALLOW_MSBUILD=1 + "msbuild":true) to build the .dproj.';
+        Exit;
+      end;
+    end
+    else
+      ProjDpr := ProjAbs;
+    LogInfo('delphi_build: dcc %s (%s/%s)', [ProjDpr, Config, Platform_]);
+    ExitCode := BuildViaDcc(BinDir, ProjDpr, Platform_, Config, Out_);
+  end;
+
+  Diags := ParseDelphiOutput(Out_, NErr, NWarn, NHint);
+  if (ExitCode = 0) and (NErr = 0) then
+    Result := Format('build OK (%s/%s): %d warning(s), %d hint(s)',
+                     [Config, Platform_, NWarn, NHint])
+  else
+    Result := Format('build FAILED (%s/%s, exit=%d): %d error(s), %d warning(s)',
+                     [Config, Platform_, ExitCode, NErr, NWarn]);
+  if Diags <> '' then
+    Result := Result + #10 + Diags
+  else if ExitCode <> 0 then
+    { No coded diagnostics parsed but the compiler failed -- surface the
+      raw tail so the model isn't blind (e.g. "file not found", env issues). }
+    Result := Result + #10 + Copy(Trim(Out_), 1, 1500);
+end;
+
+procedure RegisterDelphiBuildTool(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if DiscoverDelphiBin = '' then Exit;   { no toolchain -> tool stays hidden }
+  T.Name        := 'delphi_build';
+  T.Description :=
+    'Compile a Delphi/RAD Studio project on the host with dcc32/dcc64 ' +
+    '(runs host-side even when shell_exec is in a docker container). Args: ' +
+    'project (path to a .dpr, or a .dproj for MSBuild mode), platform ' +
+    '(Win32|Win64, default Win32), config (Debug|Release, default Debug), ' +
+    'msbuild (bool, default false -- MSBuild/.dproj mode is operator-gated). ' +
+    'Returns a build status plus parsed errors/warnings/hints.';
+  T.Schema :=
+    '{"type":"object","properties":{' +
+    '"project":{"type":"string","description":"Path to the .dpr (.dproj for MSBuild mode), inside the workspace."},' +
+    '"platform":{"type":"string","enum":["Win32","Win64"]},' +
+    '"config":{"type":"string","enum":["Debug","Release"]},' +
+    '"msbuild":{"type":"boolean","description":"Build the .dproj via MSBuild (IDE-identical; runs build events; operator-gated)."}' +
+    '},"required":["project"]}';
+  T.Handler  := Tool_DelphiBuild;
+  T.HandlerObj := nil;
+  T.IsCore   := False;
+  T.Category := tcMutating;   { produces binaries / .dcu }
+  R.Register(T);
+end;
+
+end.

--- a/src/tests/delphi_build_tests.pas
+++ b/src/tests/delphi_build_tests.pas
@@ -1,0 +1,104 @@
+program delphi_build_tests;
+(*
+  Covers PasClaw.Tools.DelphiBuild.ParseDelphiOutput -- the tolerant,
+  format-agnostic classifier that turns raw dcc / MSBuild output into
+  error/warning/hint counts + a compact diagnostic list. It keys off the
+  Delphi code token (E####/W####/H####/F####), which both the raw dcc
+  format and MSBuild's "[dcc32 Error]" bracket form embed.
+
+  The discovery + actual compile path is Windows/RAD-Studio only and is
+  not exercised here; this pins the one piece that is cross-platform.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Tools.DelphiBuild;
+
+procedure Fail(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertEq(Got, Want: Integer; const Msg: string);
+begin
+  if Got <> Want then
+    Fail(Msg + Format(' (got %d, want %d)', [Got, Want]));
+end;
+
+procedure AssertContains(const Hay, Needle, Msg: string);
+begin
+  if Pos(Needle, Hay) = 0 then
+    Fail(Msg + ' (missing "' + Needle + '")');
+end;
+
+procedure AssertMissing(const Hay, Needle, Msg: string);
+begin
+  if Pos(Needle, Hay) > 0 then
+    Fail(Msg + ' (unexpected "' + Needle + '")');
+end;
+
+procedure TestRawDccFormat;
+var
+  Raw, Diags: string;
+  E, W, H: Integer;
+begin
+  Raw :=
+    'Embarcadero Delphi for Win32 compiler version 36.0'  + #10 +
+    'MyForm.pas(42): E2003 Undeclared identifier: ''Foo''' + #10 +
+    'MyForm.pas(50): W1002 Symbol is specific to a platform' + #10 +
+    'MyForm.pas(60): H2077 Value assigned to ''X'' never used' + #10 +
+    'Fatal: F2613 Unit ''Baz'' not found.'                 + #10 +
+    '53 lines, 0.1 seconds, 12345 bytes code';
+  Diags := ParseDelphiOutput(Raw, E, W, H);
+  AssertEq(E, 2, 'errors (E2003 + fatal F2613)');
+  AssertEq(W, 1, 'warnings');
+  AssertEq(H, 1, 'hints');
+  AssertContains(Diags, 'E2003', 'error line kept');
+  AssertContains(Diags, 'F2613', 'fatal line kept');
+  AssertMissing(Diags, 'compiler version', 'non-diagnostic header dropped');
+end;
+
+procedure TestMsbuildBracketFormat;
+var
+  Raw, Diags: string;
+  E, W, H: Integer;
+begin
+  Raw :=
+    '  Building MyApp.dproj'                                       + #10 +
+    '  [dcc32 Error] MyForm.pas(42): E2003 Undeclared identifier'  + #10 +
+    '  [dcc32 Warning] MyForm.pas(50): W1002 platform symbol'      + #10 +
+    '  [dcc32 Hint] MyForm.pas(60): H2077 never used'              + #10 +
+    '  [dcc32 Fatal Error] MyForm.pas(1): F2613 Unit not found';
+  Diags := ParseDelphiOutput(Raw, E, W, H);
+  AssertEq(E, 2, 'errors (E + F)');
+  AssertEq(W, 1, 'warnings');
+  AssertEq(H, 1, 'hints');
+  AssertContains(Diags, 'E2003', 'bracket error kept');
+end;
+
+procedure TestCleanBuildAndNoFalsePositives;
+var
+  Raw, Diags: string;
+  E, W, H: Integer;
+begin
+  { No diagnostic codes, plus a token that must NOT be mistaken for one
+    (FIRE2003: the digits are preceded by letters -> not a code). }
+  Raw := 'Build succeeded.' + #10 + 'class TFIRE2003Handler done' + #10 +
+         'hash ABCDEF12 written';
+  Diags := ParseDelphiOutput(Raw, E, W, H);
+  AssertEq(E, 0, 'no errors on clean build');
+  AssertEq(W, 0, 'no warnings');
+  AssertEq(H, 0, 'no hints');
+  if Diags <> '' then Fail('clean build yields no diagnostics, got: ' + Diags);
+end;
+
+begin
+  TestRawDccFormat;
+  TestMsbuildBracketFormat;
+  TestCleanBuildAndNoFalsePositives;
+  WriteLn('delphi_build_tests: OK');
+end.


### PR DESCRIPTION
## Problem

With the docker shell backend on a Windows host, `dcc32`/`dcc64` live on the **host** but `shell_exec`/`execute_code` run in the **Linux container**, so the model can't compile Delphi code (`dcc32: not found`, `C:\...: No such file`).

## Approach (per design discussion)

A native `delphi_build` tool that runs **host-side** — via `Platform.RunOneShot`, **not** the shell backend — exactly like `fs_read`/`fs_write` already do. It builds against the bind-mounted workspace, so the model's **edit → build → read-errors** loop works regardless of the shell backend. (Inspired by the linked Delphi-build MCP servers, but PasClaw already runs on the host, so no separate server/HTTP bridge is needed.)

## Compiler discovery (no PATH dependency)

`DiscoverDelphiBin`: `PASCLAW_DELPHI_BIN` override → **Windows registry** (`HKCU`/`HKLM` `SOFTWARE\Embarcadero\BDS\<ver>\RootDir`, newest-first — finds installs on any drive) → Program Files probe. The compiler is then invoked by **absolute path** (RAD Studio doesn't put `dcc` on `PATH`).

## Two mechanisms (operator picks security vs fidelity)

- **dcc-direct (default):** `dcc32`/`dcc64` on the `.dpr` with RAD Studio library paths + namespaces + `PASCLAW_DELPHI_SEARCH` extras. The compiler runs no arbitrary host code → sandbox-friendly default.
- **MSBuild (opt-in, `PASCLAW_DELPHI_ALLOW_MSBUILD=1`):** `rsvars.bat` + MSBuild on the `.dproj`, IDE-identical, but runs the project's pre/post-build events on the host — gated so a model can't enable host execution via an argument.

## Other details

- **Output parser** keys off the Delphi code token (`E####`/`W####`/`H####`/`F####`), so it classifies both raw `dcc` and MSBuild's `[dcc32 Error]` formats into error/warning/hint counts + a capped diagnostic list.
- **Self-gating registration**: registers only when a RAD Studio install is discovered (invisible on Linux/macOS and Delphi-less Windows); wired into agent/tui/serve/gateway.
- **Sandbox**: the project path must be inside the workspace (`CanReadPath`).
- Env-var config (no `config.json` schema change): `PASCLAW_DELPHI_BIN`, `PASCLAW_DELPHI_SEARCH`, `PASCLAW_DELPHI_NAMESPACES`, `PASCLAW_DELPHI_ALLOW_MSBUILD`.

## Verification

- FPC/Linux build clean (rc=0); new `delphi_build_tests` (parser) pass; `.dproj` + Makefile + `.PHONY` updated.
- ⚠️ The Windows discovery (registry) + actual compile can't run in CI here (no Delphi/Windows) — verified by construction. **Needs an on-device run**, and the dcc-direct default library-paths/namespaces likely need a round of tuning against a real FMX project (MSBuild mode is the fallback for full `.dproj` fidelity).

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_