### PR TITLE
cog-build: make workspace_in optional + reword to drop workspace.zip auto-link

### DIFF
--- a/cog-build/README.md
+++ b/cog-build/README.md
@@ -11,8 +11,8 @@ Sibling to [`/cog/`](../cog/), which runs the simpler one-shot `pasclaw agent` f
 | `message` | str | — | The build task ("add X", "port Y to Z", …) |
 | `max_iters` | int | 50 | Tool-loop iteration budget |
 | `timeout_seconds` | int | 3600 | Subprocess timeout (Replicate's container ceiling applies on top) |
-| `workspace_in` | Path | None | Workspace.zip from a previous build. Cog handles both upload + URL via Path |
-| `workspace_in_url` | str | "" | Explicit URL — downloaded via [`pget`](https://github.com/replicate/pget) for parallelism. Wins over `workspace_in` when set. |
+| `workspace_in` | `Optional[Path]` | None | *Optional.* Workspace archive from a previous build. Cog handles both upload + URL via Path. Leave empty for a fresh run. |
+| `workspace_in_url` | str | "" | *Optional.* Explicit URL — downloaded via [`pget`](https://github.com/replicate/pget) for parallelism. Wins over `workspace_in` when set. |
 | `openai_api_key` / `anthropic_api_key` / `gemini_api_key` / `groq_api_key` / `openrouter_api_key` / `deepseek_api_key` | str | "" | Provider creds — same shape as `/cog/`. |
 | `provider`, `model` | str | "" | Override which provider / model is used. Empty = first key wins. |
 

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -152,16 +152,18 @@ class Predictor(BasePredictor):
             "container ceiling on top of this.",
             default=3600, ge=30, le=24 * 3600,
         ),
-        workspace_in: Path = Input(
-            description="Optional workspace.zip from a previous build. "
-            "Replicate handles both file-uploads and URL inputs through "
-            "this. For very large URL-backed workspaces, prefer "
-            "workspace_in_url to get parallel pget download.",
+        workspace_in: Optional[Path] = Input(
+            description="Workspace archive from a previous build. "
+            "Leave empty for a fresh run. Replicate handles both "
+            "file-uploads and URL inputs through this. For very "
+            "large URL-backed workspaces, prefer workspace_in_url "
+            "to get parallel pget download.",
             default=None,
         ),
         workspace_in_url: str = Input(
-            description="Optional explicit URL to a workspace.zip. When "
-            "set, downloaded via pget for parallelism; takes precedence "
+            description="Explicit URL to a previous-build workspace "
+            "archive. Leave empty for a fresh run. When set, "
+            "downloaded via pget for parallelism; takes precedence "
             "over workspace_in.",
             default="",
         ),


### PR DESCRIPTION
## Summary

Two Replicate UI field-level issues reported on the merged `cog-build/` predictor:

### 1. `workspace_in` was marked **required**

Cog generates the OpenAPI schema from the parameter's **type annotation**, not the `default` value. So:

```python
workspace_in: Path = Input(default=None, ...)   # ❌ schema field type = Path (required)
```

Replicate's UI sees a non-nullable `Path`, blocks the predict button until something is uploaded, no matter what the description says.

Fix:

```python
workspace_in: Optional[Path] = Input(default=None, ...)   # ✅ schema field type = Path | None
```

`Optional` was already imported in the file (used in helper-function signatures), so the fix is just the parameter annotation.

`workspace_in_url: str = Input(default="", ...)` was already optional because cog treats `str` with `default=""` as optional, but it now gets the same "Leave empty for a fresh run" line in the description for consistency.

### 2. `workspace.zip` in descriptions auto-linked

Replicate's UI auto-detects filename-shaped strings and renders them as links that go nowhere useful. Reworded both descriptions to use "workspace archive" / "previous-build workspace archive" instead.

### Files

```
cog-build/predict.py    # type annotation + reworded descriptions, no logic change
cog-build/README.md     # input table updated to match (Optional[Path], *Optional.* badges, dropped "Workspace.zip")
```

### Test plan

- [x] `python3 -c "import ast; ast.parse(open('cog-build/predict.py').read())"` — syntax OK
- [ ] Push the cog to Replicate and verify the UI now shows both `workspace_in` and `workspace_in_url` as optional (no asterisks / no upload-required banner).
- [ ] Hover over the field and verify "workspace archive" renders as plain text, not as a link.

No Pascal-side changes; no behavior change in predict.py beyond the schema effect of the type-annotation fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_