### PR TITLE
onboarding: six new loop-shaping prompts + flip CondenseReversible / VaultTools / WebFetch defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,12 @@ test-self-improving-skills: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/self_improving_skills_tests.pas -o$(BUILDDIR)/self_improving_skills_tests
 	@$(BUILDDIR)/self_improving_skills_tests
 
+# Loop-shaping defaults + JSON round-trip (PR #289).
+test-loop-shaping-defaults: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/loop_shaping_defaults_tests.pas -o$(BUILDDIR)/loop_shaping_defaults_tests
+	@$(BUILDDIR)/loop_shaping_defaults_tests
+
 # Tool-RPC server: the in-process callback the execute_code script uses
 # to reach back into the parent's tool registry. PASCLAW_HOME isolated so
 # the info file lands in a scratch dir.
@@ -618,4 +624,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,10 +105,10 @@ There is no escape sequence for a literal `${UPPER}` string in a config value. W
 | `prompt_cache.enabled` | `true` | Anthropic+OpenAI prompt caching. See [Providers](./providers.md). |
 | `prompt_cache.ttl` | `"5m"` | Extended-TTL hint (Anthropic). Set `"1h"` for the long bucket. |
 | `vector_search_enabled` | `true` | Hybrid FTS5+vector backend for `memory_search`. |
-| `web_fetch_enabled` | `false` | Registers the `web_fetch` tool. Off by default — explicit opt-in. |
-| `vault_tools_enabled` | `false` | Registers `vault_search` / `vault_get`. |
-| `promptware_enabled` | `true` | Indirect-input prompt-injection scan. |
-| `condense_reversible` | `true` | Stash original tool bytes under a `tool_output_get` handle when a condenser shrinks them. |
+| `web_fetch_enabled` | `true` | Registers the `web_fetch` tool. On by default since PR #289 — onboarding asks (default Y). |
+| `vault_tools_enabled` | `true` | Registers `vault_search` / `vault_get`. On by default since PR #289 — onboarding asks (default Y). |
+| `promptware_enabled` | `true` | Indirect-input prompt-injection scan. Onboarding asks (default Y). |
+| `condense_reversible` | `false` | Stash original tool bytes under a `tool_output_get` handle when a condenser shrinks them. **Off by default since PR #289** — fresh deploys see raw tool output verbatim. Onboarding asks (default N). |
 | `tool_output_cap` | `0` | Truncate tool outputs over this many bytes; model dereferences via `tool_output_get`. |
 | `auto_router.enabled` | `false` | Cheap-tier routing for easy turns. See [Providers](./providers.md). |
 | `stats_collection_enabled` | `false` | Persist per-turn counters into each session JSON's `meta.stats` block. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,7 +66,7 @@ The wizard:
 1. Creates `$PASCLAW_HOME` (default `~/.pasclaw/`) with the workspace skeleton.
 2. Asks which provider you want and prompts for an API key — auto-discovers the live `/v1/models` roster and presents a picker.
 3. Optionally enables any of the 5 bundled MCP servers (`replicate`, `digitalocean-apps`, `digitalocean-databases`, `runpod-docs`, `huggingface`).
-4. Optionally toggles `vault_tools_enabled`, `vector_search_enabled`, `web_fetch_enabled`, `auto_router.enabled`, `stats_collection_enabled`, the heartbeat daemon, and the docker shell backend.
+4. Walks through every loop-affecting knob: `vault_tools_enabled`, `vector_search_enabled`, `web_fetch_enabled`, `promptware_enabled`, `condense_reversible`, `tool_output_cap`, `orient_task_aware`, the four `self_improving_skills.*` switches, `auto_router.enabled`, `stats_collection_enabled`, the heartbeat daemon, and the docker shell backend. Each prompt's default keystroke matches the config default — pressing Enter all the way through lands the documented defaults.
 
 Re-run any time to change settings; the wizard preserves any keys you set out of band.
 

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -557,6 +557,255 @@ begin
   PrintLn('  ' + Ansi.Dim + '  pasclaw heartbeat' + Ansi.Reset);
 end;
 
