### PR TITLE
web UI security: hide config.json and other secret files from the Files tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,6 +548,14 @@ test-gateway-token: | $(BUILDDIR)
 	@PASCLAW_GATEWAY_TOKEN=sk-pasclaw-env-test-aaaaaaaa $(BUILDDIR)/gateway_token_tests --env-mode
 	@OPENCLAW_GATEWAY_TOKEN=sk-openclaw-env-test-bbbbbb $(BUILDDIR)/gateway_token_tests --env-mode
 
+# /v1/fs operator-browse secret gate: config.json (and .env / TLS keys)
+# must never list or read through HandleFSList/HandleFSRead. PASCLAW_CONFIG
+# points at a non-config.json name so the exact-resolved-path branch runs.
+test-fs-secret-gate: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/fs_secret_gate_tests.pas -o$(BUILDDIR)/fs_secret_gate_tests
+	@PASCLAW_CONFIG=$(BUILDDIR)/fs-gate-test.cfg $(BUILDDIR)/fs_secret_gate_tests
+
 # ${VAR_NAME} env-substitution in config.json. Pins the pattern
 # (uppercase only, [A-Z_][A-Z0-9_]*), the splice + JSON-escape, the
 # unset-env "leave the literal in place" diagnostic behaviour, and
@@ -586,4 +594,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -235,6 +235,15 @@ procedure AccumulateGatewayStatsRaw(const Cfg: TConfig;
                                     ToolCallsDispatched: Int64;
                                     TruncatedBytesSaved: Int64);
 
+(* True when Path is a secret-bearing file the operator-facing /v1/fs
+   browse must neither list nor serve. config.json holds cleartext
+   provider api_keys, the gateway bearer token, mcp env, and the
+   web_search key -- GET /v1/config masks all of those, but the raw file
+   would leak them. Also hides .env files and TLS private keys that
+   commonly sit beside it. Matches the resolved config path exactly
+   (honours $PASCLAW_CONFIG) plus a basename denylist. Exposed for tests. *)
+function IsRestrictedFsPath(const Path: string): Boolean;
+
 implementation
 
 uses
@@ -1728,6 +1737,24 @@ begin
   end;
 end;
 
+function IsRestrictedFsPath(const Path: string): Boolean;
+var
+  Full, CfgFull, Base: string;
+begin
+  Result := False;
+  if Path = '' then Exit;
+  try Full := ExpandFileName(Path); except Full := Path; end;
+  { Exact match against the resolved config file, so an operator who moved
+    it via $PASCLAW_CONFIG (a non-"config.json" name) is still covered. }
+  try CfgFull := ExpandFileName(GetConfigPath); except CfgFull := GetConfigPath; end;
+  if (CfgFull <> '') and SameFileName(Full, CfgFull) then Exit(True);
+  { Basename denylist for the conventional secret files. }
+  Base := LowerCase(ExtractFileName(Full));
+  if Base = 'config.json' then Exit(True);
+  if (Base = '.env') or HasPrefix(Base, '.env.') then Exit(True);
+  if HasSuffix(Base, '.pem') or HasSuffix(Base, '.key') then Exit(True);
+end;
+
 procedure TGatewayServer.HandleFSList(ARequest: TIdHTTPRequestInfo;
                                        AResp: TIdHTTPResponseInfo);
 var
@@ -1786,6 +1813,9 @@ begin
     try
       repeat
         if (SR.Name = '.') or (SR.Name = '..') then Continue;
+        { Hide secret-bearing files (config.json, .env, TLS keys) from the
+          operator browse so cleartext api_keys / tokens never surface. }
+        if IsRestrictedFsPath(JoinPath(Dir, SR.Name)) then Continue;
         Item := TJsonObject.Create;
         Item.PutStr ('name', SR.Name);
         Item.PutInt ('size', SR.Size);
@@ -1826,6 +1856,14 @@ begin
   if not CanReadPath(Path, Reason) then
   begin
     WriteJSON(AResp, 403, '{"error":"' + JsonEscape(Reason) + '"}');
