### PR TITLE
skills_manage: drop empty string from `kind` enum (Gemini 400)

### DIFF
--- a/src/pkg/skills/PasClaw.Skills.Manage.pas
+++ b/src/pkg/skills/PasClaw.Skills.Manage.pas
@@ -579,7 +579,18 @@ const
     '"name":{"type":"string","description":"skill name (lowercase, digits, - _)"},' +
     '"content":{"type":"string","description":"full SKILL.md (frontmatter + body) for create/edit"},' +
     '"description":{"type":"string"},' +
-    '"kind":{"type":"string","enum":["","shell","prompt"]},' +
+    (* Gemini rejects empty strings in enum arrays with "enum[0]: cannot
+       be empty" -- so the historical {"enum":["","shell","prompt"]}
+       shape that used "" to signal "knowledge-only skill" broke any
+       deploy that registered skills_manage against a Gemini model
+       (max-build profile + Gemini provider was the reported repro).
+       Drop the empty-string member; absent / missing `kind` already
+       means knowledge-only (the assembler at line ~336 skips writing
+       the `kind:` frontmatter line when GetStr('kind','') returns
+       empty), so this is a schema cleanup, not a behaviour change. *)
+    '"kind":{"type":"string","enum":["shell","prompt"],' +
+      '"description":"omit for knowledge-only skills (markdown body only); ' +
+      '\"shell\" or \"prompt\" registers a callable skill_<name> tool"},' +
     '"shell":{"type":"string"},"prompt":{"type":"string"},"schema":{"type":"string"},' +
     '"body":{"type":"string","description":"markdown body when not passing full content"},' +
     '"old_string":{"type":"string","description":"patch: unique text to replace"},' +


### PR DESCRIPTION
## Summary

Live error on a max-build deploy talking to Gemini:

```
gemini error 400: GenerateContentRequest.tools[0].function_declarations[15]
.parameters.properties[kind].enum[0]: cannot be empty
```

Gemini's `GenerateContent` endpoint validates every tool's JSON schema and refuses any `"enum": [...]` that contains an empty string. PR #288's `skills_manage` schema used `""` as the sentinel for "knowledge-only skill" (no callable shell / prompt registered):

```json
"kind": {"type": "string", "enum": ["", "shell", "prompt"]}
```

This works on Anthropic / OpenAI / Mistral but trips Gemini's stricter validator on the **first** tool call — so any operator who enabled `self_improving_skills.self_manage` (which `max-build` profile flips on) **and** points at a Gemini model gets a 400 on every chat request.

## Fix

Drop `""` from the enum so it's just `["shell", "prompt"]`. The handler already treats absent / missing `kind` as knowledge-only — `AssembleSKILLMD` only emits the `kind:` frontmatter line when `GetStr('kind', '') <> ''` — so this is a schema cleanup, not a behaviour change. The new description string spells out the omit-for-knowledge-only semantic so the model knows the contract from the tool spec directly.

```pascal
'"kind":{"type":"string","enum":["shell","prompt"],' +
  '"description":"omit for knowledge-only skills (markdown body only); ' +
  '\"shell\" or \"prompt\" registers a callable skill_<name> tool"},'
```

## Test plan

- [x] FPC build clean
- [x] `make test-self-improving-skills` passes — the test exercises a knowledge-only skill (no `kind` passed) and confirms the SKILL.md round-trips correctly
- [x] Audited rest of `src/pkg/` for other `enum: [""...]` / `enum: ['',...]` patterns — none. This was the only one.
- [ ] Re-test on the affected max-build + Gemini deploy after merge

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_