### PR TITLE
gateway: /v1/models returns the provider's full catalog (fixes single-model picker)

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -884,6 +884,14 @@ begin
     begin
       if not NewProviderFromConfig(FConfig, FProviderName, FProvider, Err) then
         RaiseError('provider unavailable: ' + Err);
+      { Keep the config's notion of the default provider in lockstep with
+        the backend we actually booted. Without this, FConfig.DefaultProvider
+        still names the on-disk default, so /v1/models (and anything else
+        that keys off it, e.g. /v1/status) would enumerate/advertise the
+        wrong provider's catalog while /v1/chat runs FProviderName. The
+        SetProvider override path already does this via ApplyProviderOverride;
+        the bare ProviderName property must too. Codex P2 on PR #282. }
+      FConfig.DefaultProvider := FProviderName;
     end
     else if not NewDefaultProvider(FConfig, FProvider, Err) then
       RaiseError('provider unavailable: ' + Err);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -259,6 +259,8 @@ uses
   PasClaw.Skills.Install,   { InstallSkillTarget / RemoveSkillFiles / IsSafeSkillName }
   PasClaw.Tools.Sandbox,
   PasClaw.Providers.Factory,
+  PasClaw.Providers.Catalog,   { TProviderSpec for /v1/models discovery }
+  PasClaw.Providers.Models,    { DiscoverModels / cache -- /v1/models roster }
   PasClaw.Tools.ToolLoop,
   PasClaw.Stream.Reliability,
   PasClaw.Agent.Compact,
@@ -4596,34 +4598,73 @@ begin
 end;
 
 procedure TGatewayServer.HandleModels(AResp: TIdHTTPResponseInfo);
-{ OpenAI-compatible model list. Reports the default model only;
-  enumerating every supported provider/model combination is a deeper
-  change. A real one-model response is the contract most clients
-  need to validate the endpoint. }
+{ OpenAI-compatible model list. Enumerates the default provider's full
+  catalog via PasClaw.Providers.Models so the web UI's picker shows every
+  model the operator can choose, not just the configured default. The
+  on-disk cache ($PASCLAW_HOME/cache/models/<provider>.json) is preferred
+  so a warm gateway answers instantly; a cold cache triggers one live
+  fetch (shared with `pasclaw model refresh`) that is then persisted.
+  Discovery never raises -- when it is unavailable (offline, no key,
+  placeholder provider) the response still carries the configured default,
+  preserving the historical one-model contract. }
 var
   Root, Item: TJsonObject;
   DataArr: TJsonArray;
-  ModelId: string;
-begin
-  ModelId := FCfg.DefaultModel;
-  if ModelId = '' then ModelId := 'pasclaw';
+  DefModel, ProvName, Base, Key, Err: string;
+  Spec: TProviderSpec;
+  Disc: TModelDiscoveryResult;
+  Seen: TStringList;
+  i: Integer;
 
+  procedure AddModel(const Id, OwnedBy: string; Created: Int64);
+  begin
+    if (Id = '') or (Seen.IndexOf(Id) >= 0) then Exit;
+    Seen.Add(Id);
+    Item := TJsonObject.Create;
+    Item.PutStr('id',     Id);
+    Item.PutStr('object', 'model');
+    if Created > 0 then Item.PutInt('created', Created)
+    else                Item.PutInt('created', DateTimeToUnix(Now, False));
+    Item.PutStr('owned_by', OwnedBy);
+    DataArr.AddObject(Item);
+  end;
+
+begin
+  DefModel := FCfg.DefaultModel;
+  if DefModel = '' then DefModel := 'pasclaw';
+  ProvName := FCfg.DefaultProvider;
+
+  Seen := TStringList.Create;
   Root := TJsonObject.Create;
   try
     Root.PutStr('object', 'list');
     DataArr := TJsonArray.Create;
 
-    Item := TJsonObject.Create;
-    Item.PutStr('id',       ModelId);
-    Item.PutStr('object',   'model');
-    Item.PutInt('created',  DateTimeToUnix(Now, False));
-    Item.PutStr('owned_by', 'pasclaw');
-    DataArr.AddObject(Item);
+    if (ProvName <> '') and
+       ResolveProviderSpecForName(FCfg, ProvName, Spec, Base, Key, Err) then
+    begin
+      { Cache first (instant, no network on every page load); fall back to
+        a single live fetch and persist it for next time. }
+      if not LoadCachedModels(ProvName, Disc) then
+      begin
+        Disc := DiscoverModels(Spec, Base, Key);
+        if Disc.Ok and (Length(Disc.Models) > 0) then
+          SaveCachedModels(ProvName, Disc);
+      end;
+      if Disc.Ok then
+        for i := 0 to High(Disc.Models) do
+          AddModel(Disc.Models[i].Id, ProvName, Disc.Models[i].CreatedAt);
+    end;
+
+    { Always surface the configured default so the contract holds even when
+      discovery yields nothing. Dedup keeps it from doubling a catalog row. }
+    AddModel(DefModel, 'pasclaw', 0);
 
     Root.PutArray('data', DataArr);
     WriteJSON(AResp, 200, Root.ToJSON);
   finally
     Root.Free;
+    Seen.Free;
   end;
 end;
 


### PR DESCRIPTION
## The bug

The web UI's model picker only ever showed the configured default — for a Gemini default that's literally just `default model` + `gemini-3.5-flash`, never the rest of the provider's catalog. Root cause: `HandleModels` (`GET /v1/models`) hard-coded a single-element list:

```pascal
{ Reports the default model only; enumerating every supported
  provider/model combination is a deeper change. }
ModelId := FCfg.DefaultModel;
…AddObject(one item)…
```

## Fix

`HandleModels` now enumerates the default provider's full catalog via `PasClaw.Providers.Models` (the same discovery+cache layer `pasclaw model refresh` and the TUI use):

1. **Cache first** — read `$PASCLAW_HOME/cache/models/<provider>.json` so a warm gateway answers instantly with no network on every page load.
2. **Cold cache → one live fetch** — `DiscoverModels` against the provider's `/v1/models` (Gemini/OpenAI/Anthropic families all supported), then persist it for next time.
3. **Always include the configured default** (deduped) so the response is never empty — when discovery is unavailable (offline, no key, placeholder provider) the historical one-model contract still holds.

Server-only change — the existing picker JS (`loadModels()`) already renders a multi-entry list and persists the selection.

## Verification

Socket binding is blocked in my sandbox, so I couldn't boot the gateway for a live HTTP check. Instead I exercised the exact data path `HandleModels` walks (`ResolveProviderSpecForName` + `LoadCachedModels`) against a seeded Gemini cache:

```
default_provider=gemini default_model=gemini-3.5-flash
cached models (4):
  - gemini-3.5-flash
  - gemini-3-pro
  - gemini-2.5-flash
  - gemini-2.0-pro
```

All four enumerate (previously only the default would). Full binary builds clean.

> Note: the originally-planned "models dropdown" UI already existed in main (commit `ee239b3`); this PR fixes the empty roster behind it. Next series item: Skills catalog search.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_