### PR TITLE
cmd/profile: declare TStringArray locally to keep dcc64 happy

### DIFF
--- a/src/cmd/PasClaw.Cmd.Profile.pas
+++ b/src/cmd/PasClaw.Cmd.Profile.pas
@@ -423,6 +423,15 @@ type
   end;
   TBenchAggArray = array of TBenchAgg;
 
+  (* dcc64 E2003 fix: FPC accepted the bare `array of string` return
+     type via name-equivalence with a TStringArray declared somewhere
+     reachable through the uses chain, but Delphi requires the
+     identifier be in scope locally. Declare it here so the two
+     compilers agree without dragging an unrelated unit into the
+     uses block. Same idiom PasClaw.Tools.Registry / PasClaw.Tools.
+     Shell.Filters / MVCFramework.Console.pas use. *)
+  TStringArray = array of string;
+
 (* Split "a,b,c" into ['a','b','c'], trimming each entry. *)
 function SplitCSV(const S: string): TStringArray;
 var


### PR DESCRIPTION
## Summary

Fixes a dcc64 (Delphi) compile error introduced in PR #292:

```
[dcc64 Error] PasClaw.Cmd.Profile.pas(427): E2003 Undeclared identifier: 'TStringArray'
```

FPC accepted the bare `array of string` return type on `SplitCSV` via name-equivalence with a `TStringArray` declared somewhere reachable through the `uses` chain (e.g. `PasClaw.Tools.Registry`); Delphi requires the identifier to be in scope locally. The fix is a local type declaration in the implementation's `type` block right before `SplitCSV`, matching the idiom used in `PasClaw.Tools.Registry`, `PasClaw.Tools.Shell.Filters`, and `vendor/MVCFramework.Console.pas`.

## Fix

```pascal
  TBenchAggArray = array of TBenchAgg;

  (* dcc64 E2003 fix: ... *)
  TStringArray = array of string;

(* Split "a,b,c" into ['a','b','c'], trimming each entry. *)
function SplitCSV(const S: string): TStringArray;
```

No behavioural change — both the `SplitCSV` return type and the `DoBench` local var (`Profiles: TStringArray`) now reference this one identifier.

## Test plan

- [x] `make` — FPC build clean
- [x] `make test-delphi-build` — pasclaw's existing dcc64-path test stays green
- [x] No behavioural change; the affected lines compile under both toolchains

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_