### PR TITLE
serve/gateway: host docker shell backend + fix blank assistant bubbles

### DIFF
--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -44,8 +44,11 @@ uses
   PasClaw.Tools.Vault,
   PasClaw.Tools.OutputCache,
   PasClaw.Tools.Sandbox,
-  PasClaw.Shell.Backend,    { TShellBackendKind -- gate on Cfg.ShellBackend
-                              so we refuse docker on gateway cleanly }
+  PasClaw.Shell.Backend,    { TShellBackendKind + StartShellSession /
+                              SetCurrentSessionId / CloseShellSession --
+                              one container per gateway process }
+  PasClaw.Shell.Backend.Factory,  { InstallShellBackend }
+  PasClaw.Session.Store,    { NewSessionId for the shell session id }
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Cron.Scheduler,
@@ -176,26 +179,47 @@ var
   Email:    TEmailChannel;
   Scheduler: TCronScheduler;
   Skills: TSkillSpecArray;
+  KindSelected: TShellBackendKind;
+  BackendDesc, ShellSessionId: string;
 begin
   Cfg := LoadConfig;
   ConfigureSandbox(Cfg.Sandbox, '');
+  ShellSessionId := '';
   try
     Args := ParseGw(Argv, Cfg);
-    { Phase 1: docker backend not yet wired on the multi-tenant gateway
-      (per-request session containers + cross-thread session-id
-      propagation are Phase 1.5). Refuse when tools are on so an
-      operator with shell_backend=docker globally isn't silently
-      running on the host. Codex P2 on PR #233: skip the gate when
-      --no-tools was passed since the gateway never dispatches
-      shell_exec in that mode -- the docker isolation story doesn't
-      apply. Parse args first so the flag is read before the gate. }
-    if (Cfg.ShellBackend = sbDocker) and (not Args.NoTools) then
+    { Install the configured shell backend so shell_exec / execute_code run
+      where the operator asked -- including docker. The gateway uses ONE
+      container for the whole process (like the TUI): every request /
+      channel message shares it, since there's no per-request session
+      lifecycle here. That's coarser than per-tenant isolation but it hosts
+      the docker backend honestly instead of falling through to the host.
+      Skipped under --no-tools (no shell dispatch). }
+    if not Args.NoTools then
     begin
