### PR TITLE
shell(docker): lazy-init the container on first use + timeout-bound docker calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,13 @@ test-shell-backend: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/shell_backend_tests.pas -o$(BUILDDIR)/shell_backend_tests
 	@$(BUILDDIR)/shell_backend_tests
 
+# RunArgvCapture TimeoutMs cap -- proves a wedged child (e.g. a hung
+# `docker info`) is killed at the deadline instead of hanging the caller.
+test-run-timeout: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/run_timeout_tests.pas -o$(BUILDDIR)/run_timeout_tests
+	@$(BUILDDIR)/run_timeout_tests
+
 test-delphi-build: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/delphi_build_tests.pas -o$(BUILDDIR)/delphi_build_tests
@@ -599,4 +606,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -486,15 +486,18 @@ begin
   Handlers.Quiet := A.Quiet;
   { Allocate a one-shot session id so the active shell backend
     (docker, ssh, ...) actually isolates this turn. Codex P1 on
-    PR #233: without StartShellSession the docker backend's empty-
-    SessionId fallback dispatched to RunOneShot ON THE HOST,
-    silently bypassing the isolation the operator asked for. The
-    id is purely for the backend (one-shot turns aren't persisted
-    as PasClaw sessions); short prefix avoids docker's 64-char
-    container-name cap. }
+    PR #233: an empty SessionId let the docker backend fall back to
+    RunOneShot ON THE HOST, bypassing isolation -- so we always set a
+    real id here. The id is purely for the backend (one-shot turns
+    aren't persisted as PasClaw sessions); short prefix avoids docker's
+    64-char container-name cap.
+    Lazy docker (PR #286): we set the current session id but no longer
+    pre-spawn the container -- TDockerShellBackend.Exec spawns it on the
+    first shell tool call, so a turn that never shells out never touches
+    Docker and `pasclaw agent` doesn't stall at startup when Docker is
+    down/slow. }
   OneShotSessionId := 'oneshot-' + FormatDateTime('yyyymmdd-hhnnss', Now) +
                       '-' + IntToHex(Random(1 shl 24), 6);
-  StartShellSession(OneShotSessionId);
   SetCurrentSessionId(OneShotSessionId);
   try
     SetLength(Msgs, 1);

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -205,19 +205,15 @@ begin
           Exit(1);
         end;
       end;
+      { Lazy docker (PR #286): allocate the gateway's single session id and
+        point shell_exec/execute_code at it, but spawn the container on first
+        use (TDockerShellBackend.Exec) instead of here -- the gateway starts
+        instantly even when Docker is down/slow, and Docker errors surface on
+        the first shell tool call. The finally still tears it down (no-op if
+        never spawned). }
       if KindSelected = sbDocker then
       begin
         ShellSessionId := NewSessionId;
-        PrintLn(Ansi.Dim + 'starting docker container for this gateway...' + Ansi.Reset);
-        try
-          StartShellSession(ShellSessionId);
-        except
-          on E: Exception do
-          begin
-            PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
-            Exit(1);
-          end;
-        end;
         SetCurrentSessionId(ShellSessionId);
       end;
     end;

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -163,23 +163,16 @@ begin
           Exit(1);
         end;
       end;
-      { Spawn the single docker container up front (no-op for local) so a
-        first-time image pull surfaces as a clean console error here rather
-        than stalling the first request. SetCurrentSessionId points every
-        turn's shell_exec/execute_code at this container. }
+      { Lazy docker: allocate this server's single session id and point every
+        turn's shell_exec/execute_code at it, but DON'T spawn the container
+        now -- TDockerShellBackend.Exec spawns (and health-probes) it on the
+        first shell tool call. So serve starts instantly even when Docker is
+        down/slow/wedged; only chats that use a shell tool pay the cost, and
+        any Docker error surfaces as that tool's result. The finally below
+        still tears the container down (no-op if it was never spawned). }
       if KindSelected = sbDocker then
       begin
         ShellSessionId := NewSessionId;
-        PrintLn(Ansi.Dim + 'starting docker container for this server...' + Ansi.Reset);
-        try
-          StartShellSession(ShellSessionId);
-        except
-          on E: Exception do
-          begin
-            PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + E.Message);
-            Exit(1);
-          end;
-        end;
         SetCurrentSessionId(ShellSessionId);
       end;
     end;

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -153,7 +153,8 @@ function RunOneShotWithEnv(const Cmd, WorkingDir: string;
    text out of a host shell entirely. *)
 function RunArgvCapture(const Exe: string; Args: TStrings;
                         const WorkingDir: string;
-                        out Output: string): Integer;
+                        out Output: string;
+                        TimeoutMs: Integer = 0): Integer;
 
 (* Decode a byte buffer captured from a child shell's stdout/stderr
    into a UTF-8-encoded Pascal string suitable for tool output. On
@@ -1052,21 +1053,30 @@ begin
 end;
 
 function RunArgvCapture(const Exe: string; Args: TStrings;
-                        const WorkingDir: string; out Output: string): Integer;
+                        const WorkingDir: string; out Output: string;
+                        TimeoutMs: Integer = 0): Integer;
 { Cross-platform: built on the TStdioProcess abstraction (TProcess on
   FPC, CreateProcessW on Delphi/Windows, fork+execvp on Delphi/POSIX) so
   there is exactly one implementation. MergeStderr mirrors RunOneShot's
   combined-capture contract. Drain pattern matches RunOneShot and
   MCP.StdioClient: read what's available, and only stop once the pipe is
   empty AND the child has been reaped (Running populates ExitCode on the
-  transition). }
+  transition).
+
+  TimeoutMs > 0 caps total wall-clock time: on expiry the child is
+  Terminated and 124 is returned. This is what keeps a wedged Docker
+  daemon (`docker info` that never returns) from hanging serve/agent at
+  startup -- the Docker backend passes a bounded timeout for every
+  `docker` invocation. 0 (default) preserves the historical unbounded
+  behaviour for every other caller. }
 var
   P: TStdioProcess;
   M: TMemoryStream;
   Buf: array[0..ReadBufferSize - 1] of Byte;
   Bytes: TBytes;
   N, Total: Integer;
