### PR TITLE
delphi_build: use the .dproj's unit search paths (fix dcc-direct F2613)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
+++ b/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
@@ -67,11 +67,12 @@ function DiscoverDelphiBin: string;
 function ParseDelphiOutput(const Raw: string;
                            out NErrors, NWarnings, NHints: Integer): string;
 
-{ Append the ';'-separated tokens of every <Tag>...</Tag> in Xml to Dest,
-  skipping empties, MSBuild macros ($(...)), and duplicates. Used to pull
-  DCC_UnitSearchPath / DCC_Namespace out of a .dproj for dcc-direct builds.
-  Exposed for tests. }
-procedure CollectDprojTokens(const Xml, Tag: string; Dest: TStringList);
+{ Pull a .dproj tag's tokens (DCC_UnitSearchPath / DCC_Namespace) for the
+  requested Platform_/Config: only PropertyGroups whose Condition applies to
+  that build contribute, ';'-split, $() macros + dupes dropped. Exposed for
+  tests. }
+procedure CollectDprojTokens(const Xml, Tag, Platform_, Config: string;
+                             Dest: TStringList);
 
 implementation
 
@@ -296,13 +297,28 @@ begin
   Result := (V = '1') or (V = 'true') or (V = 'yes') or (V = 'on');
 end;
 