-      PrintLn(Ansi.Yellow + '!' + Ansi.Reset +
-              ' `pasclaw gateway` does not yet host the docker shell backend.');
-      PrintLn('  Run with shell_backend=local in config.json, or pass ' +
-              Ansi.Bold + '--no-tools' + Ansi.Reset + '.');
-      Exit(1);
+      try
+        InstallShellBackend(Cfg, '', KindSelected, BackendDesc);
+      except
+        on E: Exception do
+        begin
+          PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
+          Exit(1);
+        end;
+      end;
+      if KindSelected = sbDocker then
+      begin
+        ShellSessionId := NewSessionId;
+        PrintLn(Ansi.Dim + 'starting docker container for this gateway...' + Ansi.Reset);
+        try
+          StartShellSession(ShellSessionId);
+        except
+          on E: Exception do
+          begin
+            PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
+            Exit(1);
+          end;
+        end;
+        SetCurrentSessionId(ShellSessionId);
+      end;
     end;
 
     { Stream-reliability env-var overrides -- see Cmd.Serve for the
@@ -397,6 +421,8 @@ begin
 
     Result := 0;
   finally
+    { Tear down the one shell container (no-op for local / unset). }
+    if ShellSessionId <> '' then CloseShellSession(ShellSessionId);
     Cfg.Free;
   end;
 end;

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -66,8 +66,11 @@ uses
   PasClaw.Tools.Vault,
   PasClaw.Tools.OutputCache,
   PasClaw.Tools.Sandbox,
-  PasClaw.Shell.Backend,    { TShellBackendKind -- gate on Cfg.ShellBackend
-                              so we refuse docker on serve cleanly }
+  PasClaw.Shell.Backend,    { TShellBackendKind + StartShellSession /
+                              SetCurrentSessionId / CloseShellSession --
+                              one container per serve process }
+  PasClaw.Shell.Backend.Factory,  { InstallShellBackend }
+  PasClaw.Session.Store,    { NewSessionId for the shell session id }
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
   PasClaw.Stream.Reliability,
@@ -134,32 +137,51 @@ var
   Server, MCPServer: TGatewayServer;
   Skills: TSkillSpecArray;
   BaseURL: string;
+  KindSelected: TShellBackendKind;
+  BackendDesc, ShellSessionId: string;
 begin
   Cfg := LoadConfig;
   ConfigureSandbox(Cfg.Sandbox, '');
+  ShellSessionId := '';
   try
     Args := ParseServe(Argv, Cfg);
-    { Phase 1 scope: docker shell-backend is wired for `pasclaw agent`
-      and `pasclaw heartbeat`. The multi-tenant serve path needs
-      per-request session containers and cross-thread session-id
-      propagation, which is Phase 1.5 work. Refuse docker here
-      loudly so an operator who flipped on docker globally doesn't
-      silently end up on the host when they hit /v1.
-
-      Skip the gate when --no-tools was passed -- a tool-disabled
-      server never dispatches shell_exec, so the docker isolation
-      story doesn't apply. Codex P2 on PR #233: parse args before
-      the gate so the help text's `--no-tools` advice is actually
-      honoured. }
-    if (Cfg.ShellBackend = sbDocker) and (not Args.NoTools) then
+    { Install the active shell backend so shell_exec / execute_code run on
+      the backend the operator configured -- including docker. serve uses
+      ONE container for the whole process (like the TUI): every /v1 request
+      shares it, since the gateway has no per-request session lifecycle.
+      That's coarser than per-tenant isolation but it does host the docker
+      backend honestly instead of silently falling through to the host.
+      Skip entirely when --no-tools (no shell dispatch at all). }
+    if not Args.NoTools then
     begin
-      PrintLn(Ansi.Yellow + '!' + Ansi.Reset +
-              ' `pasclaw serve` does not yet host the docker shell backend.');
-      PrintLn('  Run with shell_backend=local in config.json (single-tenant ' +
-              'docker is on `pasclaw agent` only),');
-      PrintLn('  or pass ' + Ansi.Bold + '--no-tools' + Ansi.Reset +
-              ' to disable tool execution.');
-      Exit(1);
+      try
+        InstallShellBackend(Cfg, '', KindSelected, BackendDesc);
+      except
+        on E: Exception do
+        begin
+          PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
+          Exit(1);
+        end;
+      end;
+      { Spawn the single docker container up front (no-op for local) so a
+        first-time image pull surfaces as a clean console error here rather
+        than stalling the first request. SetCurrentSessionId points every
+        turn's shell_exec/execute_code at this container. }
+      if KindSelected = sbDocker then
+      begin
+        ShellSessionId := NewSessionId;
+        PrintLn(Ansi.Dim + 'starting docker container for this server...' + Ansi.Reset);
+        try
+          StartShellSession(ShellSessionId);
+        except
+          on E: Exception do
+          begin
+            PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
+            Exit(1);
+          end;
+        end;
+        SetCurrentSessionId(ShellSessionId);
+      end;
     end;
 
     { Stream-reliability env-var overrides. Lets operators tune
@@ -284,6 +306,8 @@ begin
 
     Result := 0;
   finally
+    { Tear down the one shell container (no-op for local / unset). }
+    if ShellSessionId <> '' then CloseShellSession(ShellSessionId);
     Cfg.Free;
   end;
 end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -2516,7 +2516,7 @@ begin
         LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
                 [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
       end
-      else if Loop.Content = '' then
+      else if Trim(Loop.Content) = '' then
       begin
         Loop.Content := Format('(no content returned by the model; finish_reason=%s)',
                                 [FinishReason]);
@@ -2606,7 +2606,7 @@ begin
       LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
               [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
     end
-    else if Loop.Content = '' then
+    else if Trim(Loop.Content) = '' then
     begin
       { Loop exited normally with no pending tool calls but the model
         produced no text. Some streaming clients can't represent that. }
@@ -4196,7 +4196,7 @@ begin
         LogWarn('responses: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
                 [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
       end
-      else if Loop.Content = '' then
+      else if Trim(Loop.Content) = '' then
       begin
         Loop.Content := Format('(no content returned by the model; finish_reason=%s)',
                                 [FinishReason]);


### PR DESCRIPTION
Two fixes from live web-UI testing.

## 1. `serve` / `gateway` now host the docker shell backend
Both commands previously refused `shell_backend=docker` (the `! pasclaw serve does not yet host the docker shell backend` message) and told you to switch to local or `--no-tools`. They now install the configured backend via `InstallShellBackend` and, for docker, spawn **one container for the whole process** up front — the same one-container-per-process model the TUI uses — pointing every request's `shell_exec`/`execute_code` at it (`SetCurrentSessionId`) and tearing it down on exit. A first-run image pull surfaces as a clean console error rather than stalling the first request. Skipped under `--no-tools`.

Trade-off: this is coarser than per-tenant isolation — all requests/channels share the one workspace container — but it hosts docker honestly instead of silently falling through to the host. Local backend unchanged.

## 2. Blank assistant bubbles → placeholder
**This is the "why are pasclaw messages empty" cause.** The gateway's empty-content guard compared `Loop.Content` to `''` *exactly*, so a turn whose final text was **whitespace-only** (a stray newline/space — common with some providers) slipped past it: no placeholder was substituted and the web UI rendered a blank bubble. Now it `Trim`s before the check, so whitespace-only output gets the `(no content returned by the model; finish_reason=…)` placeholder on all three paths (chat/completions stream + non-stream, responses).

Note it is **not** a "tools are off" thing: tool activity is streamed as visible `⏺`/`⎿` lines, so a tool-using turn is never blank — this only affects turns whose final text is effectively empty.

## Verification
Full binary builds; `smoke`, `test-gateway-stats-buckets`, `test-gateway-token`, `test-session-endpoints` green. The listening HTTP path can't be bound in CI/sandbox, so the docker lifecycle wiring is compile-verified and mirrors the TUI's proven pattern.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_