-  Overflow: Boolean;
+  Overflow, TimedOut: Boolean;
+  StartT: TDateTime;
 begin
   Result := -1;
   Output := '';
@@ -1076,6 +1086,8 @@ begin
     if not P.Spawn(Exe, Args, {MergeStderr=}True, WorkingDir) then Exit;
     Total := 0;
     Overflow := False;
+    TimedOut := False;
+    StartT := Now;
     while True do
     begin
       N := P.ReadAvailable(Buf, SizeOf(Buf));
@@ -1094,9 +1106,18 @@ begin
         Break
       else
         Sleep(20);
+      { Wall-clock cap. 86400000 = ms/day; Now's resolution (~10-16ms) is
+        ample for the second-scale timeouts callers use. }
+      if (TimeoutMs > 0) and
+         (Trunc((Now - StartT) * 86400000.0) >= TimeoutMs) then
+      begin
+        TimedOut := True;
+        P.Terminate;
+        Break;
+      end;
     end;
-    if Overflow then
-      Result := 124          { killed for exceeding OneShotMaxBytes; matches RunOneShot }
+    if Overflow or TimedOut then
+      Result := 124          { killed (byte cap or timeout); matches RunOneShot }
     else
       Result := P.ExitCode;
     if M.Size > 0 then
@@ -1106,6 +1127,8 @@ begin
       M.ReadBuffer(Bytes[0], M.Size);
       Output := DecodeShellOutputBytes(Bytes, Length(Bytes));
     end;
+    if TimedOut then
+      Output := Trim(Output + Format(' (timed out after %d ms)', [TimeoutMs]));
   finally
     M.Free;
     P.Free;

--- a/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
@@ -126,6 +126,18 @@ uses
 const
   KeepAliveCmd = 'tail -f /dev/null';
 
+  { Timeouts (ms) for `docker` invocations, so a wedged Docker daemon
+    fails fast with a clear error instead of hanging serve/agent at
+    startup (Windows: Docker Desktop mid-restart is the classic case).
+    `docker info` is the boot-time reachability probe -- keep it short.
+    `docker run` is allowed a generous window so a first-run image pull
+    isn't killed mid-download. `docker stop` is bounded so cleanup on
+    exit can't wedge either. Exec (model commands) stays unbounded --
+    legitimate builds run long. }
+  DockerInfoTimeoutMs = 12000;     { DockerCliReachable probe }
+  DockerRunTimeoutMs  = 180000;    { SpawnContainer (allows image pull) }
+  DockerStopTimeoutMs = 15000;     { StopContainer }
+
 function DefaultDockerBackendOptions: TDockerBackendOptions;
 begin
   Result.Image      := 'debian:bookworm-slim';
