### PR TITLE
config: profile system (baseline / low-token / security / max-build / all-on)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,15 @@ test-plan-build-mode: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/plan_build_mode_tests.pas -o$(BUILDDIR)/plan_build_mode_tests
 	@$(BUILDDIR)/plan_build_mode_tests
 
+# Configuration profiles -- builtins, _inherits, user shadow, LoadConfig merge (PR #291).
+# Uses PASCLAW_HOME pointing at a temp dir so it never touches the user's real config.
+test-config-profile: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/config_profile_tests.pas -o$(BUILDDIR)/config_profile_tests
+	@PASCLAW_HOME=$$(mktemp -d) ; \
+	  trap "rm -rf $$PASCLAW_HOME" EXIT ; \
+	  PASCLAW_HOME=$$PASCLAW_HOME $(BUILDDIR)/config_profile_tests
+
 # Tool-RPC server: the in-process callback the execute_code script uses
 # to reach back into the parent's tool registry. PASCLAW_HOME isolated so
 # the info file lands in a scratch dir.
@@ -630,4 +639,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,11 +8,16 @@ A **profile** is a small JSON patch that gets merged into `TConfig` *before* you
 
 | Profile | What it flips |
 |---|---|
+| `stock` | Explicit no-op profile mirroring `TConfig.Create` defaults. `pasclaw profile show stock` documents the fresh-install state. Applying it is identical to no profile at all. |
 | `baseline` | Everything off. Control profile for A/B testing — *"how does pasclaw behave with no features enabled?"* |
 | `low-token` | Condenser on, output cap 8 KB, MEMORY task-aware slicing, prompt cache, progressive skill disclosure, auto-router. |
 | `security` | Workspace restriction + shell deny + private-network block, promptware scan, no `web_fetch`, no vault, agent-authored skills stage for approval. |
 | `max-build` | `_inherits: ["low-token"]` plus `web_fetch`, vault, vector search, checkpoints, stats, 16 KB cap, 1 h prompt cache, all four self-improving skill switches. |
 | `all-on` | `_inherits: ["max-build"]`. Every boolean knob flipped on. Surface-area testing only. |
+
+### Onboarding
+
+`pasclaw onboard` asks **"Pick a starter profile"** at the top of its loop-shaping section. Picking one of `stock` / `baseline` / `low-token` / `security` / `max-build` / `all-on` persists the choice as `"profile": "<name>"` in `config.json` AND skips the per-feature prompts below it (the profile encapsulates those choices). Picking option 7 (skip) or hitting Enter through leaves the per-feature flow exactly as before, with no `profile` field written.
 
 ### Selection precedence (highest wins)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,57 @@
 
 PasClaw stores configuration as a single JSON file at `$PASCLAW_HOME/config.json`. Every field has a sensible default; nothing here is required for a basic setup.
 
+## Profiles
+
+A **profile** is a small JSON patch that gets merged into `TConfig` *before* your `config.json` is applied. Five built-ins ship; operators can drop more at `$PASCLAW_HOME/profiles/<name>.json`.
+
+| Profile | What it flips |
+|---|---|
+| `baseline` | Everything off. Control profile for A/B testing — *"how does pasclaw behave with no features enabled?"* |
+| `low-token` | Condenser on, output cap 8 KB, MEMORY task-aware slicing, prompt cache, progressive skill disclosure, auto-router. |
+| `security` | Workspace restriction + shell deny + private-network block, promptware scan, no `web_fetch`, no vault, agent-authored skills stage for approval. |
+| `max-build` | `_inherits: ["low-token"]` plus `web_fetch`, vault, vector search, checkpoints, stats, 16 KB cap, 1 h prompt cache, all four self-improving skill switches. |
+| `all-on` | `_inherits: ["max-build"]`. Every boolean knob flipped on. Surface-area testing only. |
+
+### Selection precedence (highest wins)
+
+1. `pasclaw <cmd> --profile <name>` — per-invocation.
+2. `PASCLAW_PROFILE=<name>` env var — process scope.
+3. `"profile": "<name>"` field in `config.json` — persistent default (write via `pasclaw profile use <name>`).
+4. None — `TConfig.Create` defaults flow straight through.
+
+### Layering
+
+`TConfig.Create` defaults → profile (with `_inherits` chain) → operator `config.json`. Each layer is applied via `FromJSON`, which is merge-style: every field defaults to the current `TConfig` value, so unset fields preserve the lower layer and set fields override. **Your explicit `config.json` always wins**, so you can pick `max-build` and still pin one field your own way.
+
+### Inheritance
+
+A profile may declare `"_inherits": ["other"]` (or several). Ancestors apply first, in order, then the current profile. Cycles are rejected, depth is capped at 4.
+
+### CLI
+
+```sh
+pasclaw profile list                 # show built-ins + your $PASCLAW_HOME/profiles/
+pasclaw profile show low-token       # print the resolved body
+pasclaw profile show max-build       # show two layers: low-token, then max-build
+pasclaw profile use security         # write "profile": "security" into config.json
+
+pasclaw agent --profile baseline -m "do X"   # per-run override
+PASCLAW_PROFILE=max-build pasclaw agent ...  # process-scope override
+```
+
+### Custom profiles
+
+Drop any JSON file at `$PASCLAW_HOME/profiles/<name>.json`. A user file with the same name as a built-in **shadows** it (same convention the skills loader uses). Useful for forking a built-in:
+
+```json
+{
+  "_description": "low-token but with a smaller cap",
+  "_inherits": ["low-token"],
+  "tool_output_cap": 4096
+}
+```
+
 ## File location
 
 | Override | Effect |

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -116,6 +116,11 @@ type
        current value before each turn so an in-session /mode switch
        takes effect immediately. *)
     Mode: TPasClawMode;
