### PR TITLE
build: pasclaw build cmd + cog-build/ predictor with workspace.zip handshake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -618,6 +618,15 @@ test-checkpoints-zpaq: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/checkpoints_zpaq_tests.pas -o$(BUILDDIR)/checkpoints_zpaq_tests
 	@$(BUILDDIR)/checkpoints_zpaq_tests
 
+# `pasclaw build` workspace.zip handshake: round-trips PackDirToZip +
+# ExtractZipToDir over text + binary + nested + exclusion-denylist
+# cases. The agent-loop / provider half of `pasclaw build` is covered
+# by the smoke target on a temp PASCLAW_HOME with a real provider.
+test-build-roundtrip: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/build_workspace_roundtrip_tests.pas -o$(BUILDDIR)/build_workspace_roundtrip_tests
+	@$(BUILDDIR)/build_workspace_roundtrip_tests
+
 # End-to-end undo/redo via the zpaq backend: spins a temp PASCLAW_HOME,
 # drives BeginTurn / SnapshotBeforeWrite / UndoTurns / RedoTurns, and
 # asserts the file contents and redo-stack semantics across the
@@ -707,4 +716,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/cog-build/README.md
+++ b/cog-build/README.md
@@ -1,0 +1,103 @@
+# PasClaw BUILD cog
+
+A Replicate [cog](https://github.com/replicate/cog) that exposes `pasclaw build` — multi-iteration agent runs with a `workspace.zip` handshake — for use against ephemeral cloud compute.
+
+Sibling to [`/cog/`](../cog/), which runs the simpler one-shot `pasclaw agent` flow. This one is for the "ship the whole brain back and forth" pattern: feed in a workspace.zip from a previous run, get a workspace.zip back containing everything the agent did (memory updates, knowledge-base writes, checkpoint history, source files written, …).
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `message` | str | — | The build task ("add X", "port Y to Z", …) |
+| `max_iters` | int | 50 | Tool-loop iteration budget |
+| `timeout_seconds` | int | 3600 | Subprocess timeout (Replicate's container ceiling applies on top) |
+| `workspace_in` | Path | None | Workspace.zip from a previous build. Cog handles both upload + URL via Path |
+| `workspace_in_url` | str | "" | Explicit URL — downloaded via [`pget`](https://github.com/replicate/pget) for parallelism. Wins over `workspace_in` when set. |
+| `openai_api_key` / `anthropic_api_key` / `gemini_api_key` / `groq_api_key` / `openrouter_api_key` / `deepseek_api_key` | str | "" | Provider creds — same shape as `/cog/`. |
+| `provider`, `model` | str | "" | Override which provider / model is used. Empty = first key wins. |
+
+## Outputs
+
+A pydantic `BaseModel`:
+
+```jsonc
+{
+  "workspace": "<Path to workspace_out.zip>",
+  "text":      "<model's final reply, same as `pasclaw agent -q`>"
+}
+```
+
+The `text` field lets the caller decide whether to feed the workspace back for another round. Typical control-loop:
+
+```python
+import replicate
+
+ws = None
+for step in range(20):
+    out = replicate.run(
+        "owner/pasclaw-build",
+        input={
+            "message": "implement issue #42",
+            "max_iters": 30,
+            "workspace_in_url": ws,        # None on the first call
+            "anthropic_api_key": KEY,
+        },
+    )
+    ws = out["workspace"]
+    print(out["text"])
+    if "DONE" in out["text"]:
+        break
+```
+
+## Workspace contents
+
+Everything under `$PASCLAW_HOME` ships back:
+
+```
+config.json
+workspace/
+├── memory/MEMORY.md           ← rules + scars carry forward
+├── kb.db                      ← knowledgebase
+├── kb-files/*                 ← uploaded reference docs (including binaries)
+├── sessions/<id>.json         ← chat history
+├── checkpoints/<id>/          ← zpaq-backed undo/redo journal
+│   ├── archive.zpaq
+│   └── index.json
+├── skills/                    ← installed skills
+└── AGENTS.md                  ← project rules (if present)
+```
+
+A small denylist (`pasclaw build` enforces) keeps surrounding-repo noise out:
+- `.git` directories at any depth
+- `.DS_Store`, `Thumbs.db`
+- `kb.db-journal` (SQLite WAL, regenerated)
+
+Everything else — tmp files, log dumps, kb-files binaries — does ship. The whole point of the handshake is "preserve the entire brain".
+
+## Size cap
+
+**4 GiB** input, enforced at both ends (Python + Pascal). Replicate's upload + container limits will catch this earlier in practice; the cap is there so a runaway caller fails fast with a clean error.
+
+## Why `pget` for the input?
+
+For large URL-backed workspaces (multi-hundred-MB checkpoint archives), cog's default Path-input fetch is single-stream. Replicate's [pget](https://github.com/replicate/pget) does parallel multi-connection downloads from S3-compatible storage — typically 3–5× faster. Use `workspace_in_url` (string) to opt in; `workspace_in` (Path) still works for upload-from-disk or smaller URLs that don't benefit from parallelism.
+
+## Build
+
+```sh
+cd cog-build/
+cog build -t pasclaw-build
+```
+
+Then push to Replicate as usual.
+
+## Run locally
+
+```sh
+cd cog-build/
+cog predict \
+  -i message="add a --version flag to the CLI" \
+  -i max_iters=30 \
+  -i anthropic_api_key=sk-ant-… \
+  -i workspace_in=@/tmp/prev_workspace.zip
+```

--- a/cog-build/README.md
+++ b/cog-build/README.md
@@ -54,7 +54,6 @@ for step in range(20):
 Everything under `$PASCLAW_HOME` ships back:
 
 ```
-config.json
 workspace/
 ├── memory/MEMORY.md           ← rules + scars carry forward
 ├── kb.db                      ← knowledgebase
@@ -73,6 +72,17 @@ A small denylist (`pasclaw build` enforces) keeps surrounding-repo noise out:
 - `kb.db-journal` (SQLite WAL, regenerated)
 
 Everything else — tmp files, log dumps, kb-files binaries — does ship. The whole point of the handshake is "preserve the entire brain".
+
+### What does NOT ship: `config.json` (API keys)
+
+`config.json` is deliberately kept **outside** `$PASCLAW_HOME` so it never ends up in `workspace.zip`:
+
+- The predictor writes it to a sibling scratch dir and sets `PASCLAW_CONFIG` so PasClaw finds it there.
+- API keys stay in the predict.py process scope.
+- A `workspace_in.zip` from a prior run can't clobber the fresh API keys this call was given.
+- The output `workspace.zip` is provider-agnostic — safe to log, share, or store anywhere the rest of the workspace already goes.
+
+Backward-compatible with every other `pasclaw` caller: when `PASCLAW_CONFIG` is unset (the normal case for CLI / TUI / gateway users), `GetConfigPath` falls back to `$PASCLAW_HOME/config.json` exactly as it did before.
 
 ## Size cap
 

--- a/cog-build/cog.yaml
+++ b/cog-build/cog.yaml
@@ -1,0 +1,79 @@
+# Configuration for Cog (replicate.com) -- PasClaw BUILD mode.
+#
+# Sibling to /cog/, which runs `pasclaw agent` one-shot for a single
+# response. This one runs `pasclaw build`: multi-iteration tool-using
+# loop, max-iters tunable, with a workspace.zip handshake so the
+# agent's memory / KB / checkpoints / project files survive between
+# calls on different ephemeral hosts.
+#
+# Layout:
+#   - cog-build/cog.yaml      : you're here. Builds the image with FPC,
+#                               PasClaw binary, OpenSSL 1.0.2 for Indy,
+#                               and `pget` for fast workspace.zip
+#                               downloads.
+#   - cog-build/predict.py    : the Predictor.
+#   - cog-build/requirements.txt : Python deps.
+#
+# For more info see https://github.com/replicate/cog/blob/main/docs/yaml.md
+
+build:
+  gpu: false
+  base_image: "debian:bookworm-slim"
+  system_packages:
+    # FPC + units used by the binary
+    - "fpc"
+    - "fp-units-db"
+    - "fp-units-misc"
+    - "lazarus-src"
+    - "libsqlite3-dev"
+    # generic build tooling
+    - "make"
+    - "git"
+    - "curl"
+    - "ca-certificates"
+    - "patchelf"
+    - "libsqlite3-0"
+    - "tzdata"
+    # zip CLI -- used as a fallback if Pascal-side zip-out hits an
+    # edge case; predict.py doesn't rely on it but keeps it around
+    # for debugging.
+    - "zip"
+    - "unzip"
+  python_version: "3.10"
+  python_requirements: "requirements.txt"
+  run:
+    # 1. Clone PasClaw + Indy
+    - git clone https://github.com/FMXExpress/PasClaw.git /src
+    - cd /src && make get-indy
+
+    # 2. Compile the PasClaw binary (FPC build = `cbZpaq` checkpoints
+    #    backend enabled automatically since the zpaq vendor is in-tree).
+    - cd /src && make LAZUTILS_DIR=/usr/lib/lazarus/2.2.6/components/lazutils
+
+    # 3. Runtime dir
+    - mkdir -p /opt/pasclaw
+    - cp /src/build/pasclaw /opt/pasclaw/pasclaw
+
+    # 4. OpenSSL 1.0.2 next to the binary (Indy's TLS path needs it)
+    - mkdir -p /openssl /tmp/x
+    - curl -fsSL --retry 3 --max-time 90 "https://snapshot.debian.org/archive/debian-archive/20240331T102506Z/debian-security/pool/updates/main/o/openssl1.0/libssl1.0.2_1.0.2u-1~deb9u7_amd64.deb" -o /tmp/libssl.deb
+    - dpkg-deb -x /tmp/libssl.deb /tmp/x
+    - cp /tmp/x/usr/lib/x86_64-linux-gnu/libssl.so.1.0.2 /opt/pasclaw/
+    - cp /tmp/x/usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.2 /opt/pasclaw/
+    - ln -sf libssl.so.1.0.2 /opt/pasclaw/libssl.so
+    - ln -sf libcrypto.so.1.0.2 /opt/pasclaw/libcrypto.so
+    - chmod +x /opt/pasclaw/pasclaw
+    - patchelf --set-rpath '$ORIGIN' /opt/pasclaw/pasclaw
+
+    # 5. Install `pget` for fast multi-connection downloads of the
+    #    input workspace.zip. Cog's default Path-input download path
+    #    is single-stream; pget parallelises which matters when
+    #    workspace.zip is multi-hundred-MB. See
+    #    https://github.com/replicate/pget for the project itself.
+    - curl -fsSL -o /usr/local/bin/pget https://github.com/replicate/pget/releases/latest/download/pget_linux_x86_64
+    - chmod +x /usr/local/bin/pget
+
+    # 6. Cleanup
+    - rm -rf /src /tmp/x /tmp/libssl.deb /openssl
+
+run: "predict.py:Predictor"

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -289,19 +289,31 @@ class Predictor(BasePredictor):
             os.makedirs(home_dir, exist_ok=True)
             out_zip_path = os.path.join(scratch, "workspace_out.zip")
 
-            # Pre-seed config.json inside the home dir BEFORE `pasclaw
-            # build` runs. If the input zip also carries one, the
-            # extraction will overwrite ours -- that's fine, the cog
-            # caller's intent ("use the workspace I sent") wins. But
-            # if there's no input zip we need a config so the agent
-            # has provider creds.
-            config_path = os.path.join(home_dir, "config.json")
+            # Write config.json OUTSIDE home_dir and point PasClaw at it
+            # via the PASCLAW_CONFIG env var (PasClaw.Config.GetConfigPath
+            # honours that override and falls back to $PASCLAW_HOME/
+            # config.json only when unset -- backward-compatible for every
+            # other caller).
+            #
+            # Why outside? Two reasons:
+            #   1. The output workspace.zip is everything under PASCLAW_HOME.
+            #      A config.json there would mean API keys bake into the zip
+            #      and travel back to the Replicate caller. Whatever they
+            #      do with the zip (store, share, log) becomes a key-leak
+            #      surface. Keeping config.json in `scratch/` keeps secrets
+            #      in the predict.py process scope.
+            #   2. workspace_in extraction unpacks into PASCLAW_HOME. A
+            #      config.json inside an old workspace zip would clobber
+            #      the fresh API keys this call was given -- silently
+            #      keeping the previous run's provider/model/auth.
+            config_path = os.path.join(scratch, "config.json")
             import json as _json
             with open(config_path, "w") as f:
                 _json.dump(config_data, f, indent=2)
 
             env = os.environ.copy()
-            env["PASCLAW_HOME"] = home_dir
+            env["PASCLAW_HOME"]   = home_dir
+            env["PASCLAW_CONFIG"] = config_path
 
             cmd = [
                 self.binary_path, "build",

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -1,0 +1,363 @@
+"""
+PasClaw BUILD cog: multi-iteration agent run with workspace.zip handshake.
+
+Inputs
+------
+  message          : str  -- the build task ("add a --foo flag", "port X to Y", ...)
+  max_iters        : int  -- tool-loop iteration budget (default 50)
+  timeout_seconds  : int  -- subprocess timeout (default 3600 = 1 h)
+  workspace_in     : Path -- optional zip from a previous build. Replicate
+                             materialises HTTP URLs and direct uploads via the
+                             Path type; large URL-backed inputs are fetched
+                             through pget for parallelism.
+  workspace_in_url : str  -- explicit URL form. When set, takes precedence
+                             over `workspace_in` and is downloaded with pget.
+                             Useful when the caller already has the file in
+                             cloud storage and wants the fastest fetch path.
+  provider, model, ... API keys -- same shape as the sibling /cog/ predictor.
+
+Outputs
+-------
+A pydantic BaseModel with two fields:
+  workspace : Path -- the new workspace.zip (full PASCLAW_HOME, includes
+                       memory/, sessions/, kb.db, checkpoints/<id>/archive.zpaq,
+                       skills/, plus whatever files the agent wrote into cwd).
+                       Caller passes this back as `workspace_in` next call to
+                       continue building on top of the prior state.
+  text      : str  -- the model's final reply, stdout-captured from
+                       `pasclaw build`. Same shape as `pasclaw agent -q`.
+                       Useful for deciding whether to feed the workspace
+                       back in for another build pass.
+
+Notes
+-----
+- Workspace cap: 4 GiB. Replicate timeouts the upload before that anyway,
+  but we fail fast with a clean error if a runaway caller hands us one.
+- Everything in PASCLAW_HOME ships back -- tmp/, logs, kb-files/*.bin --
+  because the point of the handshake is "ship the whole brain". The
+  pasclaw build command honors a small denylist (.git, .DS_Store,
+  Thumbs.db, kb.db-journal) to keep zip-build noise out.
+- `pget` is invoked for explicit URL inputs only; cog's Path handles
+  the regular upload + URL paths transparently.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from typing import Optional
+
+from cog import BasePredictor, BaseModel, Input, Path
+
+
+# 4 GiB. Mirror the Pascal-side cap in PasClaw.Cmd.Build's
+# PASCLAW_WORKSPACE_ZIP_CAP so both ends fail with the same message.
+WORKSPACE_ZIP_CAP_BYTES = 4 * 1024 * 1024 * 1024
+
+
+class Output(BaseModel):
+    workspace: Path
+    text: str
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        self.binary_path = "/opt/pasclaw/pasclaw"
+        if not os.path.exists(self.binary_path):
+            self.binary_path = "pasclaw"
+
+        # `pget` install verification -- non-fatal if absent so a host
+        # that opts out can still use the upload-via-cog path.
+        self.pget_path = shutil.which("pget") or "/usr/local/bin/pget"
+        if not os.path.exists(self.pget_path):
+            print(
+                f"Warning: pget not found at {self.pget_path}. "
+                "Explicit-URL workspace inputs will fall back to single-stream "
+                "download via urllib; multi-GB workspaces will be slow."
+            )
+            self.pget_path = None
+
+        try:
+            result = subprocess.run(
+                [self.binary_path, "version"],
+                capture_output=True, text=True, check=True,
+            )
+            print(f"PasClaw binary verified: {result.stdout.strip()}")
+        except Exception as e:
+            print(
+                f"Warning: failed to verify pasclaw binary at "
+                f"{self.binary_path}: {e}. Ensure it is built and on PATH."
+            )
+
+    # ------------------------------------------------------------------
+    # download / unzip helpers
+    # ------------------------------------------------------------------
+
+    def _download_via_pget(self, url: str, dest: str) -> None:
+        """Multi-connection download of a single URL to dest."""
+        if self.pget_path is None:
+            # Fallback: stream via urllib so the URL path still works
+            # without pget. Single-stream so it's slower but functional.
+            import urllib.request
+
+            with urllib.request.urlopen(url) as r, open(dest, "wb") as f:
+                shutil.copyfileobj(r, f)
+            return
+        subprocess.run(
+            [self.pget_path, url, dest], check=True, capture_output=True
+        )
+
+    def _resolve_workspace_in(
+        self,
+        workspace_in: Optional[Path],
+        workspace_in_url: str,
+        scratch_dir: str,
+    ) -> Optional[str]:
+        """Return a local path to the input zip, or None when no input was given.
+
+        Order of precedence (matches the cog convention where explicit URL
+        inputs beat the Path-typed input):
+          1. workspace_in_url (downloaded via pget)
+          2. workspace_in     (already materialised on disk by cog)
+        """
+        if workspace_in_url:
+            local = os.path.join(scratch_dir, "workspace_in.zip")
+            print(f"build: downloading workspace via pget: {workspace_in_url}")
+            self._download_via_pget(workspace_in_url, local)
+            return local
+        if workspace_in is not None:
+            # cog's Path is os.PathLike -- str() gives the local path.
+            return str(workspace_in)
+        return None
+
+    # ------------------------------------------------------------------
+    # main entry
+    # ------------------------------------------------------------------
+
+    def predict(
+        self,
+        message: str = Input(
+            description="Build task. The agent runs up to max_iters "
+            "tool-using iterations to satisfy it."
+        ),
+        max_iters: int = Input(
+            description="Tool-loop iteration budget. One iteration ~= one "
+            "model response (which may include multiple tool calls).",
+            default=50, ge=1, le=500,
+        ),
+        timeout_seconds: int = Input(
+            description="Subprocess timeout in seconds. Default 3600 = 1 h. "
+            "Set high for long horizon builds; Replicate enforces its own "
+            "container ceiling on top of this.",
+            default=3600, ge=30, le=24 * 3600,
+        ),
+        workspace_in: Path = Input(
+            description="Optional workspace.zip from a previous build. "
+            "Replicate handles both file-uploads and URL inputs through "
+            "this. For very large URL-backed workspaces, prefer "
+            "workspace_in_url to get parallel pget download.",
+            default=None,
+        ),
+        workspace_in_url: str = Input(
+            description="Optional explicit URL to a workspace.zip. When "
+            "set, downloaded via pget for parallelism; takes precedence "
+            "over workspace_in.",
+            default="",
+        ),
+        openai_api_key: str = Input(default="", description="Optional"),
+        anthropic_api_key: str = Input(default="", description="Optional"),
+        gemini_api_key: str = Input(default="", description="Optional"),
+        groq_api_key: str = Input(default="", description="Optional"),
+        openrouter_api_key: str = Input(default="", description="Optional"),
+        deepseek_api_key: str = Input(default="", description="Optional"),
+        provider: str = Input(
+            default="",
+            description="LLM provider (openai/anthropic/gemini/groq/openrouter/deepseek). "
+            "Empty = first configured key wins.",
+        ),
+        model: str = Input(
+            default="",
+            description="Override model id. Empty = provider's catalog default.",
+        ),
+    ) -> Output:
+        """
+        Run `pasclaw build` with the configured provider against the
+        unzipped workspace, then ship the resulting PASCLAW_HOME back
+        as workspace.zip alongside the model's final reply text.
+        """
+
+        # --- validate inputs ---
+        keys = {
+            "openai": openai_api_key,
+            "anthropic": anthropic_api_key,
+            "gemini": gemini_api_key,
+            "groq": groq_api_key,
+            "openrouter": openrouter_api_key,
+            "deepseek": deepseek_api_key,
+        }
+        available_providers = [p for p, k in keys.items() if k]
+        if not available_providers:
+            raise ValueError(
+                "No API keys provided -- supply at least one of "
+                "openai_api_key / anthropic_api_key / gemini_api_key / "
+                "groq_api_key / openrouter_api_key / deepseek_api_key."
+            )
+
+        selected_provider = provider.lower().strip() if provider else available_providers[0]
+        if selected_provider not in keys:
+            raise ValueError(
+                f"Unsupported provider '{selected_provider}'. "
+                f"Choose from: {list(keys.keys())}"
+            )
+        if not keys[selected_provider]:
+            raise ValueError(
+                f"Provider '{selected_provider}' selected but its API key is empty."
+            )
+
+        # Catalog defaults -- same shape as cog/predict.py
+        catalog_defaults = {
+            "openai":     {"kind": "openai",    "api_base": "https://api.openai.com",                 "model": "gpt-4o-mini"},
+            "anthropic":  {"kind": "anthropic", "api_base": "https://api.anthropic.com",              "model": "claude-opus-4-7"},
+            "gemini":     {"kind": "gemini",    "api_base": "https://generativelanguage.googleapis.com", "model": "gemini-3.5-flash"},
+            "groq":       {"kind": "openai",    "api_base": "https://api.groq.com/openai",            "model": "qwen-max"},
+            "openrouter": {"kind": "openai",    "api_base": "https://openrouter.ai/api",              "model": "gpt-4o-mini"},
+            "deepseek":   {"kind": "openai",    "api_base": "https://api.deepseek.com",               "model": "deepseek-chat"},
+        }
+
+        providers_list = []
+        for prov_name, api_key in keys.items():
+            if api_key:
+                spec = catalog_defaults.get(prov_name, {"kind": prov_name, "api_base": "", "model": ""})
+                prov_model = model if (prov_name == selected_provider and model) else spec["model"]
+                providers_list.append({
+                    "name": prov_name, "kind": spec["kind"],
+                    "api_base": spec["api_base"], "api_key": api_key,
+                    "model": prov_model,
+                })
+
+        default_model = model or catalog_defaults.get(selected_provider, {}).get("model", "")
+
+        config_data = {
+            "default_provider": selected_provider,
+            "default_model":    default_model,
+            "providers":        providers_list,
+            "render_markdown":  False,
+            "stats_collection_enabled": False,
+            "checkpoints_enabled": True,    # zpaq backend: /undo + /redo survive the zip round-trip
+            "sandbox": {
+                "restrict_to_workspace":      False,
+                "allow_read_outside_workspace": True,
+                "shell_deny_enabled":         True,
+                "block_private_networks":     False,
+                "allow_read_paths":           [],
+                "allow_write_paths":          [],
+                "custom_shell_deny":          [],
+            },
+        }
+
+        # --- workspace handshake setup ---
+
+        # Two scratch dirs: one for the (possibly pget-downloaded) input
+        # zip, one for the output zip. PASCLAW_HOME is created and
+        # managed by `pasclaw build` itself.
+        with tempfile.TemporaryDirectory(prefix="pasclaw_build_cog_") as scratch:
+
+            in_zip = self._resolve_workspace_in(
+                workspace_in, workspace_in_url, scratch
+            )
+
+            # Size cap check (mirrors the Pascal-side
+            # PASCLAW_WORKSPACE_ZIP_CAP). Replicate's upload+container
+            # limits would catch this too but we fail fast with a
+            # clean error message.
+            if in_zip is not None:
+                size = os.path.getsize(in_zip)
+                if size > WORKSPACE_ZIP_CAP_BYTES:
+                    raise ValueError(
+                        f"workspace_in is {size} bytes (> "
+                        f"{WORKSPACE_ZIP_CAP_BYTES} cap). Split the workspace "
+                        "by skill or session before sending."
+                    )
+                if not zipfile.is_zipfile(in_zip):
+                    raise ValueError(
+                        "workspace_in is not a valid zip file. "
+                        "Did the upload truncate?"
+                    )
+
+            home_dir = os.path.join(scratch, "home")
+            os.makedirs(home_dir, exist_ok=True)
+            out_zip_path = os.path.join(scratch, "workspace_out.zip")
+
+            # Pre-seed config.json inside the home dir BEFORE `pasclaw
+            # build` runs. If the input zip also carries one, the
+            # extraction will overwrite ours -- that's fine, the cog
+            # caller's intent ("use the workspace I sent") wins. But
+            # if there's no input zip we need a config so the agent
+            # has provider creds.
+            config_path = os.path.join(home_dir, "config.json")
+            import json as _json
+            with open(config_path, "w") as f:
+                _json.dump(config_data, f, indent=2)
+
+            env = os.environ.copy()
+            env["PASCLAW_HOME"] = home_dir
+
+            cmd = [
+                self.binary_path, "build",
+                "-d", message,
+                "--max-iters", str(max_iters),
+                "--home", home_dir,
+                "--workspace-out", out_zip_path,
+            ]
+            if in_zip is not None:
+                cmd += ["--workspace-in", in_zip]
+
+            print(
+                f"build: invoking {self.binary_path} build "
+                f"max_iters={max_iters} timeout={timeout_seconds}s "
+                f"provider={selected_provider} model={default_model} "
+                f"workspace_in={'yes' if in_zip else 'no'}"
+            )
+
+            try:
+                result = subprocess.run(
+                    cmd, env=env, capture_output=True, text=True,
+                    check=True, timeout=timeout_seconds,
+                )
+                text_out = result.stdout.strip()
+            except subprocess.CalledProcessError as e:
+                # Surface stdout (model's partial reply, if any) +
+                # stderr (PasClaw's diagnostic log lines) so the
+                # operator can debug from Replicate logs.
+                raise RuntimeError(
+                    "pasclaw build exited non-zero.\n"
+                    f"STDOUT:\n{e.stdout}\n"
+                    f"STDERR:\n{e.stderr}"
+                )
+            except subprocess.TimeoutExpired:
+                raise RuntimeError(
+                    f"pasclaw build timed out after {timeout_seconds}s. "
+                    "Re-run with a higher timeout_seconds, or split the "
+                    "build into smaller calls and re-feed workspace_in."
+                )
+
+            if not os.path.exists(out_zip_path):
+                raise RuntimeError(
+                    "pasclaw build did not produce workspace_out.zip "
+                    "(build flag missed? out path unwritable?)."
+                )
+
+            # Move the output zip to a path Replicate will keep alive
+            # past the TemporaryDirectory cleanup. cog's Output Path
+            # serialiser copies it out as the prediction completes.
+            persist = tempfile.NamedTemporaryFile(
+                suffix=".zip", delete=False, prefix="workspace_out_"
+            )
+            persist.close()
+            shutil.move(out_zip_path, persist.name)
+
+            return Output(
+                workspace=Path(persist.name),
+                text=text_out,
+            )

--- a/cog-build/requirements.txt
+++ b/cog-build/requirements.txt
@@ -1,0 +1,6 @@
+# PasClaw BUILD cog -- Python deps.
+#
+# Cog 0.13 brings the Output BaseModel + pget interop we rely on.
+# pget itself is a binary, installed via curl in cog.yaml `run:`,
+# not a pip package.
+cog>=0.13.0

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,6 +36,7 @@ Top-level commands are dispatched by `src/cmd/PasClaw.Cmd.Root.pas`. Run `pascla
 | [`export`](#export) | Render PasClaw state into agent-runtime rules files. |
 | [`init`](#init) | Scan cwd + ask the model for a starter `AGENTS.md` (one-shot, no tool loop). |
 | [`runbook`](#runbook) | Tool-driven variant of `init`: agent loop probes the repo via `execute_code`. |
+| [`build`](#build) | One-shot multi-iteration agent run with `workspace.zip` handshake. For cog / CI / ephemeral GPU runners. |
 | [`session`](#session) | List, show, delete, export saved sessions. |
 | [`resume`](#resume) | Alias: `agent --session <id>`. |
 | [`steer`](#steer) | Push a mid-loop follow-up into a running agent. |
@@ -330,6 +331,45 @@ pasclaw runbook --force         # overwrite an existing AGENTS.md
 ```
 
 Tool-driven variant of `init`. Spins the full agent loop with `execute_code` so the **model** runs the probe (`ls -la`, `cat Makefile`, parse package.json, `git log --oneline -10`, etc.) and writes the file via `fs_write`. Produces richer output than `init` because the model can chase whatever the project shape needs; takes longer and requires `shell_exec` to be allowed.
+
+## build
+
+```sh
+pasclaw build -d "implement the X feature" \
+              --max-iters 30 \
+              --workspace-in /tmp/prev.zip \
+              --workspace-out /tmp/next.zip \
+              --provider openai --model gpt-4o
+```
+
+One-shot multi-iteration agent run with an optional `workspace.zip` handshake, designed for **unattended use** in ephemeral compute (Replicate cog, CI runners, k8s Jobs, …). The cog at [`cog-build/`](../cog-build/) wraps this as a Replicate predictor.
+
+**Compared to `pasclaw agent`:**
+
+| | `agent` | `build` |
+|---|---|---|
+| Default `--max-iterations` | 8 (interactive — converges fast with operator feedback) | 50 (unattended — needs headroom to finish) |
+| Default output mode | interactive (TUI or REPL) | `-q` quiet (machine-friendly) |
+| Workspace handshake | no | yes — `--workspace-in <zip>` and `--workspace-out <zip>` round-trip the entire `$PASCLAW_HOME` |
+| `PASCLAW_HOME` | env var or `~/.pasclaw` | env, `--home`, or a fresh tempdir |
+
+**Flags `build` adds:**
+- `--workspace-in <zip>` — unpack into `$PASCLAW_HOME` first. Carries memory, KB, sessions, checkpoint archives, skills, and any project files from a previous run.
+- `--workspace-out <zip>` — repack `$PASCLAW_HOME` after the run, ready to feed back next call.
+- `--max-iters N` — defaults to 50.
+- `--cwd <dir>` — cwd for the model's `fs_write` / `execute_code`. Defaults to `$PASCLAW_HOME/workspace`.
+- `--home <dir>` — override `$PASCLAW_HOME` (otherwise: env var, otherwise: fresh tempdir).
+- `--keep-home` — don't clean up the tempdir on exit. For local debugging.
+
+**Flags forwarded as-is to `agent`:** `--provider`, `--model`, `--max-tokens`, `--thinking`, `--session`, `--profile`, `--mode {plan|build}`, `--no-tools`, `--no-mcp`, `--no-hashline`, `--system`.
+
+**Output:** the model's final reply on stdout (same as `pasclaw agent -q`), progress + `workspace.zip` size on stderr.
+
+**Input zip cap:** 4 GiB. Above that, fail fast with a clear error; split by session or skill.
+
+**Exclusions from the output zip:** `.git`, `.DS_Store`, `Thumbs.db`, `kb.db-journal` (transient SQLite WAL). Everything else — logs, tmp/, kb-files binaries — ships back, since the point of the handshake is "preserve the entire brain".
+
+See [`docs/checkpoints.md`](./checkpoints.md) for how the zpaq-backed `/undo` and `/redo` survive the round-trip, and [`cog-build/README.md`](../cog-build/README.md) for the matching Replicate predictor wiring.
 
 ## session
 

--- a/src/cmd/PasClaw.Cmd.Build.pas
+++ b/src/cmd/PasClaw.Cmd.Build.pas
@@ -1,0 +1,487 @@
+unit PasClaw.Cmd.Build;
+(*
+  PasClaw.Cmd.Build - one-shot multi-iteration build runs with an
+  optional workspace.zip handshake for shipping PASCLAW_HOME state
+  between ephemeral compute environments (Replicate cogs, k8s Jobs,
+  GitHub Actions runners, etc.).
+
+  This is a thin orchestration layer over `pasclaw agent`. The
+  agent already supports multi-turn tool-using loops via
+  --max-iterations; build just gives it a friendlier surface with
+  saner defaults for unattended runs (max-iters = 50, quiet output)
+  and adds two workspace-zip flags so the entire $PASCLAW_HOME
+  (memory, sessions, kb, checkpoints, skills, scars + the project
+  files the model just wrote) can round-trip through cloud storage.
+
+  Usage:
+
+    pasclaw build -d "<task>"
+                  [--max-iters N]                (default 50)
+                  [--workspace-in <zip>]         optional, unpacked
+                                                 into PASCLAW_HOME
+                                                 before the run
+                  [--workspace-out <zip>]        optional, written
+                                                 after the run
+                  [--cwd <dir>]                  cwd for fs_write
+                  [--home <dir>]                 override PASCLAW_HOME
+                                                 (defaults to env or a
+                                                 fresh tempdir)
+                  [--keep-home]                  do not delete the
+                                                 tempdir on exit;
+                                                 useful for local
+                                                 debugging
+                  ... forwarded agent flags (--provider, --model,
+                       --max-tokens, --thinking, --session, --mode,
+                       --profile, ...)
+
+  Output: the model's final reply text goes to stdout (same as
+  `pasclaw agent -q`), so callers piping through subprocess.run can
+  capture it verbatim. The workspace.zip (when --workspace-out is
+  set) is written to disk; size logged to stderr.
+
+  The handshake protocol:
+
+    in_zip  -> ExtractZipToDir($home)
+    cwd     -> SetCurrentDir(--cwd or $home/workspace)
+    agent   -> Cmd_Agent_Run with forwarded argv
+    out_zip -> PackDirToZip($home -> --workspace-out)
+
+  $home contents are walked verbatim (no exclusions beyond the
+  ExcludeNames denylist below) so logs / tmp / kb-files all ship.
+  The denylist hides only zip-build noise: the .git dir of any
+  surrounding repo (the operator probably doesn't want to ship
+  that), and the per-session ephemeral lockfiles SQLite leaves
+  behind.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+{$ENDIF}
+
+interface
+
+function Cmd_Build_Run(const Argv: array of string): Integer;
+
+const
+  { 4 GiB hard cap on the input zip. Replicate's container limits and
+    network timeouts are the real bound; the cap is here so a runaway
+    operator who passes a wrong file fails fast instead of OOM'ing
+    the unzip. Operators with genuine multi-gig workspaces should
+    split by skill or session. }
+  PASCLAW_WORKSPACE_ZIP_CAP = Int64(4) * 1024 * 1024 * 1024;
+
+  { Default iteration budget for `pasclaw build`. agent's default is
+    8 (interactive sessions correct themselves quickly); build is
+    unattended and may need more headroom to finish a feature. }
+  PASCLAW_BUILD_DEFAULT_MAX_ITERS = 50;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  {$IFDEF MSWINDOWS}Windows,{$ENDIF}
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Utils,
+  PasClaw.Skills.Zip,
+  PasClaw.Cmd.Agent;
+
+{$IFDEF UNIX}
+{ libc setenv is POSIX-portable across glibc / musl / macOS / BSD --
+  FPC's RTL doesn't expose it (only the env-modification helpers in
+  the unitsrc/3.2.2 tree's UnixUtil which aren't packaged on every
+  distro). Declare it directly. }
+function libc_setenv(const Name, Value: PAnsiChar; Overwrite: Integer): Integer;
+  cdecl; external 'c' name 'setenv';
+{$ENDIF}
+
+procedure SetEnv(const Name, Value: string);
+begin
+  {$IFDEF UNIX}
+  libc_setenv(PAnsiChar(AnsiString(Name)), PAnsiChar(AnsiString(Value)), 1);
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  Windows.SetEnvironmentVariable(PChar(Name), PChar(Value));
+  {$ENDIF}
+end;
+
+type
+  TBuildArgs = record
+    Description:   string;
+    MaxIters:      Integer;
+    WorkspaceIn:   string;
+    WorkspaceOut:  string;
+    Cwd:           string;
+    HomeOverride:  string;
+    KeepHome:      Boolean;
+    HelpRequested: Boolean;
+    Forwarded:     TStringList;  { remaining flags handed to Cmd_Agent_Run }
+  end;
+
+procedure InitArgs(out A: TBuildArgs);
+begin
+  A.Description   := '';
+  A.MaxIters      := PASCLAW_BUILD_DEFAULT_MAX_ITERS;
+  A.WorkspaceIn   := '';
+  A.WorkspaceOut  := '';
+  A.Cwd           := '';
+  A.HomeOverride  := '';
+  A.KeepHome      := False;
+  A.HelpRequested := False;
+  A.Forwarded     := TStringList.Create;
+end;
+
+procedure PrintHelp;
+begin
+  PrintLn('Usage: pasclaw build -d "<task>" [flags] [agent flags]');
+  PrintLn;
+  PrintLn('One-shot multi-iteration agent run, designed for unattended');
+  PrintLn('use in ephemeral compute (Replicate cog, CI runners, etc.).');
+  PrintLn('Optionally round-trips $PASCLAW_HOME via two zip handshakes');
+  PrintLn('so the agent''s memory / KB / checkpoints / project files');
+  PrintLn('survive between calls on different hosts.');
+  PrintLn;
+  PrintLn('Build flags:');
+  PrintLn('  -d, --describe <text>      The task to perform (REQUIRED).');
+  PrintLn('  --max-iters N              Iteration budget (default 50).');
+  PrintLn('  --workspace-in <zip>       Unzip this into PASCLAW_HOME first.');
+  PrintLn('  --workspace-out <zip>      Zip PASCLAW_HOME here after the run.');
+  PrintLn('  --cwd <dir>                cwd for fs_write (default: ');
+  PrintLn('                             $PASCLAW_HOME/workspace).');
+  PrintLn('  --home <dir>               Override PASCLAW_HOME (default: env');
+  PrintLn('                             or a fresh tempdir).');
+  PrintLn('  --keep-home                Don''t delete the tempdir on exit.');
+  PrintLn;
+  PrintLn('Agent flags forwarded as-is:');
+  PrintLn('  --provider, --model, --max-tokens, --thinking,');
+  PrintLn('  --session, --profile, --mode {plan|build}, --no-tools,');
+  PrintLn('  --no-mcp, --no-hashline, --system <prompt>, ...');
+  PrintLn;
+  PrintLn('Output:');
+  PrintLn('  stdout: the model''s final reply (same as `pasclaw agent -q`).');
+  PrintLn('  stderr: progress + workspace.zip size when applicable.');
+  PrintLn;
+  PrintLn('Example:');
+  PrintLn('  pasclaw build -d "add a --version flag to the CLI" \');
+  PrintLn('    --max-iters 30 \');
+  PrintLn('    --workspace-in /tmp/prev.zip \');
+  PrintLn('    --workspace-out /tmp/next.zip \');
+  PrintLn('    --provider openai --model gpt-4o');
+end;
+
+function ParseArgs(const Argv: array of string;
+                   var A: TBuildArgs;
+                   out ErrMsg: string): Boolean;
+var
+  i: Integer;
+  Token: string;
+begin
+  Result := False;
+  ErrMsg := '';
+  i := Low(Argv);
+  while i <= High(Argv) do
+  begin
+    Token := Argv[i];
+    if (Token = '-h') or (Token = '--help') then
+    begin
+      A.HelpRequested := True;
+      Exit(True);
+    end
+    else if (Token = '-d') or (Token = '--describe') or (Token = '-m') then
+    begin
+      { -m is accepted as an alias for -d / --describe so scripts
+        already using the agent's syntax keep working. }
+      if i = High(Argv) then
+      begin
+        ErrMsg := Token + ' needs a value';
+        Exit;
+      end;
+      Inc(i);
+      A.Description := Argv[i];
+    end
+    else if Token = '--max-iters' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--max-iters needs a value'; Exit; end;
+      Inc(i);
+      A.MaxIters := StrToIntDef(Argv[i], A.MaxIters);
+      if A.MaxIters <= 0 then
+      begin
+        ErrMsg := '--max-iters must be positive (got ' + Argv[i] + ')';
+        Exit;
+      end;
+    end
+    else if Token = '--workspace-in' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--workspace-in needs a path'; Exit; end;
+      Inc(i); A.WorkspaceIn := Argv[i];
+    end
+    else if Token = '--workspace-out' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--workspace-out needs a path'; Exit; end;
+      Inc(i); A.WorkspaceOut := Argv[i];
+    end
+    else if Token = '--cwd' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--cwd needs a path'; Exit; end;
+      Inc(i); A.Cwd := Argv[i];
+    end
+    else if Token = '--home' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--home needs a path'; Exit; end;
+      Inc(i); A.HomeOverride := Argv[i];
+    end
+    else if Token = '--keep-home' then
+    begin
+      A.KeepHome := True;
+    end
+    else
+    begin
+      { Everything we don't recognise is forwarded to `pasclaw agent`
+        verbatim, including any value that follows. Agent's argv
+        parser handles its own validation. }
+      A.Forwarded.Add(Token);
+    end;
+    Inc(i);
+  end;
+
+  if A.Description = '' then
+  begin
+    ErrMsg := '-d / --describe is required (see -h for usage)';
+    Exit;
+  end;
+
+  Result := True;
+end;
+
+function ResolveHome(const A: TBuildArgs; out IsTemp: Boolean): string;
+{ Pick the PASCLAW_HOME we'll run under.
+
+   Priority:
+    1. --home <dir>                        (operator override)
+    2. existing PASCLAW_HOME env var       (cog already sets one)
+    3. fresh tempdir                       (default; cleaned on exit
+                                            unless --keep-home) }
+var
+  Env: string;
+begin
+  IsTemp := False;
+  if A.HomeOverride <> '' then
+  begin
+    Result := A.HomeOverride;
+    Exit;
+  end;
+  Env := GetEnvironmentVariable('PASCLAW_HOME');
+  if Env <> '' then
+  begin
+    Result := Env;
+    Exit;
+  end;
+  Result := JoinPath(GetTempDir(False),
+                     'pasclaw_build_' + IntToStr(GetProcessID) + '_' +
+                     IntToStr(Random(MaxInt)));
+  IsTemp := True;
+end;
+
+procedure RemoveTree(const Path: string);
+{ Best-effort rm -rf. Survives transient lock failures by ignoring
+  errors -- the OS reclaims the tempdir on next boot if we miss
+  anything. }
+var
+  SR: TSearchRec;
+  Child: string;
+begin
+  if (Path = '') or (not DirectoryExists(Path)) then
+  begin
+    if FileExists(Path) then DeleteFile(Path);
+    Exit;
+  end;
+  if FindFirst(JoinPath(Path, '*'), faAnyFile or faDirectory, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Child := JoinPath(Path, SR.Name);
+      if (SR.Attr and faDirectory) <> 0 then
+        RemoveTree(Child)
+      else
+        DeleteFile(Child);
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  RemoveDir(Path);
+end;
+
+function GetFileSize(const Path: string): Int64;
+var
+  SR: TSearchRec;
+begin
+  Result := -1;
+  if FindFirst(Path, faAnyFile, SR) = 0 then
+  begin
+    Result := SR.Size;
+    FindClose(SR);
+  end;
+end;
+
+function BuildForwardedArgv(const A: TBuildArgs;
+                            out Argv: TStringList): Boolean;
+{ Construct the argv pasclaw agent will see. Always inject -q
+  (machine-friendly stdout), -m (the description), and
+  --max-iterations (the operator's choice or our default 50). Then
+  append whatever flags survived our parser. }
+begin
+  Result := True;
+  Argv := TStringList.Create;
+  Argv.Add('-q');
+  Argv.Add('-m');
+  Argv.Add(A.Description);
+  Argv.Add('--max-iterations');
+  Argv.Add(IntToStr(A.MaxIters));
+  Argv.AddStrings(A.Forwarded);
+end;
+
+function ToDynArray(L: TStringList): TArray<string>;
+var
+  i: Integer;
+begin
+  SetLength(Result, L.Count);
+  for i := 0 to L.Count - 1 do Result[i] := L[i];
+end;
+
+function Cmd_Build_Run(const Argv: array of string): Integer;
+const
+  ExcludeFromZip: array[0..3] of string = (
+    '.git',          { surrounding repo metadata if /workspace is a clone }
+    '.DS_Store',     { macOS finder noise }
+    'Thumbs.db',     { Windows explorer noise }
+    'kb.db-journal'  { SQLite WAL/journal -- transient, regenerated }
+  );
+var
+  A: TBuildArgs;
+  ErrMsg, Home, Cwd, SavedHomeEnv, SavedCwd: string;
+  AgentArgv: TStringList;
+  Argv_: TArray<string>;
+  HomeIsTemp: Boolean;
+  Bytes: Int64;
+  Rc: Integer;
+begin
+  Result := 1;
+  Randomize;
+  InitArgs(A);
+  try
+    if not ParseArgs(Argv, A, ErrMsg) then
+    begin
+      PrintErr('build: ' + ErrMsg);
+      Exit(2);
+    end;
+    if A.HelpRequested then
+    begin
+      PrintHelp;
+      Exit(0);
+    end;
+
+    Home := ResolveHome(A, HomeIsTemp);
+    if not ForceDirectories(Home) then
+    begin
+      PrintErr('build: cannot create home dir: ' + Home);
+      Exit(1);
+    end;
+
+    SavedHomeEnv := GetEnvironmentVariable('PASCLAW_HOME');
+    SavedCwd     := GetCurrentDir;
+    SetEnv('PASCLAW_HOME', Home);
+    LogInfo('build: PASCLAW_HOME=%s (temp=%s)',
+            [Home, BoolToStr(HomeIsTemp, True)]);
+
+    try
+      { 1. Unzip in. }
+      if A.WorkspaceIn <> '' then
+      begin
+        if not FileExists(A.WorkspaceIn) then
+        begin
+          PrintErr('build: workspace-in not found: ' + A.WorkspaceIn);
+          Exit(1);
+        end;
+        Bytes := GetFileSize(A.WorkspaceIn);
+        if Bytes > PASCLAW_WORKSPACE_ZIP_CAP then
+        begin
+          PrintErr(Format('build: workspace-in is %d bytes (> %d cap); ' +
+                          'split by session or skill',
+                          [Bytes, PASCLAW_WORKSPACE_ZIP_CAP]));
+          Exit(1);
+        end;
+        LogInfo('build: unpacking %s (%d bytes) -> %s',
+                [A.WorkspaceIn, Bytes, Home]);
+        if not ExtractZipToDir(A.WorkspaceIn, Home, ErrMsg) then
+        begin
+          PrintErr('build: unzip failed: ' + ErrMsg);
+          Exit(1);
+        end;
+      end;
+
+      { 2. cwd. }
+      Cwd := A.Cwd;
+      if Cwd = '' then
+        Cwd := JoinPath(Home, 'workspace');
+      if not ForceDirectories(Cwd) then
+      begin
+        PrintErr('build: cannot create cwd: ' + Cwd);
+        Exit(1);
+      end;
+      if not SetCurrentDir(Cwd) then
+      begin
+        PrintErr('build: SetCurrentDir failed: ' + Cwd);
+        Exit(1);
+      end;
+      LogInfo('build: cwd=%s', [Cwd]);
+
+      { 3. Run the agent. Its stdout becomes our stdout under -q --
+        Replicate (and any subprocess.run caller) captures that. }
+      if not BuildForwardedArgv(A, AgentArgv) then
+      begin
+        PrintErr('build: failed to build agent argv');
+        Exit(1);
+      end;
+      try
+        Argv_ := ToDynArray(AgentArgv);
+        Rc := Cmd_Agent_Run(Argv_);
+      finally
+        AgentArgv.Free;
+      end;
+      if Rc <> 0 then
+        LogWarn('build: agent exited with status %d', [Rc]);
+
+      { 4. Zip out. Failure to pack is logged but doesn't override
+        the agent's exit code -- the operator can still inspect
+        --home for state if --keep-home was set. }
+      if A.WorkspaceOut <> '' then
+      begin
+        SetCurrentDir(SavedCwd);
+        LogInfo('build: zipping %s -> %s', [Home, A.WorkspaceOut]);
+        if not PackDirToZip(Home, A.WorkspaceOut, ExcludeFromZip, ErrMsg) then
+        begin
+          PrintErr('build: zip failed: ' + ErrMsg);
+          if Rc = 0 then Rc := 1;
+        end
+        else
+        begin
+          Bytes := GetFileSize(A.WorkspaceOut);
+          LogInfo('build: wrote workspace.zip (%d bytes)', [Bytes]);
+        end;
+      end;
+
+      Result := Rc;
+    finally
+      SetCurrentDir(SavedCwd);
+      SetEnv('PASCLAW_HOME', SavedHomeEnv);
+      if HomeIsTemp and (not A.KeepHome) then
+        RemoveTree(Home);
+    end;
+  finally
+    A.Forwarded.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -60,6 +60,8 @@ uses
   PasClaw.Cmd.Export,
   PasClaw.Cmd.Init,         (* Pascal-driven AGENTS.md bootstrap -- complements
                                Cmd.Runbook's tool-driven variant *)
+  PasClaw.Cmd.Build,        (* `pasclaw build` -- one-shot multi-iter agent
+                               with workspace.zip handshake *)
   PasClaw.Cmd.Runbook,
   PasClaw.Cmd.Heartbeat,
   PasClaw.Cmd.TUI;
@@ -134,7 +136,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 28);
+  SetLength(Sub, 29);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
@@ -161,8 +163,9 @@ begin
   Sub[23] := 'export       Render memory/skills/sandbox into AGENTS.md / CLAUDE.md / Cursor / Gemini / Zed';
   Sub[24] := 'init         Scan cwd and ask the model for a starter AGENTS.md (one-shot, no tool loop)';
   Sub[25] := 'runbook      Tool-driven variant of init: agent loop probes the repo via execute_code';
-  Sub[26] := 'heartbeat    Run the proactive periodic wake-up daemon (off by default; opt in via onboard)';
-  Sub[27] := 'version      Show version info';
+  Sub[26] := 'build        One-shot multi-iter agent run with workspace.zip handshake (for cog / CI)';
+  Sub[27] := 'heartbeat    Run the proactive periodic wake-up daemon (off by default; opt in via onboard)';
+  Sub[28] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -192,6 +195,7 @@ begin
   else if Cmd = 'learn'    then Result := Cmd_Learn_Run(Argv)
   else if Cmd = 'export'   then Result := Cmd_Export_Run(Argv)
   else if Cmd = 'init'     then Result := Cmd_Init_Run(Argv)
+  else if Cmd = 'build'    then Result := Cmd_Build_Run(Argv)
   else if Cmd = 'runbook'  then Result := Cmd_Runbook_Run(Argv)
   { resume <id> is shorthand for `agent --session <id>` -- wire it
     here so `pasclaw resume foo` works as a top-level shortcut. }

--- a/src/pkg/skills/PasClaw.Skills.Zip.pas
+++ b/src/pkg/skills/PasClaw.Skills.Zip.pas
@@ -2,23 +2,33 @@
   PasClaw.Skills.Zip - thin cross-toolchain wrapper around the two
   bundled zip libraries:
 
-    FPC    : Zipper.TUnZipper (fcl-base, ships in every FPC install)
+    FPC    : Zipper.TUnZipper / TZipper (fcl-base, ships in every FPC install)
     Delphi : System.Zip.TZipFile (RTL since Delphi XE2)
 
-  Single function exposed:
+  Surface:
 
     ExtractZipToDir(const ZipPath, DestDir: string; out ErrMsg)
+        Unpack ZipPath into DestDir. Used by the skills install path.
 
-  Caller is responsible for creating DestDir if needed. ErrMsg is
-  set on failure; the function returns False without raising so the
-  skills-install path can format a user-friendly message instead of
-  surfacing the raw Indy / TZipFile exception text.
+    PackDirToZip(const SrcDir, ZipPath: string;
+                 const ExcludeNames: array of string;
+                 out ErrMsg)
+        Walk SrcDir and bundle every file under it into ZipPath at
+        paths relative to SrcDir. ExcludeNames is a case-insensitive
+        denylist of basenames anywhere in the tree (e.g. ".git" to
+        skip vendor metadata). Used by `pasclaw build`'s
+        workspace.zip output handshake.
 
-  We deliberately do not pre-validate the archive (size limit, file
-  count, etc.) -- the install layer in PasClaw.Skills.GitHub already
-  bounds the download to a sensible cap and validates the final tree
-  by looking for SKILL.md. Anything weirder (zip-slip, encrypted
-  archives, etc.) should be checked there, not here.
+  Both return False without raising on failure; ErrMsg carries the
+  reason so callers can format a user-facing message rather than
+  surfacing a raw Indy / TZipFile exception.
+
+  We deliberately do not pre-validate archives (size limit, file
+  count) here. Callers bound the input + validate the result (e.g.
+  PasClaw.Skills.GitHub looks for SKILL.md after extraction;
+  PasClaw.Cmd.Build caps the input zip at PASCLAW_WORKSPACE_ZIP_CAP
+  bytes). Anything weirder (zip-slip, encrypted archives) should be
+  checked there, not here.
 *)
 unit PasClaw.Skills.Zip;
 
@@ -30,10 +40,20 @@ interface
 function ExtractZipToDir(const ZipPath, DestDir: string;
                          out ErrMsg: string): Boolean;
 
+{ Bundle every file under SrcDir into ZipPath, with paths stored
+  relative to SrcDir. ExcludeNames is a case-insensitive list of
+  basenames to skip at any depth (e.g. ['.git', 'node_modules']);
+  pass [] to include everything. Returns False with ErrMsg set on
+  any error; on success ZipPath is a valid zip readable by any
+  standard tool. }
+function PackDirToZip(const SrcDir, ZipPath: string;
+                      const ExcludeNames: array of string;
+                      out ErrMsg: string): Boolean;
+
 implementation
 
 uses
-  SysUtils,
+  SysUtils, Classes,
   {$IFDEF FPC}
     Zipper
   {$ELSE}
@@ -84,6 +104,162 @@ begin
     Result := True;
   except
     on E: Exception do ErrMsg := 'unzip failed: ' + E.Message;
+  end;
+end;
+{$ENDIF}
+
+function NameExcluded(const Name: string;
+                      const ExcludeNames: array of string): Boolean;
+var
+  i: Integer;
+  L: string;
+begin
+  L := LowerCase(Name);
+  for i := Low(ExcludeNames) to High(ExcludeNames) do
+    if L = LowerCase(ExcludeNames[i]) then Exit(True);
+  Result := False;
+end;
+
+function JoinFromParts(const A, B, C: string): string;
+{ Three-part path joiner that handles empty middle segments cleanly.
+  Local because including PasClaw.Utils.JoinPath from a pkg/skills
+  unit would create a cycle once Cmd.Build pulls in both. }
+begin
+  Result := A;
+  if (B <> '') then
+  begin
+    if (Result <> '') and (Result[Length(Result)] <> PathDelim) and
+       (Result[Length(Result)] <> '/') then
+      Result := Result + PathDelim;
+    Result := Result + B;
+  end;
+  if (C <> '') then
+  begin
+    if (Result <> '') and (Result[Length(Result)] <> PathDelim) and
+       (Result[Length(Result)] <> '/') then
+      Result := Result + PathDelim;
+    Result := Result + C;
+  end;
+end;
+
+procedure CollectFiles(const Root, Rel: string;
+                       const ExcludeNames: array of string;
+                       Files: TStringList);
+{ Recursive walk. Files entries are stored as forward-slash-separated
+  paths relative to Root, which is what both Zipper.TZipper and
+  System.Zip.TZipFile expect as the in-archive name. }
+var
+  SR: TSearchRec;
+  NextRel, EntryName: string;
+begin
+  if FindFirst(JoinFromParts(Root, Rel, '*'), faAnyFile or faDirectory, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      if NameExcluded(SR.Name, ExcludeNames) then Continue;
+      if Rel = '' then EntryName := SR.Name
+      else EntryName := Rel + '/' + SR.Name;
+      if (SR.Attr and faDirectory) <> 0 then
+      begin
+        if Rel = '' then NextRel := SR.Name
+        else NextRel := Rel + '/' + SR.Name;
+        CollectFiles(Root, NextRel, ExcludeNames, Files);
+      end
+      else
+        Files.Add(EntryName);
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+end;
+
+function PackDirToZip(const SrcDir, ZipPath: string;
+                      const ExcludeNames: array of string;
+                      out ErrMsg: string): Boolean;
+{$IFDEF FPC}
+var
+  Z: TZipper;
+  Files: TStringList;
+  i: Integer;
+  Src, OnDisk, InZip: string;
+begin
+  Result := False;
+  ErrMsg := '';
+  if not DirectoryExists(SrcDir) then
+  begin
+    ErrMsg := 'source directory not found: ' + SrcDir;
+    Exit;
+  end;
+  Src := ExcludeTrailingPathDelimiter(SrcDir);
+
+  { Make sure the destination parent dir exists -- TZipper.SaveToFile
+    raises a generic exception otherwise. Don't ForceDirectories on
+    ZipPath itself; that would create it as a directory. }
+  if ExtractFilePath(ZipPath) <> '' then
+    ForceDirectories(ExtractFilePath(ZipPath));
+
+  Files := TStringList.Create;
+  Z := TZipper.Create;
+  try
+    try
+      CollectFiles(Src, '', ExcludeNames, Files);
+      for i := 0 to Files.Count - 1 do
+      begin
+        InZip := Files[i];
+        OnDisk := Src + PathDelim + StringReplace(InZip, '/', PathDelim,
+                                                 [rfReplaceAll]);
+        Z.Entries.AddFileEntry(OnDisk, InZip);
+      end;
+      Z.FileName := ZipPath;
+      Z.ZipAllFiles;
+      Result := True;
+    except
+      on E: Exception do ErrMsg := 'zip failed: ' + E.Message;
+    end;
+  finally
+    Z.Free;
+    Files.Free;
+  end;
+end;
+{$ELSE}
+var
+  Z: TZipFile;
+  Files: TStringList;
+  i: Integer;
+  Src, OnDisk, InZip: string;
+begin
+  Result := False;
+  ErrMsg := '';
+  if not DirectoryExists(SrcDir) then
+  begin
+    ErrMsg := 'source directory not found: ' + SrcDir;
+    Exit;
+  end;
+  Src := ExcludeTrailingPathDelimiter(SrcDir);
+  if ExtractFilePath(ZipPath) <> '' then
+    ForceDirectories(ExtractFilePath(ZipPath));
+
+  Files := TStringList.Create;
+  Z := TZipFile.Create;
+  try
+    try
+      CollectFiles(Src, '', ExcludeNames, Files);
+      Z.Open(ZipPath, zmWrite);
+      for i := 0 to Files.Count - 1 do
+      begin
+        InZip := Files[i];
+        OnDisk := Src + PathDelim + StringReplace(InZip, '/', PathDelim,
+                                                 [rfReplaceAll]);
+        Z.Add(OnDisk, InZip);
+      end;
+      Z.Close;
+      Result := True;
+    except
+      on E: Exception do ErrMsg := 'zip failed: ' + E.Message;
+    end;
+  finally
+    Z.Free;
+    Files.Free;
   end;
 end;
 {$ENDIF}

--- a/src/pkg/skills/PasClaw.Skills.Zip.pas
+++ b/src/pkg/skills/PasClaw.Skills.Zip.pas
@@ -53,18 +53,179 @@ function PackDirToZip(const SrcDir, ZipPath: string;
 implementation
 
 uses
-  SysUtils, Classes,
+  SysUtils, Classes, StrUtils,
   {$IFDEF FPC}
     Zipper
   {$ELSE}
     System.Zip
   {$ENDIF};
 
-function ExtractZipToDir(const ZipPath, DestDir: string;
-                         out ErrMsg: string): Boolean;
+function IsUnsafeMemberName(const Name, AbsDest: string;
+                            out Reason: string): Boolean;
+{ Zip-slip guard. Reject when:
+    1. The archive entry name is empty.
+    2. It starts with a path separator -- absolute POSIX path.
+    3. It looks like a Windows drive (X:\...) or UNC (\\...).
+    4. Any segment is exactly "..".  Paranoid: ExpandFileName below
+       handles arbitrary "../" composition, but a leading-segment
+       reject gives a clearer error.
+    5. The resolved absolute target falls outside AbsDest.  This is
+       the canonical check; ExpandFileName collapses sequences like
+       "foo/../../etc/passwd" so even clever encodings end up at a
+       resolved path the containment test will reject.
+
+  AbsDest must already be the ExpandFileName'd + slash-terminated
+  destination root. Reason is set on rejection so the caller can
+  surface a useful diagnostic. }
+var
+  i: Integer;
+  Norm, AbsTarget, Segment: string;
+  Sep: Char;
+begin
+  Reason := '';
+  Result := True;
+  if Name = '' then
+  begin
+    Reason := 'empty entry name';
+    Exit;
+  end;
+  { Normalise separators so the segment scan + ExpandFileName both
+    see a single canonical form. Zip entries are documented to use
+    '/', but defensive code shouldn't trust that on a malicious input. }
+  Norm := StringReplace(Name, '\', '/', [rfReplaceAll]);
+  if (Norm[1] = '/') then
+  begin
+    Reason := 'absolute path';
+    Exit;
+  end;
+  if (Length(Norm) >= 2) and
+     (((Norm[1] >= 'A') and (Norm[1] <= 'Z')) or
+      ((Norm[1] >= 'a') and (Norm[1] <= 'z'))) and
+     (Norm[2] = ':') then
+  begin
+    Reason := 'Windows drive prefix';
+    Exit;
+  end;
+  if (Length(Norm) >= 2) and (Norm[1] = '/') and (Norm[2] = '/') then
+  begin
+    Reason := 'UNC prefix';
+    Exit;
+  end;
+  Segment := '';
+  for i := 1 to Length(Norm) do
+  begin
+    if Norm[i] = '/' then
+    begin
+      if Segment = '..' then
+      begin
+        Reason := '".." segment';
+        Exit;
+      end;
+      Segment := '';
+    end
+    else
+      Segment := Segment + Norm[i];
+  end;
+  if Segment = '..' then
+  begin
+    Reason := '".." segment';
+    Exit;
+  end;
+
+  { Canonical containment check. PathDelim on the host (Unix uses '/',
+    Windows '\') is what ExpandFileName + filesystem APIs honour, so
+    translate forward slashes to PathDelim before resolving. }
+  Sep := PathDelim;
+  AbsTarget := ExpandFileName(AbsDest +
+    StringReplace(Norm, '/', Sep, [rfReplaceAll]));
+  { Compare prefix using a string-aware case-insensitive match. On
+    POSIX paths are case-sensitive so SameText is overkill but
+    harmless; Windows demands case-insensitive. }
+  if not StartsText(AbsDest, AbsTarget) then
+  begin
+    Reason := Format('resolves outside destination (%s -> %s)',
+                     [Norm, AbsTarget]);
+    Exit;
+  end;
+
+  Result := False;
+end;
+
+function ValidateZipEntries(const ZipPath, AbsDest: string;
+                            out ErrMsg: string): Boolean;
 {$IFDEF FPC}
 var
   UZ: TUnZipper;
+  i: Integer;
+  EntryName, Reason: string;
+begin
+  Result := False;
+  ErrMsg := '';
+  UZ := TUnZipper.Create;
+  try
+    try
+      UZ.FileName := ZipPath;
+      UZ.Examine;
+      for i := 0 to UZ.Entries.Count - 1 do
+      begin
+        EntryName := UZ.Entries[i].ArchiveFileName;
+        if IsUnsafeMemberName(EntryName, AbsDest, Reason) then
+        begin
+          ErrMsg := Format('unsafe zip entry "%s": %s', [EntryName, Reason]);
+          Exit;
+        end;
+      end;
+      Result := True;
+    except
+      on E: Exception do ErrMsg := 'zip scan failed: ' + E.Message;
+    end;
+  finally
+    UZ.Free;
+  end;
+end;
+{$ELSE}
+var
+  Z: TZipFile;
+  i: Integer;
+  EntryName, Reason: string;
+begin
+  Result := False;
+  ErrMsg := '';
+  Z := TZipFile.Create;
+  try
+    try
+      Z.Open(ZipPath, zmRead);
+      try
+        for i := 0 to Z.FileCount - 1 do
+        begin
+          EntryName := Z.FileNames[i];
+          if IsUnsafeMemberName(EntryName, AbsDest, Reason) then
+          begin
+            ErrMsg := Format('unsafe zip entry "%s": %s', [EntryName, Reason]);
+            Exit;
+          end;
+        end;
+        Result := True;
+      finally
+        Z.Close;
+      end;
+    except
+      on E: Exception do ErrMsg := 'zip scan failed: ' + E.Message;
+    end;
+  finally
+    Z.Free;
+  end;
+end;
+{$ENDIF}
+
+function ExtractZipToDir(const ZipPath, DestDir: string;
+                         out ErrMsg: string): Boolean;
+var
+  AbsDest: string;
+{$IFDEF FPC}
+var
+  UZ: TUnZipper;
+{$ENDIF}
 begin
   Result := False;
   ErrMsg := '';
@@ -74,6 +235,20 @@ begin
     ErrMsg := 'cannot create destination directory: ' + DestDir;
     Exit;
   end;
+  { Resolve destination once + slash-terminate so the containment
+    check is byte-prefix-comparable. ExpandFileName on macOS resolves
+    /var -> /private/var and similar symlinks; doing this once up
+    front means every entry resolves into the same realpath space. }
+  AbsDest := IncludeTrailingPathDelimiter(ExpandFileName(DestDir));
+
+  { Validate every entry before letting either backend extract.
+    Zip-slip: a malicious archive with "../../etc/passwd" or absolute-
+    path entries could write outside DestDir under FPC's
+    UnZipAllFiles or Delphi's ExtractZipFile, which neither library
+    rejects. Codex P1 on PR #300. }
+  if not ValidateZipEntries(ZipPath, AbsDest, ErrMsg) then Exit;
+
+{$IFDEF FPC}
   UZ := TUnZipper.Create;
   try
     try
@@ -88,25 +263,15 @@ begin
   finally
     UZ.Free;
   end;
-end;
 {$ELSE}
-begin
-  Result := False;
-  ErrMsg := '';
-  if not FileExists(ZipPath) then begin ErrMsg := 'archive not found'; Exit; end;
-  if not ForceDirectories(DestDir) then
-  begin
-    ErrMsg := 'cannot create destination directory: ' + DestDir;
-    Exit;
-  end;
   try
     TZipFile.ExtractZipFile(ZipPath, DestDir);
     Result := True;
   except
     on E: Exception do ErrMsg := 'unzip failed: ' + E.Message;
   end;
-end;
 {$ENDIF}
+end;
 
 function NameExcluded(const Name: string;
                       const ExcludeNames: array of string): Boolean;

--- a/src/tests/build_workspace_roundtrip_tests.pas
+++ b/src/tests/build_workspace_roundtrip_tests.pas
@@ -21,6 +21,7 @@ program build_workspace_roundtrip_tests;
 
 uses
   SysUtils, Classes,
+  {$IFDEF FPC} Zipper {$ELSE} System.Zip {$ENDIF},
   PasClaw.Skills.Zip,
   PasClaw.Utils;
 
@@ -269,6 +270,154 @@ begin
              'err mentions not-found (got: ' + Err + ')');
 end;
 
+{ ----- Zip-slip regression suite (Codex P1 on PR #300) ----- }
+
+procedure WriteMaliciousZip(const ZipPath, MaliciousMember, Content: string);
+{ Build a zip whose single entry has MaliciousMember as its archive
+  name. The on-disk source path is benign (an actual file in a temp
+  scratch dir); only the in-archive name is dangerous. The point of
+  this helper is to hand the extractor an entry name that tries to
+  escape the destination. }
+var
+  Z: {$IFDEF FPC}TZipper{$ELSE}TZipFile{$ENDIF};
+  Bench: string;
+  FS: TFileStream;
+begin
+  Bench := JoinPath(GetTempDir(False), 'mz_' + IntToStr(Random(MaxInt)) + '.bin');
+  FS := TFileStream.Create(Bench, fmCreate);
+  try
+    if Content <> '' then FS.WriteBuffer(Content[1], Length(Content));
+  finally
+    FS.Free;
+  end;
+  Z := {$IFDEF FPC}TZipper{$ELSE}TZipFile{$ENDIF}.Create;
+  try
+    {$IFDEF FPC}
+    Z.Entries.AddFileEntry(Bench, MaliciousMember);
+    Z.FileName := ZipPath;
+    Z.ZipAllFiles;
+    {$ELSE}
+    Z.Open(ZipPath, zmWrite);
+    Z.Add(Bench, MaliciousMember);
+    Z.Close;
+    {$ENDIF}
+  finally
+    Z.Free;
+    DeleteFile(Bench);
+  end;
+end;
+
+procedure TestRejectsParentTraversal;
+var
+  Dest, Zip, Err: string;
+begin
+  Dest := MakeTempDir('slip_dest');
+  Zip := JoinPath(GetTempDir(False),
+                  'slip_parent_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    WriteMaliciousZip(Zip, '../escaped.txt', 'OWNED');
+    AssertTrue(not ExtractZipToDir(Zip, Dest, Err),
+               '../escaped.txt should be rejected, got Result=True');
+    AssertTrue(Pos('unsafe', Err) > 0,
+               'err mentions "unsafe": ' + Err);
+    AssertTrue(not FileExists(JoinPath(ExtractFileDir(Dest), 'escaped.txt')),
+               'no file written outside Dest');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Dest);
+  end;
+end;
+
+procedure TestRejectsDeepParentTraversal;
+{ Sneakier: legitimate-looking prefix that then climbs out via ../. }
+var
+  Dest, Zip, Err: string;
+begin
+  Dest := MakeTempDir('slip_deep');
+  Zip := JoinPath(GetTempDir(False),
+                  'slip_deep_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    WriteMaliciousZip(Zip, 'workspace/../../escaped.txt', 'OWNED');
+    AssertTrue(not ExtractZipToDir(Zip, Dest, Err),
+               'workspace/../../escaped.txt should be rejected');
+    AssertTrue(Pos('unsafe', Err) > 0,
+               'err mentions "unsafe": ' + Err);
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Dest);
+  end;
+end;
+
+procedure TestRejectsAbsolutePath;
+var
+  Dest, Zip, Err: string;
+begin
+  Dest := MakeTempDir('slip_abs');
+  Zip := JoinPath(GetTempDir(False),
+                  'slip_abs_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    WriteMaliciousZip(Zip, '/tmp/__pasclaw_owned__', 'OWNED');
+    AssertTrue(not ExtractZipToDir(Zip, Dest, Err),
+               'absolute /tmp/... should be rejected');
+    AssertTrue(not FileExists('/tmp/__pasclaw_owned__'),
+               'no file written at the absolute path');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Dest);
+  end;
+end;
+
+procedure TestRejectsBackslashTraversal;
+{ Zips occasionally carry backslash separators (Windows-produced
+  archives). Our validator normalises to forward-slash before the
+  segment scan; a sneaky ..\.. should be rejected just like ../.. }
+var
+  Dest, Zip, Err: string;
+begin
+  Dest := MakeTempDir('slip_bs');
+  Zip := JoinPath(GetTempDir(False),
+                  'slip_bs_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    WriteMaliciousZip(Zip, '..\..\escaped.txt', 'OWNED');
+    AssertTrue(not ExtractZipToDir(Zip, Dest, Err),
+               'backslash ..\..\escaped.txt should be rejected');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Dest);
+  end;
+end;
+
+procedure TestAcceptsLegitimateNested;
+{ Containment check must not over-fire on legitimate nested paths
+  that LOOK like they could escape but actually resolve inside Dest. }
+var
+  Src, Dest, Zip, Err: string;
+  Empty: array of string;
+begin
+  SetLength(Empty, 0);
+  Src := MakeTempDir('legit_src');
+  Dest := MakeTempDir('legit_dest');
+  Zip := JoinPath(GetTempDir(False),
+                  'legit_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    { Legitimate deeply-nested file -- the validator MUST accept this. }
+    WriteText(JoinPath(JoinPath(JoinPath(JoinPath(Src, 'workspace'),
+                                          'sessions'), 'foo'),
+                       'session.json'),
+              '{"ok": true}');
+    AssertTrue(PackDirToZip(Src, Zip, Empty, Err), 'pack: ' + Err);
+    AssertTrue(ExtractZipToDir(Zip, Dest, Err),
+               'legitimate nested path should extract: ' + Err);
+    AssertTrue(FileExists(JoinPath(JoinPath(JoinPath(JoinPath(Dest,
+                          'workspace'), 'sessions'), 'foo'), 'session.json')),
+               'legitimate file extracted to correct location');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Src);
+    RemoveTree(Dest);
+  end;
+end;
+
 begin
   Randomize;
   TestSimpleRoundtrip;
@@ -276,5 +425,10 @@ begin
   TestExclusionDenylist;
   TestEmptyDir;
   TestMissingSource;
+  TestRejectsParentTraversal;
+  TestRejectsDeepParentTraversal;
+  TestRejectsAbsolutePath;
+  TestRejectsBackslashTraversal;
+  TestAcceptsLegitimateNested;
   Writeln('ok - build workspace round-trip tests passed');
 end.

--- a/src/tests/build_workspace_roundtrip_tests.pas
+++ b/src/tests/build_workspace_roundtrip_tests.pas
@@ -1,0 +1,280 @@
+program build_workspace_roundtrip_tests;
+(*
+  Coverage for the bits of `pasclaw build` that don't need a real
+  provider:
+
+    * PackDirToZip + ExtractZipToDir round-trip (the workspace.zip
+      handshake on its own).
+    * Exclusion denylist (.git, .DS_Store, ...) honoured.
+    * Binary files (NULs + high bytes) survive the round-trip.
+    * Nested directory structure preserved.
+
+  Build's argv parser, env override, and agent dispatch are exercised
+  via the smoke target on a temp PASCLAW_HOME with a real provider --
+  not appropriate for unit tests that run on every PR.
+*)
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+{$ENDIF}
+
+uses
+  SysUtils, Classes,
+  PasClaw.Skills.Zip,
+  PasClaw.Utils;
+
+procedure Fail_(const Msg: string);
+begin
+  Writeln('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertEqS(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")');
+end;
+
+procedure AssertBytesEq(const Got, Want: TBytes; const Msg: string);
+var i: Integer;
+begin
+  if Length(Got) <> Length(Want) then
+    Fail_(Format('%s: length got=%d want=%d', [Msg, Length(Got), Length(Want)]));
+  for i := 0 to Length(Want) - 1 do
+    if Got[i] <> Want[i] then
+      Fail_(Format('%s: byte %d differs (got %d, want %d)',
+                   [Msg, i, Got[i], Want[i]]));
+end;
+
+procedure WriteText(const Path, Content: string);
+var FS: TFileStream;
+begin
+  ForceDirectories(ExtractFilePath(Path));
+  FS := TFileStream.Create(Path, fmCreate);
+  try
+    if Content <> '' then FS.WriteBuffer(Content[1], Length(Content));
+  finally
+    FS.Free;
+  end;
+end;
+
+procedure WriteBytes(const Path: string; const Bytes: TBytes);
+var FS: TFileStream;
+begin
+  ForceDirectories(ExtractFilePath(Path));
+  FS := TFileStream.Create(Path, fmCreate);
+  try
+    if Length(Bytes) > 0 then FS.WriteBuffer(Bytes[0], Length(Bytes));
+  finally
+    FS.Free;
+  end;
+end;
+
+function ReadText(const Path: string): string;
+var FS: TFileStream;
+begin
+  Result := '';
+  if not FileExists(Path) then Exit;
+  FS := TFileStream.Create(Path, fmOpenRead or fmShareDenyNone);
+  try
+    SetLength(Result, FS.Size);
+    if FS.Size > 0 then FS.ReadBuffer(Result[1], FS.Size);
+  finally
+    FS.Free;
+  end;
+end;
+
+function ReadBytes(const Path: string): TBytes;
+var FS: TFileStream;
+begin
+  SetLength(Result, 0);
+  if not FileExists(Path) then Exit;
+  FS := TFileStream.Create(Path, fmOpenRead or fmShareDenyNone);
+  try
+    SetLength(Result, FS.Size);
+    if FS.Size > 0 then FS.ReadBuffer(Result[0], FS.Size);
+  finally
+    FS.Free;
+  end;
+end;
+
+function MakeTempDir(const Tag: string): string;
+begin
+  Result := JoinPath(GetTempDir(False),
+                     'pasclaw_build_test_' + Tag + '_' + IntToStr(Random(MaxInt)));
+  ForceDirectories(Result);
+end;
+
+procedure RemoveTree(const Path: string);
+var SR: TSearchRec; Sub: string;
+begin
+  if not DirectoryExists(Path) then Exit;
+  if FindFirst(JoinPath(Path, '*'), faAnyFile or faDirectory, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Sub := JoinPath(Path, SR.Name);
+      if (SR.Attr and faDirectory) <> 0 then RemoveTree(Sub)
+      else DeleteFile(Sub);
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  RemoveDir(Path);
+end;
+
+procedure TestSimpleRoundtrip;
+{ A small workspace with text + nested dirs round-trips through
+  PackDirToZip and ExtractZipToDir cleanly. }
+var
+  Src, Dst, Zip, Err: string;
+  Empty: array of string;
+begin
+  SetLength(Empty, 0);
+  Src := MakeTempDir('src');
+  Dst := MakeTempDir('dst');
+  Zip := JoinPath(GetTempDir(False), 'roundtrip_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    WriteText(JoinPath(Src, 'README.md'),
+              '# project' + sLineBreak + 'hello world' + sLineBreak);
+    WriteText(JoinPath(JoinPath(Src, 'src'), 'main.pas'),
+              'program p; begin end.');
+    WriteText(JoinPath(JoinPath(JoinPath(Src, 'workspace'), 'memory'), 'MEMORY.md'),
+              '## rules' + sLineBreak + '- be excellent.');
+
+    AssertTrue(PackDirToZip(Src, Zip, Empty, Err), 'pack: ' + Err);
+    AssertTrue(FileExists(Zip), 'zip file exists');
+    AssertTrue(ExtractZipToDir(Zip, Dst, Err), 'extract: ' + Err);
+
+    AssertTrue(FileExists(JoinPath(Dst, 'README.md')), 'README round-tripped');
+    AssertEqS(ReadText(JoinPath(Dst, 'README.md')),
+              '# project' + sLineBreak + 'hello world' + sLineBreak,
+              'README content preserved');
+    AssertTrue(FileExists(JoinPath(JoinPath(Dst, 'src'), 'main.pas')),
+               'nested src/main.pas round-tripped');
+    AssertTrue(FileExists(JoinPath(JoinPath(JoinPath(Dst, 'workspace'),
+                                            'memory'), 'MEMORY.md')),
+               '3-level-deep MEMORY.md round-tripped');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Src);
+    RemoveTree(Dst);
+  end;
+end;
+
+procedure TestBinaryRoundtrip;
+{ Snapshots / kb.db / checkpoints archive.zpaq are all binary -- must
+  survive the zip path without bit mangling. Test with a payload that
+  has every byte value 0..255. }
+var
+  Src, Dst, Zip, Err: string;
+  Empty: array of string;
+  Want, Got: TBytes;
+  i: Integer;
+begin
+  SetLength(Empty, 0);
+  Src := MakeTempDir('bin_src');
+  Dst := MakeTempDir('bin_dst');
+  Zip := JoinPath(GetTempDir(False), 'binroundtrip_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    SetLength(Want, 256);
+    for i := 0 to 255 do Want[i] := i;
+    WriteBytes(JoinPath(JoinPath(Src, 'workspace'), 'kb.db'), Want);
+
+    AssertTrue(PackDirToZip(Src, Zip, Empty, Err), 'pack: ' + Err);
+    AssertTrue(ExtractZipToDir(Zip, Dst, Err), 'extract: ' + Err);
+
+    Got := ReadBytes(JoinPath(JoinPath(Dst, 'workspace'), 'kb.db'));
+    AssertBytesEq(Got, Want, 'binary kb.db round-trip');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Src);
+    RemoveTree(Dst);
+  end;
+end;
+
+procedure TestExclusionDenylist;
+{ ExcludeFromZip in PasClaw.Cmd.Build drops .git / .DS_Store etc.
+  Verify the underlying PackDirToZip honours an arbitrary denylist. }
+var
+  Src, Dst, Zip, Err: string;
+  Excludes: array of string;
+begin
+  SetLength(Excludes, 2);
+  Excludes[0] := '.git';
+  Excludes[1] := '.DS_Store';
+  Src := MakeTempDir('excl_src');
+  Dst := MakeTempDir('excl_dst');
+  Zip := JoinPath(GetTempDir(False), 'excl_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    WriteText(JoinPath(Src, 'README.md'), 'keep');
+    WriteText(JoinPath(JoinPath(Src, '.git'), 'HEAD'), 'ref: refs/heads/main');
+    WriteText(JoinPath(JoinPath(JoinPath(Src, 'src'), '.git'), 'config'),
+              '[core]');
+    WriteText(JoinPath(Src, '.DS_Store'), 'finder noise');
+
+    AssertTrue(PackDirToZip(Src, Zip, Excludes, Err), 'pack: ' + Err);
+    AssertTrue(ExtractZipToDir(Zip, Dst, Err), 'extract: ' + Err);
+
+    AssertTrue(FileExists(JoinPath(Dst, 'README.md')), 'README kept');
+    AssertTrue(not DirectoryExists(JoinPath(Dst, '.git')),
+               '.git at root dropped');
+    AssertTrue(not DirectoryExists(JoinPath(JoinPath(Dst, 'src'), '.git')),
+               '.git at depth 2 dropped (case-insensitive denylist)');
+    AssertTrue(not FileExists(JoinPath(Dst, '.DS_Store')),
+               '.DS_Store dropped');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Src);
+    RemoveTree(Dst);
+  end;
+end;
+
+procedure TestEmptyDir;
+{ Pack of an empty source dir must succeed (produce a zip file).
+  Re-extracting an empty archive is a corner case the underlying
+  TZipper / TZipFile don't all handle uniformly, so we don't assert
+  on that side -- the build flow that needs this property would
+  have included at least config.json or AGENTS.md before zipping. }
+var
+  Src, Zip, Err: string;
+  Empty: array of string;
+begin
+  SetLength(Empty, 0);
+  Src := MakeTempDir('empty_src');
+  Zip := JoinPath(GetTempDir(False), 'empty_' + IntToStr(Random(MaxInt)) + '.zip');
+  try
+    AssertTrue(PackDirToZip(Src, Zip, Empty, Err), 'pack empty: ' + Err);
+    AssertTrue(FileExists(Zip), 'empty zip file produced');
+  finally
+    DeleteFile(Zip);
+    RemoveTree(Src);
+  end;
+end;
+
+procedure TestMissingSource;
+var
+  Zip, Err: string;
+  Empty: array of string;
+begin
+  SetLength(Empty, 0);
+  Zip := JoinPath(GetTempDir(False), 'never.zip');
+  AssertTrue(not PackDirToZip('/tmp/__pasclaw_no_such_src__', Zip, Empty, Err),
+             'pack of missing src should fail');
+  AssertTrue(Pos('not found', Err) > 0,
+             'err mentions not-found (got: ' + Err + ')');
+end;
+
+begin
+  Randomize;
+  TestSimpleRoundtrip;
+  TestBinaryRoundtrip;
+  TestExclusionDenylist;
+  TestEmptyDir;
+  TestMissingSource;
+  Writeln('ok - build workspace round-trip tests passed');
+end.


### PR DESCRIPTION
## Summary

Adds `pasclaw build` + a sibling `cog-build/` Replicate predictor for the "ship state between ephemeral compute" pattern: feed in `workspace.zip` from a previous run, get `workspace.zip` (full `$PASCLAW_HOME`) back together with the model's reply text.

### CLI — `pasclaw build`

```sh
pasclaw build -d "implement the X feature" \
              --max-iters 30 \
              --workspace-in /tmp/prev.zip \
              --workspace-out /tmp/next.zip \
              --provider openai --model gpt-4o
```

Thin orchestration over `Cmd_Agent_Run` with unattended-friendly defaults (`--max-iterations 50`, `-q`). All agent flags forward verbatim.

| | `pasclaw agent` | `pasclaw build` |
|---|---|---|
| Default iters | 8 | 50 |
| Output | TUI / REPL | quiet stdout |
| Workspace zip | — | `--workspace-in` / `--workspace-out` |
| `PASCLAW_HOME` | env or `~/.pasclaw` | env, `--home`, or fresh tempdir |

Input zip capped at **4 GiB**, matched on both sides. Output zip's only exclusions are noise: `.git`, `.DS_Store`, `Thumbs.db`, `kb.db-journal`. Logs, `tmp/`, `kb-files/*.bin` all ship back — the point is to preserve the entire brain, including kb upload binaries and execution logs.

### `cog-build/` — Replicate predictor

- `cog.yaml` — builds the image with FPC + PasClaw + OpenSSL 1.0.2 (Indy TLS) and installs [`pget`](https://github.com/replicate/pget) for parallel multi-connection downloads of large workspace URLs.
- `predict.py` — returns an Output BaseModel with **two** fields the caller wants:
  - `workspace: Path` — the new `workspace.zip` (cog handles persistence past temp-dir cleanup).
  - `text: str` — model's final reply, so the caller can decide whether to feed the workspace back for another round.
- Inputs cover `message`, `max_iters` (1–500), `timeout_seconds` (30s–24h), the API keys, plus **two workspace inputs**:
  - `workspace_in: Path` — cog handles upload + URL via Path.
  - `workspace_in_url: str` — explicit URL → downloaded via pget (parallel) for big files. Wins over `workspace_in` when set.

Sample control loop in [`cog-build/README.md`](cog-build/README.md) — chain builds sequentially by feeding the previous call's `workspace` URL back as `workspace_in_url`.

### Zip helper

`PackDirToZip` added to `PasClaw.Skills.Zip` (next to existing `ExtractZipToDir`). Cross-toolchain: `TZipper` under FPC, `TZipFile` under Delphi. Honors a case-insensitive `ExcludeNames` denylist at any depth.

### Files

```
src/cmd/PasClaw.Cmd.Build.pas          # new -- the build command
src/cmd/PasClaw.Cmd.Root.pas           # wire dispatch + help line
src/pkg/skills/PasClaw.Skills.Zip.pas  # add PackDirToZip
src/tests/build_workspace_roundtrip_tests.pas  # new -- 5 zip round-trip tests
cog-build/cog.yaml                     # new -- predictor image
cog-build/predict.py                   # new -- the Predictor
cog-build/requirements.txt             # new
cog-build/README.md                    # new -- usage, control-loop example
docs/commands.md                       # build section + agent comparison
Makefile                               # test-build-roundtrip target + aggregator + .PHONY
```

### Test plan

- [x] `make test-build-roundtrip` — 5 tests: text/binary/nested round-trip, exclusion denylist (case-insensitive at depth), empty-dir pack, missing-source-dir failure mode.
- [x] `make` — full binary compiles clean under FPC 3.2.2.
- [x] End-to-end smoke: `pasclaw build -d "..." --workspace-in in.zip --workspace-out out.zip --max-iters 1` unpacks input, runs agent, packs output. Verified the workspace round-trip carries `workspace/memory/MEMORY.md` and `config.json` from input through to output.
- [ ] Delphi build covered by existing `test-delphi-build` (`PackDirToZip` uses `TZipFile.Add` which is RTL since XE2).
- [ ] Cog build itself — needs Replicate infra; the YAML is set up to install `pget` from GitHub releases and pin OpenSSL 1.0.2 the same way `/cog/` does.

### Why two workspace inputs (`Path` *and* `str`)

Cog's `Path` type handles both file-upload and URL-input transparently, but the URL fetch is single-stream. For multi-hundred-MB workspaces (typical once `kb.db` + `kb-files/` + checkpoint archives accumulate), pget's parallel multi-connection download is 3–5× faster. Letting callers explicitly pick the fast path is cheap; falling back to cog's default is fine for smaller workspaces.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_