### PR TITLE
providers: add Perplexity (Sonar) + per-provider chat-path override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -291,6 +291,12 @@ test-model-discovery: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/model_discovery_tests.pas -o$(BUILDDIR)/model_discovery_tests
 	@$(BUILDDIR)/model_discovery_tests
+
+# Provider catalog rows + ChatPath override (Perplexity uses /chat/completions).
+test-provider-catalog: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/provider_catalog_tests.pas -o$(BUILDDIR)/provider_catalog_tests
+	@$(BUILDDIR)/provider_catalog_tests
 
 # PasClaw.Tools.OutputCache — truncation thresholds + handle round-trip.
 test-output-cache: | $(BUILDDIR)
@@ -606,4 +612,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -61,6 +61,10 @@ type
     DefaultModel: string;            { empty when the provider has no obvious default }
     Auth:         TAuthScheme;
     Notes:        string;            { one-line description, shown in onboard menus }
+    ChatPath:     string;            { path appended to the base for chat
+                                       completions; '/v1/chat/completions' for
+                                       OpenAI-shaped APIs, but e.g. Perplexity
+                                       uses '/chat/completions' (no /v1) }
   end;
 
   TProviderSpecArray = array of TProviderSpec;
@@ -91,7 +95,8 @@ end;
 
 function MkSpec(const Kind, DisplayName: string; Family: TProtocolFamily;
                 const DefaultBase, DefaultModel: string;
-                const Auth: TAuthScheme; const Notes: string): TProviderSpec;
+                const Auth: TAuthScheme; const Notes: string;
+                const ChatPath: string = '/v1/chat/completions'): TProviderSpec;
 begin
   Result.Kind         := Kind;
   Result.DisplayName  := DisplayName;
@@ -100,13 +105,14 @@ begin
   Result.DefaultModel := DefaultModel;
   Result.Auth         := Auth;
   Result.Notes        := Notes;
+  Result.ChatPath     := ChatPath;
 end;
 
 { The catalog. New providers go here -- one entry per row, no other code
   change required for OpenAI-compatible endpoints. }
 function BuildCatalog: TProviderSpecArray;
 begin
-  SetLength(Result, 21);
+  SetLength(Result, 22);
   Result[0]  := MkSpec('anthropic',  'Anthropic',
                        pfAnthropic,  'https://api.anthropic.com',
                        'claude-opus-4-7',
@@ -233,11 +239,21 @@ begin
                        'grok-4-fast',
                        MkAuth(asBearer),
                        'Grok 4 Fast / Grok 3 / Grok Code Fast 1');
-  (* Cohere intentionally not in this catalog: their chat API lives
-     at /v2/chat rather than /v1/chat/completions, and the pfOpenAI
-     provider hard-codes the OpenAI path. Lands when a TCohereProvider
-     gets written or when pfOpenAI grows a path-override knob; until
-     then the placeholder row was more confusing than helpful. *)
+  { Perplexity speaks the OpenAI chat shape but at /chat/completions
+    (no /v1) -- handled via the ChatPath override. Sonar models are
+    web-grounded; no separate /models discovery endpoint, so the catalog
+    DefaultModel stands in. }
+  Result[21] := MkSpec('perplexity', 'Perplexity (Sonar)',
+                       pfOpenAI,     'https://api.perplexity.ai',
+                       'sonar',
+                       MkAuth(asBearer),
+                       'Sonar / Sonar Pro / Sonar Reasoning (web-grounded)',
+                       '/chat/completions');
+  (* Cohere intentionally not in this catalog: their chat API lives at
+     /v2/chat with a non-OpenAI request/response body, so the ChatPath
+     override alone isn't enough -- it needs a real TCohereProvider (or
+     pfOpenAI body adapters). Until then a placeholder row is more
+     confusing than helpful. *)
 end;
 
 function LookupProvider(const Kind: string; out Spec: TProviderSpec): Boolean;

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -170,7 +170,7 @@ begin
                                     and IsGenuineOpenAI(Cfg.Providers[Idx].Kind,
                                                         Cfg.Providers[Idx].Name);
         Provider := TOpenAIProvider.Create(APIKey, Base, Model, Kind, Spec.Auth,
-                                            OAIServerTools);
+                                            OAIServerTools, Spec.ChatPath);
       end;
     pfGemini:
       begin

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -35,6 +35,9 @@ type
   private
     FAPIKey:       string;
     FAPIBase:      string;
+    FChatPath:     string;   { path appended to FAPIBase for chat; default
+                               '/v1/chat/completions'. Perplexity et al.
+                               omit the /v1 segment. }
     FDefaultModel: string;
     FAuth:         TAuthScheme;
     FDisplayName:  string;   { surface in GetName / log lines }