+    Exit;
+  end;
+  { Refuse secret-bearing files even when the sandbox would allow them --
+    same denylist HandleFSList hides from the browse. Without this an
+    operator could read config.json's cleartext keys via a direct path. }
+  if IsRestrictedFsPath(Path) then
+  begin
+    WriteJSON(AResp, 403, '{"error":"access to this file is restricted"}');
     Exit;
   end;
   if not FileExists(Path) then

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -241,13 +241,16 @@ procedure AccumulateGatewayStatsRaw(const Cfg: TConfig;
    web_search key -- GET /v1/config masks all of those, but the raw file
    would leak them. Also hides .env files and TLS private keys that
    commonly sit beside it. Matches the resolved config path exactly
-   (honours $PASCLAW_CONFIG) plus a basename denylist. Exposed for tests. *)
+   (honours $PASCLAW_CONFIG) plus a basename denylist. On Unix it follows
+   symlinks/hardlinks so an innocuously-named alias to the config cannot
+   slip past the lexical compare. Exposed for tests. *)
 function IsRestrictedFsPath(const Path: string): Boolean;
 
 implementation
 
 uses
   DateUtils,
+  {$IFDEF FPC}{$IFDEF UNIX}BaseUnix,{$ENDIF}{$ENDIF}
   IdTCPConnection,
   PasClaw.JSON,
   PasClaw.Logger,
@@ -1737,9 +1740,41 @@ begin
   end;
 end;
 
+{$IFDEF FPC}{$IFDEF UNIX}
+function CRealPath(path: PAnsiChar; resolved_path: PAnsiChar): PAnsiChar; cdecl;
+  external 'c' name 'realpath';
+
+(* Canonical, symlink-resolved absolute path, or '' if it cannot be
+   resolved (e.g. the path does not exist). ExpandFileName only
+   normalises `.`/`..` lexically -- it does NOT follow symlinks, so a
+   browseable alias whose target is the config file slips past a purely
+   lexical compare. realpath(3) collapses every link in the chain. *)
+function CanonicalPath(const P: string): string;
+var
+  Buf: array[0..4095] of AnsiChar;  { PATH_MAX on Linux }
+begin
+  if CRealPath(PAnsiChar(AnsiString(P)), @Buf[0]) <> nil then
+    Result := string(PAnsiChar(@Buf[0]))
+  else
+    Result := '';
+end;
+
+{ True when A and B name the same underlying file. FpStat follows
+  symlinks, so this also catches a hardlink to the config file (which
+  realpath cannot, since a hardlink has its own canonical name). }
+function SameInode(const A, B: string): Boolean;
+var
+  SA, SB: Stat;
+begin
+  Result := (FpStat(AnsiString(A), SA) = 0) and (FpStat(AnsiString(B), SB) = 0)
+            and (SA.st_dev = SB.st_dev) and (SA.st_ino = SB.st_ino);
+end;
+{$ENDIF}{$ENDIF}
+
 function IsRestrictedFsPath(const Path: string): Boolean;
 var
   Full, CfgFull, Base: string;
+  {$IFDEF FPC}{$IFDEF UNIX}CP: string;{$ENDIF}{$ENDIF}
 begin
   Result := False;
   if Path = '' then Exit;
@@ -1747,6 +1782,18 @@ begin
   { Exact match against the resolved config file, so an operator who moved
     it via $PASCLAW_CONFIG (a non-"config.json" name) is still covered. }
   try CfgFull := ExpandFileName(GetConfigPath); except CfgFull := GetConfigPath; end;
+  {$IFDEF FPC}{$IFDEF UNIX}
+  { PR #280 Codex P1: an innocuously-named symlink (notes.txt ->
+    $PASCLAW_CONFIG) or a hardlink would pass the lexical + basename
+    checks below, and HandleFSRead's TFileStream follows it to serve the
+    cleartext config. Catch the link by inode, and run the checks below
+    against the symlink-resolved target rather than the lexical name. }
+  if SameInode(Path, GetConfigPath) then Exit(True);
+  CP := CanonicalPath(Path);
+  if CP <> '' then Full := CP;
+  CP := CanonicalPath(GetConfigPath);
+  if CP <> '' then CfgFull := CP;
+  {$ENDIF}{$ENDIF}
   if (CfgFull <> '') and SameFileName(Full, CfgFull) then Exit(True);
   { Basename denylist for the conventional secret files. }
   Base := LowerCase(ExtractFileName(Full));

