### PR TITLE
providers: support tool_choice force-a-specific-tool (named function) form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -255,6 +255,12 @@ test-openai-server-tools: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/openai_server_tools_tests.pas -o$(BUILDDIR)/openai_server_tools_tests
 	@$(BUILDDIR)/openai_server_tools_tests
+
+# tool_choice keyword + force-a-specific-tool forms (OpenAI + Anthropic).
+test-tool-choice: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/tool_choice_tests.pas -o$(BUILDDIR)/tool_choice_tests
+	@$(BUILDDIR)/tool_choice_tests
 
 # PasClaw.CliUI Print/PrintLn helpers — link + UTF-8 byte round-trip.
 test-println-helper: | $(BUILDDIR)
@@ -654,4 +660,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -261,6 +261,12 @@ test-tool-choice: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/tool_choice_tests.pas -o$(BUILDDIR)/tool_choice_tests
 	@$(BUILDDIR)/tool_choice_tests
+
+# /v1/responses tool_choice parse (flat top-level name + nested function.name).
+test-responses-tool-choice: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/responses_tool_choice_tests.pas -o$(BUILDDIR)/responses_tool_choice_tests
+	@$(BUILDDIR)/responses_tool_choice_tests
 
 # PasClaw.CliUI Print/PrintLn helpers — link + UTF-8 byte round-trip.
 test-println-helper: | $(BUILDDIR)
@@ -660,4 +666,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -4531,6 +4531,8 @@ var
                                     the bucket-stats accumulation. }
   ParamsObj: TJsonObject;
   ParamsRaw, ToolKind, ToolDisplayName: string;
+  TCObjIn, FnObjIn: TJsonObject;   { object-form tool_choice parse }
+  ForcedFn: string;
   EmptyToolCalls: array of TToolCall;
   FcCallIdVal, FcSignatureVal: string;
 
@@ -4910,21 +4912,43 @@ begin
       else if Req.Has('max_tokens') then
         PassthroughOpts.MaxTokens := Req.GetInt('max_tokens', PassthroughOpts.MaxTokens);
 