@@ -51,7 +54,8 @@ type
       ServerTools turns on web_search_options on the request body. }
     constructor Create(const APIKey, APIBase, DefaultModel, DisplayName: string;
                        const Auth: TAuthScheme;
-                       const ServerTools: TOpenAIServerTools); overload;
+                       const ServerTools: TOpenAIServerTools;
+                       const ChatPath: string = '/v1/chat/completions'); overload;
     function Chat(const Messages: array of TMessage;
                   const Tools:    array of TToolDefinition;
                   const Model:    string;
@@ -110,11 +114,13 @@ end;
 
 constructor TOpenAIProvider.Create(const APIKey, APIBase, DefaultModel, DisplayName: string;
                                     const Auth: TAuthScheme;
-                                    const ServerTools: TOpenAIServerTools);
+                                    const ServerTools: TOpenAIServerTools;
+                                    const ChatPath: string);
 begin
   inherited Create;
   FAPIKey := APIKey;
   if APIBase <> '' then FAPIBase := APIBase else FAPIBase := 'https://api.openai.com';
+  if ChatPath <> '' then FChatPath := ChatPath else FChatPath := '/v1/chat/completions';
   if DefaultModel <> '' then FDefaultModel := DefaultModel else FDefaultModel := 'gpt-4o-mini';
   if DisplayName <> '' then FDisplayName := DisplayName else FDisplayName := 'openai';
   FAuth := Auth;
@@ -378,7 +384,7 @@ var
   Headers: TArray<THeaderPair>;
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
-  URL  := FAPIBase + '/v1/chat/completions';
+  URL  := FAPIBase + FChatPath;
   Body := BuildOAIRequest(Messages, Tools, UseModel, Options, FServerTools);
 
   Headers := BuildAuthHeaders;

--- a/src/tests/provider_catalog_tests.pas
+++ b/src/tests/provider_catalog_tests.pas
@@ -1,0 +1,52 @@
+program provider_catalog_tests;
+(*
+  Pins the provider catalog rows that matter for the ChatPath override:
+  Perplexity (OpenAI-shaped but at /chat/completions, no /v1) and that
+  every other OpenAI-family row keeps the default /v1/chat/completions.
+  A wrong path here silently sends chat requests to a 404.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Providers.Catalog;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure Expect(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+var
+  Spec: TProviderSpec;
+begin
+  { Perplexity: OpenAI family, bearer, sonar default, no-/v1 chat path. }
+  Expect(LookupProvider('perplexity', Spec), 'perplexity not in catalog');
+  Expect(Spec.Family = pfOpenAI,            'perplexity should be pfOpenAI');
+  Expect(Spec.Auth.Kind = asBearer,         'perplexity should be bearer auth');
+  Expect(Spec.DefaultBase = 'https://api.perplexity.ai',
+         'perplexity base wrong: ' + Spec.DefaultBase);
+  Expect(Spec.DefaultModel = 'sonar',       'perplexity default model wrong: ' + Spec.DefaultModel);
+  Expect(Spec.ChatPath = '/chat/completions',
+         'perplexity ChatPath must be /chat/completions (no /v1), got: ' + Spec.ChatPath);
+
+  { Case-insensitive lookup still works. }
+  Expect(LookupProvider('Perplexity', Spec), 'perplexity lookup not case-insensitive');
+
+  { Existing rows keep the default /v1/chat/completions path. }
+  Expect(LookupProvider('openai', Spec), 'openai not in catalog');
+  Expect(Spec.ChatPath = '/v1/chat/completions',
+         'openai ChatPath default regressed: ' + Spec.ChatPath);
+  Expect(LookupProvider('groq', Spec), 'groq not in catalog');
+  Expect(Spec.ChatPath = '/v1/chat/completions',
+         'groq ChatPath default regressed: ' + Spec.ChatPath);
+
+  WriteLn('provider_catalog_tests: OK');
+end.


### PR DESCRIPTION
Adds **Perplexity (Sonar)** as a provider. (Cloudflare AI Gateway and Replicate from the plan are intentionally skipped for now.)

## The one wrinkle
Perplexity speaks the OpenAI chat shape but at `https://api.perplexity.ai/chat/completions` — **no `/v1`** — and `TOpenAIProvider` hard-coded `URL := FAPIBase + '/v1/chat/completions'`. So this adds a tiny, general path-override knob (the catalog comment literally anticipated it):

- New `ChatPath` field on `TProviderSpec`, default `'/v1/chat/completions'`.
- Optional `ChatPath` arg on `TOpenAIProvider.Create` (default preserves old behavior), used to build the request URL.
- Factory threads `Spec.ChatPath` through. **Every existing row is unchanged** (default); only Perplexity overrides to `/chat/completions`.

## The provider
One catalog row:

| Kind | Family | Base | Default model | Auth | ChatPath |
|---|---|---|---|---|---|
| `perplexity` | `pfOpenAI` | `https://api.perplexity.ai` | `sonar` | Bearer | `/chat/completions` |

Notes: Sonar models are web-grounded; Perplexity has no `/models` discovery endpoint, so the catalog default model stands in (handled gracefully by the `/v1/models` fallback). It auto-appears in the onboarding menu (catalog-driven). Config: a `providers[]` entry with `kind: "perplexity"` + `api_key`.

## Tests
New `provider_catalog_tests` (wired into `make test`) pins the Perplexity row (family/base/model/auth/ChatPath) and asserts existing OpenAI-family rows (`openai`, `groq`) keep `/v1/chat/completions`. `make test-model-discovery` still passes; full binary builds clean.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_