### PR TITLE
cog-build: default profile to max-build, expose `profile` input

### DIFF
--- a/cog-build/README.md
+++ b/cog-build/README.md
@@ -21,6 +21,31 @@ Sibling to [`/cog/`](../cog/), which runs the simpler one-shot `pasclaw agent` f
 | `custom_provider_model` | str | "" | Default model id for the custom provider. |
 | `provider` | str | "" | Route through this provider name. Any of the cloud names above, `ollama` / `lmstudio` / `vllm`, or whatever's in `custom_provider_kind`. Empty = first configured provider wins. |
 | `model` | str | "" | Override the model id. Empty = provider's catalog default (or whatever the local server is currently serving). |
+| `profile` | str | `"max-build"` | PasClaw [config profile](../docs/configuration.md#profiles) applied on top of stock defaults. See **Profile defaults** below for what `max-build` flips on, and the other built-ins. Empty to skip. |
+
+### Profile defaults
+
+The cog defaults `profile` to **`max-build`** — the richest unattended-build toolset. Compared to PasClaw's stock defaults, `max-build` turns on:
+
+- `web_fetch`, `web_search` — let the model fetch docs and crawl the web for API references
+- `vector_search` — better memory recall via the hybrid FTS+vector backend
+- `auto_router` — route cheap turns to a cheap model
+- `prompt_cache` — Anthropic / OpenAI prompt-cache TTL on (1 h)
+- `condense_reversible` — longer effective context windows
+- `orient_task_aware` — only task-relevant memory sections enter the system prompt
+- `promptware` — prompt-injection guard scans incoming tool output
+- the self-improving-skills suite (4 switches)
+- vault tools (Code Vault search)
+- `tool_output_cap` bumped from 0 (uncapped) to 16384
+
+Override `profile` to:
+- `baseline` — everything off. A/B reference against a feature-poor PasClaw.
+- `low-token` — cheaper / smaller context. Same flags as `max-build` *minus* the wide-net ones.
+- `security` — workspace restriction + shell deny + private-network block; promptware on; vault and `web_fetch` off; agent-authored skills stage for approval.
+- `all-on` — inherits `max-build` and flips every remaining boolean. Surface-area testing only.
+- *(empty)* — skip profile application entirely.
+
+Profile is layered *under* the seeded `config.json` fields (provider catalog, sandbox, `checkpoints_enabled`), so the cog's explicit choices always win over the profile.
 
 **At least one provider must be configured** — either a cloud API key, a local-server URL, or the `custom_provider_*` set.
 

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -289,6 +289,21 @@ class Predictor(BasePredictor):
             default="",
             description="Override model id. Empty = provider's catalog default.",
         ),
+        profile: str = Input(
+            default="max-build",
+            description="PasClaw config profile applied on top of stock "
+            "defaults. `max-build` (default) turns on web_fetch, "
+            "web_search, vector_search, auto_router, prompt_cache, "
+            "task-aware memory orientation, promptware guard, the "
+            "self-improving-skills suite, and bumps tool_output_cap "
+            "to 16 KB -- the richest unattended-build toolset. Other "
+            "choices: `baseline` (everything off, useful for A/B), "
+            "`low-token` (cheaper, smaller context window), "
+            "`security` (workspace restriction + shell deny + "
+            "private-network block), `all-on` (max-build plus every "
+            "remaining flag flipped on). Empty to skip profile "
+            "application.",
+        ),
     ) -> list[Path]:
         """
         Run `pasclaw build` against the unzipped workspace, then ship the
@@ -422,6 +437,11 @@ class Predictor(BasePredictor):
                     default_model = entry["model"]
                     break
 
+        # PasClaw applies the profile (with _inherits resolved) BEFORE
+        # this config layer, so any explicit field below wins over the
+        # profile's defaults. We deliberately set checkpoints_enabled
+        # outside the profile so /undo + /redo work even under profiles
+        # that don't enable them (baseline / security).
         config_data = {
             "default_provider": selected_provider,
             "default_model":    default_model,
@@ -439,6 +459,19 @@ class Predictor(BasePredictor):
                 "custom_shell_deny":          [],
             },
         }
+
+        # Apply the profile when non-empty. PasClaw's selection
+        # precedence (PasClaw.Config.LoadConfig) is:
+        #   1. --profile CLI flag           (we don't use this)
+        #   2. PASCLAW_PROFILE env var      (we don't use this either)
+        #   3. "profile" field in config.json   <-- this path
+        #   4. None
+        # Setting it in the seeded config means a fresh run gets the
+        # richer toolset; the operator's `profile` override flows
+        # through unchanged for baseline / low-token / security / etc.
+        profile_normalised = profile.strip()
+        if profile_normalised:
+            config_data["profile"] = profile_normalised
 
         # --- workspace handshake setup ---
 
@@ -498,6 +531,7 @@ class Predictor(BasePredictor):
                 f"build: invoking {self.binary_path} build "
                 f"max_iters={max_iters} timeout={timeout_seconds}s "
                 f"provider={selected_provider} model={default_model} "
+                f"profile={profile_normalised or '(none)'} "
                 f"workspace_in={'yes' if in_zip else 'no'}"
             )
 


### PR DESCRIPTION
## Summary

The cog-build predictor was running PasClaw with stock `TConfig` defaults — everything off. For unattended build runs that's the wrong default; `max-build` is the profile [PR #291](https://github.com/FMXExpress/PasClaw/pull/291) designed for exactly this use case.

Two changes:

### 1. Seed `"profile": "max-build"` in the cog's `config.json`

PasClaw's profile-selection precedence (`PasClaw.Config.LoadConfig`):
1. `--profile` CLI flag (cog doesn't pass this)
2. `PASCLAW_PROFILE` env var (we don't set it)
3. `"profile"` field in config.json *(now we set this)*
4. None

PasClaw resolves the profile (including `_inherits` chains — `max-build` inherits from `low-token`) *before* applying our explicit fields, so the cog's `checkpoints_enabled`, sandbox config, and provider catalog still win where they conflict.

### 2. Expose `profile` as a cog input

```python
profile: str = Input(default="max-build", description="...")
```

Operator can override to any built-in:

| Profile | Effect |
|---|---|
| `max-build` *(default)* | `web_fetch`, `web_search`, `vector_search`, `auto_router`, `prompt_cache`, `promptware`, self-improving-skills, vault, `tool_output_cap=16384`, task-aware memory orientation — all on |
| `baseline` | Everything off. A/B reference. |
| `low-token` | Cheaper / smaller context |
| `security` | Workspace restrict + shell deny + private-net block; promptware on; `web_fetch` + vault off |
| `all-on` | Inherits `max-build`, flips every remaining boolean. Surface-area testing only. |
| *(empty)* | Skip profile application entirely. |

Launch-log line gained a `profile=...` field so it's visible in Replicate's prediction logs.

### Files

```
cog-build/predict.py    # ~25 LOC delta (new Input + 2-line config_data set + log)
cog-build/README.md     # new row + "Profile defaults" subsection
```

### Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — syntax OK
- [ ] `cog push` and verify the launch-log line shows `profile=max-build`
- [ ] Run a build; verify `web_search` / `web_fetch` tools are available to the model (max-build turns them on)
- [ ] Override `profile=baseline` and verify those tools fall back off

No Pascal-side changes. The profile machinery has been in PasClaw since PR #291; the cog is just opting into it via a config field that's been there since that PR shipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_