-      (* tool_choice forwarding. Accept the three string forms every
-        provider understands ("auto", "none", "required"). Anything
-        else -- most notably the object form
-        {"type":"function","function":{"name":"..."}}, which would
-        need per-provider translation -- is logged at debug and
-        dropped; the provider's default behaviour (typically
-        "auto" when tools are present) applies. *)
+      (* tool_choice forwarding. Two shapes:
+           - the string forms "auto" / "none" / "required";
+           - the object form {"type":"function","function":{"name":"..."}}
+             that forces a specific tool. We carry the forced name in
+             PassthroughOpts.ToolChoice (any non-keyword value is a tool
+             name by convention); each provider emits its own native shape
+             (OpenAI {"type":"function",...}, Anthropic {"type":"tool",...}).
+         Anything we can't interpret is logged at debug and dropped, so the
+         provider's default (typically "auto" with tools present) applies. *)
       if Req.Has('tool_choice') then
       begin
         ToolKind := LowerCase(Trim(Req.GetStr('tool_choice', '')));
         if (ToolKind = 'auto') or (ToolKind = 'none') or (ToolKind = 'required') then
           PassthroughOpts.ToolChoice := ToolKind
         else
-          LogDebug('responses: dropping tool_choice (only string forms ' +
-                   'auto/none/required supported; object form is a follow-up)', []);
+        begin
+          ForcedFn := '';
+          TCObjIn := Req.ChildObject('tool_choice');
+          if TCObjIn <> nil then
+          try
+            FnObjIn := TCObjIn.ChildObject('function');
+            if FnObjIn <> nil then
+            try
+              ForcedFn := Trim(FnObjIn.GetStr('name', ''));
+            finally
+              FnObjIn.Free;
+            end;
+          finally
+            TCObjIn.Free;
+          end;
+          if ForcedFn <> '' then
+            PassthroughOpts.ToolChoice := ForcedFn
+          else
+            LogDebug('responses: dropping unrecognised tool_choice ' +
+                     '(want auto/none/required or {"type":"function",' +
+                     '"function":{"name":...}})', []);
+        end;
       end;
 
       LogDebug('responses: passthrough %d msg(s), %d tool def(s), tool_choice=%s -> %s',

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -45,6 +45,7 @@ uses
   SysUtils, Classes, SyncObjs,
   IdHTTPServer, IdContext, IdCustomHTTPServer, IdGlobal, IdSocketHandle,
   PasClaw.Config,
+  PasClaw.JSON,            { TJsonObject -- ResolveResponsesToolChoice param }
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
   PasClaw.Tools.Registry,
@@ -277,13 +278,20 @@ procedure AccumulateGatewayStatsRaw(const Cfg: TConfig;
    slip past the lexical compare. Exposed for tests. *)
 function IsRestrictedFsPath(const Path: string): Boolean;
 
+(* Resolve a /v1/responses request's tool_choice into the
+   TChatOptions.ToolChoice convention: '' when absent/unrecognised (the
+   provider default applies), 'auto'/'none'/'required', or a tool NAME to
+   force. Accepts the keyword string form and both object forms that name
+   a function -- the Responses API's flat top-level "name", and the
+   Chat-Completions nested function.name. Exposed for tests. *)
+function ResolveResponsesToolChoice(Req: TJsonObject): string;
+
 implementation
 
 uses
   DateUtils,
   {$IFDEF FPC}{$IFDEF UNIX}BaseUnix,{$ENDIF}{$ENDIF}
   IdTCPConnection,
-  PasClaw.JSON,
   PasClaw.Logger,
   PasClaw.Utils,
   PasClaw.Crypto.HMAC,        { Base64ToBytes -- decode binary KB uploads }
@@ -3673,6 +3681,40 @@ begin
   end;
 end;
 
+function ResolveResponsesToolChoice(Req: TJsonObject): string;
+var
+  ToolKind: string;
+  TCObj, FnObj: TJsonObject;
+begin
+  Result := '';
+  if (Req = nil) or not Req.Has('tool_choice') then Exit;
+  { Keyword string form: "auto" / "none" / "required". GetStr returns ''
+    when tool_choice is an object, so this falls through to the object
+    parse below for the force-a-function shapes. }
+  ToolKind := LowerCase(Trim(Req.GetStr('tool_choice', '')));
+  if (ToolKind = 'auto') or (ToolKind = 'none') or (ToolKind = 'required') then
+    Exit(ToolKind);
+  TCObj := Req.ChildObject('tool_choice');
+  if TCObj = nil then Exit;
+  try
+    { Responses API: flat top-level name. Then fall back to the
+      Chat-Completions nested function.name. }
+    Result := Trim(TCObj.GetStr('name', ''));
+    if Result = '' then
+    begin
+      FnObj := TCObj.ChildObject('function');
+      if FnObj <> nil then
+      try
+        Result := Trim(FnObj.GetStr('name', ''));
+      finally
+        FnObj.Free;
+      end;
+    end;
+  finally
+    TCObj.Free;
+  end;
+end;
+
 function BuildResponsesObject(const Id, Model, Status, Content: string;
                                const ToolCalls: array of TToolCall;
                                const ToolsRawJSON: string;
@@ -4531,8 +4573,6 @@ var
                                     the bucket-stats accumulation. }
   ParamsObj: TJsonObject;
   ParamsRaw, ToolKind, ToolDisplayName: string;
-  TCObjIn, FnObjIn: TJsonObject;   { object-form tool_choice parse }
-  ForcedFn: string;
   EmptyToolCalls: array of TToolCall;
   FcCallIdVal, FcSignatureVal: string;
 
@@ -4912,53 +4952,20 @@ begin
       else if Req.Has('max_tokens') then
         PassthroughOpts.MaxTokens := Req.GetInt('max_tokens', PassthroughOpts.MaxTokens);
 
-      (* tool_choice forwarding. Two shapes:
-           - the string forms "auto" / "none" / "required";
-           - the object form {"type":"function","function":{"name":"..."}}
-             that forces a specific tool. We carry the forced name in
-             PassthroughOpts.ToolChoice (any non-keyword value is a tool
-             name by convention); each provider emits its own native shape
-             (OpenAI {"type":"function",...}, Anthropic {"type":"tool",...}).
-         Anything we can't interpret is logged at debug and dropped, so the
-         provider's default (typically "auto" with tools present) applies. *)
+      (* tool_choice forwarding. ResolveResponsesToolChoice handles the
+         keyword string forms ("auto"/"none"/"required") AND the two
+         force-a-function object shapes (Responses flat top-level name;
+         Chat-Completions nested function.name), returning the forced tool
+         NAME by convention. Each provider then emits its own native shape.
+         '' means absent or unrecognised -> drop and let the provider
+         default (typically "auto" with tools present) apply. *)
       if Req.Has('tool_choice') then
       begin
-        ToolKind := LowerCase(Trim(Req.GetStr('tool_choice', '')));
-        if (ToolKind = 'auto') or (ToolKind = 'none') or (ToolKind = 'required') then
-          PassthroughOpts.ToolChoice := ToolKind
-        else
-        begin
-          ForcedFn := '';
-          TCObjIn := Req.ChildObject('tool_choice');
-          if TCObjIn <> nil then
-          try
-            (* Two object shapes force a specific function:
-                 Responses API : type=function with a TOP-LEVEL name (the
-                                 same shape tools[] entries use);
-                 Chat Compl.   : type=function with a NESTED function.name.
-               Prefer the top-level name (the standard for /v1/responses),
-               then fall back to the nested Chat-Completions form. *)
-            ForcedFn := Trim(TCObjIn.GetStr('name', ''));
-            if ForcedFn = '' then
-            begin
-              FnObjIn := TCObjIn.ChildObject('function');
-              if FnObjIn <> nil then
-              try
-                ForcedFn := Trim(FnObjIn.GetStr('name', ''));
-              finally
-                FnObjIn.Free;
-              end;
-            end;
-          finally
-            TCObjIn.Free;
-          end;
-          if ForcedFn <> '' then
-            PassthroughOpts.ToolChoice := ForcedFn
-          else
-            LogDebug('responses: dropping unrecognised tool_choice ' +
-                     '(want auto/none/required, {"type":"function","name":...}, ' +
-                     'or {"type":"function","function":{"name":...}})', []);
-        end;
+        PassthroughOpts.ToolChoice := ResolveResponsesToolChoice(Req);
+        if PassthroughOpts.ToolChoice = '' then
+          LogDebug('responses: dropping unrecognised tool_choice ' +
+                   '(want auto/none/required, type=function with a name, ' +
+                   'or the nested function.name form)', []);
       end;
 
       LogDebug('responses: passthrough %d msg(s), %d tool def(s), tool_choice=%s -> %s',

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -4932,12 +4932,22 @@ begin
           TCObjIn := Req.ChildObject('tool_choice');
           if TCObjIn <> nil then
           try
-            FnObjIn := TCObjIn.ChildObject('function');
-            if FnObjIn <> nil then
-            try
-              ForcedFn := Trim(FnObjIn.GetStr('name', ''));
-            finally
-              FnObjIn.Free;
+            (* Two object shapes force a specific function:
+                 Responses API : type=function with a TOP-LEVEL name (the
+                                 same shape tools[] entries use);
+                 Chat Compl.   : type=function with a NESTED function.name.
+               Prefer the top-level name (the standard for /v1/responses),
+               then fall back to the nested Chat-Completions form. *)
+            ForcedFn := Trim(TCObjIn.GetStr('name', ''));
+            if ForcedFn = '' then
+            begin
+              FnObjIn := TCObjIn.ChildObject('function');
+              if FnObjIn <> nil then
+              try
+                ForcedFn := Trim(FnObjIn.GetStr('name', ''));
+              finally
+                FnObjIn.Free;
+              end;
             end;
           finally
             TCObjIn.Free;
@@ -4946,8 +4956,8 @@ begin
             PassthroughOpts.ToolChoice := ForcedFn
           else
             LogDebug('responses: dropping unrecognised tool_choice ' +
-                     '(want auto/none/required or {"type":"function",' +
-                     '"function":{"name":...}})', []);
+                     '(want auto/none/required, {"type":"function","name":...}, ' +
+                     'or {"type":"function","function":{"name":...}})', []);
         end;
       end;
 

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -382,7 +382,10 @@ begin
                                               because omitting the field with
                                               a non-empty tools array still
                                               lets the model call them)
-        Empty string means "don't emit; let provider default apply". *)
+          <tool name> -> {"type":"tool","name":<name>}  (force that tool)
+        Empty string means "don't emit; let provider default apply". By
+        convention any non-keyword, non-empty value is a tool name to
+        force -- see TChatOptions.ToolChoice. *)
       if (Options.ToolChoice = 'auto')
          or (Options.ToolChoice = 'required')
          or (Options.ToolChoice = 'none') then
