### PR TITLE
execute_code: write scripts with LF endings (fix bash \r in docker container)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -331,6 +331,13 @@ begin
                            ScriptExtension(Lang)]));
   Sl := TStringList.Create;
   try
+    { LF line endings, always. TStringList.SaveToFile defaults to the host
+      line ending -- CRLF on Windows -- but with the docker backend the
+      script runs in a Linux container where bash treats the trailing \r as
+      part of the last token ("ls -la\r" -> "invalid option", "-maxdepth
+      2\r" -> "not a positive integer"). LF is correct for bash and
+      accepted by PowerShell, so force it unconditionally. }
+    Sl.LineBreak := #10;
     Sl.Text := Code;
     try
       Sl.SaveToFile(Path);


### PR DESCRIPTION
## Symptom (docker backend on Windows)

```
execute_code bash "pwd && ls -la"        -> /workspace
                                            's: invalid option -- '   (ls saw "-la\r")
execute_code bash "find . -maxdepth 2"   -> find: ... got '2\r'
```

The bash script "works" line-by-line but every command's last token has a stray carriage return.

## Cause

`MakeTempScript` writes the script with `TStringList.SaveToFile`, which uses the **host** line ending — **CRLF on Windows**. The script is materialised on the Windows host (the `tmp` dir is bind-mounted into the container), then executed by **bash inside the Linux container**, where the trailing `\r` becomes part of the last token on each line (`ls -la`+CR → "invalid option"; `-maxdepth 2`+CR → "not a positive integer").

## Fix

Force **LF** (`Sl.LineBreak := #10`) regardless of host. LF is correct for bash and accepted by PowerShell. It's a **no-op on Linux/macOS hosts** (already LF), so the change is scoped to the Windows-host case — no regression risk.

## Verification

- Build clean (rc=0); `execute_code_tests` pass.
- The CRLF→`\r` failure only manifests on a Windows host feeding a Linux container; verified by construction here (CI is Linux, where the default was already LF). Confirms on an on-device docker run.

---

Also re your other point: **`delphi_build` is already available with the local backend** — `RegisterDelphiBuildTool` self-gates only on discovering a RAD Studio install (no docker check) and is registered unconditionally in the agent/tui/serve/gateway registries. So local PasClaw already has the compile tool whenever `dcc` is found; the model "hunting for dcc" via shell is it not reaching for the tool, not a missing registration.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_