### PR TITLE
delphi_build: prioritize errors so the line cap never hides them

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
+++ b/src/pkg/tools/PasClaw.Tools.DelphiBuild.pas
@@ -250,15 +250,36 @@ function ParseDelphiOutput(const Raw: string;
 const
   MaxKept = 200;   { cap so a runaway build can't blow the tool-result budget }
 var
-  Lines: TStringList;
+  Lines, Errs, Warns, Hints: TStringList;
   Sb: TStringBuilder;
   i, Kept: Integer;
   Letter: Char;
   Ln: string;
+
+  { Drain a bucket into the result, newest-cap-aware, until either the
+    bucket is empty or the shared MaxKept budget is exhausted. Errors are
+    drained first by call order, so a flood of hints/warnings can never
+    push a real error out of the model's view. }
+  procedure Drain(Src: TStringList);
+  var
+    j: Integer;
+  begin
+    for j := 0 to Src.Count - 1 do
+    begin
+      if Kept >= MaxKept then Exit;
+      if Sb.Length > 0 then Sb.Append(#10);
+      Sb.Append(Src[j]);
+      Inc(Kept);
+    end;
+  end;
+
 begin
   NErrors := 0; NWarnings := 0; NHints := 0;
   Kept := 0;
   Lines := TStringList.Create;
+  Errs  := TStringList.Create;
+  Warns := TStringList.Create;
+  Hints := TStringList.Create;
   Sb := TStringBuilder.Create;
   try
     Lines.Text := StringReplace(Raw, #13, '', [rfReplaceAll]);
@@ -267,24 +288,26 @@ begin
       Ln := Lines[i];
       if not FindDelphiCode(Ln, Letter) then Continue;
       case Letter of
-        'F': Inc(NErrors);   { fatal counts as an error for the model }
-        'E': Inc(NErrors);
-        'W': Inc(NWarnings);
-        'H': Inc(NHints);
-      end;
-      if Kept < MaxKept then
-      begin
-        if Sb.Length > 0 then Sb.Append(#10);
-        Sb.Append(Trim(Ln));
-        Inc(Kept);
+        'F': begin Inc(NErrors);   Errs.Add(Trim(Ln)); end;  { fatal counts as an error }
+        'E': begin Inc(NErrors);   Errs.Add(Trim(Ln)); end;
+        'W': begin Inc(NWarnings); Warns.Add(Trim(Ln)); end;
+        'H': begin Inc(NHints);    Hints.Add(Trim(Ln)); end;
       end;
     end;
+    { Errors first so they always lead and are never dropped by the cap;
+      then warnings, then hints fill whatever budget remains. }
+    Drain(Errs);
+    Drain(Warns);
+    Drain(Hints);
     Result := Sb.ToString;
     {$IFDEF FPC}
     SetCodePage(RawByteString(Result), CP_UTF8, False);
     {$ENDIF}
   finally
     Sb.Free;
+    Hints.Free;
+    Warns.Free;
+    Errs.Free;
     Lines.Free;
   end;
 end;

--- a/src/tests/delphi_build_tests.pas
+++ b/src/tests/delphi_build_tests.pas
@@ -96,6 +96,34 @@ begin
   if Diags <> '' then Fail('clean build yields no diagnostics, got: ' + Diags);
 end;
 
+procedure TestErrorsLeadAndSurviveCap;
+{ A real build can emit hundreds of hints/warnings -- more than the 200-line
+  keep cap. The model must still SEE the actual errors, and they must lead the
+  output, so they can't be silently dropped behind a hint flood. }
+var
+  Raw, Diags: string;
+  E, W, H, i: Integer;
+  Sb: TStringBuilder;
+begin
+  Sb := TStringBuilder.Create;
+  try
+    { 300 hints (over the 200 cap), then the one error that matters, last. }
+    for i := 1 to 300 do
+      Sb.Append(Format('Unit.pas(%d): H2077 Value assigned to ''X'' never used'#10, [i]));
+    Sb.Append('Broken.pas(7): E2003 Undeclared identifier: ''DoThing''');
+    Raw := Sb.ToString;
+  finally
+    Sb.Free;
+  end;
+  Diags := ParseDelphiOutput(Raw, E, W, H);
+  AssertEq(E, 1, 'one error counted under hint flood');
+  AssertEq(H, 300, 'all hints counted');
+  AssertContains(Diags, 'E2003', 'error survives the keep cap');
+  { The error must come first -- before any hint text in the kept output. }
+  if Pos('E2003', Diags) > Pos('H2077', Diags) then
+    Fail('error must lead the diagnostics, not trail the hints');
+end;
+
 procedure TestDprojTokenExtraction;
 { dcc-direct pulls the project's own search paths + namespaces from the
   .dproj so multi-dir projects compile without hand-rolled -U flags. Verify:
@@ -151,6 +179,7 @@ begin
   TestRawDccFormat;
   TestMsbuildBracketFormat;
   TestCleanBuildAndNoFalsePositives;
+  TestErrorsLeadAndSurviveCap;
   TestDprojTokenExtraction;
   WriteLn('delphi_build_tests: OK');
 end.


### PR DESCRIPTION
## Problem

`delphi_build` could report "48 error(s)" yet the visible diagnostics led with a single hint and showed no errors at all. The build output is **not** filtered before the model sees it (the terminal preview is cosmetic, and `ToolOutputCap` defaults to off), but `ParseDelphiOutput` had a latent hole: it kept diagnostics in dcc's emit order under a 200-line cap. dcc interleaves hints/warnings, so on a large project a flood of them ahead of the errors could push the actual errors past the cap — leaving the model a result that leads with a hint and drops the errors it needs to fix.

## Fix

Bucket diagnostics into errors / warnings / hints and drain **errors first**, then warnings, then hints, under one shared cap. Errors now always lead the output and can never be dropped. Counts are unchanged.

## Test

Adds a case that floods 300 hints before a single error and asserts the error is both kept and leads the diagnostics. Full suite green.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_