@@ -394,6 +397,13 @@ begin
           ToolObj.PutStr('type', 'any')
         else
           ToolObj.PutStr('type', 'none');
+        Root.PutObject('tool_choice', ToolObj);
+      end
+      else if Options.ToolChoice <> '' then
+      begin
+        ToolObj := TJsonObject.Create;
+        ToolObj.PutStr('type', 'tool');
+        ToolObj.PutStr('name', Options.ToolChoice);
         Root.PutObject('tool_choice', ToolObj);
       end;
     end;

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -168,7 +168,7 @@ function BuildOAIRequest(const Messages: array of TMessage;
                          const Options:  TChatOptions;
                          const ServerTools: TOpenAIServerTools): string;
 var
-  Root, M, ToolObj, FObj, TCObj, EmptyParams, WSO: TJsonObject;
+  Root, M, ToolObj, FObj, TCObj, TCFnObj, EmptyParams, WSO: TJsonObject;
   MsgArr, ToolArr, TCArr: TJsonArray;
   i, j: Integer;
   Sys: string;
@@ -267,14 +267,26 @@ begin
       end;
       Root.PutArray('tools', ToolArr);
 
-      { tool_choice maps 1:1 to the OpenAI Chat Completions schema:
-          "auto" / "none" / "required" -- emitted as a string field.
-        Empty means "do not emit; provider default applies". The
-        function-by-name object form is not yet supported here;
-        TChatOptions.ToolChoice is a plain string. }
+      (* tool_choice maps to the OpenAI Chat Completions schema:
+           "auto" / "none" / "required" -- emitted as a string field;
+           a specific tool NAME -- emitted as the object form
+           {"type":"function","function":{"name":<name>}}.
+         Empty means "do not emit; provider default applies". By
+         convention any ToolChoice value that isn't one of the three
+         keywords (and isn't empty) is treated as a function name to
+         force -- see TChatOptions.ToolChoice. *)
       if (Options.ToolChoice = 'auto') or (Options.ToolChoice = 'none') or
          (Options.ToolChoice = 'required') then
-        Root.PutStr('tool_choice', Options.ToolChoice);
+        Root.PutStr('tool_choice', Options.ToolChoice)
+      else if Options.ToolChoice <> '' then
+      begin
+        TCObj := TJsonObject.Create;
+        TCFnObj := TJsonObject.Create;
+        TCFnObj.PutStr('name', Options.ToolChoice);
+        TCObj.PutStr('type', 'function');
+        TCObj.PutObject('function', TCFnObj);
+        Root.PutObject('tool_choice', TCObj);
+      end;
     end;
 
     Result := Root.ToJSON;

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -95,14 +95,19 @@ type
     Stream:        Boolean;
     SystemPrompt:  string;
     ThinkingLevel: string;   { "", "low", "medium", "high" }
-    ToolChoice:    string;   { "", "auto", "none", "required" -- the three forms
-                               every provider can represent. Empty means "do
-                               not emit the field"; the provider's own default
-                               (typically "auto" when tools are present) applies.
-                               Object-shaped tool_choice (force a specific
-                               function by name) is not currently supported by
-                               this field -- when a client sends one the
-                               gateway logs and drops it. }
+    ToolChoice:    string;   { Tool-selection control. Recognised values:
+                                 ""         -- do not emit; provider default
+                                               (typically "auto" with tools)
+                                 "auto"     -- model decides
+                                 "none"     -- must not call a tool
+                                 "required" -- must call some tool
+                                 <tool name> -- force that specific tool.
+                               Any non-empty value that isn't one of the three
+                               keywords is treated as a tool/function NAME to
+                               force; each provider emits its native object
+                               shape (OpenAI type=function with function.name,
+                               Anthropic type=tool with name). Gemini ignores
+                               tool_choice entirely. }
     (* Prompt caching. When CacheEnabled, the Anthropic builder tags
        the system prompt and the trailing tools-array entry with an
        ephemeral cache_control breakpoint; the OpenAI builder emits

--- a/src/tests/responses_tool_choice_tests.pas
+++ b/src/tests/responses_tool_choice_tests.pas
@@ -1,0 +1,70 @@
+program responses_tool_choice_tests;
+(*
+  Pins ResolveResponsesToolChoice -- the /v1/responses tool_choice parser.
+  Two parse bugs lived here (PR #297): the object form was dropped entirely,
+  then only the nested Chat-Completions function.name was read while the
+  Responses API actually forces a tool with a flat top-level "name". This
+  locks in both object shapes plus the keyword forms.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.JSON,
+  PasClaw.Gateway.Server;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+{ Parse JSON -> resolve tool_choice -> assert -> free. }
+procedure Check(const JSON, Want, Msg: string);
+var
+  Req: TJsonObject;
+  Got: string;
+begin
+  Req := TJsonObject.Parse(JSON);
+  if Req = nil then Fail_(Msg + ' (test JSON did not parse: ' + JSON + ')');
+  try
+    Got := ResolveResponsesToolChoice(Req);
+  finally
+    Req.Free;
+  end;
+  if Got <> Want then
+    Fail_(Msg + ' -- got "' + Got + '", want "' + Want + '" (json: ' + JSON + ')');
+end;
+
+begin
+  { Absent -> '' (caller leaves the provider default). }
+  Check('{}', '', 'absent tool_choice');
+
+  { Keyword string forms pass through (lower-cased). }
+  Check('{"tool_choice":"auto"}',     'auto',     'keyword auto');
+  Check('{"tool_choice":"none"}',     'none',     'keyword none');
+  Check('{"tool_choice":"required"}', 'required', 'keyword required');
+  Check('{"tool_choice":"AUTO"}',     'auto',     'keyword case-folded');
+
+  { A bare non-keyword string is not a valid tool_choice -> dropped. }
+  Check('{"tool_choice":"banana"}', '', 'bare non-keyword string dropped');
+
+  { Responses API force form: flat top-level name. }
+  Check('{"tool_choice":{"type":"function","name":"get_weather"}}',
+        'get_weather', 'responses flat top-level name');
+
+  { Chat-Completions force form: nested function.name. }
+  Check('{"tool_choice":{"type":"function","function":{"name":"get_weather"}}}',
+        'get_weather', 'chat-completions nested function.name');
+
+  { Top-level name wins when both are present. }
+  Check('{"tool_choice":{"type":"function","name":"top","function":{"name":"nested"}}}',
+        'top', 'top-level name preferred over nested');
+
+  { Object with no name anywhere -> dropped. }
+  Check('{"tool_choice":{"type":"function"}}', '', 'object without a name dropped');
+
+  WriteLn('responses_tool_choice_tests: OK');
+end.

--- a/src/tests/tool_choice_tests.pas
+++ b/src/tests/tool_choice_tests.pas
@@ -1,0 +1,93 @@
+program tool_choice_tests;
+(*
+  Pins tool_choice emission across the keyword forms AND the
+  force-a-specific-tool form. The gap this guards: the named-function
+  tool_choice ({"type":"function","function":{"name":...}}) used to be
+  dropped, so a client could not force a specific tool. By convention any
+  non-keyword ToolChoice value is a tool NAME; each provider emits its
+  native object shape (OpenAI type=function, Anthropic type=tool).
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.OpenAI,
+  PasClaw.Providers.Anthropic;
+
+procedure Fail_(const Msg, Body: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  WriteLn('--- body ---'); WriteLn(Body);
+  Halt(1);
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) = 0 then Fail_(Msg + ' (want: ' + Needle + ')', Haystack);
+end;
+
+procedure AssertMissing(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) > 0 then Fail_(Msg + ' (did NOT expect: ' + Needle + ')', Haystack);
+end;
+
+function OneUser: TMessageArray;
+begin
+  SetLength(Result, 1);
+  Result[0] := MakeMessage(mrUser, 'hi');
+end;
+
+function OneTool: TToolDefinitionArray;
+begin
+  SetLength(Result, 1);
+  Result[0].Name        := 'get_weather';
+  Result[0].Description := 'look up the weather';
+  Result[0].Schema      := '{"type":"object","properties":{}}';
+end;
+
+var
+  Opts: TChatOptions;
+  Body: string;
+begin
+  { ---- OpenAI ---- }
+  { keyword form stays a plain string (NB: the tools array always carries
+    "function", so we assert on the tool_choice VALUE specifically). }
+  Opts := DefaultChatOptions; Opts.ToolChoice := 'required';
+  Body := BuildOAIRequest(OneUser, OneTool, 'gpt-4o', Opts, NoOpenAIServerTools);
+  AssertContains(Body, '"tool_choice" : "required"', 'openai: required is the string form');
+  AssertMissing(Body, '"tool_choice" : {', 'openai: required is NOT the object form');
+
+  { named form -> object: type=function with function.name }
+  Opts := DefaultChatOptions; Opts.ToolChoice := 'get_weather';
+  Body := BuildOAIRequest(OneUser, OneTool, 'gpt-4o', Opts, NoOpenAIServerTools);
+  AssertContains(Body, '"tool_choice" : {', 'openai: named is the object form');
+  AssertContains(Body, 'get_weather',       'openai: named carries the function name');
+
+  { empty -> no tool_choice }
+  Opts := DefaultChatOptions; Opts.ToolChoice := '';
+  Body := BuildOAIRequest(OneUser, OneTool, 'gpt-4o', Opts, NoOpenAIServerTools);
+  AssertMissing(Body, '"tool_choice"', 'openai: empty omits tool_choice');
+
+  { ---- Anthropic ---- }
+  { keyword: required -> type=any }
+  Opts := DefaultChatOptions; Opts.ToolChoice := 'required';
+  Body := BuildRequest(OneUser, OneTool, 'claude-opus-4-7', Opts, NoAnthropicServerTools);
+  AssertContains(Body, '"tool_choice"', 'anthropic: required emits tool_choice');
+  AssertContains(Body, '"type" : "any"', 'anthropic: required maps to any');
+
+  { named -> object: type=tool with name }
+  Opts := DefaultChatOptions; Opts.ToolChoice := 'get_weather';
+  Body := BuildRequest(OneUser, OneTool, 'claude-opus-4-7', Opts, NoAnthropicServerTools);
+  AssertContains(Body, '"type" : "tool"', 'anthropic: named maps to type=tool');
+  AssertContains(Body, 'get_weather', 'anthropic: named carries the tool name');
+
+  { empty -> no tool_choice }
+  Opts := DefaultChatOptions; Opts.ToolChoice := '';
+  Body := BuildRequest(OneUser, OneTool, 'claude-opus-4-7', Opts, NoAnthropicServerTools);
+  AssertMissing(Body, '"tool_choice"', 'anthropic: empty omits tool_choice');
+
+  WriteLn('tool_choice_tests: OK');
+end.


### PR DESCRIPTION
## What
Adds support for the **force-a-specific-tool** form of `tool_choice` (OpenAI's `{"type":"function","function":{"name":...}}`). It needed *needed* doing — but the original "minor, just `OpenAI.pas`" framing was incomplete: the named form was dropped in **two** places, so a provider-only change would've been a no-op.

## Where it was dropped
1. **Gateway `/v1/responses` parse** — `Req.GetStr('tool_choice')` returns `''` for the object form, so it fell into the "drop + debug log" branch and never reached the provider.
2. **OpenAI request builder** — only emitted `auto`/`none`/`required`.

(Note: `/v1/chat/completions` doesn't forward `tool_choice` at all — it runs tools server-side — so this is scoped to the `/v1/responses` client-tools passthrough, which is where it matters.)

## The fix (end-to-end)
Convention: any non-empty `TChatOptions.ToolChoice` that isn't a keyword (`auto`/`none`/`required`) is a **tool name to force**. Each provider emits its own native shape:
- **Gateway:** parse the object-form `tool_choice`, extract `function.name`, carry it in `ToolChoice` (provider-agnostic) — frees the `ChildObject` wrappers correctly.
- **OpenAI builder:** `{"type":"function","function":{"name":<n>}}`.
- **Anthropic builder:** `{"type":"tool","name":<n>}` — included for parity, otherwise a forwarded name would silently fall back to `auto`.
- **Gemini:** unchanged (it ignores `tool_choice` entirely today — documented in the field comment).

`TChatOptions.ToolChoice`'s doc comment now spells out the full contract.

## Tests
New `tool_choice_tests` (in `make test`) pins, for both builders: keyword form stays a string / maps to `any`, the named form emits the object shape carrying the tool name, and empty omits the field. `make test-openai-server-tools` + `test-anthropic-server-tools` still pass; full binary builds clean.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_