+    (* --profile <name> (PR #291). Overrides PASCLAW_PROFILE / the
+       config.json "profile" field for this invocation. Empty string
+       means "fall through to the env var / config.json / no-profile
+       chain". *)
+    Profile: string;
   end;
 
   TLoopHandlers = class
@@ -201,6 +206,7 @@ begin
     end;
     if Argv[i] = '--plan'        then begin A.Mode := pmPlan;  Inc(i); Continue; end;
     if Argv[i] = '--build'       then begin A.Mode := pmBuild; Inc(i); Continue; end;
+    if Argv[i] = '--profile'     then begin if i = High(Argv) then Exit(False); A.Profile := Argv[i + 1]; Inc(i, 2); Continue; end;
     Inc(i);
   end;
 end;
@@ -1399,10 +1405,11 @@ begin
     PrintLnErr('                     [--thinking low|medium|high] [--max-tokens N]');
     PrintLnErr('                     [--max-iterations N] [--no-tools] [-q|--quiet]');
     PrintLnErr('                     [--mode plan|build] [--plan|--build]');
+    PrintLnErr('                     [--profile baseline|low-token|security|max-build|all-on|<custom>]');
     Exit(1);
   end;
 
-  Cfg := LoadConfig;
+  Cfg := LoadConfig(A.Profile);
   ConfigureSandbox(Cfg.Sandbox, '');
   { Install the active shell backend BEFORE any session can spawn a
     container or build its tool registry (shell_exec's description

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -183,8 +183,21 @@ var
   Skills: TSkillSpecArray;
   KindSelected: TShellBackendKind;
   BackendDesc, ShellSessionId: string;
+  ProfileName: string;
+  pi: Integer;
 begin
-  Cfg := LoadConfig;
+  { Pre-scan for --profile so LoadConfig sees it. Profile selection
+    has its own precedence chain (CLI > PASCLAW_PROFILE > config.json
+    "profile" field); passing '' here lets LoadConfig fall through to
+    the env/config-json layers. PR #291. }
+  ProfileName := '';
+  for pi := 0 to High(Argv) - 1 do
+    if Argv[pi] = '--profile' then
+    begin
+      ProfileName := Argv[pi + 1];
+      Break;
+    end;
+  Cfg := LoadConfig(ProfileName);
   ConfigureSandbox(Cfg.Sandbox, '');
   ShellSessionId := '';
   try

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -25,6 +25,7 @@ implementation
 uses
   SysUtils,
   PasClaw.Config,
+  PasClaw.Config.Profile,    { ResolveProfileBodies for PromptStarterProfile -- PR #291 }
   PasClaw.Utils,
   PasClaw.CliUI,
   PasClaw.Logger,
@@ -830,6 +831,90 @@ begin
   end;
 end;
 
+(* PR #291: starter profile picker. Sits at the top of the
+   loop-shaping block; when the operator picks a profile, every
+   loop-shaping prompt below it is skipped (the profile encapsulates
+   those choices) AND the profile name is persisted into config.json
+   so a later `pasclaw agent` invocation re-applies the bundle. The
+   default is "skip", which leaves the per-feature prompts behind
+   wired exactly like the pre-PR-#291 flow.
+
+   PickedAProfile is OUT True when the operator chose a real profile
+   (1-6); callers use this to short-circuit the loop-shaping prompts
+   below. *)
+procedure PromptStarterProfile(Cfg: TConfig; out PickedAProfile: Boolean);
+const
+  ChoiceLabels: array[0..5] of string = (
+    'stock      -- explicit no-op profile mirroring TConfig.Create defaults',
+    'baseline   -- everything off; A/B reference',
+    'low-token  -- condenser, output cap, cache, progressive disclosure, auto-router',
+    'security   -- sandbox tight, no outbound HTTP, agent skill writes staged',
+    'max-build  -- opinionated coding setup; low-token + web_fetch + vault + checkpoints + ...',
+    'all-on     -- every flag on; surface-area testing only'
+  );
+  ChoiceNames: array[0..5] of string = (
+    'stock', 'baseline', 'low-token', 'security', 'max-build', 'all-on'
+  );
+var
+  Input: string;
+  Idx: Integer;
+  Bodies: TProfileBodyArray;
+  Err: string;
+  i: Integer;
+begin
+  PickedAProfile := False;
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Starter profile' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'A profile bundles loop-shaping defaults (condenser, output cap, ' +
+    'skills, etc).' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Pick one to skip the per-feature prompts below, or skip to choose ' +
+    'à la carte.' + Ansi.Reset);
+  PrintLn;
+  for i := 0 to High(ChoiceLabels) do
+    PrintLn(Format('  %d. %s', [i + 1, ChoiceLabels[i]]));
+  PrintLn('  7. skip   -- per-feature prompts (default)');
+  PrintLn;
+  Input := Trim(ReadLineEcho('  Pick [1-7] (default 7): '));
+  if Input = '' then Idx := 7
+  else if not TryStrToInt(Input, Idx) then Idx := 7;
+  if (Idx < 1) or (Idx > 6) then
+  begin
+    PrintLn('  ' + Ansi.Dim + '(skipped -- per-feature prompts continue)' + Ansi.Reset);
+    Exit;
+  end;
+
+  { Apply the profile body chain so the operator can SEE the chosen
+    bundle in /v1/config + so other prompts that DON'T have profile
+    coverage (KB / stats / checkpoints / shell backend / heartbeat /
+    auto-router) get sensible defaults relative to the profile. Even
+    though Cfg.Profile is persisted and LoadConfig re-applies it on
+    every run, applying here makes the rest of onboarding consistent
+    with what's about to ship. }
+  if not ResolveProfileBodies(GetHome, ChoiceNames[Idx - 1], Bodies, Err) then
+  begin
+    PrintLn('  ' + Ansi.Red + '✗ ' + Ansi.Reset +
+            'profile lookup failed (' + Err + ') -- falling back to per-feature prompts');
+    Exit;
+  end;
+  for i := 0 to High(Bodies) do
+  try
+    Cfg.FromJSON(Bodies[i]);
+  except
+    { Bad profile body: leave Cfg as-is and bail. Shouldn't happen for
+      built-ins; protective for user profiles. }
+    PrintLn('  ' + Ansi.Yellow + '! ' + Ansi.Reset +
+            'profile layer ' + IntToStr(i + 1) + ' failed to apply -- partial state');
+  end;
+  Cfg.Profile := ChoiceNames[Idx - 1];
+  PickedAProfile := True;
+  PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' profile = ' +
+          ChoiceNames[Idx - 1] + Ansi.Dim +
+          '  (LoadConfig re-applies it on every run; override with --profile <other>)' +
+          Ansi.Reset);
+end;
+
 procedure PromptStatsCollection(Cfg: TConfig);
 { Opt-in toggle for persisting per-session usage stats (tokens,
   turns, tool calls, truncation savings) into the session JSON so
@@ -1248,6 +1333,7 @@ var
   Catalog: TProviderSpecArray;
   Spec: TProviderSpec;
   ExistingIdx, i: Integer;
+  PickedAProfile: Boolean;
 begin
   Home    := GetHome;
   CfgPath := GetConfigPath;
@@ -1337,19 +1423,29 @@ begin
       header value (same shape pasclaw mcp install writes when an
       env var is set). }
     PromptMCPInstalls(Cfg);
+    { PR #291: starter profile picker. When the operator picks a real
+      profile, the loop-shaping prompts below are skipped (the profile
+      bundle encapsulates those choices). VaultTools / Vector / KB /
+      Stats / Checkpoints / Shell / Heartbeat / AutoRouter still run
+      unconditionally -- those touch operator-environment concerns the
+      profile doesn't cover. }
+    PromptStarterProfile(Cfg, PickedAProfile);
     PromptVaultTools(Cfg);
     PromptVectorSearch(Cfg);
     PromptKnowledgebase(Cfg);
-    { Loop-shaping prompts (PR #289). Order is intentional: each
-      successive prompt is less likely to be wanted by an operator
-      who said yes to the previous one, so a quick "enter, enter,
-      enter" leaves the minimal-surprise defaults in place. }
-    PromptWebFetch(Cfg);
-    PromptPromptware(Cfg);
-    PromptCondenseReversible(Cfg);
-    PromptToolOutputCap(Cfg);
-    PromptOrientTaskAware(Cfg);
-    PromptSelfImprovingSkills(Cfg);
+    if not PickedAProfile then
+    begin
+      { Loop-shaping prompts (PR #289). Order is intentional: each
+        successive prompt is less likely to be wanted by an operator
+        who said yes to the previous one, so a quick "enter, enter,
+        enter" leaves the minimal-surprise defaults in place. }
+      PromptWebFetch(Cfg);
+      PromptPromptware(Cfg);
+      PromptCondenseReversible(Cfg);
+      PromptToolOutputCap(Cfg);
+      PromptOrientTaskAware(Cfg);
+      PromptSelfImprovingSkills(Cfg);
+    end;
     PromptStatsCollection(Cfg);
     PromptCheckpoints(Cfg);
     PromptShellBackend(Cfg);

--- a/src/cmd/PasClaw.Cmd.Profile.pas
+++ b/src/cmd/PasClaw.Cmd.Profile.pas
@@ -1,0 +1,199 @@
+(*
+  pasclaw profile - configuration profile management (PR #291).
+
+  Three subcommands shipping in this PR:
+
+    pasclaw profile list           List built-in + user profiles
+    pasclaw profile show <name>    Print the profile's effective JSON
+                                   (after _inherits resolution)
+    pasclaw profile use <name>     Write "profile": "<name>" into
+                                   config.json so it sticks across runs
+
+  Future (Stage D, separate PR):
+
+    pasclaw profile diff <a> <b>   Show field-level differences
+    pasclaw profile bench ...      A/B test profiles against a task
+
+  Profile selection precedence at LoadConfig time:
+
+    1. --profile <name>   (CLI per-invocation)
+    2. PASCLAW_PROFILE    (env var, process scope)
+    3. "profile": "<name>" in config.json   (persisted; `profile use` writes this)
+    4. None
+*)
+unit PasClaw.Cmd.Profile;
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+function Cmd_Profile_Run(const Argv: array of string): Integer;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  PasClaw.CliUI,
+  PasClaw.Config,
+  PasClaw.Config.Profile,
+  PasClaw.JSON,
+  PasClaw.Utils;
+
+procedure Help;
+begin
+  PrintLn('Usage: pasclaw profile <list|show|use> [args]');
+  PrintLn;
+  PrintLn('  list                List built-in + $PASCLAW_HOME/profiles/ profiles.');
+  PrintLn('  show <name>         Print the profile body (with _inherits resolved).');
+  PrintLn('  use  <name>         Save "profile": <name> into config.json.');
+  PrintLn;
+  PrintLn('Built-in profiles: baseline | low-token | security | max-build | all-on');
+  PrintLn('Per-invocation override: ' + Ansi.Bold + 'pasclaw <cmd> --profile <name>' + Ansi.Reset);
+  PrintLn('Process override:        ' + Ansi.Bold + 'PASCLAW_PROFILE=<name> pasclaw ...' + Ansi.Reset);
+end;
+
+function DoList: Integer;
+var
+  Profiles: TProfileSpecArray;
+  i: Integer;
+  Src, Active: string;
+begin
+  Profiles := ListAvailableProfiles(GetHome);
+  if Length(Profiles) = 0 then
+  begin
+    PrintLn('(no profiles)');
+    Exit(0);
+  end;
+
+  Active := GetEnvironmentVariable('PASCLAW_PROFILE');
+  if Active = '' then
+  try
+    Active := ExtractProfileField(ReadFileText(GetConfigPath));
+  except
+    Active := '';
+  end;
+
+  PrintLn(Ansi.Bold + 'name           source         description' + Ansi.Reset);
+  for i := 0 to High(Profiles) do
+  begin
+    Src := Profiles[i].Source;
+    if Src <> 'builtin' then
+    begin
+      { Show ~/.../ relative path so the line stays readable. }
+      if Pos(GetHome, Src) = 1 then
+        Src := '~' + Copy(Src, Length(GetHome) + 1, MaxInt);
+    end;
+    if SameText(Profiles[i].Name, Active) then
+      PrintLn(Format('* %-12s  %-12s  %s',
+        [Profiles[i].Name, Src, Profiles[i].Description]))
+    else
+      PrintLn(Format('  %-12s  %-12s  %s',
+        [Profiles[i].Name, Src, Profiles[i].Description]));
+  end;
+  if Active <> '' then
+    PrintLn(Ansi.Dim + sLineBreak + '(* marks the active profile from ' +
+            'PASCLAW_PROFILE or config.json)' + Ansi.Reset);
+  Result := 0;
+end;
+
+function DoShow(const Argv: array of string): Integer;
+var
+  Bodies: TProfileBodyArray;
+  Err: string;
+  i: Integer;
+  Sb: TStringBuilder;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  if not ResolveProfileBodies(GetHome, Argv[1], Bodies, Err) then
+  begin
+    PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + Err);
+    Exit(1);
+  end;
+  PrintLn(Ansi.Bold + 'profile ' + Argv[1] +
+          Ansi.Reset + Ansi.Dim +
+          Format('  (%d layer(s) including ancestors)', [Length(Bodies)]) +
+          Ansi.Reset);
+  PrintLn;
+  Sb := TStringBuilder.Create;
+  try
+    for i := 0 to High(Bodies) do
+    begin
+      if Length(Bodies) > 1 then
+      begin
+        PrintLn(Ansi.Dim + Format('--- layer %d/%d ---', [i + 1, Length(Bodies)]) +
+                Ansi.Reset);
+      end;
+      PrintLn(Bodies[i]);
+      if i < High(Bodies) then PrintLn;
+    end;
+  finally
+    Sb.Free;
+  end;
+  Result := 0;
+end;
+
+function DoUse(const Argv: array of string): Integer;
+var
+  Err: string;
+  Bodies: TProfileBodyArray;
+  Path, Body, NewBody: string;
+  Cfg: TJsonObject;
+begin
+  if Length(Argv) < 2 then begin Help; Exit(1); end;
+  { Validate the profile resolves BEFORE writing -- prevents stamping
+    a typo into config.json that LoadConfig will then warn about
+    forever. }
+  if not ResolveProfileBodies(GetHome, Argv[1], Bodies, Err) then
+  begin
+    PrintLn(Ansi.Red + '✗ ' + Ansi.Reset + Err);
+    Exit(1);
+  end;
+
+  Path := GetConfigPath;
+  if FileExists(Path) then Body := ReadFileText(Path)
+  else Body := '{}';
+
+  try
+    Cfg := TJsonObject.Parse(Body);
+  except
+    on E: Exception do
+    begin
+      PrintLn(Ansi.Red + '✗ ' + Ansi.Reset +
+              'config.json parse failed (' + E.Message + ') -- aborting');
+      Exit(1);
+    end;
+  end;
+  if Cfg = nil then Cfg := TJsonObject.Create;
+  try
+    Cfg.PutStr('profile', Argv[1]);
+    NewBody := Cfg.ToJSON;
+  finally
+    Cfg.Free;
+  end;
+  WriteFileText(Path, NewBody);
+  PrintLn(Ansi.Green + '✓ ' + Ansi.Reset +
+          'config.json now selects profile "' + Argv[1] + '"');
+  PrintLn(Ansi.Dim +
+          '  Override per-invocation: pasclaw <cmd> --profile <other>' +
+          Ansi.Reset);
+  Result := 0;
+end;
+
+function Cmd_Profile_Run(const Argv: array of string): Integer;
+var
+  Sub: string;
+begin
+  if Length(Argv) = 0 then begin Help; Exit(1); end;
+  Sub := Argv[0];
+  if      Sub = 'list' then Result := DoList
+  else if Sub = 'show' then Result := DoShow(Argv)
+  else if Sub = 'use'  then Result := DoUse(Argv)
+  else begin Help; Result := 1; end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Profile.pas
+++ b/src/cmd/PasClaw.Cmd.Profile.pas
@@ -141,8 +141,7 @@ function DoUse(const Argv: array of string): Integer;
 var
   Err: string;
   Bodies: TProfileBodyArray;
-  Path, Body, NewBody: string;
-  Cfg: TJsonObject;
+  Cfg: TConfig;
 begin
   if Length(Argv) < 2 then begin Help; Exit(1); end;
   { Validate the profile resolves BEFORE writing -- prevents stamping
@@ -154,28 +153,18 @@ begin
     Exit(1);
   end;
 
-  Path := GetConfigPath;
-  if FileExists(Path) then Body := ReadFileText(Path)
-  else Body := '{}';
-
+  { PR #291 Codex fix: write through TConfig + SaveConfig, not by
+    hand-rolling JSON. Cfg.Profile is a proper field now, so any
+    config-mutating command after this (auth login, model set, /v1/config
+    PUT, ...) preserves it instead of dropping the key on the next save. }
+  Cfg := LoadConfig('');
   try
-    Cfg := TJsonObject.Parse(Body);
-  except
-    on E: Exception do
-    begin
-      PrintLn(Ansi.Red + '✗ ' + Ansi.Reset +
-              'config.json parse failed (' + E.Message + ') -- aborting');
-      Exit(1);
-    end;
-  end;
-  if Cfg = nil then Cfg := TJsonObject.Create;
-  try
-    Cfg.PutStr('profile', Argv[1]);
-    NewBody := Cfg.ToJSON;
+    Cfg.Profile := Argv[1];
+    SaveConfig(Cfg);
   finally
     Cfg.Free;
   end;
-  WriteFileText(Path, NewBody);
+
   PrintLn(Ansi.Green + '✓ ' + Ansi.Reset +
           'config.json now selects profile "' + Argv[1] + '"');
   PrintLn(Ansi.Dim +

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -44,6 +44,7 @@ uses
   PasClaw.Cmd.MCP,
   PasClaw.Cmd.Migrate,
   PasClaw.Cmd.Skills,
+  PasClaw.Cmd.Profile,    (* PR #291: pasclaw profile list/show/use *)
   PasClaw.Cmd.Vault,
   PasClaw.Cmd.Session,
   PasClaw.Cmd.Learn,
@@ -182,6 +183,7 @@ begin
   else if Cmd = 'mcp'      then Result := Cmd_MCP_Run(Argv)
   else if Cmd = 'migrate'  then Result := Cmd_Migrate_Run(Argv)
   else if Cmd = 'skills'   then Result := Cmd_Skills_Run(Argv)
+  else if Cmd = 'profile'  then Result := Cmd_Profile_Run(Argv)
   else if Cmd = 'vault'    then Result := Cmd_Vault_Run(Argv)
   else if Cmd = 'session'  then Result := Cmd_Session_Run(Argv)
   else if Cmd = 'learn'    then Result := Cmd_Learn_Run(Argv)

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -140,9 +140,20 @@ var
   Skills: TSkillSpecArray;
   BaseURL: string;
   KindSelected: TShellBackendKind;
-  BackendDesc, ShellSessionId: string;
+  BackendDesc, ShellSessionId, ProfileName: string;
+  pi: Integer;
 begin
-  Cfg := LoadConfig;
+  { Pre-scan for --profile so LoadConfig sees it. Same shape as
+    Cmd.Gateway -- precedence stays CLI > PASCLAW_PROFILE > config.json
+    field. PR #291. }
+  ProfileName := '';
+  for pi := 0 to High(Argv) - 1 do
+    if Argv[pi] = '--profile' then
+    begin
+      ProfileName := Argv[pi + 1];
+      Break;
+    end;
+  Cfg := LoadConfig(ProfileName);
   ConfigureSandbox(Cfg.Sandbox, '');
   ShellSessionId := '';
   try

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -59,6 +59,7 @@ type
     NoTools:         Boolean;
     NoHashline:      Boolean;
     BackendOverride: string;
+    Profile:         string;   { --profile <name>; PR #291 }
   end;
 
 function ParseArgs(const Argv: array of string; var A: TTUIArgs): Boolean;
@@ -69,6 +70,7 @@ begin
   A.Model := ''; A.Provider := ''; A.Session := ''; A.Theme := '';
   A.NoMCP := False; A.NoTools := False; A.NoHashline := False;
   A.BackendOverride := '';
+  A.Profile := '';
   i := 0;
   while i <= High(Argv) do
   begin
@@ -80,6 +82,7 @@ begin
     if Argv[i] = '--no-mcp'       then begin A.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-tools'     then begin A.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline'  then begin A.NoHashline := True; Inc(i); Continue; end;
+    if Argv[i] = '--profile'      then begin if i = High(Argv) then Exit(False); A.Profile  := Argv[i + 1]; Inc(i, 2); Continue; end;
     Inc(i);
   end;
 end;
@@ -103,7 +106,7 @@ var
   ShellSessionId: string;
 begin
   if not ParseArgs(Argv, A) then Exit(1);
-  Cfg := LoadConfig;
+  Cfg := LoadConfig(A.Profile);
   ConfigureSandbox(Cfg.Sandbox, '');
   { Docker backend: the TUI runs ONE container for its whole process,
     not one per chat session. The container is a workspace sandbox --

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -1,0 +1,481 @@
+(*
+  PasClaw.Config.Profile - configuration profiles.
+
+  A profile is a small JSON blob that gets merged into TConfig BEFORE
+  the operator's config.json is applied. Five built-in profiles ship
+  embedded as Pascal string constants below; operators can add their
+  own by dropping files at $PASCLAW_HOME/profiles/<name>.json.
+
+  Five built-ins (PR #291):
+
+    baseline    Everything off. Bare-minimum control profile for A/B
+                comparison ("how does pasclaw behave with no features").
+
+    low-token   Minimise tokens going to/from the model: condenser on,
+                output cap on, MEMORY task-aware slicing, prompt cache,
+                progressive disclosure for skills, auto-router for
+                easy turns.
+
+    security    Maximum sandboxing: workspace restriction + shell deny
+                + private-network block, promptware scan, web_fetch
+                and vault tools off, agent-authored skills stage for
+                approval (auto_approve off).
+
+    max-build   Best settings for productive coding: web_fetch, vault,
+                vector search, checkpoints, stats, condenser, large
+                output cap, 1h prompt cache, all four self-improving
+                skill switches on.
+
+    all-on      Every boolean knob flipped on. For surface-area /
+                integration testing only.
+
+  Selection precedence (highest wins):
+
+    1. --profile <name> CLI flag (per-invocation).
+    2. PASCLAW_PROFILE env var (process scope).
+    3. "profile": "<name>" field in $PASCLAW_HOME/config.json (persisted).
+    4. None -- TConfig.Create defaults flow straight through.
+
+  Inheritance: a profile MAY carry "_inherits": ["a", "b"] -- the
+  named profiles are loaded first, applied in order, then the current
+  profile's fields override. Cycles are detected; depth is capped at
+  4 to bound recursion. The _description / _inherits / _name keys
+  themselves are stripped before the body reaches TConfig.FromJSON.
+
+  Merge mechanics: TConfig.FromJSON is merge-style (every GetX call
+  has the current TConfig value as its default), so we just call
+  FromJSON once per resolved profile body in order: ancestors first,
+  current profile, then the operator's config.json. The last write
+  wins by construction -- no separate deep-merge helper needed.
+*)
+unit PasClaw.Config.Profile;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+type
+  TProfileSpec = record
+    Name:        string;
+    Description: string;
+    Source:      string;   { 'builtin' | absolute path }
+  end;
+  TProfileSpecArray = array of TProfileSpec;
+
+  TProfileBodyArray = array of string;
+
+{ Return the catalogue: built-in profiles first, then any user
+  $PASCLAW_HOME/profiles/<name>.json shadowing or extending them. }
+function ListAvailableProfiles(const HomeDir: string): TProfileSpecArray;
+
+{ True iff a profile with this exact name is shipped as a built-in.
+  Used by `pasclaw profile show` to label "built-in" rows. }
+function IsBuiltinProfile(const Name: string): Boolean;
+
+{ Resolve a profile name to the FULL ordered list of JSON bodies that
+  LoadConfig should apply via TConfig.FromJSON (ancestors first, then
+  the profile itself). Each body is the raw profile JSON with the
+  meta keys (_description / _inherits / _name) STILL PRESENT --
+  TConfig.FromJSON ignores unknown keys, and keeping the meta keys
+  in the returned blobs lets `pasclaw profile show` reuse this path
+  without a second read. ErrMsg names a missing profile, a cycle, or
+  an inheritance over-depth. }
+function ResolveProfileBodies(const HomeDir, Name: string;
+                              out Bodies: TProfileBodyArray;
+                              out ErrMsg: string): Boolean;
+
+{ Read JUST the "profile" field from a raw config.json body, without
+  parsing the whole thing into TConfig. Returns '' when the field is
+  absent or the body is malformed. Used by LoadConfig before it knows
+  whether to apply a profile. }
+function ExtractProfileField(const ConfigJSON: string): string;
+
+{ Look up one profile's raw JSON body + a TProfileSpec describing it.
+  No inheritance resolution -- this is the leaf operation
+  ResolveProfileBodies recurses against. Returns False on unknown
+  name. }
+function LookupProfile(const HomeDir, Name: string;
+                      out Spec: TProfileSpec;
+                      out Body: string): Boolean;
+
+const
+  MaxInheritDepth = 4;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Logger;
+
+(* ====================================================================
+   Built-in profile blobs. Kept as multi-line string concatenations so
+   FPC + dcc64 are both happy and source diffs are readable. Order
+   matches docs/configuration.md's table.
+   ==================================================================== *)
+
+const
+  Profile_Baseline: string =
+    '{' +
+    '"_description":"Everything off. Bare-minimum baseline for A/B testing.",' +
+    '"condense_reversible":false,' +
+    '"tool_output_cap":0,' +
+    '"orient_task_aware":false,' +
+    '"promptware_enabled":false,' +
+    '"web_fetch_enabled":false,' +
+    '"vault_tools_enabled":false,' +
+    '"vector_search_enabled":false,' +
+    '"checkpoints_enabled":false,' +
+    '"stats_collection_enabled":false,' +
+    '"self_improving_skills":{' +
+      '"self_manage":false,' +
+      '"progressive_disclosure":false,' +
+      '"auto_approve":false,' +
+      '"distiller":{"enabled":false}' +
+    '},' +
+    '"auto_router":{"enabled":false},' +
+    '"prompt_cache":{"enabled":false}' +
+    '}';
+
+  Profile_LowToken: string =
+    '{' +
+    '"_description":"Minimise tokens. Condenser on, output cap, MEMORY ' +
+    'task-aware, prompt cache, progressive disclosure, auto-router.",' +
+    '"condense_reversible":true,' +
+    '"tool_output_cap":8192,' +
+    '"orient_task_aware":true,' +
+    '"prompt_cache":{"enabled":true,"ttl":"5m"},' +
+    '"self_improving_skills":{' +
+      '"progressive_disclosure":true' +
+    '},' +
+    '"auto_router":{"enabled":true}' +
+    '}';
+
+  Profile_Security: string =
+    '{' +
+    '"_description":"Maximum sandboxing: workspace restriction, shell ' +
+    'denylist, private-net block, promptware scan, no outbound HTTP, ' +
+    'agent-authored skill writes staged for approval.",' +
+    '"sandbox":{' +
+      '"restrict_to_workspace":true,' +
+      '"shell_deny_enabled":true,' +
+      '"block_private_networks":true,' +
+      '"allow_read_outside_workspace":false' +
+    '},' +
+    '"promptware_enabled":true,' +
+    '"web_fetch_enabled":false,' +
+    '"vault_tools_enabled":false,' +
+    '"self_improving_skills":{' +
+      '"auto_approve":false' +
+    '}' +
+    '}';
+
+  Profile_MaxBuild: string =
+    '{' +
+    '"_description":"Best settings for productive coding sessions: ' +
+    'web_fetch, vault, vector search, checkpoints, stats, condenser, ' +
+    '16KB cap, 1h prompt cache, all four self-improving skill switches.",' +
+    '"_inherits":["low-token"],' +
+    '"web_fetch_enabled":true,' +
+    '"vault_tools_enabled":true,' +
+    '"vector_search_enabled":true,' +
+    '"checkpoints_enabled":true,' +
+    '"checkpoints_keep_last":32,' +
+    '"stats_collection_enabled":true,' +
+    '"promptware_enabled":true,' +
+    '"condense_reversible":true,' +
+    '"tool_output_cap":16384,' +
+    '"prompt_cache":{"enabled":true,"ttl":"1h"},' +
+    '"self_improving_skills":{' +
+      '"self_manage":true,' +
+      '"progressive_disclosure":true,' +
+      '"auto_approve":false,' +
+      '"distiller":{"enabled":true,"min_tool_calls":5}' +
+    '}' +
+    '}';
+
+  Profile_AllOn: string =
+    '{' +
+    '"_description":"Every boolean knob flipped on. Surface-area / ' +
+    'integration testing only -- not recommended for daily use.",' +
+    '"_inherits":["max-build"],' +
+    '"orient_task_aware":true,' +
+    '"self_improving_skills":{' +
+      '"auto_approve":true' +
+    '}' +
+    '}';
+
+type
+  TBuiltin = record
+    Name:        string;
+    Body:        string;
+    Description: string;
+  end;
+  TBuiltinArray = array of TBuiltin;
+
+function Builtins: TBuiltinArray;
+begin
+  SetLength(Result, 5);
+  Result[0].Name := 'baseline';   Result[0].Body := Profile_Baseline;
+  Result[1].Name := 'low-token';  Result[1].Body := Profile_LowToken;
+  Result[2].Name := 'security';   Result[2].Body := Profile_Security;
+  Result[3].Name := 'max-build';  Result[3].Body := Profile_MaxBuild;
+  Result[4].Name := 'all-on';     Result[4].Body := Profile_AllOn;
+end;
+
+function ExtractDescription(const Body: string): string;
+var
+  O: TJsonObject;
+begin
+  Result := '';
+  try
+    O := TJsonObject.Parse(Body);
+  except
+    Exit;
+  end;
+  if O = nil then Exit;
+  try
+    Result := O.GetStr('_description', '');
+  finally
+    O.Free;
+  end;
+end;
+
+function IsBuiltinProfile(const Name: string): Boolean;
+var
+  i: Integer;
+  B: TBuiltinArray;
+begin
+  Result := False;
+  B := Builtins;
+  for i := 0 to High(B) do
+    if SameText(B[i].Name, Name) then Exit(True);
+end;
+
+function UserProfilePath(const HomeDir, Name: string): string;
+begin
+  Result := JoinPath(JoinPath(HomeDir, 'profiles'), Name + '.json');
+end;
+
+(* Name safety: a profile name reaches the filesystem, so reject
+   slashes, dots, and anything outside lowercase-alphanumeric-dash-
+   underscore. Same shape as IsSafeSkillName. *)
+function IsSafeProfileName(const Name: string): Boolean;
+var
+  i: Integer;
+  c: Char;
+begin
+  Result := False;
+  if (Name = '') or (Name = '.') or (Name = '..') then Exit;
+  if Length(Name) > 64 then Exit;
+  for i := 1 to Length(Name) do
+  begin
+    c := Name[i];
+    if not (((c >= 'a') and (c <= 'z')) or
+            ((c >= '0') and (c <= '9')) or
+            (c = '-') or (c = '_')) then Exit;
+  end;
+  Result := True;
+end;
+
+function LookupProfile(const HomeDir, Name: string;
+                      out Spec: TProfileSpec;
+                      out Body: string): Boolean;
+var
+  i: Integer;
+  B: TBuiltinArray;
+  Path: string;
+begin
+  Result := False;
+  Body := '';
+  Spec := Default(TProfileSpec);
+  Spec.Name := Name;
+  if not IsSafeProfileName(Name) then Exit;
+
+  { User profile takes precedence over a same-named built-in --
+    same shadowing rule the skills loader uses. Lets an operator
+    customise a built-in without forking the binary. }
+  Path := UserProfilePath(HomeDir, Name);
+  if FileExists(Path) then
+  begin
+    Body := ReadFileText(Path);
+    Spec.Source := Path;
+    Spec.Description := ExtractDescription(Body);
+    Exit(True);
+  end;
+
+  B := Builtins;
+  for i := 0 to High(B) do
+    if SameText(B[i].Name, Name) then
+    begin
+      Body := B[i].Body;
+      Spec.Source := 'builtin';
+      Spec.Description := ExtractDescription(Body);
+      Exit(True);
+    end;
+end;
+
+function ListAvailableProfiles(const HomeDir: string): TProfileSpecArray;
+var
+  i: Integer;
+  B: TBuiltinArray;
+  SR: TSearchRec;
+  Root, Name, Body: string;
+  Spec: TProfileSpec;
+
+  procedure AddSpec(const S: TProfileSpec);
+  var
+    j: Integer;
+  begin
+    for j := 0 to High(Result) do
+      if SameText(Result[j].Name, S.Name) then
+      begin
+        { User entries shadow built-ins -- replace, don't dupe. }
+        Result[j] := S;
+        Exit;
+      end;
+    SetLength(Result, Length(Result) + 1);
+    Result[High(Result)] := S;
+  end;
+
+begin
+  SetLength(Result, 0);
+  B := Builtins;
+  for i := 0 to High(B) do
+  begin
+    Spec.Name        := B[i].Name;
+    Spec.Source      := 'builtin';
+    Spec.Description := ExtractDescription(B[i].Body);
+    AddSpec(Spec);
+  end;
+
+  Root := JoinPath(HomeDir, 'profiles');
+  if DirectoryExists(Root) and (FindFirst(JoinPath(Root, '*.json'), faAnyFile, SR) = 0) then
+  try
+    repeat
+      if (SR.Attr and faDirectory) <> 0 then Continue;
+      Name := ExtractFileName(SR.Name);
+      if Length(Name) > 5 then Delete(Name, Length(Name) - 4, 5);   { strip .json }
+      if not IsSafeProfileName(Name) then Continue;
+      Body := ReadFileText(JoinPath(Root, SR.Name));
+      Spec.Name        := Name;
+      Spec.Source      := JoinPath(Root, SR.Name);
+      Spec.Description := ExtractDescription(Body);
+      AddSpec(Spec);
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+(* Recursive resolver. Visited is the cycle-guard; Depth caps inheritance.
+   On success, appends one body per ancestor in inheritance order, then
+   the current profile's body at the end. *)
+function ResolveInto(const HomeDir, Name: string;
+                    var Bodies: TProfileBodyArray;
+                    var Visited: TStringList;
+                    Depth: Integer;
+                    out ErrMsg: string): Boolean;
+var
+  Spec: TProfileSpec;
+  Body: string;
+  O: TJsonObject;
+  Inh: TJsonArray;
+  ParentName: string;
+  i: Integer;
+begin
+  Result := False;
+  ErrMsg := '';
+  if Depth > MaxInheritDepth then
+  begin
+    ErrMsg := 'profile inheritance over depth cap (' + IntToStr(MaxInheritDepth) +
+              ') resolving "' + Name + '"';
+    Exit;
+  end;
+  if Visited.IndexOf(LowerCase(Name)) >= 0 then
+  begin
+    ErrMsg := 'profile inheritance cycle through "' + Name + '"';
+    Exit;
+  end;
+  Visited.Add(LowerCase(Name));
+
+  if not LookupProfile(HomeDir, Name, Spec, Body) then
+  begin
+    ErrMsg := 'profile "' + Name + '" not found';
+    Exit;
+  end;
+
+  try
+    O := TJsonObject.Parse(Body);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'profile "' + Name + '" parse error: ' + E.Message;
+      Exit;
+    end;
+  end;
+  if O = nil then begin ErrMsg := 'profile "' + Name + '" empty / invalid'; Exit; end;
+  try
+    Inh := O.ChildArray('_inherits');
+    if Inh <> nil then
+    try
+      for i := 0 to Inh.Count - 1 do
+      begin
+        ParentName := Trim(Inh.ItemStr(i, ''));
+        if ParentName = '' then Continue;
+        if not ResolveInto(HomeDir, ParentName, Bodies, Visited, Depth + 1, ErrMsg) then
+          Exit;
+      end;
+    finally
+      Inh.Free;
+    end;
+  finally
+    O.Free;
+  end;
+
+  SetLength(Bodies, Length(Bodies) + 1);
+  Bodies[High(Bodies)] := Body;
+  Result := True;
+end;
+
+function ResolveProfileBodies(const HomeDir, Name: string;
+                              out Bodies: TProfileBodyArray;
+                              out ErrMsg: string): Boolean;
+var
+  Visited: TStringList;
+begin
+  SetLength(Bodies, 0);
+  Visited := TStringList.Create;
+  Visited.Sorted := True;
+  Visited.Duplicates := dupIgnore;
+  try
+    Result := ResolveInto(HomeDir, Name, Bodies, Visited, 0, ErrMsg);
+  finally
+    Visited.Free;
+  end;
+end;
+
+function ExtractProfileField(const ConfigJSON: string): string;
+var
+  O: TJsonObject;
+begin
+  Result := '';
+  if Trim(ConfigJSON) = '' then Exit;
+  try
+    O := TJsonObject.Parse(ConfigJSON);
+  except
+    Exit;
+  end;
+  if O = nil then Exit;
+  try
+    Result := Trim(O.GetStr('profile', ''));
+  finally
+    O.Free;
+  end;
+end;
+
+end.

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -282,9 +282,20 @@ begin
   Result := True;
 end;
 
-function LookupProfile(const HomeDir, Name: string;
-                      out Spec: TProfileSpec;
-                      out Body: string): Boolean;
+(* Internal lookup with an explicit user-shadow bypass switch.
+   Codex P2 on PR #291: the documented fork pattern
+     $PASCLAW_HOME/profiles/low-token.json:
+       {"_inherits":["low-token"], "tool_output_cap":4096}
+   would loop forever, because LookupProfile('low-token') hit the user
+   file for both the child AND the inherited parent, and the resolver
+   then saw 'low-token' twice and reported a cycle. The resolver passes
+   BypassUserShadow=True when it's chasing an _inherits parent whose
+   name matches the CURRENT profile's name, so the parent lookup
+   reaches past the user shadow to the built-in underneath. *)
+function LookupProfileInternal(const HomeDir, Name: string;
+                               BypassUserShadow: Boolean;
+                               out Spec: TProfileSpec;
+                               out Body: string): Boolean;
 var
   i: Integer;
   B: TBuiltinArray;
@@ -299,13 +310,16 @@ begin
   { User profile takes precedence over a same-named built-in --
     same shadowing rule the skills loader uses. Lets an operator
     customise a built-in without forking the binary. }
-  Path := UserProfilePath(HomeDir, Name);
-  if FileExists(Path) then
+  if not BypassUserShadow then
   begin
-    Body := ReadFileText(Path);
-    Spec.Source := Path;
-    Spec.Description := ExtractDescription(Body);
-    Exit(True);
+    Path := UserProfilePath(HomeDir, Name);
+    if FileExists(Path) then
+    begin
+      Body := ReadFileText(Path);
+      Spec.Source := Path;
+      Spec.Description := ExtractDescription(Body);
+      Exit(True);
+    end;
   end;
 
   B := Builtins;
@@ -317,6 +331,13 @@ begin
       Spec.Description := ExtractDescription(Body);
       Exit(True);
     end;
+end;
+
+function LookupProfile(const HomeDir, Name: string;
+                      out Spec: TProfileSpec;
+                      out Body: string): Boolean;
+begin
+  Result := LookupProfileInternal(HomeDir, Name, False, Spec, Body);
 end;
 
 function ListAvailableProfiles(const HomeDir: string): TProfileSpecArray;
@@ -374,22 +395,31 @@ end;
 
 (* Recursive resolver. Visited is the cycle-guard; Depth caps inheritance.
    On success, appends one body per ancestor in inheritance order, then
-   the current profile's body at the end. *)
-function ResolveInto(const HomeDir, Name: string;
+   the current profile's body at the end.
+
+   NameToBypass: when non-empty AND matches Name, the current lookup
+   bypasses the user-shadow file and reaches the built-in directly.
+   Set by the caller when recursing for an _inherits parent whose name
+   matches the current profile's name (Codex P2 on PR #291 -- the
+   "fork a built-in" pattern). Empty otherwise. *)
+function ResolveInto(const HomeDir, Name, NameToBypass: string;
                     var Bodies: TProfileBodyArray;
                     var Visited: TStringList;
                     Depth: Integer;
                     out ErrMsg: string): Boolean;
 var
   Spec: TProfileSpec;
-  Body: string;
+  Body, VisitedKey: string;
   O: TJsonObject;
   Inh: TJsonArray;
   ParentName: string;
-  i: Integer;
+  i, VisitedIdx: Integer;
+  PoppedSelf: Boolean;
+  BypassThisLookup: Boolean;
 begin
   Result := False;
   ErrMsg := '';
+  PoppedSelf := False;
   if Depth > MaxInheritDepth then
   begin
     ErrMsg := 'profile inheritance over depth cap (' + IntToStr(MaxInheritDepth) +
@@ -403,7 +433,8 @@ begin
   end;
   Visited.Add(LowerCase(Name));
 
-  if not LookupProfile(HomeDir, Name, Spec, Body) then
+  BypassThisLookup := (NameToBypass <> '') and SameText(Name, NameToBypass);
+  if not LookupProfileInternal(HomeDir, Name, BypassThisLookup, Spec, Body) then
   begin
     ErrMsg := 'profile "' + Name + '" not found';
     Exit;
@@ -427,8 +458,33 @@ begin
       begin
         ParentName := Trim(Inh.ItemStr(i, ''));
         if ParentName = '' then Continue;
-        if not ResolveInto(HomeDir, ParentName, Bodies, Visited, Depth + 1, ErrMsg) then
-          Exit;
+
+        if SameText(ParentName, Name) and (not BypassThisLookup) and
+           (Spec.Source <> 'builtin') then
+        begin
+          (* Self-shadow case (Codex P2): user file
+             $PASCLAW_HOME/profiles/<X>.json whose _inherits list
+             contains "X". Pop our own name from Visited so the
+             recursive call doesn't false-cycle, signal "bypass the
+             user-shadow for this one lookup", then re-add (no-op
+             via dupIgnore but explicit for readability). *)
+          VisitedKey := LowerCase(Name);
+          VisitedIdx := Visited.IndexOf(VisitedKey);
+          if VisitedIdx >= 0 then
+          begin
+            Visited.Delete(VisitedIdx);
+            PoppedSelf := True;
+          end;
+          try
+            if not ResolveInto(HomeDir, ParentName, Name,
+                               Bodies, Visited, Depth + 1, ErrMsg) then Exit;
+          finally
+            if PoppedSelf then Visited.Add(VisitedKey);
+            PoppedSelf := False;
+          end;
+        end
+        else if not ResolveInto(HomeDir, ParentName, '',
+                                Bodies, Visited, Depth + 1, ErrMsg) then Exit;
       end;
     finally
       Inh.Free;
@@ -453,7 +509,7 @@ begin
   Visited.Sorted := True;
   Visited.Duplicates := dupIgnore;
   try
-    Result := ResolveInto(HomeDir, Name, Bodies, Visited, 0, ErrMsg);
+    Result := ResolveInto(HomeDir, Name, '', Bodies, Visited, 0, ErrMsg);
   finally
     Visited.Free;
   end;

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -6,7 +6,11 @@
   embedded as Pascal string constants below; operators can add their
   own by dropping files at $PASCLAW_HOME/profiles/<name>.json.
 
-  Five built-ins (PR #291):
+  Six built-ins (PR #291):
+
+    stock       Mirrors TConfig.Create's exact defaults. Applying it is
+                a no-op; it exists so `pasclaw profile show stock`
+                documents the no-profile fresh-install state.
 
     baseline    Everything off. Bare-minimum control profile for A/B
                 comparison ("how does pasclaw behave with no features").
@@ -209,6 +213,46 @@ const
     '}' +
     '}';
 
+  (* `stock` mirrors TConfig.Create's exact defaults as an explicit
+     profile so `pasclaw profile show stock` documents the fresh-
+     install state. Applying it is a no-op (FromJSON sees its own
+     defaults), but it makes the no-profile case visible and lets
+     `pasclaw profile diff stock low-token` work cleanly (Stage D
+     follow-up). Keep this in lockstep with TConfig.Create -- a
+     drift between the two is what the test-config-profile suite's
+     stock cross-check catches. *)
+  Profile_Stock: string =
+    '{' +
+    '"_description":"Stock TConfig.Create defaults. Documents the ' +
+    'fresh-install state explicitly so `profile show stock` reveals ' +
+    'what `pasclaw agent` does with no --profile / PASCLAW_PROFILE / ' +
+    'config.json profile field set.",' +
+    '"vault_tools_enabled":true,' +
+    '"web_fetch_enabled":true,' +
+    '"vector_search_enabled":true,' +
+    '"render_markdown":true,' +
+    '"promptware_enabled":true,' +
+    '"condense_reversible":false,' +
+    '"tool_output_cap":0,' +
+    '"orient_task_aware":false,' +
+    '"stats_collection_enabled":false,' +
+    '"checkpoints_enabled":false,' +
+    '"self_improving_skills":{' +
+      '"self_manage":false,' +
+      '"progressive_disclosure":false,' +
+      '"auto_approve":false,' +
+      '"distiller":{"enabled":false}' +
+    '},' +
+    '"auto_router":{"enabled":false},' +
+    '"prompt_cache":{"enabled":true},' +
+    '"sandbox":{' +
+      '"restrict_to_workspace":false,' +
+      '"shell_deny_enabled":true,' +
+      '"block_private_networks":true,' +
+      '"allow_read_outside_workspace":false' +
+    '}' +
+    '}';
+
 type
   TBuiltin = record
     Name:        string;
@@ -219,12 +263,13 @@ type
 
 function Builtins: TBuiltinArray;
 begin
-  SetLength(Result, 5);
-  Result[0].Name := 'baseline';   Result[0].Body := Profile_Baseline;
-  Result[1].Name := 'low-token';  Result[1].Body := Profile_LowToken;
-  Result[2].Name := 'security';   Result[2].Body := Profile_Security;
-  Result[3].Name := 'max-build';  Result[3].Body := Profile_MaxBuild;
-  Result[4].Name := 'all-on';     Result[4].Body := Profile_AllOn;
+  SetLength(Result, 6);
+  Result[0].Name := 'stock';      Result[0].Body := Profile_Stock;
+  Result[1].Name := 'baseline';   Result[1].Body := Profile_Baseline;
+  Result[2].Name := 'low-token';  Result[2].Body := Profile_LowToken;
+  Result[3].Name := 'security';   Result[3].Body := Profile_Security;
+  Result[4].Name := 'max-build';  Result[4].Body := Profile_MaxBuild;
+  Result[5].Name := 'all-on';     Result[5].Body := Profile_AllOn;
 end;
 
 function ExtractDescription(const Body: string): string;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -646,6 +646,15 @@ type
     (* Agent-authored / self-improving skills. All sub-switches
        default off -- see TSelfImprovingSkillsConfig. *)
     SelfImprovingSkills:  TSelfImprovingSkillsConfig;
+    (* Persisted profile selection (PR #291). Written by
+       `pasclaw profile use <name>`, read by LoadConfig as the third-
+       level fallback selector (after --profile and PASCLAW_PROFILE).
+       Round-trips through FromJSON / ToJSON so SaveConfig from any
+       config-mutating command (auth login, model set, /v1/config PUT,
+       ...) preserves the operator's choice instead of dropping it on
+       the next read -- Codex P2 on the original PR. Empty = no
+       persisted profile. *)
+    Profile:              string;
     constructor Create;
     function  ToJSON: string;
     procedure FromJSON(const S: string);
@@ -886,6 +895,7 @@ begin
   SelfImprovingSkills.Distiller.Enabled      := False;
   SelfImprovingSkills.Distiller.MinToolCalls := 5;
   SelfImprovingSkills.Distiller.Model        := '';
+  Profile := '';   { PR #291: empty == no persisted profile selection }
   VectorSearchEnabled  := True;  { on by default; onboarding asks (default Y) -- see TConfig comment }
   AnthropicServerTools.WebSearch        := False;
   AnthropicServerTools.WebSearchMaxUses := 0;
@@ -985,6 +995,11 @@ begin
   try
     Root.PutStr('default_provider', DefaultProvider);
     Root.PutStr('default_model',    DefaultModel);
+    { PR #291: persisted profile selection. Emit only when non-empty
+      so a no-profile install stays tidy. SaveConfig from any
+      config-mutating command preserves this verbatim. }
+    if Profile <> '' then
+      Root.PutStr('profile', Profile);
     if Length(Fallbacks) > 0 then
     begin
       FallbacksArr := TJsonArray.Create;
@@ -1337,6 +1352,7 @@ begin
   try
     DefaultProvider := Root.GetStr('default_provider', DefaultProvider);
     DefaultModel    := Root.GetStr('default_model',    DefaultModel);
+    Profile         := Root.GetStr('profile',          Profile);   { PR #291 }
     if Root.Has('fallbacks') then
     begin
       Arr := Root.ChildArray('fallbacks');
@@ -1790,11 +1806,14 @@ var
   Path, S, ProfileName, PErr, B: string;
   Bodies: TProfileBodyArray;
   i: Integer;
+  HasConfigFile: Boolean;
 begin
   Result := TConfig.Create;
   Path := GetConfigPath;
+  S := '';
+  HasConfigFile := FileExists(Path);
   try
-    if FileExists(Path) then
+    if HasConfigFile then
     begin
       S := ReadFileText(Path);
       (* Resolve ${VAR_NAME} markers BEFORE FromJSON parses. Lets
@@ -1804,44 +1823,50 @@ begin
          leave the literal marker in place so config-back-from-disk
          diagnostics still show which variable didn't resolve. *)
       S := ExpandEnvVarsInJSON(S);
+    end;
 
-      (* Profile resolution (PR #291). Selection precedence:
-           1. ProfileOverride (CLI --profile)
-           2. PASCLAW_PROFILE env var
-           3. "profile" field in config.json
-           4. None
-         When a profile name resolves, apply the ancestor chain + the
-         profile body via TConfig.FromJSON BEFORE the operator's own
-         config.json -- so explicit user fields win. FromJSON is
-         merge-style (every GetX call defaults to the current TConfig
-         value), so multiple applies layer cleanly. *)
-      ProfileName := ProfileOverride;
-      if ProfileName = '' then
-        ProfileName := GetEnvironmentVariable('PASCLAW_PROFILE');
-      if ProfileName = '' then
-        ProfileName := ExtractProfileField(S);
-      if ProfileName <> '' then
+    (* Profile resolution (PR #291). Selection precedence:
+         1. ProfileOverride (CLI --profile)
+         2. PASCLAW_PROFILE env var
+         3. "profile" field in config.json (when one exists)
+         4. None
+       Lives OUTSIDE the FileExists guard so a fresh deploy that has
+       no config.json yet still honours --profile / PASCLAW_PROFILE
+       (Codex P2 on PR #291). When a profile name resolves, apply
+       the ancestor chain + the profile body via TConfig.FromJSON
+       BEFORE the operator's own config.json -- so explicit user
+       fields win. FromJSON is merge-style (every GetX call defaults
+       to the current TConfig value), so multiple applies layer
+       cleanly. *)
+    ProfileName := ProfileOverride;
+    if ProfileName = '' then
+      ProfileName := GetEnvironmentVariable('PASCLAW_PROFILE');
+    if (ProfileName = '') and HasConfigFile then
+      ProfileName := ExtractProfileField(S);
+    if ProfileName <> '' then
+    begin
+      if ResolveProfileBodies(GetHome, ProfileName, Bodies, PErr) then
       begin
-        if ResolveProfileBodies(GetHome, ProfileName, Bodies, PErr) then
+        for i := 0 to High(Bodies) do
         begin
-          for i := 0 to High(Bodies) do
-          begin
-            B := ExpandEnvVarsInJSON(Bodies[i]);
-            try
-              Result.FromJSON(B);
-            except
-              on E: Exception do
-                LogWarn('config: profile "%s" layer %d apply failed: %s',
-                        [ProfileName, i, E.Message]);
-            end;
+          B := ExpandEnvVarsInJSON(Bodies[i]);
+          try
+            Result.FromJSON(B);
+          except
+            on E: Exception do
+              LogWarn('config: profile "%s" layer %d apply failed: %s',
+                      [ProfileName, i, E.Message]);
           end;
-          LogInfo('config: profile "%s" applied (%d layer(s))',
-                  [ProfileName, Length(Bodies)]);
-        end
-        else
-          LogWarn('config: %s -- using defaults + config.json only', [PErr]);
-      end;
+        end;
+        LogInfo('config: profile "%s" applied (%d layer(s))',
+                [ProfileName, Length(Bodies)]);
+      end
+      else
+        LogWarn('config: %s -- using defaults + config.json only', [PErr]);
+    end;
 
+    if HasConfigFile then
+    begin
       try
         Result.FromJSON(S);
       except

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -653,7 +653,19 @@ type
 
 function GetHome: string;
 function GetConfigPath: string;
-function LoadConfig: TConfig;
+function LoadConfig: TConfig; overload;
+
+(* Profile-aware overload (PR #291). When ProfileOverride is non-empty,
+   apply the named profile (and its _inherits ancestors) BEFORE the
+   operator's config.json. Empty string -> selection precedence:
+     1. PASCLAW_PROFILE env var
+     2. "profile" field inside config.json
+     3. None -- behave exactly like LoadConfig() does today.
+   Profile fields layer on top of TConfig.Create defaults; the
+   operator's config.json fields layer on top of the profile so
+   explicit config-json choices always win. See PasClaw.Config.Profile
+   for the catalogue and inheritance semantics. *)
+function LoadConfig(const ProfileOverride: string): TConfig; overload;
 procedure SaveConfig(C: TConfig);
 
 const
@@ -772,6 +784,8 @@ uses
   StrUtils,                   { IndexStr -- shell_backend enum parsing }
   PasClaw.Utils,
   PasClaw.JSON,
+  PasClaw.Config.Profile,     { ResolveProfileBodies / ExtractProfileField -- PR #291 }
+  PasClaw.Logger,             { LogWarn / LogInfo on the profile-apply path }
   PasClaw.Promptware,         { LoadConfig propagates promptware_enabled --
                                 see the comment inside LoadConfig }
   PasClaw.Tools.OutputCache,  { LoadConfig propagates condense_reversible
@@ -1767,8 +1781,15 @@ begin
 end;
 
 function LoadConfig: TConfig;
+begin
+  Result := LoadConfig('');
+end;
+
+function LoadConfig(const ProfileOverride: string): TConfig;
 var
-  Path, S: string;
+  Path, S, ProfileName, PErr, B: string;
+  Bodies: TProfileBodyArray;
+  i: Integer;
 begin
   Result := TConfig.Create;
   Path := GetConfigPath;
@@ -1783,6 +1804,44 @@ begin
          leave the literal marker in place so config-back-from-disk
          diagnostics still show which variable didn't resolve. *)
       S := ExpandEnvVarsInJSON(S);
+
+      (* Profile resolution (PR #291). Selection precedence:
+           1. ProfileOverride (CLI --profile)
+           2. PASCLAW_PROFILE env var
+           3. "profile" field in config.json
+           4. None
+         When a profile name resolves, apply the ancestor chain + the
+         profile body via TConfig.FromJSON BEFORE the operator's own
+         config.json -- so explicit user fields win. FromJSON is
+         merge-style (every GetX call defaults to the current TConfig
+         value), so multiple applies layer cleanly. *)
+      ProfileName := ProfileOverride;
+      if ProfileName = '' then
+        ProfileName := GetEnvironmentVariable('PASCLAW_PROFILE');
+      if ProfileName = '' then
+        ProfileName := ExtractProfileField(S);
+      if ProfileName <> '' then
+      begin
+        if ResolveProfileBodies(GetHome, ProfileName, Bodies, PErr) then
+        begin
+          for i := 0 to High(Bodies) do
+          begin
+            B := ExpandEnvVarsInJSON(Bodies[i]);
+            try
+              Result.FromJSON(B);
+            except
+              on E: Exception do
+                LogWarn('config: profile "%s" layer %d apply failed: %s',
+                        [ProfileName, i, E.Message]);
+            end;
+          end;
+          LogInfo('config: profile "%s" applied (%d layer(s))',
+                  [ProfileName, Length(Bodies)]);
+        end
+        else
+          LogWarn('config: %s -- using defaults + config.json only', [PErr]);
+      end;
+
       try
         Result.FromJSON(S);
       except

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -219,6 +219,98 @@ begin
   end;
 end;
 
+(* Codex P2 #1: --profile / PASCLAW_PROFILE must work even when
+   config.json doesn't exist. *)
+procedure TestProfileWithoutConfigFile;
+var
+  CfgPath: string;
+  C: TConfig;
+begin
+  CfgPath := JoinPath(Home, 'config.json');
+  if FileExists(CfgPath) then DeleteFile(CfgPath);
+  AssertTrue(not FileExists(CfgPath), 'config.json removed before test');
+
+  C := LoadConfig('low-token');
+  try
+    AssertTrue(C.CondenseReversible, 'profile applied without config.json');
+    AssertTrue(C.ToolOutputCap = 8192, 'tool_output_cap set from profile alone');
+  finally
+    C.Free;
+  end;
+end;
+
+(* Codex P2 #2: SaveConfig must preserve the persisted profile field
+   so mutating commands (auth login, model set, ...) don't drop it. *)
+procedure TestSaveConfigPreservesProfile;
+var
+  C, C2: TConfig;
+  CfgPath: string;
+begin
+  CfgPath := JoinPath(Home, 'config.json');
+  WriteFileText(CfgPath, '{}');
+
+  { Stamp "profile": "low-token" via the TConfig field + SaveConfig
+    (same path `pasclaw profile use` writes through). }
+  C := LoadConfig('');
+  try
+    C.Profile := 'low-token';
+    SaveConfig(C);
+  finally
+    C.Free;
+  end;
+
+  { Simulate a config-mutating command: load, edit something
+    unrelated, save again. The profile field must survive. }
+  C := LoadConfig('');
+  try
+    AssertEqS(C.Profile, 'low-token', 'persisted profile read back');
+    C.DefaultModel := 'claude-opus-4-7';
+    SaveConfig(C);
+  finally
+    C.Free;
+  end;
+
+  { Final load: profile is still there. }
+  C2 := LoadConfig('');
+  try
+    AssertEqS(C2.Profile, 'low-token', 'profile survives SaveConfig');
+    AssertEqS(C2.DefaultModel, 'claude-opus-4-7', 'unrelated edit persisted');
+    AssertTrue(C2.CondenseReversible,
+               'profile actually applied on the persisted-field path');
+  finally
+    C2.Free;
+  end;
+end;
+
+(* Codex P2 #3: a user file at $HOME/profiles/low-token.json whose
+   _inherits contains "low-token" should resolve to (built-in low-token
+   layer, then user's overrides) -- not a cycle error. *)
+procedure TestSelfShadowInherit;
+var
+  ProfilesDir, UserFile: string;
+  Bodies: TProfileBodyArray;
+  Err: string;
+begin
+  ProfilesDir := JoinPath(Home, 'profiles');
+  EnsureDir(ProfilesDir);
+  UserFile := JoinPath(ProfilesDir, 'low-token.json');
+  WriteFileText(UserFile,
+    '{"_description":"USER fork of low-token, smaller cap",' +
+    '"_inherits":["low-token"],' +
+    '"tool_output_cap":4096}');
+  try
+    AssertTrue(ResolveProfileBodies(Home, 'low-token', Bodies, Err),
+               'self-shadow resolves: ' + Err);
+    AssertEqI(Length(Bodies), 2, 'two layers: built-in then user override');
+    AssertTrue(Pos('"_description":"Minimise tokens', Bodies[0]) > 0,
+               'first layer is the built-in low-token');
+    AssertTrue(Pos('USER fork of low-token', Bodies[1]) > 0,
+               'second layer is the user file');
+  finally
+    DeleteFile(UserFile);
+  end;
+end;
+
 begin
   { PASCLAW_HOME is set by the Makefile target before launching --
     fpc doesn't ship fpSetenv on every supported version and setting
@@ -241,6 +333,9 @@ begin
     TestExtractProfileField;
     TestLoadConfigAppliesProfile;
     TestLoadConfigInheritsChain;
+    TestProfileWithoutConfigFile;
+    TestSaveConfigPreservesProfile;
+    TestSelfShadowInherit;
     WriteLn('ok - config profile tests passed');
   finally
     try RemoveDir(JoinPath(Home, 'profiles')); except end;

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -1,0 +1,250 @@
+program config_profile_tests;
+(*
+  PR #291: configuration profile machinery.
+
+  Coverage:
+    - Built-in catalogue: ListAvailableProfiles returns the five
+      built-ins, each with a non-empty description.
+    - LookupProfile + ResolveProfileBodies handle the base case,
+      inheritance, and the error paths (unknown name, cycle).
+    - max-build inherits low-token; both layers come back in the
+      right order (parent first, child last).
+    - User profile at $PASCLAW_HOME/profiles/<name>.json shadows a
+      built-in with the same name.
+    - ExtractProfileField pulls the "profile" key out of a config.json
+      blob; returns '' on absent / malformed input.
+    - End-to-end LoadConfig(name) applies the profile fields, and an
+      operator config.json value wins over the profile value.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Config.Profile,
+  PasClaw.Utils;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertEqS(const Got, Want, Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")'); end;
+
+procedure AssertEqI(Got, Want: Integer; const Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got ' + IntToStr(Got) + ', want ' + IntToStr(Want) + ')'); end;
+
+var
+  Home: string;
+
+procedure TestCatalogue;
+var
+  Profiles: TProfileSpecArray;
+  i: Integer;
+  HaveBaseline, HaveLowToken, HaveSecurity, HaveMaxBuild, HaveAllOn: Boolean;
+begin
+  Profiles := ListAvailableProfiles(Home);
+  AssertTrue(Length(Profiles) >= 5, 'at least five built-ins');
+  HaveBaseline := False; HaveLowToken := False; HaveSecurity := False;
+  HaveMaxBuild := False; HaveAllOn := False;
+  for i := 0 to High(Profiles) do
+  begin
+    AssertTrue(Profiles[i].Description <> '', 'profile "' + Profiles[i].Name + '" has a description');
+    if Profiles[i].Name = 'baseline'  then HaveBaseline  := True;
+    if Profiles[i].Name = 'low-token' then HaveLowToken  := True;
+    if Profiles[i].Name = 'security'  then HaveSecurity  := True;
+    if Profiles[i].Name = 'max-build' then HaveMaxBuild  := True;
+    if Profiles[i].Name = 'all-on'    then HaveAllOn     := True;
+  end;
+  AssertTrue(HaveBaseline, 'baseline present');
+  AssertTrue(HaveLowToken, 'low-token present');
+  AssertTrue(HaveSecurity, 'security present');
+  AssertTrue(HaveMaxBuild, 'max-build present');
+  AssertTrue(HaveAllOn,    'all-on present');
+  AssertTrue(IsBuiltinProfile('baseline'), 'baseline is built-in');
+  AssertTrue(not IsBuiltinProfile('not-a-real-one'), 'unknown is not built-in');
+end;
+
+procedure TestResolveSingleLayer;
+var
+  Bodies: TProfileBodyArray;
+  Err: string;
+begin
+  AssertTrue(ResolveProfileBodies(Home, 'low-token', Bodies, Err),
+             'resolve low-token: ' + Err);
+  AssertEqI(Length(Bodies), 1, 'low-token has one layer');
+  AssertTrue(Pos('"condense_reversible":true', Bodies[0]) > 0,
+             'low-token body contains condense_reversible');
+end;
+
+procedure TestResolveInherits;
+var
+  Bodies: TProfileBodyArray;
+  Err: string;
+begin
+  { max-build _inherits low-token. Resolution order is parent first,
+    so Bodies[0] should be low-token and Bodies[1] should be max-build. }
+  AssertTrue(ResolveProfileBodies(Home, 'max-build', Bodies, Err),
+             'resolve max-build: ' + Err);
+  AssertEqI(Length(Bodies), 2, 'max-build has two layers');
+  AssertTrue(Pos('"_description":"Minimise tokens', Bodies[0]) > 0,
+             'first layer is low-token (the parent)');
+  AssertTrue(Pos('"_description":"Best settings', Bodies[1]) > 0,
+             'second layer is max-build itself');
+
+  { all-on _inherits max-build, which itself _inherits low-token.
+    So three layers in transitive order: low-token, max-build, all-on. }
+  AssertTrue(ResolveProfileBodies(Home, 'all-on', Bodies, Err),
+             'resolve all-on: ' + Err);
+  AssertEqI(Length(Bodies), 3, 'all-on resolves three layers');
+end;
+
+procedure TestUnknownProfile;
+var
+  Bodies: TProfileBodyArray;
+  Err: string;
+begin
+  AssertTrue(not ResolveProfileBodies(Home, 'not-a-real-one', Bodies, Err),
+             'unknown profile rejected');
+  AssertTrue(Pos('not found', Err) > 0, 'error message mentions not found');
+end;
+
+procedure TestUserProfileShadowsBuiltin;
+var
+  Bodies: TProfileBodyArray;
+  Err, ProfilesDir: string;
+  Spec: TProfileSpec;
+  Body: string;
+begin
+  ProfilesDir := JoinPath(Home, 'profiles');
+  EnsureDir(ProfilesDir);
+  { Write a user "low-token" that sets a distinctive field so we can
+    confirm it WINS over the built-in. }
+  WriteFileText(JoinPath(ProfilesDir, 'low-token.json'),
+    '{"_description":"USER override low-token","tool_output_cap":4242}');
+  try
+    AssertTrue(LookupProfile(Home, 'low-token', Spec, Body),
+               'lookup low-token after user shadow');
+    AssertTrue(Pos('USER override', Body) > 0, 'user body wins');
+    AssertEqS(Spec.Source, JoinPath(ProfilesDir, 'low-token.json'),
+              'source is the user file path');
+  finally
+    DeleteFile(JoinPath(ProfilesDir, 'low-token.json'));
+  end;
+end;
+
+procedure TestExtractProfileField;
+begin
+  AssertEqS(ExtractProfileField('{"profile":"low-token"}'),
+            'low-token', 'extract profile field');
+  AssertEqS(ExtractProfileField('{"other":"x"}'),
+            '', 'absent returns empty');
+  AssertEqS(ExtractProfileField(''), '', 'empty body returns empty');
+  AssertEqS(ExtractProfileField('not-json'), '', 'malformed returns empty');
+end;
+
+procedure TestLoadConfigAppliesProfile;
+var
+  CfgPath: string;
+  C: TConfig;
+begin
+  { Write a config.json with NO profile field and ONE explicit
+    override: condense_reversible=false (matches the post-PR-#289
+    default). Then call LoadConfig with --profile low-token. The
+    profile sets condense_reversible=true, tool_output_cap=8192.
+    The config.json has no condense_reversible field (since it
+    matches the default and our ToJSON suppresses it). After load:
+      tool_output_cap should be 8192 (profile value, no override)
+      orient_task_aware should be True (profile set, no override)
+    Then write an explicit operator value and prove it wins. }
+  CfgPath := JoinPath(Home, 'config.json');
+
+  { Case 1: profile only, no operator overrides. }
+  WriteFileText(CfgPath, '{}');
+  C := LoadConfig('low-token');
+  try
+    AssertTrue(C.CondenseReversible, 'profile sets CondenseReversible');
+    AssertTrue(C.ToolOutputCap = 8192, 'profile sets ToolOutputCap=8192');
+    AssertTrue(C.OrientTaskAware, 'profile sets OrientTaskAware');
+  finally
+    C.Free;
+  end;
+
+  { Case 2: operator config.json wins over profile. }
+  WriteFileText(CfgPath, '{"tool_output_cap":2048}');
+  C := LoadConfig('low-token');
+  try
+    AssertTrue(C.CondenseReversible, 'profile still applies (no override)');
+    if C.ToolOutputCap <> 2048 then
+      Fail_('operator wins over profile (got cap=' + IntToStr(C.ToolOutputCap) + ', want 2048)');
+  finally
+    C.Free;
+  end;
+
+  { Case 3: config.json "profile" field is honoured when no CLI flag. }
+  WriteFileText(CfgPath, '{"profile":"low-token"}');
+  C := LoadConfig('');
+  try
+    AssertTrue(C.CondenseReversible, 'config.json "profile" field is read');
+    AssertTrue(C.ToolOutputCap = 8192, 'config.json profile applies');
+  finally
+    C.Free;
+  end;
+end;
+
+procedure TestLoadConfigInheritsChain;
+var
+  CfgPath: string;
+  C: TConfig;
+begin
+  CfgPath := JoinPath(Home, 'config.json');
+  WriteFileText(CfgPath, '{}');
+  C := LoadConfig('max-build');
+  try
+    { max-build inherits low-token, then overrides tool_output_cap to 16384. }
+    AssertTrue(C.ToolOutputCap = 16384, 'max-build override wins over parent');
+    AssertTrue(C.OrientTaskAware, 'low-token field inherited through max-build');
+    AssertTrue(C.WebFetchEnabled, 'max-build sets WebFetchEnabled');
+    AssertTrue(C.SelfImprovingSkills.SelfManage,
+               'max-build sets self_manage on top of progressive_disclosure from parent');
+    AssertTrue(C.SelfImprovingSkills.ProgressiveDisclosure,
+               'progressive_disclosure inherited from low-token');
+  finally
+    C.Free;
+  end;
+end;
+
+begin
+  { PASCLAW_HOME is set by the Makefile target before launching --
+    fpc doesn't ship fpSetenv on every supported version and setting
+    the env from Pascal mid-process is unreliable across libc/FPC
+    runtime boundaries. Read it back here. }
+  Home := GetEnvironmentVariable('PASCLAW_HOME');
+  if Home = '' then
+  begin
+    WriteLn('FAIL: test must be invoked with PASCLAW_HOME set ' +
+            '(see Makefile target test-config-profile)');
+    Halt(1);
+  end;
+  EnsureDir(Home);
+  try
+    TestCatalogue;
+    TestResolveSingleLayer;
+    TestResolveInherits;
+    TestUnknownProfile;
+    TestUserProfileShadowsBuiltin;
+    TestExtractProfileField;
+    TestLoadConfigAppliesProfile;
+    TestLoadConfigInheritsChain;
+    WriteLn('ok - config profile tests passed');
+  finally
+    try RemoveDir(JoinPath(Home, 'profiles')); except end;
+    try DeleteFile(JoinPath(Home, 'config.json')); except end;
+    try RemoveDir(Home); except end;
+  end;
+end.

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -46,28 +46,82 @@ procedure TestCatalogue;
 var
   Profiles: TProfileSpecArray;
   i: Integer;
-  HaveBaseline, HaveLowToken, HaveSecurity, HaveMaxBuild, HaveAllOn: Boolean;
+  HaveStock, HaveBaseline, HaveLowToken, HaveSecurity, HaveMaxBuild, HaveAllOn: Boolean;
 begin
   Profiles := ListAvailableProfiles(Home);
-  AssertTrue(Length(Profiles) >= 5, 'at least five built-ins');
-  HaveBaseline := False; HaveLowToken := False; HaveSecurity := False;
-  HaveMaxBuild := False; HaveAllOn := False;
+  AssertTrue(Length(Profiles) >= 6, 'at least six built-ins');
+  HaveStock := False; HaveBaseline := False; HaveLowToken := False;
+  HaveSecurity := False; HaveMaxBuild := False; HaveAllOn := False;
   for i := 0 to High(Profiles) do
   begin
     AssertTrue(Profiles[i].Description <> '', 'profile "' + Profiles[i].Name + '" has a description');
+    if Profiles[i].Name = 'stock'     then HaveStock     := True;
     if Profiles[i].Name = 'baseline'  then HaveBaseline  := True;
     if Profiles[i].Name = 'low-token' then HaveLowToken  := True;
     if Profiles[i].Name = 'security'  then HaveSecurity  := True;
     if Profiles[i].Name = 'max-build' then HaveMaxBuild  := True;
     if Profiles[i].Name = 'all-on'    then HaveAllOn     := True;
   end;
+  AssertTrue(HaveStock,    'stock present');
   AssertTrue(HaveBaseline, 'baseline present');
   AssertTrue(HaveLowToken, 'low-token present');
   AssertTrue(HaveSecurity, 'security present');
   AssertTrue(HaveMaxBuild, 'max-build present');
   AssertTrue(HaveAllOn,    'all-on present');
+  AssertTrue(IsBuiltinProfile('stock'),    'stock is built-in');
   AssertTrue(IsBuiltinProfile('baseline'), 'baseline is built-in');
   AssertTrue(not IsBuiltinProfile('not-a-real-one'), 'unknown is not built-in');
+end;
+
+(* PR #291 follow-up: `stock` mirrors TConfig.Create defaults so
+   applying it is a no-op. The drift test: load a fresh TConfig, snap
+   the relevant booleans/ints, then apply `stock`, then compare. They
+   must match -- a divergence means the stock profile and
+   TConfig.Create have drifted. *)
+procedure TestStockMatchesDefaults;
+var
+  Fresh, Stocked: TConfig;
+begin
+  Fresh   := TConfig.Create;
+  Stocked := LoadConfig('stock');
+  try
+    AssertTrue(Fresh.VaultToolsEnabled    = Stocked.VaultToolsEnabled,    'stock: vault_tools_enabled');
+    AssertTrue(Fresh.WebFetchEnabled      = Stocked.WebFetchEnabled,      'stock: web_fetch_enabled');
+    AssertTrue(Fresh.VectorSearchEnabled  = Stocked.VectorSearchEnabled,  'stock: vector_search_enabled');
+    AssertTrue(Fresh.RenderMarkdown       = Stocked.RenderMarkdown,       'stock: render_markdown');
+    AssertTrue(Fresh.PromptwareEnabled    = Stocked.PromptwareEnabled,    'stock: promptware_enabled');
+    AssertTrue(Fresh.CondenseReversible   = Stocked.CondenseReversible,   'stock: condense_reversible');
+    AssertTrue(Fresh.ToolOutputCap        = Stocked.ToolOutputCap,        'stock: tool_output_cap');
+    AssertTrue(Fresh.OrientTaskAware      = Stocked.OrientTaskAware,      'stock: orient_task_aware');
+    AssertTrue(Fresh.StatsCollectionEnabled = Stocked.StatsCollectionEnabled, 'stock: stats_collection_enabled');
+    AssertTrue(Fresh.CheckpointsEnabled   = Stocked.CheckpointsEnabled,   'stock: checkpoints_enabled');
+    AssertTrue(Fresh.SelfImprovingSkills.SelfManage =
+               Stocked.SelfImprovingSkills.SelfManage,
+               'stock: self_improving_skills.self_manage');
+    AssertTrue(Fresh.SelfImprovingSkills.ProgressiveDisclosure =
+               Stocked.SelfImprovingSkills.ProgressiveDisclosure,
+               'stock: self_improving_skills.progressive_disclosure');
+    AssertTrue(Fresh.SelfImprovingSkills.AutoApprove =
+               Stocked.SelfImprovingSkills.AutoApprove,
+               'stock: self_improving_skills.auto_approve');
+    AssertTrue(Fresh.SelfImprovingSkills.Distiller.Enabled =
+               Stocked.SelfImprovingSkills.Distiller.Enabled,
+               'stock: self_improving_skills.distiller.enabled');
+    AssertTrue(Fresh.AutoRouter.Enabled   = Stocked.AutoRouter.Enabled,   'stock: auto_router.enabled');
+    AssertTrue(Fresh.PromptCache.Enabled  = Stocked.PromptCache.Enabled,  'stock: prompt_cache.enabled');
+    AssertTrue(Fresh.Sandbox.RestrictToWorkspace =
+               Stocked.Sandbox.RestrictToWorkspace,
+               'stock: sandbox.restrict_to_workspace');
+    AssertTrue(Fresh.Sandbox.ShellDenyEnabled =
+               Stocked.Sandbox.ShellDenyEnabled,
+               'stock: sandbox.shell_deny_enabled');
+    AssertTrue(Fresh.Sandbox.BlockPrivateNetworks =
+               Stocked.Sandbox.BlockPrivateNetworks,
+               'stock: sandbox.block_private_networks');
+  finally
+    Stocked.Free;
+    Fresh.Free;
+  end;
 end;
 
 procedure TestResolveSingleLayer;
@@ -326,6 +380,7 @@ begin
   EnsureDir(Home);
   try
     TestCatalogue;
+    TestStockMatchesDefaults;
     TestResolveSingleLayer;
     TestResolveInherits;
     TestUnknownProfile;


### PR DESCRIPTION
## Summary

Adds configuration profiles — Stages A + B + the foundation of C from the prior planning thread. A **profile** is a small JSON patch merged into `TConfig` *before* `config.json` is applied. Five built-ins ship, operators can drop more at `$PASCLAW_HOME/profiles/<name>.json`.

This unlocks the comparison you actually asked about: `pasclaw agent --profile baseline -m "task"` vs `pasclaw agent --profile max-build -m "task"`, with everything you've shipped on one side and nothing on the other.

## The five built-ins

| Profile | What it flips on |
|---|---|
| **`baseline`** | Everything off. A/B reference — *"how does pasclaw behave with no features enabled?"* |
| **`low-token`** | Condenser, output cap 8 KB, MEMORY task-aware slicing, prompt cache, progressive skill disclosure, auto-router. |
| **`security`** | Workspace restriction + shell deny + private-network block, promptware scan, no `web_fetch` / vault, agent-authored skills stage for approval. |
| **`max-build`** | `_inherits: ["low-token"]` plus `web_fetch`, vault, vector search, checkpoints, stats, 16 KB cap, 1 h prompt cache, all four self-improving-skill switches. |
| **`all-on`** | `_inherits: ["max-build"]`. Every boolean knob flipped on. Surface-area testing only. |

## Selection precedence (highest wins)

1. `pasclaw <cmd> --profile <name>` — per-invocation.
2. `PASCLAW_PROFILE=<name>` env var — process scope.
3. `"profile": "<name>"` field in `config.json` — persistent default (write via `pasclaw profile use <name>`).
4. None — `TConfig.Create` defaults flow straight through.

## Layering

`TConfig.Create` defaults → profile (with `_inherits` chain) → operator `config.json`. Each layer is applied via `FromJSON`, which is **merge-style** (every `GetX` call defaults to the current `TConfig` value), so unset fields preserve the lower layer and set fields override. **The operator's explicit `config.json` always wins**, so you can pick `max-build` and still pin one field your own way.

`_inherits` is a list — ancestors apply first in declared order, then the current profile. Cycles rejected, depth capped at 4. Meta keys (`_description` / `_inherits` / `_name`) stay in the body because `FromJSON` ignores unknown keys, which lets `pasclaw profile show` reuse the same blob.

## User shadow

A file at `$PASCLAW_HOME/profiles/<name>.json` with the same name as a built-in **wins**, mirroring the skills loader's convention. Useful for forking a built-in:

```json
{
  "_description": "low-token but with a smaller cap",
  "_inherits": ["low-token"],
  "tool_output_cap": 4096
}
```

## CLI

```sh
pasclaw profile list                 # built-ins + $PASCLAW_HOME/profiles/
pasclaw profile show low-token       # print resolved body
pasclaw profile show max-build       # shows two layers: low-token, then max-build
pasclaw profile use security         # write "profile": "security" into config.json

pasclaw agent --profile baseline -m "task X"   # per-run override
PASCLAW_PROFILE=max-build pasclaw agent ...    # process-scope override
```

`--profile <name>` is wired into all four CLI surfaces: `agent`, `tui`, `gateway`, `serve`.

## Files

- `src/pkg/config/PasClaw.Config.Profile.pas` — `TProfileSpec`, `ListAvailableProfiles`, `LookupProfile`, `ResolveProfileBodies` (recursive `_inherits` resolver + cycle guard), `ExtractProfileField`, the five built-in JSON blobs embedded as Pascal string constants
- `src/pkg/config/PasClaw.Config.pas` — new `LoadConfig(ProfileOverride: string)` overload; the parameterless `LoadConfig` delegates so every existing caller still works
- `src/cmd/PasClaw.Cmd.Profile.pas` — `pasclaw profile {list, show, use}` subcommand
- `src/cmd/PasClaw.Cmd.Root.pas` — register the subcommand
- `src/cmd/PasClaw.Cmd.{Agent,TUI,Gateway,Serve}.pas` — `--profile <name>` flag, threaded into `LoadConfig`

## Test plan

- [x] `make test-config-profile` — new test (`src/tests/config_profile_tests.pas`):
  - catalogue contains all five built-ins, each with a non-empty description
  - `LookupProfile` + `ResolveProfileBodies` handle base case, `_inherits`, unknown name, and parent-first ordering
  - `max-build` resolves to two layers (low-token then max-build), `all-on` to three (low-token → max-build → all-on)
  - user-shadow: `$PASCLAW_HOME/profiles/<name>.json` wins over a built-in with the same name
  - `ExtractProfileField`: present / absent / malformed / empty body
  - **End-to-end `LoadConfig`**: profile fields apply; an operator `config.json` value wins over the profile; the `config.json` "profile" field is honoured when no CLI flag is set
  - `max-build` round-trip: `tool_output_cap=16384` (override wins over the parent's 8192), `orient_task_aware` inherited from low-token, `progressive_disclosure` inherited, `self_manage` set by max-build
- [x] `make clean && make` — full FPC 3.2.2 build clean
- [x] Regression: `test-config-secret-merge`, `test-config-env-subst`, `test-plan-build-mode`, `test-loop-shaping-defaults` all green
- [x] Live CLI: `pasclaw profile list` shows all five; `profile show` prints layers; `profile use security` writes `{"profile":"security"}` into `config.json`; unknown names return a clean `✗ profile "X" not found`; `agent --profile low-token` logs `[info] config: profile "low-token" applied (1 layer(s))`

The test uses `PASCLAW_HOME` via the Makefile target wrapper (`mktemp -d` + `trap rm`) so it touches no real state.

## Docs

`docs/configuration.md` gains a "Profiles" section covering the five built-ins, precedence, layering, the CLI commands, and the user-shadow pattern.

## Out of scope (separate PRs)

- `pasclaw profile diff <a> <b>` — field-level differences
- `pasclaw profile bench --task ... --profiles ...` — the A/B test harness against a fixed task

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_