--- a/src/tests/fs_secret_gate_tests.pas
+++ b/src/tests/fs_secret_gate_tests.pas
@@ -1,0 +1,60 @@
+program fs_secret_gate_tests;
+(*
+  Pins IsRestrictedFsPath -- the denylist that keeps the operator-facing
+  /v1/fs browse (HandleFSList / HandleFSRead) from listing or serving
+  secret-bearing files. The leak it closes: config.json carries cleartext
+  provider api_keys, the gateway bearer token, mcp env, and the web_search
+  key, all of which GET /v1/config masks but the raw file would expose.
+
+  Run with PASCLAW_CONFIG pointed at a non-"config.json" path so the
+  exact-resolved-path branch is exercised alongside the basename rules.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Config,          { GetConfigPath }
+  PasClaw.Gateway.Server;  { IsRestrictedFsPath }
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertRestricted(const Path: string; Want: Boolean; const Msg: string);
+begin
+  if IsRestrictedFsPath(Path) <> Want then
+    Fail_(Msg + ' (path "' + Path + '", got ' + BoolToStr(IsRestrictedFsPath(Path), True)
+          + ', want ' + BoolToStr(Want, True) + ')');
+end;
+
+begin
+  { Basename denylist -- conventional secret files anywhere. }
+  AssertRestricted('/home/op/.pasclaw/config.json', True,  'config.json hidden');
+  AssertRestricted('/srv/app/.env',                 True,  '.env hidden');
+  AssertRestricted('/srv/app/.env.local',           True,  '.env.local hidden');
+  AssertRestricted('/etc/ssl/server.pem',           True,  '.pem hidden');
+  AssertRestricted('/etc/ssl/server.key',           True,  '.key hidden');
+
+  { Ordinary files stay visible. }
+  AssertRestricted('/home/op/workspace/README.md',  False, 'README visible');
+  AssertRestricted('/home/op/workspace/notes.txt',  False, 'txt visible');
+  AssertRestricted('/home/op/workspace/config.yaml', False, 'unrelated yaml visible');
+  AssertRestricted('',                              False, 'empty path not restricted');
+
+  { Exact-resolved-config-path branch: PASCLAW_CONFIG points the test at a
+    file NOT named config.json, so only the exact match can catch it. }
+  if LowerCase(ExtractFileName(GetConfigPath)) <> 'config.json' then
+  begin
+    AssertRestricted(GetConfigPath, True, 'resolved $PASCLAW_CONFIG hidden');
+    { A sibling that is not the config file is still visible. }
+    AssertRestricted(ExtractFilePath(GetConfigPath) + 'sibling.txt', False,
+                     'sibling of moved config visible');
+  end;
+
+  WriteLn('fs_secret_gate_tests: OK');
+end.

--- a/src/tests/fs_secret_gate_tests.pas
+++ b/src/tests/fs_secret_gate_tests.pas
@@ -16,6 +16,7 @@ program fs_secret_gate_tests;
 
 uses
   SysUtils,
+  {$IFDEF UNIX}BaseUnix,{$ENDIF}
   PasClaw.Config,          { GetConfigPath }
   PasClaw.Gateway.Server;  { IsRestrictedFsPath }
 
@@ -31,6 +32,61 @@ begin
     Fail_(Msg + ' (path "' + Path + '", got ' + BoolToStr(IsRestrictedFsPath(Path), True)
           + ', want ' + BoolToStr(Want, True) + ')');
 end;
+
+{$IFDEF UNIX}
+procedure WriteSmallFile(const Path, Content: string);
+var
+  F: Text;
+begin
+  AssignFile(F, Path);
+  Rewrite(F);
+  Write(F, Content);
+  CloseFile(F);
+end;
+
+procedure RunSymlinkChecks;
+var
+  Dir, Cfg, KeyTarget, Plain: string;
+  AliasCfg, AliasKey, AliasPlain, HardCfg: string;
+begin
+  { Absolute paths so the symlink targets resolve regardless of cwd. }
+  Cfg := ExpandFileName(GetConfigPath); { build/fs-gate-test.cfg via Makefile }
+  Dir := ExtractFilePath(Cfg);
+  { The config target must exist so realpath/inode can resolve it. }
+  WriteSmallFile(Cfg, '{"api_key":"secret"}');
+
+  { Innocuously-named symlink whose target IS the config -> caught by inode
+    and by the canonical-path exact match. }
+  AliasCfg := Dir + 'notes.txt';
+  DeleteFile(AliasCfg);
+  if fpSymlink(PChar(Cfg), PChar(AliasCfg)) <> 0 then Fail_('could not symlink notes.txt');
+  AssertRestricted(AliasCfg, True, 'symlink to config hidden');
+
+  { Symlink to a *.key target under a harmless name -> caught by the
+    denylist running against the resolved target basename. }
+  KeyTarget := Dir + 'tls-server.key';
+  WriteSmallFile(KeyTarget, 'PRIVATE KEY');
+  AliasKey := Dir + 'harmless.txt';
+  DeleteFile(AliasKey);
+  if fpSymlink(PChar(KeyTarget), PChar(AliasKey)) <> 0 then Fail_('could not symlink harmless.txt');
+  AssertRestricted(AliasKey, True, 'symlink to .key hidden');
+
+  { Symlink to an ordinary file stays visible. }
+  Plain := Dir + 'plain.txt';
+  WriteSmallFile(Plain, 'hello');
+  AliasPlain := Dir + 'link-ok.txt';
+  DeleteFile(AliasPlain);
+  if fpSymlink(PChar(Plain), PChar(AliasPlain)) <> 0 then Fail_('could not symlink link-ok.txt');
+  AssertRestricted(AliasPlain, False, 'symlink to ordinary file visible');
+
+  { Hardlink to the config (own name, shared inode) -> caught by inode.
+    Skip silently if the platform/fs refuses the link. }
+  HardCfg := Dir + 'hard.txt';
+  DeleteFile(HardCfg);
+  if fpLink(PChar(Cfg), PChar(HardCfg)) = 0 then
+    AssertRestricted(HardCfg, True, 'hardlink to config hidden');
+end;
+{$ENDIF}
 
 begin
   { Basename denylist -- conventional secret files anywhere. }
@@ -55,6 +111,14 @@ begin
     AssertRestricted(ExtractFilePath(GetConfigPath) + 'sibling.txt', False,
                      'sibling of moved config visible');
   end;
+
+  { Symlink/hardlink bypass (PR #280 Codex P1): an innocuously-named alias
+    whose target is a secret file must still be restricted, because
+    HandleFSRead opens it with a symlink-following TFileStream. Exercise
+    the realpath + inode resolution on Unix with real files. }
+  {$IFDEF UNIX}
+  RunSymlinkChecks;
+  {$ENDIF}
 
   WriteLn('fs_secret_gate_tests: OK');
 end.


### PR DESCRIPTION
## The leak

The Files tab is backed by `GET /v1/fs` (list) and `GET /v1/fs/read` (read), which served **every** file under `$PASCLAW_HOME` when the sandbox isn't workspace-restricted — including `config.json`. That file holds, in cleartext:

- `providers[].api_key`
- `gateway.token` (the inbound bearer)
- `mcp_servers[].env`
- `web_search.api_key`

`GET /v1/config` masks all of these (`•••`), but an operator could just read `config.json` verbatim through the file browser — fully defeating the set-not-view secret model the config endpoints enforce.

## Fix

New exported `IsRestrictedFsPath(Path)`:
- **Exact match** against the resolved config path (`GetConfigPath`, so it still covers a config moved via `$PASCLAW_CONFIG` to a non-`config.json` name).
- **Basename denylist** for the conventional secret files: `config.json`, `.env` / `.env.*`, `*.pem`, `*.key`.

Wiring:
- `HandleFSList` skips restricted entries — they don't appear in the listing at all.
- `HandleFSRead` refuses them with `403 {"error":"access to this file is restricted"}` even when the sandbox would otherwise allow the path (defends the direct-path read).

## Tests

New `fs_secret_gate_tests` pins the basename rules, the ordinary-file passthrough, and the exact-resolved-path branch (run with `PASCLAW_CONFIG` pointed at a non-`config.json` name). Wired as `test-fs-secret-gate` and into `make test`. Full binary builds; gateway unit + new test green.

First of the web-UI follow-up series (security fix before the feature work: hub/catalog search, models dropdown, tab-in-URL, chat attachments, KB tab, dynamic settings form).

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_