+(* ---------------- Loop-shaping prompts (PR #289) ----------------
+
+   Six knobs that change what the model sees in its tool loop. The
+   PR-#289 audit found these were the loop-affecting features without
+   an onboarding question; each is wired in here defaulting to its
+   TConfig.Create value so pressing Enter through onboarding leaves the
+   defaults intact.
+
+     PromptCondenseReversible   default N  (Cfg default off)
+     PromptToolOutputCap        default N  (Cfg default off / 0)
+     PromptOrientTaskAware      default N  (Cfg default off)
+     PromptPromptware           default Y  (Cfg default on)
+     PromptWebFetch             default Y  (Cfg default on)
+     PromptSelfImprovingSkills  4 nested questions, all default N
+
+   All six follow the existing PromptStatsCollection / PromptVaultTools
+   shape: a bold header, two dim explainer lines, the y/N or Y/n
+   prompt, and a green ✓ / dim "(skipped)" tail line on either branch. *)
+
+procedure PromptCondenseReversible(Cfg: TConfig);
+{ Reversible condensation (CCR) -- when a JSON or shell-filter
+  condenser actually shrinks a tool result, stash the original under a
+  fresh tool_output_get handle and replace the in-context body with a
+  structural view + a footer naming the handle. Off by default since
+  PR #289: silently rewriting `ls -l` or `grep -r` output into a
+  shape view surprised operators on fresh deploys. The condenser
+  itself is harmless; the visibility change isn't. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Condense long tool output' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Replace long ls/grep/JSON tool results with a structural summary + a ' +
+    'handle the' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'model can dereference. Off by default -- the raw output goes to the ' +
+    'model verbatim.' + Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable reversible condensation [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.CondenseReversible := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' reversible condensation enabled');
+  end
+  else
+  begin
+    Cfg.CondenseReversible := False;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- raw tool output preserved; flip condense_reversible in config.json to enable later)' + Ansi.Reset);
+  end;
+end;
+
+procedure PromptToolOutputCap(Cfg: TConfig);
+{ Byte cap on per-tool-result bytes that enter the LLM context. When
+  > 0, RunToolLoop diverts overlong tool outputs into PasClaw.Tools.
+  OutputCache and replaces the in-context body with a head + tail
+  snippet plus a handle. Off by default; 8 KiB is the recommended
+  starting point (~2K tokens). Independent of CondenseReversible --
+  the cap is structural (cap N bytes), the condenser is semantic
+  (compress an N-byte JSON to a shape). }
+var
+  Choice, Input: string;
+  Cap: Integer;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Cap tool output size' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Truncate any tool result above N bytes to head + tail + a handle the ' +
+    'model' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'can read back. Useful when a runaway grep can dump megabytes into the ' +
+    'context.' + Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Cap tool output [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Input := Trim(ReadLineEcho('  Cap (bytes) [8192]: '));
+    Cap := StrToIntDef(Input, 8192);
+    if Cap < 256 then Cap := 256;
+    Cfg.ToolOutputCap := Cap;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + Format(' tool output cap = %d bytes', [Cap]));
+  end
+  else
+  begin
+    Cfg.ToolOutputCap := 0;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- tool output is uncapped; flip tool_output_cap in config.json to enable later)' + Ansi.Reset);
+  end;
+end;
+
+procedure PromptOrientTaskAware(Cfg: TConfig);
+{ Task-aware MEMORY orientation: instead of injecting the whole
+  MEMORY.md + daily notes into the system prompt, slice them to the
+  sections that lexically overlap the user's task hint. Off by
+  default -- the whole-file injection is the documented contract;
+  this is a context-budget optimisation for operators with large
+  MEMORY.md files. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Task-aware MEMORY slicing' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Slice MEMORY.md + daily notes to the sections that overlap the task ' +
+    'instead of' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'injecting whole files. Useful once your MEMORY.md outgrows the always-inject ' +
+    'budget.' + Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable task-aware orient [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.OrientTaskAware := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' task-aware orient enabled');
+  end
+  else
+  begin
+    Cfg.OrientTaskAware := False;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- whole-file MEMORY injection stays the default)' + Ansi.Reset);
+  end;
+end;
+
+procedure PromptPromptware(Cfg: TConfig);
+{ Prompt-injection scan (PasClaw.Promptware). Lowercase substring
+  scan over tool output / recalled memory / skill descriptions that
+  annotates matches with a warning banner. On by default -- it's a
+  free defense layer; the prompt exists so an operator wanting raw
+  unannotated tool output can flip it off without grepping config. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Promptware defense' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Annotate tool output / recalled memory / skill descriptions matching ' +
+    'known' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'prompt-injection patterns ("ignore previous instructions" etc.) with a ' +
+    'warning.' + Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable promptware scan [Y/n]: ')));
+  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.PromptwareEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' promptware scan enabled');
+  end
+  else
+  begin
+    Cfg.PromptwareEnabled := False;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- raw tool output passes through unannotated)' + Ansi.Reset);
+  end;
+end;
+
+procedure PromptWebFetch(Cfg: TConfig);
+{ web_fetch / memory_fetch tools. On by default since PR #289 --
+  picoclaw historically uses shell + curl, but PasClaw runs in
+  sandboxed containers where curl isn't always available. The
+  prompt is so operators not wanting outbound HTTP from the agent
+  can flip it off. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'web_fetch tool' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Let the agent fetch URLs through a tracked tool (size cap, save_to, ' +
+    'tracing)' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'instead of shelling out to curl. memory_fetch is registered alongside ' +
+    'when on.' + Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable web_fetch [Y/n]: ')));
+  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.WebFetchEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' web_fetch / memory_fetch enabled');
+  end
+  else
+  begin
+    Cfg.WebFetchEnabled := False;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses shell + curl for outbound HTTP)' + Ansi.Reset);
+  end;
+end;
+
+procedure PromptSelfImprovingSkills(Cfg: TConfig);
+{ Four nested toggles for the Hermes-style self-improving skills
+  (PR #288). Each defaults N because the feature touches:
+    - what tools the model has (skills_manage)
+    - how the system prompt is built (progressive disclosure)
+    - whether an extra LLM call happens per qualifying turn (distiller)
+    - the auto-approve gate on every model-authored skill write
+  An operator opting in for one piece usually doesn't want the
+  others by default. So we ask separately. Skipping the top-level
+  switch skips all four. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Self-improving skills' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Let the agent author / edit / refine skills on disk during a turn ' +
+    '(Hermes-style).' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Off by default. See docs/skills.md for the safety model.' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Configure self-improving skills now [y/N]: ')));
+  if not ((Choice = 'y') or (Choice = 'yes')) then
+  begin
+    PrintLn('  ' + Ansi.Dim + '(skipped -- all four sub-flags stay off)' + Ansi.Reset);
+    Exit;
+  end;
+
+  Choice := Trim(LowerCase(ReadLineEcho('  Register skills_manage so the model can author skills [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.SelfImprovingSkills.SelfManage := True;
+    PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' skills_manage registered');
+  end
+  else
+    PrintLn('    ' + Ansi.Dim + '(skipped)' + Ansi.Reset);
+
+  Choice := Trim(LowerCase(ReadLineEcho('  Use progressive disclosure (skills_list/skills_view) instead of the full SKILLS prompt [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.SelfImprovingSkills.ProgressiveDisclosure := True;
+    PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' progressive disclosure on');
+  end
+  else
+    PrintLn('    ' + Ansi.Dim + '(skipped)' + Ansi.Reset);
+
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable the post-turn distiller (one extra LLM call per qualifying turn) [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.SelfImprovingSkills.Distiller.Enabled := True;
+    PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' distiller enabled (min_tool_calls=5; model inherits the turn)');
+  end
+  else
+    PrintLn('    ' + Ansi.Dim + '(skipped)' + Ansi.Reset);
+
+  Choice := Trim(LowerCase(ReadLineEcho('  Auto-approve agent-authored skill writes [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.SelfImprovingSkills.AutoApprove := True;
+    PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' auto-approve on (writes commit straight to workspace/skills/)');
+  end
+  else
+    PrintLn('    ' + Ansi.Dim + '(skipped -- writes stage under .pending/; run "pasclaw skills approve" to commit)' + Ansi.Reset);
+end;
+
 procedure PromptStatsCollection(Cfg: TConfig);
 { Opt-in toggle for persisting per-session usage stats (tokens,
   turns, tool calls, truncation savings) into the session JSON so
@@ -1067,6 +1316,16 @@ begin
     PromptVaultTools(Cfg);
     PromptVectorSearch(Cfg);
     PromptKnowledgebase(Cfg);
+    { Loop-shaping prompts (PR #289). Order is intentional: each
+      successive prompt is less likely to be wanted by an operator
+      who said yes to the previous one, so a quick "enter, enter,
+      enter" leaves the minimal-surprise defaults in place. }
+    PromptWebFetch(Cfg);
+    PromptPromptware(Cfg);
+    PromptCondenseReversible(Cfg);
+    PromptToolOutputCap(Cfg);
+    PromptOrientTaskAware(Cfg);
+    PromptSelfImprovingSkills(Cfg);
     PromptStatsCollection(Cfg);
     PromptCheckpoints(Cfg);
     PromptShellBackend(Cfg);

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -765,10 +765,22 @@ begin
   Choice := Trim(LowerCase(ReadLineEcho('  Configure self-improving skills now [y/N]: ')));
   if not ((Choice = 'y') or (Choice = 'yes')) then
   begin
-    PrintLn('  ' + Ansi.Dim + '(skipped -- all four sub-flags stay off)' + Ansi.Reset);
+    { Codex PR #289 P2: re-running onboarding on a config that already
+      had any sub-flag on must be able to turn them off. The original
+      "Exit" left previously-set True values intact, so a user who
+      enabled the feature once couldn't ever disable it via onboarding.
+      Reset all four explicitly. }
+    Cfg.SelfImprovingSkills.SelfManage            := False;
+    Cfg.SelfImprovingSkills.ProgressiveDisclosure := False;
+    Cfg.SelfImprovingSkills.Distiller.Enabled     := False;
+    Cfg.SelfImprovingSkills.AutoApprove           := False;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- all four sub-flags reset to off)' + Ansi.Reset);
     Exit;
   end;
 
+  { Same preserve-old-true bug at each nested else: explicitly assign
+    False when the operator answers N, so a previously-on sub-flag
+    actually flips off on the re-run. }
   Choice := Trim(LowerCase(ReadLineEcho('  Register skills_manage so the model can author skills [y/N]: ')));
   if (Choice = 'y') or (Choice = 'yes') then
   begin
@@ -776,7 +788,10 @@ begin
     PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' skills_manage registered');
   end
   else
+  begin
+    Cfg.SelfImprovingSkills.SelfManage := False;
     PrintLn('    ' + Ansi.Dim + '(skipped)' + Ansi.Reset);
+  end;
 
   Choice := Trim(LowerCase(ReadLineEcho('  Use progressive disclosure (skills_list/skills_view) instead of the full SKILLS prompt [y/N]: ')));
   if (Choice = 'y') or (Choice = 'yes') then
@@ -785,7 +800,10 @@ begin
     PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' progressive disclosure on');
   end
   else
+  begin
+    Cfg.SelfImprovingSkills.ProgressiveDisclosure := False;
     PrintLn('    ' + Ansi.Dim + '(skipped)' + Ansi.Reset);
+  end;
 
   Choice := Trim(LowerCase(ReadLineEcho('  Enable the post-turn distiller (one extra LLM call per qualifying turn) [y/N]: ')));
   if (Choice = 'y') or (Choice = 'yes') then
@@ -794,7 +812,10 @@ begin
     PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' distiller enabled (min_tool_calls=5; model inherits the turn)');
   end
   else
+  begin
+    Cfg.SelfImprovingSkills.Distiller.Enabled := False;
     PrintLn('    ' + Ansi.Dim + '(skipped)' + Ansi.Reset);
+  end;
 
   Choice := Trim(LowerCase(ReadLineEcho('  Auto-approve agent-authored skill writes [y/N]: ')));
   if (Choice = 'y') or (Choice = 'yes') then
@@ -803,7 +824,10 @@ begin
     PrintLn('    ' + Ansi.Green + '✓' + Ansi.Reset + ' auto-approve on (writes commit straight to workspace/skills/)');
   end
   else
+  begin
+    Cfg.SelfImprovingSkills.AutoApprove := False;
     PrintLn('    ' + Ansi.Dim + '(skipped -- writes stage under .pending/; run "pasclaw skills approve" to commit)' + Ansi.Reset);
+  end;
 end;
 
 procedure PromptStatsCollection(Cfg: TConfig);

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -519,19 +519,18 @@ type
        picoclaw's pkg/channels/base.go IsAllowedSender semantics).
        Configure via "allow_senders": [...] in config.json. *)
     AllowSenders: array of string;
-    (* Off-by-default: when True, Cmd.Agent.NewBuiltinRegistry
-       registers vault_search and vault_get for the model. The
-       onboarding flow asks the user to opt in (default yes).
-       Operators who skip onboarding can flip this directly in
-       config.json or re-run `pasclaw onboard`. *)
+    (* On-by-default since PR #289: when True, Cmd.Agent.NewBuiltinRegistry
+       registers vault_search and vault_get for the model -- read-only
+       HTTP GETs against the curated pasclaw.dev registry, no execution
+       path. The onboarding flow asks (default Y). Operators who don't
+       want any HTTP from this surface can flip it off in config.json. *)
     VaultToolsEnabled: Boolean;
-    (* Off-by-default: when True, Cmd.Agent / Cmd.Gateway / Cmd.Serve
-       register the web_fetch tool. Picoclaw doesn't ship a web_fetch
-       -- its model fetches arbitrary URLs through shell + curl -- so
-       PasClaw's default posture mirrors that. Flip this on for
-       deployments where curl isn't available (sandboxed containers,
-       constrained shells), or where the operator wants the tracked
-       web_fetch path with its size cap / save_to convenience. *)
+    (* On-by-default since PR #289: register the web_fetch tool in
+       Cmd.Agent / Cmd.Gateway / Cmd.Serve. Picoclaw historically
+       leaves it off (its model uses shell + curl), but PasClaw runs
+       fine in sandboxed containers where curl isn't available, so
+       the default is now on. Onboarding asks (default Y); operators
+       who don't want outbound HTTP from the agent flip it off. *)
     WebFetchEnabled:   Boolean;
     (* On-by-default: when True, memory_search uses a hybrid keyword
        (FTS5 BM25) + vector (sqlite-vec ANN) index over
@@ -604,14 +603,17 @@ type
        the model sees -- operators opt in via "orient_task_aware":
        true once their MEMORY.md outgrows the always-inject budget. *)
     OrientTaskAware:       Boolean;
-    (* On-by-default: reversible condensation (CCR, headroom-inspired).
-       When a condenser (JSON, shell filters) actually shrinks tool
-       output, stash the ORIGINAL under a fresh OutputCache handle and
-       append a footer naming it -- the model gets the structural view
-       by default and can call tool_output_get when the shape isn't
-       enough. tool_output_get registers whenever this is on OR
-       Cfg.ToolOutputCap > 0. Flip "condense_reversible": false to
-       revert to destructive condensation. *)
+    (* Off-by-default since PR #289: reversible condensation (CCR,
+       headroom-inspired). When True, a condenser (JSON, shell
+       filters) that actually shrinks tool output stashes the
+       ORIGINAL under a fresh OutputCache handle and appends a footer
+       naming it -- the model gets the structural view by default and
+       can call tool_output_get when the shape isn't enough.
+       tool_output_get registers whenever this is on OR
+       Cfg.ToolOutputCap > 0. Flipped to off-by-default because
+       silently rewriting `ls -l`/`grep` output into a structural
+       view surprised operators on fresh deploys (PR #289). Onboarding
+       asks (default N). *)
     CondenseReversible:    Boolean;
     (* Proactive periodic wake-up (picoclaw / openclaw heartbeat).
        Off by default. When Enabled, the standalone `pasclaw
@@ -838,8 +840,8 @@ begin
   WebSearch.MaxResults := 5;
   PromptCache.Enabled  := True;  { default-on; see TPromptCacheConfig comment }
   PromptCache.TTL      := '';    { default 5m via empty }
-  VaultToolsEnabled    := False; { off by default; onboarding asks to opt in }
-  WebFetchEnabled      := False; { off by default; the model uses shell+curl }
+  VaultToolsEnabled    := True;  { on by default -- vault_search/get are read-only HTTP GETs against pasclaw.dev. Onboarding asks (default Y). }
+  WebFetchEnabled      := True;  { on by default -- onboarding asks (default Y); operators not wanting outbound HTTP from the agent flip it off. }
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   ToolOutputCap        := 0;     { off by default; operators opt in. See TConfig.ToolOutputCap. }
   StatsCollectionEnabled := False; { opt-in via onboarding; see TConfig.StatsCollectionEnabled. }
@@ -847,7 +849,7 @@ begin
   CheckpointsKeepLast    := 0;     { 0 means default (32) inside PasClaw.Checkpoints. }
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
   OrientTaskAware        := False; { opt-in; whole-file MEMORY injection is the contract. }
-  CondenseReversible     := True;  { on by default -- condense + stash original under handle. }
+  CondenseReversible     := False; { off by default -- raw tool output preserved verbatim. Onboarding asks (default N). Flipped from on-by-default in PR #289 so a fresh deploy doesn't silently rewrite ls/grep output behind the operator's back. }
   Heartbeat.Enabled      := False; { opt-in via onboarding; off by default. }
   Heartbeat.IntervalMins := 30;
   Heartbeat.ContentPath  := '';    { empty -> default workspace/heartbeat.md at load time }
@@ -1060,11 +1062,13 @@ begin
       Root.PutArray('allow_senders', Arr);
     end;
 
-    { Off-by-default -- only serialise when True so stock configs stay tidy. }
-    if VaultToolsEnabled then
-      Root.PutBool('vault_tools_enabled', True);
-    if WebFetchEnabled then
-      Root.PutBool('web_fetch_enabled', True);
+    { vault_tools_enabled, web_fetch_enabled: defaults flipped to ON
+      in PR #289. Emit only the explicit-off so a fresh config stays
+      tidy and an operator who explicitly opted out round-trips. }
+    if not VaultToolsEnabled then
+      Root.PutBool('vault_tools_enabled', False);
+    if not WebFetchEnabled then
+      Root.PutBool('web_fetch_enabled', False);
     { RenderMarkdown defaults to True; emit only when operator
       explicitly disabled it so they can flip it back via config.json
       and we round-trip correctly. }
@@ -1093,9 +1097,10 @@ begin
     { Default False -- emit only the explicit-on. }
     if OrientTaskAware then
       Root.PutBool('orient_task_aware', True);
-    { Default True -- emit only explicit-off so it round-trips. }
-    if not CondenseReversible then
-      Root.PutBool('condense_reversible', False);
+    { condense_reversible: default flipped to OFF in PR #289. Emit
+      only the explicit-on so fresh configs stay tidy. }
+    if CondenseReversible then
+      Root.PutBool('condense_reversible', True);
     if Heartbeat.Enabled
        or (Heartbeat.IntervalMins <> 30)
        or (Heartbeat.ContentPath <> '')

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -107,23 +107,33 @@ begin
     WorkDir := '';
   LogDebug('shell exec (cwd=%s): %s', [WorkDir, Cmd]);
   ExitCode := RunOneShotViaBackend(GetCurrentSessionId, Cmd, WorkDir, Out_);
-  { Per-command condenser. Tee-on-failure: ApplyShellFilter returns
-    raw output verbatim when ExitCode <> 0 so the model gets full
-    error context to debug. On the success path, known commands
-    (git status/diff/log, npm/pytest/cargo test, grep/findstr/sls,
-    ls -R / find / dir /s, with PowerShell-alias normalisation)
-    get condensed; everything else passes through and falls back
-    to the OutputCache byte cap if it's still oversize. }
-  RawOut := Out_;
-  Out_   := ApplyShellFilter(Cmd, Out_, ExitCode);
-  { Reversible condensation (CCR). When the filter actually shrunk
-    the bytes, stash the original under a fresh OutputCache handle
-    and append a footer naming it so the model can retrieve the
-    untruncated output via tool_output_get. ApplyShellFilter is
-    tee-on-failure, so RawOut and Out_ are byte-identical on failure
-    and the footer doesn't attach -- no wasted slots for raw error
-    output. No-op when SetCondenseReversible(False) is in effect. }
-  Out_ := AttachReversibleStashFooter(RawOut, Out_);
+  { Per-command condenser, gated on the reversible-condensation switch.
+    Codex PR #289 P1: when CondenseReversibleEnabled is False the
+    stash footer in AttachReversibleStashFooter no-ops, but the
+    filter itself was still rewriting ls/grep/git output and the
+    model lost access to the original bytes with no tool_output_get
+    handle to retrieve them. Skip the filter entirely so "off" means
+    raw output, not condensed-without-recovery.
+
+    Tee-on-failure: ApplyShellFilter returns raw output verbatim when
+    ExitCode <> 0 so the model gets full error context to debug. On
+    the success path, known commands (git status/diff/log, npm/pytest/
+    cargo test, grep/findstr/sls, ls -R / find / dir /s, with
+    PowerShell-alias normalisation) get condensed; everything else
+    passes through and falls back to the OutputCache byte cap if it
+    is still oversize. }
+  if CondenseReversibleEnabled then
+  begin
+    RawOut := Out_;
+    Out_   := ApplyShellFilter(Cmd, Out_, ExitCode);
+    { When the filter actually shrunk the bytes, stash the original
+      under a fresh OutputCache handle and append a footer naming it
+      so the model can retrieve the untruncated output via
+      tool_output_get. ApplyShellFilter is tee-on-failure, so RawOut
+      and Out_ are byte-identical on failure and the footer doesn't
+      attach -- no wasted slots for raw error output. }
+    Out_ := AttachReversibleStashFooter(RawOut, Out_);
+  end;
   Result := Format('exit=%d'#10'%s', [ExitCode, Out_]);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1070,28 +1070,37 @@ begin
                                               'ERROR: ' + Dispatches[Batch[j]].Err)
         else
         begin
-          { JSON-aware condensation runs FIRST: a tool that returned
-            a 200 KB JSON array of mostly-repetitive rows collapses
-            to a structural summary (first N + "...K more items" +
-            last 1) the model can still reason about, which is
-            usually small enough to skip the byte-budget truncate
-            below entirely. No-op when the body doesn't parse as
-            JSON or when condensation wouldn't shrink it.
-            See PasClaw.Condense.JSON.
+          { JSON-aware condensation, gated on the reversible-condensation
+            switch (Codex PR #289 P1). When CondenseReversibleEnabled
+            is False the stash footer no-ops, but MaybeCondenseJSON was
+            still rewriting a 200 KB JSON tool result into a structural
+            summary -- and without the footer the model lost any way
+            to retrieve the original bytes. Skip the condenser
+            entirely so "off" means the raw JSON reaches the model,
+            not condensed-without-recovery.
+
+            When the switch IS on: a tool that returned a 200 KB
+            JSON array of mostly-repetitive rows collapses to a
+            structural summary (first N + "...K more items" + last 1)
+            the model can still reason about, which is usually small
+            enough to skip the byte-budget truncate below entirely.
+            No-op when the body doesn't parse as JSON or when
+            condensation wouldn't shrink it. See PasClaw.Condense.JSON.
 
             Reversible condensation (CCR, headroom-inspired): when
             MaybeCondenseJSON actually shrinks the body, stash the
             original under a handle so the model can call
             tool_output_get to retrieve it. The model defaults to the
-            structural view; the escape hatch is one tool call away.
-            No-op when SetCondenseReversible(False) is in effect or
-            the saving is below the floor. }
-          OrigBody := Dispatches[Batch[j]].ResultText;
-          Dispatches[Batch[j]].ResultText :=
-            MaybeCondenseJSON(OrigBody);
-          Dispatches[Batch[j]].ResultText :=
-            AttachReversibleStashFooter(OrigBody,
-                                        Dispatches[Batch[j]].ResultText);
+            structural view; the escape hatch is one tool call away. }
+          if CondenseReversibleEnabled then
+          begin
+            OrigBody := Dispatches[Batch[j]].ResultText;
+            Dispatches[Batch[j]].ResultText :=
+              MaybeCondenseJSON(OrigBody);
+            Dispatches[Batch[j]].ResultText :=
+              AttachReversibleStashFooter(OrigBody,
+                                          Dispatches[Batch[j]].ResultText);
+          end;
 
           { Promptware chokepoint 1 of 3: tool output is the widest
             door for indirect prompt injection (fetched pages, read

--- a/src/tests/loop_shaping_defaults_tests.pas
+++ b/src/tests/loop_shaping_defaults_tests.pas
@@ -1,0 +1,131 @@
+program loop_shaping_defaults_tests;
+(*
+  PR #289: verifies the three loop-shaping config defaults that flipped
+  AND that round-tripping through ToJSON/FromJSON honours explicit
+  opt-outs (and opt-ins for the now-default-off knobs).
+
+  Defaults under test:
+    VaultToolsEnabled     False -> True   (PR #289)
+    WebFetchEnabled       False -> True   (PR #289)
+    CondenseReversible    True  -> False  (PR #289)
+    PromptwareEnabled     True            (unchanged)
+    VectorSearchEnabled   True            (unchanged)
+    RenderMarkdown        True            (unchanged)
+    ToolOutputCap         0               (unchanged)
+    OrientTaskAware       False           (unchanged)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.JSON,
+  PasClaw.Config;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure TestFreshDefaults;
+var C: TConfig;
+begin
+  C := TConfig.Create;
+  try
+    AssertTrue(C.VaultToolsEnabled,     'VaultToolsEnabled defaults to True');
+    AssertTrue(C.WebFetchEnabled,       'WebFetchEnabled defaults to True');
+    AssertTrue(not C.CondenseReversible,'CondenseReversible defaults to False');
+    AssertTrue(C.PromptwareEnabled,     'PromptwareEnabled stays True');
+    AssertTrue(C.VectorSearchEnabled,   'VectorSearchEnabled stays True');
+    AssertTrue(C.RenderMarkdown,        'RenderMarkdown stays True');
+    AssertTrue(C.ToolOutputCap = 0,     'ToolOutputCap stays 0');
+    AssertTrue(not C.OrientTaskAware,   'OrientTaskAware stays False');
+    AssertTrue(not C.SelfImprovingSkills.SelfManage,
+               'SelfImprovingSkills.SelfManage stays False');
+  finally
+    C.Free;
+  end;
+end;
+
+procedure TestEmittedFieldsAreTidy;
+var
+  C: TConfig;
+  S: string;
+begin
+  { A fresh config (every flag at its new default) should NOT emit the
+    flipped keys. Same posture as render_markdown / vector_search:
+    "default value, no need to spell it out". }
+  C := TConfig.Create;
+  try
+    S := C.ToJSON;
+    AssertTrue(Pos('vault_tools_enabled', S) = 0, 'fresh ToJSON omits vault_tools_enabled');
+    AssertTrue(Pos('web_fetch_enabled',   S) = 0, 'fresh ToJSON omits web_fetch_enabled');
+    AssertTrue(Pos('condense_reversible', S) = 0, 'fresh ToJSON omits condense_reversible');
+    AssertTrue(Pos('promptware_enabled',  S) = 0, 'fresh ToJSON omits promptware_enabled');
+    AssertTrue(Pos('vector_search_enabled', S) = 0, 'fresh ToJSON omits vector_search_enabled');
+    AssertTrue(Pos('render_markdown',     S) = 0, 'fresh ToJSON omits render_markdown');
+    AssertTrue(Pos('tool_output_cap',     S) = 0, 'fresh ToJSON omits tool_output_cap');
+    AssertTrue(Pos('orient_task_aware',   S) = 0, 'fresh ToJSON omits orient_task_aware');
+  finally
+    C.Free;
+  end;
+end;
+
+procedure TestExplicitOptOutRoundTrip;
+var
+  C, C2: TConfig;
+  S: string;
+begin
+  { Operator-opted-out of every now-default-on flag, and opted IN to
+    every now-default-off flag. Every field should serialise AND
+    round-trip back as set. }
+  C := TConfig.Create;
+  try
+    C.VaultToolsEnabled  := False;
+    C.WebFetchEnabled    := False;
+    C.PromptwareEnabled  := False;
+    C.VectorSearchEnabled := False;
+    C.RenderMarkdown     := False;
+    C.CondenseReversible := True;
+    C.OrientTaskAware    := True;
+    C.ToolOutputCap      := 8192;
+    S := C.ToJSON;
+    { Each non-default field must be present in the serialised form,
+      otherwise LoadConfig would silently fall back to the default. }
+    AssertTrue(Pos('"vault_tools_enabled"',   S) > 0, 'opt-out vault_tools_enabled emitted');
+    AssertTrue(Pos('"web_fetch_enabled"',     S) > 0, 'opt-out web_fetch_enabled emitted');
+    AssertTrue(Pos('"promptware_enabled"',    S) > 0, 'opt-out promptware_enabled emitted');
+    AssertTrue(Pos('"vector_search_enabled"', S) > 0, 'opt-out vector_search_enabled emitted');
+    AssertTrue(Pos('"render_markdown"',       S) > 0, 'opt-out render_markdown emitted');
+    AssertTrue(Pos('"condense_reversible"',   S) > 0, 'opt-in condense_reversible emitted');
+    AssertTrue(Pos('"orient_task_aware"',     S) > 0, 'opt-in orient_task_aware emitted');
+    AssertTrue(Pos('"tool_output_cap"',       S) > 0, 'opt-in tool_output_cap emitted');
+  finally
+    C.Free;
+  end;
+
+  C2 := TConfig.Create;
+  try
+    C2.FromJSON(S);
+    AssertTrue(not C2.VaultToolsEnabled,    'VaultToolsEnabled round-trips False');
+    AssertTrue(not C2.WebFetchEnabled,      'WebFetchEnabled round-trips False');
+    AssertTrue(not C2.PromptwareEnabled,    'PromptwareEnabled round-trips False');
+    AssertTrue(not C2.VectorSearchEnabled,  'VectorSearchEnabled round-trips False');
+    AssertTrue(not C2.RenderMarkdown,       'RenderMarkdown round-trips False');
+    AssertTrue(C2.CondenseReversible,       'CondenseReversible round-trips True');
+    AssertTrue(C2.OrientTaskAware,          'OrientTaskAware round-trips True');
+    AssertTrue(C2.ToolOutputCap = 8192,     'ToolOutputCap round-trips 8192');
+  finally
+    C2.Free;
+  end;
+end;
+
+begin
+  TestFreshDefaults;
+  TestEmittedFieldsAreTidy;
+  TestExplicitOptOutRoundTrip;
+  WriteLn('ok - loop-shaping defaults tests passed');
+end.

--- a/src/tests/loop_shaping_defaults_tests.pas
+++ b/src/tests/loop_shaping_defaults_tests.pas
@@ -22,7 +22,8 @@ program loop_shaping_defaults_tests;
 uses
   SysUtils,
   PasClaw.JSON,
-  PasClaw.Config;
+  PasClaw.Config,
+  PasClaw.Tools.OutputCache;    { CondenseReversibleEnabled / SetCondenseReversible }
 
 procedure Fail_(const Msg: string);
 begin WriteLn('FAIL: ' + Msg); Halt(1); end;
@@ -123,9 +124,27 @@ begin
   end;
 end;
 
+(* Codex PR #289 P1: when CondenseReversibleEnabled is False, BOTH the
+   stash footer AND the upstream condensers (ApplyShellFilter in
+   Tools.Shell, MaybeCondenseJSON in Tools.ToolLoop) must no-op. The
+   propagation contract being tested here is that the module-level
+   gate getter tracks SetCondenseReversible, which the LoadConfig
+   path propagates from Cfg.CondenseReversible. The dispatch-site
+   gating itself is exercised by test-condense-reversible. *)
+procedure TestCondenseGatePropagation;
+begin
+  SetCondenseReversible(True);
+  AssertTrue(CondenseReversibleEnabled, 'gate flips on');
+  SetCondenseReversible(False);
+  AssertTrue(not CondenseReversibleEnabled, 'gate flips off -- shell/json condensers must skip when this is False');
+  { Restore so a later test in the same process isn't surprised. }
+  SetCondenseReversible(False);
+end;
+
 begin
   TestFreshDefaults;
   TestEmittedFieldsAreTidy;
   TestExplicitOptOutRoundTrip;
+  TestCondenseGatePropagation;
   WriteLn('ok - loop-shaping defaults tests passed');
 end.


### PR DESCRIPTION
## Summary

Closes the audit gap from the PR-#288 review: six loop-affecting config knobs shipped with no onboarding question. This PR adds prompts for all six and brings three of the underlying config defaults in line with the documented intent.

The headline change: **`condense_reversible` flips from default-on to default-off** — so a fresh deploy no longer silently rewrites `ls -l`/`grep` output into a structural view behind the operator's back.

## New onboarding prompts

In order, between `PromptKnowledgebase` and `PromptStatsCollection`:

| Prompt | Default keystroke | Sets |
|---|---|---|
| `PromptWebFetch` | `[Y/n]` | `web_fetch_enabled` (+ `memory_fetch`) |
| `PromptPromptware` | `[Y/n]` | `promptware_enabled` |
| `PromptCondenseReversible` | `[y/N]` | `condense_reversible` |
| `PromptToolOutputCap` | `[y/N]` | `tool_output_cap` (asks for byte cap, default 8192) |
| `PromptOrientTaskAware` | `[y/N]` | `orient_task_aware` |
| `PromptSelfImprovingSkills` | `[y/N]` top-level + four nested `[y/N]` | `self_improving_skills.*` (PR #288's four sub-flags) |

Each follows the existing `PromptStatsCollection` shape — bold header, two dim explainer lines, the `y/N`/`Y/n` prompt, and a green ✓ / dim `(skipped)` tail. Pressing Enter all the way through lands the documented defaults.

## Default flips (`TConfig.Create`)

| Knob | Before | After | Notes |
|---|---|---|---|
| `VaultToolsEnabled` | `False` | **`True`** | Read-only HTTP GETs to pasclaw.dev; onboarding asks default-Y. |
| `WebFetchEnabled` | `False` | **`True`** | Tracked tool path with size cap / tracing; onboarding asks default-Y. |
| `CondenseReversible` | `True` | **`False`** | Fresh deploys preserve raw tool output verbatim. Onboarding asks default-N. |
| `PromptwareEnabled` | `True` | `True` | unchanged |
| `RenderMarkdown` | `True` | `True` | unchanged |
| `VectorSearchEnabled` | `True` | `True` | unchanged |
| `ToolOutputCap` | `0` | `0` | unchanged |
| `OrientTaskAware` | `False` | `False` | unchanged |
| `SelfImprovingSkills.*` | all `False` | all `False` | unchanged |

## Serialisation round-trip

The emit rules in `ToJSON` were flipped for the three changed defaults so a fresh config stays tidy (omits the now-default values) AND an explicit opt-out persists across `SaveConfig` → `LoadConfig`. Same posture `render_markdown` / `vector_search_enabled` have used since PR #143.

```pascal
{ Before }
if VaultToolsEnabled then  Root.PutBool('vault_tools_enabled', True);
if WebFetchEnabled   then  Root.PutBool('web_fetch_enabled',   True);
if not CondenseReversible then Root.PutBool('condense_reversible', False);

{ After }
if not VaultToolsEnabled  then Root.PutBool('vault_tools_enabled',  False);
if not WebFetchEnabled    then Root.PutBool('web_fetch_enabled',    False);
if CondenseReversible     then Root.PutBool('condense_reversible',  True);
```

## Backwards-compat call-out

Existing `config.json` files that **explicitly** wrote any of these fields keep working: the values were emitted under the old rules, and `FromJSON` still reads them. Files that **omitted** a field (because the operator was happy with the old default) will now read that field at the new default value — i.e. existing deployments that never touched `vault_tools_enabled` now have vault tools on, and existing deployments that never touched `condense_reversible` now see raw tool output. This is the intended behaviour per the PR-#288 audit thread.

## Test plan

- [x] `make test-loop-shaping-defaults` — new test (`src/tests/loop_shaping_defaults_tests.pas`):
  - fresh-config defaults match the flipped values
  - fresh `ToJSON` omits every loop-shaping key (tidy file)
  - explicit opt-out persists: every changed-from-default field round-trips through `ToJSON` → `FromJSON` exactly
- [x] `make clean && make` — full FPC 3.2.2 build clean
- [x] Regression: `test-config-secret-merge`, `test-config-env-subst`, `test-self-improving-skills`, `test-orient`, `test-condense-reversible`, `test-promptware` all green
- [x] Live press-Enter-through `pasclaw onboard` — wizard poses all 13 Y/N questions; resulting `config.json` is a tidy ~935 bytes with only the non-default keys (the agent metadata, providers, gateway, sandbox, etc. — no loop-shaping clutter)

## Docs

- `docs/configuration.md` — table updated for the three flipped fields with PR #289 references
- `docs/getting-started.md` — onboarding bullet now lists every knob the wizard walks through

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_