### PR TITLE
execute_code: default to bash (not host powershell) under a container backend

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -202,12 +202,30 @@ begin
   {$ENDIF}
 end;
 
+function AutoLang: string;
+{ Resolve 'auto'/'' to a shell that actually exists where the script will
+  RUN. Normally that's the host default, but when a non-local shell backend
+  (docker -> Linux container) is active the script runs in the container,
+  not on the host. PowerShell isn't in the debian image, so a Windows
+  host's "powershell" default fails with 'sh: powershell: not found'
+  (exit 127). Default to bash in that case. (Explicit lang=powershell is
+  still honoured -- and still fails clearly if the env lacks it.) }
+var
+  B: IShellBackend;
+begin
+  B := GetActiveShellBackend;
+  if (B <> nil) and (B.Name <> 'local') then
+    Result := 'bash'
+  else
+    Result := HostDefaultLang;
+end;
+
 function ResolveExecuteCodeLang(const Requested: string): string;
 var
   L: string;
 begin
   L := LowerCase(Trim(Requested));
-  if (L = '') or (L = 'auto') then Exit(HostDefaultLang);
+  if (L = '') or (L = 'auto') then Exit(AutoLang);
   { 'sh' is a common ask from models that want maximum portability
     -- accept it but route to bash. /bin/sh is dash on Debian /
     Ubuntu which is missing common bashisms; pinning to bash is
@@ -217,7 +235,7 @@ begin
   if (L = 'bash') or (L = 'sh') then Exit('bash');
   if (L = 'powershell') or (L = 'pwsh') or (L = 'ps') then
     Exit('powershell');
-  Result := HostDefaultLang;
+  Result := AutoLang;
 end;
 
 function FindOnPath(const Exe: string): Boolean;


### PR DESCRIPTION
## Symptom (docker backend on Windows)

```
execute_code {"code":"find DelphiPalAI/src/llama_cpp -name \"*.pas\""}   (no lang)
exit=127
sh: 1: powershell: not found
```

## Cause

`ResolveExecuteCodeLang` resolves `auto`/`''` to the **host** default shell — `powershell` on Windows — but with docker the script runs in the **Linux container**, where PowerShell doesn't exist.

## Fix

New `AutoLang`: when a **non-local** shell backend (docker → Linux container) is active, `auto`/`''` resolves to **bash**; otherwise the host default. Also used for the unrecognized-lang fallback. An explicit `lang=powershell` is still honoured.

## Re the P1 review (LF normalization)

Correct and already in effect: the bash CRLF→LF fix merged separately as **#269**, and this branch is rebased on top of that, so `auto`→bash now also gets an LF-normalized `.sh`. (#270 carries only the auto-lang change; the LF change lives on `main`.) Together they make `execute_code` with no `lang` actually run under docker-on-Windows.

## Verification

- Build clean (rc=0); `execute_code_tests` pass.
- The override is Windows-host-specific (on the Linux CI the host default is already bash, so both branches converge), so it's verified by construction; an on-device docker run is the end-to-end confirmation.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6