@@ -210,7 +222,7 @@ begin
     Args.Add('info');
     Args.Add('--format');
     Args.Add('{{.ServerVersion}}');
-    ExitCode := RunArgvCapture('docker', Args, '', Out_);
+    ExitCode := RunArgvCapture('docker', Args, '', Out_, DockerInfoTimeoutMs);
   finally
     Args.Free;
   end;
@@ -399,7 +411,7 @@ begin
 
     LogInfo('shell-backend(docker): spawning %s (image=%s)',
             [ContainerName(SessionId), FOpts.Image]);
-    ExitCode := RunArgvCapture('docker', Args, '', Out_);
+    ExitCode := RunArgvCapture('docker', Args, '', Out_, DockerRunTimeoutMs);
   finally
     Args.Free;
   end;
@@ -431,7 +443,7 @@ begin
     Args.Add('--time');
     Args.Add('2');
     Args.Add(ContainerName(SessionId));
-    RunArgvCapture('docker', Args, '', Out_);
+    RunArgvCapture('docker', Args, '', Out_, DockerStopTimeoutMs);
   finally
     Args.Free;
   end;

--- a/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
@@ -127,15 +127,15 @@ const
   KeepAliveCmd = 'tail -f /dev/null';
 
   { Timeouts (ms) for `docker` invocations, so a wedged Docker daemon
-    fails fast with a clear error instead of hanging serve/agent at
-    startup (Windows: Docker Desktop mid-restart is the classic case).
-    `docker info` is the boot-time reachability probe -- keep it short.
-    `docker run` is allowed a generous window so a first-run image pull
-    isn't killed mid-download. `docker stop` is bounded so cleanup on
-    exit can't wedge either. Exec (model commands) stays unbounded --
-    legitimate builds run long. }
+    fails fast with a clear error instead of hanging serve/agent (Windows:
+    Docker Desktop mid-restart is the classic case). `docker info` is the
+    reachability probe and is the one that actually wedges -- hard-bound it
+    short. `docker stop` is bounded so cleanup on exit can't wedge either.
+    `docker run` is deliberately NOT capped: a first-run pull of a large or
+    private image can legitimately take minutes, and a fixed cap would
+    abort an otherwise-healthy backend (Codex P2 on PR #286). The short
+    info probe already gates daemon health before we ever reach run. }
   DockerInfoTimeoutMs = 12000;     { DockerCliReachable probe }
-  DockerRunTimeoutMs  = 180000;    { SpawnContainer (allows image pull) }
   DockerStopTimeoutMs = 15000;     { StopContainer }
 
 function DefaultDockerBackendOptions: TDockerBackendOptions;
@@ -411,7 +411,10 @@ begin
 
     LogInfo('shell-backend(docker): spawning %s (image=%s)',
             [ContainerName(SessionId), FOpts.Image]);
-    ExitCode := RunArgvCapture('docker', Args, '', Out_, DockerRunTimeoutMs);
+    { Unbounded on purpose -- a cache-miss image pull can run for minutes;
+      see the timeout-const comment. Daemon health is already gated by the
+      bounded `docker info` probe before we get here. }
+    ExitCode := RunArgvCapture('docker', Args, '', Out_);
   finally
     Args.Free;
   end;