-procedure CollectDprojTokens(const Xml, Tag: string; Dest: TStringList);
-{ Append the ';'-separated tokens from every <Tag>...</Tag> in Xml to Dest,
-  skipping empties, MSBuild macro tokens ($(...)), and duplicates. A
-  lightweight string scan -- no XML-parser dependency, which is plenty for
-  the flat <DCC_UnitSearchPath> / <DCC_Namespace> values RAD Studio writes.
-  Exposed (below) so dcc-direct builds use the project's own search paths
-  and namespaces instead of making the model hand-roll -U flags. }
+function CondMatchesBuild(const Cond, Platform_, Config: string): Boolean;
+{ A .dproj PropertyGroup applies to this build unless its Condition names
+  ONLY the other platform or the other config. Unconditional / Base groups
+  (no platform/config mention) always apply. Heuristic -- avoids a full
+  MSBuild condition evaluator while keeping, e.g., Win64-only search dirs
+  out of a Win32 build (Codex P2 on PR #271). }
+var
+  C, P, Cfg, OtherP, OtherC: string;
+begin
+  C := LowerCase(Cond);
+  P := LowerCase(Platform_);
+  Cfg := LowerCase(Config);
+  if P = 'win64' then OtherP := 'win32' else OtherP := 'win64';
+  if Cfg = 'debug' then OtherC := 'release' else OtherC := 'debug';
+  Result := True;
+  if (Pos(OtherP, C) > 0) and (Pos(P, C) = 0) then Exit(False);     { other platform only }
+  if (Pos(OtherC, C) > 0) and (Pos(Cfg, C) = 0) then Exit(False);   { other config only }
+end;
+
+procedure ExtractTagTokens(const Body, Tag: string; Dest: TStringList);
+{ Append the ';'-separated tokens of every <Tag>...</Tag> in Body to Dest,
+  skipping empties, MSBuild macros ($(...)), and duplicates. }
 var
   OpenT, CloseT, Inner, Tok: string;
   p, q, e, sp: Integer;
@@ -311,12 +327,12 @@ begin
   CloseT := '</' + Tag + '>';
   p := 1;
   repeat
-    p := Pos(OpenT, Xml, p);
+    p := Pos(OpenT, Body, p);
     if p = 0 then Break;
     q := p + Length(OpenT);
-    e := Pos(CloseT, Xml, q);
+    e := Pos(CloseT, Body, q);
     if e = 0 then Break;
-    Inner := Copy(Xml, q, e - q) + ';';   { trailing ';' so the last token splits }
+    Inner := Copy(Body, q, e - q) + ';';   { trailing ';' so the last token splits }
     repeat
       sp := Pos(';', Inner);
       if sp = 0 then Break;
@@ -326,6 +342,49 @@ begin
         Dest.Add(Tok);
     until Inner = '';
     p := e + Length(CloseT);
+  until False;
+end;
+
+procedure CollectDprojTokens(const Xml, Tag, Platform_, Config: string;
+                             Dest: TStringList);
+{ Walk <PropertyGroup ...>...</PropertyGroup> blocks; for each whose
+  Condition applies to the requested Platform_/Config (see CondMatchesBuild),
+  extract the Tag's tokens. A lightweight string scan -- no XML-parser
+  dependency, which is plenty for the flat DCC_UnitSearchPath /
+  DCC_Namespace values RAD Studio writes. Exposed so dcc-direct builds use
+  the project's own (config-correct) search paths/namespaces rather than
+  making the model hand-roll -U flags. }
+var
+  p, openEnd, gClose, cs, ce: Integer;
+  OpenTag, Cond, Body: string;
+begin
+  p := 1;
+  repeat
+    p := Pos('<PropertyGroup', Xml, p);
+    if p = 0 then Break;
+    openEnd := Pos('>', Xml, p);
+    if openEnd = 0 then Break;
+    OpenTag := Copy(Xml, p, openEnd - p + 1);   { <PropertyGroup Condition="..."> }
+    { self-closing <PropertyGroup .../> has no body to scan }
+    if (Length(OpenTag) >= 2) and (OpenTag[Length(OpenTag) - 1] = '/') then
+    begin
+      p := openEnd + 1;
+      Continue;
+    end;
+    gClose := Pos('</PropertyGroup>', Xml, openEnd);
+    if gClose = 0 then gClose := Length(Xml) + 1;
+    Body := Copy(Xml, openEnd + 1, gClose - (openEnd + 1));
+    Cond := '';
+    cs := Pos('Condition="', OpenTag);
+    if cs > 0 then
+    begin
+      cs := cs + Length('Condition="');
+      ce := Pos('"', OpenTag, cs);
+      if ce > 0 then Cond := Copy(OpenTag, cs, ce - cs);
+    end;
+    if CondMatchesBuild(Cond, Platform_, Config) then
+      ExtractTagTokens(Body, Tag, Dest);
+    p := gClose + 1;
   until False;
 end;
 
@@ -377,8 +436,8 @@ begin
     if FileExists(DprojPath) then
     begin
       Xml := ReadFileText(DprojPath);
-      CollectDprojTokens(Xml, 'DCC_UnitSearchPath', SearchDirs);
-      CollectDprojTokens(Xml, 'DCC_Namespace', ProjNs);
+      CollectDprojTokens(Xml, 'DCC_UnitSearchPath', Platform_, Config, SearchDirs);
+      CollectDprojTokens(Xml, 'DCC_Namespace', Platform_, Config, ProjNs);
     end;
     for i := 0 to ProjNs.Count - 1 do
       if Pos(';' + ProjNs[i] + ';', ';' + NS + ';') = 0 then

--- a/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
+++ b/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
@@ -67,6 +67,12 @@ function DiscoverDelphiBin: string;
 function ParseDelphiOutput(const Raw: string;
                            out NErrors, NWarnings, NHints: Integer): string;
 
+{ Append the ';'-separated tokens of every <Tag>...</Tag> in Xml to Dest,
+  skipping empties, MSBuild macros ($(...)), and duplicates. Used to pull
+  DCC_UnitSearchPath / DCC_Namespace out of a .dproj for dcc-direct builds.
+  Exposed for tests. }
+procedure CollectDprojTokens(const Xml, Tag: string; Dest: TStringList);
+
 implementation
 
 uses
@@ -290,6 +296,39 @@ begin
   Result := (V = '1') or (V = 'true') or (V = 'yes') or (V = 'on');
 end;
 
+procedure CollectDprojTokens(const Xml, Tag: string; Dest: TStringList);
+{ Append the ';'-separated tokens from every <Tag>...</Tag> in Xml to Dest,
+  skipping empties, MSBuild macro tokens ($(...)), and duplicates. A
+  lightweight string scan -- no XML-parser dependency, which is plenty for
+  the flat <DCC_UnitSearchPath> / <DCC_Namespace> values RAD Studio writes.
+  Exposed (below) so dcc-direct builds use the project's own search paths
+  and namespaces instead of making the model hand-roll -U flags. }
+var
+  OpenT, CloseT, Inner, Tok: string;
+  p, q, e, sp: Integer;
+begin
+  OpenT  := '<' + Tag + '>';
+  CloseT := '</' + Tag + '>';
+  p := 1;
+  repeat
+    p := Pos(OpenT, Xml, p);
+    if p = 0 then Break;
+    q := p + Length(OpenT);
+    e := Pos(CloseT, Xml, q);
+    if e = 0 then Break;
+    Inner := Copy(Xml, q, e - q) + ';';   { trailing ';' so the last token splits }
+    repeat
+      sp := Pos(';', Inner);
+      if sp = 0 then Break;
+      Tok := Trim(Copy(Inner, 1, sp - 1));
+      Delete(Inner, 1, sp);
+      if (Tok <> '') and (Pos('$(', Tok) = 0) and (Dest.IndexOf(Tok) < 0) then
+        Dest.Add(Tok);
+    until Inner = '';
+    p := e + Length(CloseT);
+  until False;
+end;
+
 function BuildViaDcc(const BinDir, ProjDpr, Platform_, Config: string;
                      out Output: string): Integer;
 { Spawn dcc directly via its argv (RunArgvCapture -> CreateProcessW), NOT
@@ -298,10 +337,16 @@ function BuildViaDcc(const BinDir, ProjDpr, Platform_, Config: string;
   re-escaped as \" by the process layer and cmd.exe rejects it
   ('\"...dcc32.exe\"' is not recognized). argv sidesteps quoting entirely:
   each element reaches dcc verbatim. RunArgvCapture also merges stderr, so
-  no 2>&1. }
+  no 2>&1.
+
+  Search paths come from the sibling .dproj's DCC_UnitSearchPath +
+  DCC_Namespace -- so a multi-dir project (e.g. src\llama_cpp\...) compiles
+  without the model hand-constructing -U flags, which is the F2613
+  "unit not found" trap. }
 var
-  Bds, Dcc, LibBase, NS, Extra, DbgDcu, RelDcu: string;
-  Args: TStringList;
+  Bds, Dcc, LibBase, NS, Extra, DbgDcu, RelDcu, DprojPath, Xml: string;
+  Args, SearchDirs, ProjNs: TStringList;
+  i: Integer;
 begin
   Bds := ExtractFileDir(ExcludeTrailingPathDelimiter(BinDir));   { ...\Studio\NN.0 }
 
@@ -321,8 +366,24 @@ begin
 
   Extra := GetEnvironmentVariable('PASCLAW_DELPHI_SEARCH');
 
+  SearchDirs := TStringList.Create;
+  ProjNs := TStringList.Create;
   Args := TStringList.Create;
   try
+    { Pull the project's own unit search paths + namespaces from the .dproj
+      (sibling of the .dpr). These are relative to the project dir, which is
+      the cwd we run dcc from, so they resolve as-is. }
+    DprojPath := ChangeFileExt(ProjDpr, '.dproj');
+    if FileExists(DprojPath) then
+    begin
+      Xml := ReadFileText(DprojPath);
+      CollectDprojTokens(Xml, 'DCC_UnitSearchPath', SearchDirs);
+      CollectDprojTokens(Xml, 'DCC_Namespace', ProjNs);
+    end;
+    for i := 0 to ProjNs.Count - 1 do
+      if Pos(';' + ProjNs[i] + ';', ';' + NS + ';') = 0 then
+        NS := NS + ';' + ProjNs[i];
+
     { -B build all; -NS namespaces; -U unit search; -$D+/- debug info.
       Each flag is one argv element -- no quoting; spaces in a -U path are
       preserved because CreateProcessW quotes the whole element. Output
@@ -333,6 +394,8 @@ begin
     if SameText(Config, 'Debug') and DirectoryExists(DbgDcu) then
       Args.Add('-U' + DbgDcu);
     if Extra <> '' then Args.Add('-U' + Extra);
+    for i := 0 to SearchDirs.Count - 1 do
+      Args.Add('-U' + SearchDirs[i]);   { project's own dirs, relative to cwd }
     if SameText(Config, 'Release') then
     begin
       Args.Add('-$D-'); Args.Add('-$L-'); Args.Add('-$O+');
@@ -345,6 +408,8 @@ begin
     Result := RunArgvCapture(Dcc, Args, ExtractFileDir(ProjDpr), Output);
   finally
     Args.Free;
+    ProjNs.Free;
+    SearchDirs.Free;
   end;
 end;
 
@@ -515,11 +580,19 @@ begin
     Result := Format('build FAILED (%s/%s, exit=%d): %d error(s), %d warning(s)',
                      [Config, Platform_, ExitCode, NErr, NWarn]);
   if Diags <> '' then
-    Result := Result + #10 + Diags
-  else if ExitCode <> 0 then
-    { No coded diagnostics parsed but the compiler failed -- surface the
-      raw tail so the model isn't blind (e.g. "file not found", env issues). }
-    Result := Result + #10 + Copy(Trim(Out_), 1, 1500);
+    Result := Result + #10 + Diags;
+  { Failed but no error code was parsed (e.g. a linker/env failure, or the
+    real error scrolled past the classifier) -- surface the raw tail so the
+    model isn't left with "FAILED, 0 errors" and nothing to act on. Tail,
+    not head: dcc prints diagnostics near the end. }
+  if (ExitCode <> 0) and (NErr = 0) then
+  begin
+    Out_ := Trim(Out_);
+    if Length(Out_) > 1500 then
+      Out_ := '...' + Copy(Out_, Length(Out_) - 1500 + 1, 1500);
+    if Out_ <> '' then
+      Result := Result + #10 + '--- raw output (tail) ---' + #10 + Out_;
+  end;
 end;
 
 procedure RegisterDelphiBuildTool(R: TToolRegistry);

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -41,6 +41,13 @@ function JoinPath(const A, B: string): string;
 function FileExistsCI(const Path: string): Boolean;
 function ReadFileText(const Path: string): string;
 procedure WriteFileText(const Path, Content: string);
+{ On Windows, convert '/' to '\' so RTL path parsing (ExtractFilePath,
+  ForceDirectories) handles paths the model passes with forward slashes
+  (it copies them from fs_read's "path" output). Without this,
+  ExtractFilePath('a/b/c.pas') returns '' on Windows and ForceDirectories
+  raises "Unable to create directory". On POSIX '\' is a legal filename
+  char, so the path is returned untouched. }
+function NormalizePathSep(const P: string): string;
 function SplitToList(const S: string; Sep: Char): TStringList;
 function NowIsoUtc: string;
 
@@ -243,14 +250,25 @@ begin
   Result := FileExists(Path);
 end;
 
+function NormalizePathSep(const P: string): string;
+begin
+  {$IFDEF MSWINDOWS}
+  Result := StringReplace(P, '/', '\', [rfReplaceAll]);
+  {$ELSE}
+  Result := P;
+  {$ENDIF}
+end;
+
 function ReadFileText(const Path: string): string;
 var
   Strm: TFileStream;
   Bytes: TBytes;
+  NPath: string;
 begin
   Result := '';
-  if not FileExists(Path) then Exit;
-  Strm := TFileStream.Create(Path, fmOpenRead or fmShareDenyWrite);
+  NPath := NormalizePathSep(Path);
+  if not FileExists(NPath) then Exit;
+  Strm := TFileStream.Create(NPath, fmOpenRead or fmShareDenyWrite);
   try
     SetLength(Bytes, Strm.Size);
     if Strm.Size > 0 then Strm.ReadBuffer(Bytes[0], Strm.Size);
@@ -269,10 +287,15 @@ procedure WriteFileText(const Path, Content: string);
 var
   Strm: TFileStream;
   Bytes: TBytes;
-  Tagged: string;
+  Tagged, NPath, Dir: string;
 begin
-  EnsureDir(ExtractFilePath(Path));
-  Strm := TFileStream.Create(Path, fmCreate);
+  NPath := NormalizePathSep(Path);
+  { Only force-create the directory when there is one -- ExtractFilePath of
+    a bare filename is '', and ForceDirectories('') raises EInOutError
+    "Unable to create directory". }
+  Dir := ExtractFilePath(NPath);
+  if Dir <> '' then EnsureDir(Dir);
+  Strm := TFileStream.Create(NPath, fmCreate);
   try
     if Content <> '' then
     begin

--- a/src/tests/delphi_build_tests.pas
+++ b/src/tests/delphi_build_tests.pas
@@ -14,7 +14,7 @@ program delphi_build_tests;
 {$H+}
 
 uses
-  SysUtils,
+  SysUtils, Classes,
   PasClaw.Tools.DelphiBuild;
 
 procedure Fail(const Msg: string);
@@ -96,9 +96,48 @@ begin
   if Diags <> '' then Fail('clean build yields no diagnostics, got: ' + Diags);
 end;
 
+procedure TestDprojTokenExtraction;
+{ dcc-direct pulls the project's own search paths + namespaces from the
+  .dproj so multi-dir projects compile without hand-rolled -U flags. Verify
+  the extractor: ';'-split, skip $() macros, dedupe, multiple tags merge. }
+const
+  Dproj =
+    '<Project>' +
+    '<PropertyGroup>' +
+    '<DCC_UnitSearchPath>src;src\llama_cpp;src\llama_cpp\Api;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>' +
+    '<DCC_Namespace>System;FMX;$(DCC_Namespace)</DCC_Namespace>' +
+    '</PropertyGroup>' +
+    '<PropertyGroup>' +   { a second config group repeats one dir + adds one }
+    '<DCC_UnitSearchPath>src\llama_cpp;src\llama_cpp\CType;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>' +
+    '</PropertyGroup>' +
+    '</Project>';
+var
+  Dirs, Ns: TStringList;
+begin
+  Dirs := TStringList.Create;
+  Ns := TStringList.Create;
+  try
+    CollectDprojTokens(Dproj, 'DCC_UnitSearchPath', Dirs);
+    CollectDprojTokens(Dproj, 'DCC_Namespace', Ns);
+
+    { 4 distinct dirs across both groups; the macro + the dupe are dropped. }
+    AssertEq(Dirs.Count, 4, 'unit search paths deduped, macro skipped');
+    if Dirs.IndexOf('src\llama_cpp\Api') < 0 then Fail('expected src\llama_cpp\Api');
+    if Dirs.IndexOf('src\llama_cpp\CType') < 0 then Fail('expected src\llama_cpp\CType');
+    if Dirs.IndexOf('$(DCC_UnitSearchPath)') >= 0 then Fail('macro token must be skipped');
+
+    AssertEq(Ns.Count, 2, 'namespaces (System, FMX); macro skipped');
+    if Ns.IndexOf('FMX') < 0 then Fail('expected FMX namespace');
+  finally
+    Ns.Free;
+    Dirs.Free;
+  end;
+end;
+
 begin
   TestRawDccFormat;
   TestMsbuildBracketFormat;
   TestCleanBuildAndNoFalsePositives;
+  TestDprojTokenExtraction;
   WriteLn('delphi_build_tests: OK');
 end.

--- a/src/tests/delphi_build_tests.pas
+++ b/src/tests/delphi_build_tests.pas
@@ -98,17 +98,24 @@ end;
 
 procedure TestDprojTokenExtraction;
 { dcc-direct pulls the project's own search paths + namespaces from the
-  .dproj so multi-dir projects compile without hand-rolled -U flags. Verify
-  the extractor: ';'-split, skip $() macros, dedupe, multiple tags merge. }
+  .dproj so multi-dir projects compile without hand-rolled -U flags. Verify:
+  ';'-split, skip $() macros, dedupe across groups, AND honour PropertyGroup
+  conditions -- a Win32 build must NOT pull a Win64-only group's dirs. }
 const
   Dproj =
     '<Project>' +
+    { Base/unconditional group -- applies to every build. }
     '<PropertyGroup>' +
     '<DCC_UnitSearchPath>src;src\llama_cpp;src\llama_cpp\Api;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>' +
     '<DCC_Namespace>System;FMX;$(DCC_Namespace)</DCC_Namespace>' +
     '</PropertyGroup>' +
-    '<PropertyGroup>' +   { a second config group repeats one dir + adds one }
-    '<DCC_UnitSearchPath>src\llama_cpp;src\llama_cpp\CType;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>' +
+    { Win32 group -- applies to a Win32 build. }
+    '<PropertyGroup Condition="''$(Platform)''==''Win32''">' +
+    '<DCC_UnitSearchPath>src\llama_cpp\CType;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>' +
+    '</PropertyGroup>' +
+    { Win64-only group -- must be EXCLUDED from a Win32 build. }
+    '<PropertyGroup Condition="''$(Platform)''==''Win64''">' +
+    '<DCC_UnitSearchPath>src\only_win64;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>' +
     '</PropertyGroup>' +
     '</Project>';
 var
@@ -117,17 +124,23 @@ begin
   Dirs := TStringList.Create;
   Ns := TStringList.Create;
   try
-    CollectDprojTokens(Dproj, 'DCC_UnitSearchPath', Dirs);
-    CollectDprojTokens(Dproj, 'DCC_Namespace', Ns);
+    CollectDprojTokens(Dproj, 'DCC_UnitSearchPath', 'Win32', 'Debug', Dirs);
+    CollectDprojTokens(Dproj, 'DCC_Namespace', 'Win32', 'Debug', Ns);
 
-    { 4 distinct dirs across both groups; the macro + the dupe are dropped. }
-    AssertEq(Dirs.Count, 4, 'unit search paths deduped, macro skipped');
-    if Dirs.IndexOf('src\llama_cpp\Api') < 0 then Fail('expected src\llama_cpp\Api');
-    if Dirs.IndexOf('src\llama_cpp\CType') < 0 then Fail('expected src\llama_cpp\CType');
+    { Base (3) + Win32 group (1 new). Macro + the Win64 dir excluded. }
+    AssertEq(Dirs.Count, 4, 'Win32 build: base + Win32 dirs only');
+    if Dirs.IndexOf('src\llama_cpp\Api') < 0 then Fail('expected base dir src\llama_cpp\Api');
+    if Dirs.IndexOf('src\llama_cpp\CType') < 0 then Fail('expected Win32 dir src\llama_cpp\CType');
+    if Dirs.IndexOf('src\only_win64') >= 0 then Fail('Win64-only dir must be excluded from Win32 build');
     if Dirs.IndexOf('$(DCC_UnitSearchPath)') >= 0 then Fail('macro token must be skipped');
 
     AssertEq(Ns.Count, 2, 'namespaces (System, FMX); macro skipped');
     if Ns.IndexOf('FMX') < 0 then Fail('expected FMX namespace');
+
+    { A Win64 build picks up the Win64 dir and drops nothing of the base. }
+    Dirs.Clear;
+    CollectDprojTokens(Dproj, 'DCC_UnitSearchPath', 'Win64', 'Debug', Dirs);
+    if Dirs.IndexOf('src\only_win64') < 0 then Fail('Win64 build should include src\only_win64');
   finally
     Ns.Free;
     Dirs.Free;


### PR DESCRIPTION
## What you saw

dcc-direct kept failing `F2613 Unit 'LlamaCpp.CType.Llama' not found`, and the model resorted to **hand-constructing `-U`/`-I` path lists** (via `fs_write`/`echo`) to compensate — exactly the flailing in the transcript.

## Why

`delphi_build`'s dcc-direct mode invoked dcc with only the BDS RTL/FMX lib dirs + a default namespace list. It never read the **project's own** unit search paths, which live in the `.dproj`'s `<DCC_UnitSearchPath>`. A multi-dir project (`src\llama_cpp\…`) therefore couldn't resolve its own units — so `dcc32 -B project.dpr` failed even though the same command works in the IDE/MSBuild (which supply those paths).

## Fix

Parse the sibling `.dproj` for `DCC_UnitSearchPath` and `DCC_Namespace` (new `CollectDprojTokens`: `;`-split, skip `$(...)` macros, dedupe) and pass them as `-U` / merge into `-NS`. The `.dproj` paths are relative to the project dir = dcc's cwd, so they resolve as-is. This is what makes a plain `dcc32 -B project.dpr` actually find the units.

Also: when a build fails but **no error code** was parsed, append the raw output **tail** (previously only shown when there were no diagnostics at all) — so the model never gets "FAILED, 0 errors" with nothing actionable.

## Verification

- Build clean (rc=0); `delphi_build_tests` pass, incl. a new `CollectDprojTokens` test (split / macro-skip / dedupe / multi-tag merge).
- dcc invocation is Windows-only — verified by construction; an on-device run is the end-to-end confirmation. (The dcc-direct default may still need `PASCLAW_DELPHI_SEARCH` for third-party libs outside the `.dproj`, or `PASCLAW_DELPHI_ALLOW_MSBUILD=1` for full fidelity.)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_