--- a/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Docker.pas
@@ -490,6 +490,7 @@ function TDockerShellBackend.Exec(const SessionId, Cmd, WorkDir: string;
 var
   Args: TStringList;
   i: Integer;
+  Err: string;
 begin
   Output := '';
 
@@ -512,13 +513,33 @@ begin
     Result := -1;
     Exit;
   end;
+  { Lazy start: the container is spawned on first use, not at boot, so a
+    down/slow/wedged Docker only affects chats that actually run a shell
+    tool -- never serve/agent startup. DockerCliReachable is the bounded
+    health probe; SpawnContainer does the (unbounded) pull+run. Both stay
+    isolation-safe -- no host fallback. Surface either failure as the tool
+    result rather than crashing the agent loop. (If the operator pre-spawned
+    via StartShellSession, IsRunning is already true and we skip straight to
+    exec.) }
   if not IsRunning(SessionId) then
   begin
-    Output :=
-      'shell-backend(docker): container for SessionId "' + SessionId +
-      '" is not running. StartSession may have failed; check docker daemon.';
-    Result := -1;
-    Exit;
+    if not DockerCliReachable(Err) then
+    begin
+      Output := 'shell-backend(docker): ' + Err +
+                ' -- start Docker, or set shell_backend=local in config.json.';
+      Result := -1;
+      Exit;
+    end;
+    try
+      SpawnContainer(SessionId);
+    except
+      on E: Exception do
+      begin
+        Output := 'shell-backend(docker): ' + E.Message;
+        Result := -1;
+        Exit;
+      end;
+    end;
   end;
 
   { Build `docker exec [-e ...] [-w ...] <name> sh -c <Cmd>` as an argv

--- a/src/pkg/shell/PasClaw.Shell.Backend.Factory.pas
+++ b/src/pkg/shell/PasClaw.Shell.Backend.Factory.pas
@@ -61,7 +61,7 @@ function InstallShellBackend(const Cfg: TConfig;
 var
   Backend: IShellBackend;
   Opts: TDockerBackendOptions;
-  Err, WsHost: string;
+  WsHost: string;
 begin
   if CLIOverride <> '' then
     KindSelected := ParseKind(CLIOverride, Cfg.ShellBackend)
@@ -71,12 +71,13 @@ begin
   case KindSelected of
     sbDocker:
       begin
-        if not DockerCliReachable(Err) then
-          raise Exception.Create(
-            'shell_backend=docker selected but ' + Err + sLineBreak +
-            '  Start Docker, set shell_backend=local in config.json,' +
-            sLineBreak +
-            '  or pass --backend local on this command.');
+        { Docker is NOT probed here. Reachability + container spawn happen
+          lazily on the first shell_exec/execute_code (see
+          TDockerShellBackend.Exec), so a down/slow/wedged Docker never
+          blocks serve/agent startup -- only chats that actually run a
+          shell tool pay the cost, and the failure surfaces as that tool's
+          result. (Previously a boot-time `docker info` here could hang the
+          whole app; PR #286.) }
         Opts := DefaultDockerBackendOptions;
         if Cfg.ShellBackendDocker.Image   <> '' then Opts.Image   := Cfg.ShellBackendDocker.Image;
         if Cfg.ShellBackendDocker.Network <> '' then Opts.Network := Cfg.ShellBackendDocker.Network;

--- a/src/tests/run_timeout_tests.pas
+++ b/src/tests/run_timeout_tests.pas
@@ -1,0 +1,88 @@
+program run_timeout_tests;
+(*
+  Pins RunArgvCapture's TimeoutMs cap -- the guard that keeps a wedged
+  Docker daemon (`docker info` that never returns) from hanging
+  serve/agent at startup. A timed-out child must be terminated, report
+  124, carry a "timed out" note, and -- crucially -- the call must return
+  in roughly the timeout window, not run to completion.
+
+  Unix-only (drives /bin/sh); the CI test runner is FPC/Linux.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils, Classes,
+  PasClaw.Platform;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+{$IFDEF UNIX}
+function ElapsedMs(const StartT: TDateTime): Int64;
+begin
+  Result := Trunc((Now - StartT) * 86400000.0);
+end;
+
+procedure RunChecks;
+var
+  Args: TStrings;
+  Output: string;
+  Code: Integer;
+  StartT: TDateTime;
+  Elapsed: Int64;
+begin
+  { 1. A child that sleeps far past the timeout is killed at ~the deadline. }
+  Args := TStringList.Create;
+  try
+    Args.Add('-c');
+    Args.Add('sleep 10');
+    StartT := Now;
+    Code := RunArgvCapture('/bin/sh', Args, '', Output, 500);
+    Elapsed := ElapsedMs(StartT);
+  finally
+    Args.Free;
+  end;
+  if Code <> 124 then Fail_(Format('timed-out child should return 124, got %d', [Code]));
+  if Pos('timed out', LowerCase(Output)) = 0 then
+    Fail_('timed-out output should note the timeout, got: ' + Output);
+  if Elapsed > 4000 then
+    Fail_(Format('timeout did not bound runtime: took %d ms (cap 500)', [Elapsed]));
+
+  { 2. A fast child finishes normally well within a generous timeout -- the
+       cap must not interfere with successful runs. }
+  Args := TStringList.Create;
+  try
+    Args.Add('-c');
+    Args.Add('printf hello');
+    Code := RunArgvCapture('/bin/sh', Args, '', Output, 5000);
+  finally
+    Args.Free;
+  end;
+  if Code <> 0 then Fail_(Format('fast child should return 0, got %d', [Code]));
+  if Trim(Output) <> 'hello' then Fail_('fast child output mismatch: ' + Output);
+
+  { 3. TimeoutMs = 0 keeps the historical unbounded behaviour (still completes). }
+  Args := TStringList.Create;
+  try
+    Args.Add('-c');
+    Args.Add('printf ok');
+    Code := RunArgvCapture('/bin/sh', Args, '', Output, 0);
+  finally
+    Args.Free;
+  end;
+  if (Code <> 0) or (Trim(Output) <> 'ok') then
+    Fail_('TimeoutMs=0 path regressed: code=' + IntToStr(Code) + ' out=' + Output);
+end;
+{$ENDIF}
+
+begin
+  {$IFDEF UNIX}
+  RunChecks;
+  {$ENDIF}
+  WriteLn('run_timeout_tests: OK');
+end.


### PR DESCRIPTION
## Symptom

`pasclaw serve` / `agent` (and `gateway`) hang on Windows right after the banner when `shell_backend: docker` and Docker Desktop is wedged (e.g. mid-restart). `--no-mcp` doesn't help (the hang is before MCP); a reboot — which un-wedges Docker — fixes it.

## Root cause

With the docker backend, `InstallShellBackend` ran `DockerCliReachable` (a `docker info` call) **with no timeout** at startup, and the server commands then spawned the session container up front. A wedged daemon blocked `docker info` forever — before MCP or the listener — taking the whole app down even though no chat had used a shell tool yet.

## Fix — two parts

### 1. Lazy init (the real fix, per review discussion)
Docker is no longer touched at startup:
- `InstallShellBackend` **no longer probes** Docker.
- `TDockerShellBackend.Exec` spawns the container **on the first `shell_exec`/`execute_code`** — bounded `docker info` health-probe, then pull+run — and surfaces any failure as that tool's result. **No host fallback**, so isolation is preserved (Codex P1 #233 intact).
- `serve`/`agent`/`gateway` set the current session id but no longer call `StartShellSession`; the finally cleanup is a no-op when nothing was spawned.

Net: these commands **start instantly regardless of Docker state**; only chats that actually run a shell tool pay the cost or see Docker errors. (`StartShellSession` stays for TUI/heartbeat as an optional eager pre-spawn; `Exec`'s `IsRunning` check makes it idempotent.)

### 2. Bounded docker calls (defense for the lazy path)
- `RunArgvCapture` gains an optional `TimeoutMs` (default `0` = unbounded → every existing caller unchanged): the drain loop caps wall-clock time, `Terminate`s the child on expiry, returns `124` with a `(timed out…)` note.
- The docker backend bounds the calls that should be fast: **`docker info` 12 s**, **`docker stop` 15 s**. **`docker run` is left unbounded** — a first-run pull of a large/private image can legitimately take minutes, and a fixed cap would abort a healthy backend (**Codex P2 on this PR**); the short `info` probe already gates daemon health before `run`. `Exec` (model commands) stays unbounded too.

## Tests

`test-run-timeout` (new, wired into `make test`) proves the cap kills a child that sleeps past the deadline (returns `124`) while leaving fast/`TimeoutMs=0` runs untouched. `test-shell-backend` still passes — including the "docker backend refuses empty SessionId (no host fallback)" isolation guard. Full binary builds clean.

> Still open as a follow-up: orphaned `pasclaw-*` containers from killed/hung runs (keep-alive containers that never hit graceful `CloseShellSession`). Happy to add a startup sweep / interrupt cleanup next.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_