### PR TITLE
cog-build: drop misleading web_search claim + honor security profile sandbox

### DIFF
--- a/cog-build/README.md
+++ b/cog-build/README.md
@@ -27,7 +27,7 @@ Sibling to [`/cog/`](../cog/), which runs the simpler one-shot `pasclaw agent` f
 
 The cog defaults `profile` to **`max-build`** — the richest unattended-build toolset. Compared to PasClaw's stock defaults, `max-build` turns on:
 
-- `web_fetch`, `web_search` — let the model fetch docs and crawl the web for API references
+- `web_fetch` — let the model fetch docs by URL (the `web_search` flag is also flipped on by `max-build`, but the tool only registers when PasClaw has a search provider configured. The cog doesn't supply one, so `web_search` isn't available out of the box — use `web_fetch`.)
 - `vector_search` — better memory recall via the hybrid FTS+vector backend
 - `auto_router` — route cheap turns to a cheap model
 - `prompt_cache` — Anthropic / OpenAI prompt-cache TTL on (1 h)
@@ -45,7 +45,7 @@ Override `profile` to:
 - `all-on` — inherits `max-build` and flips every remaining boolean. Surface-area testing only.
 - *(empty)* — skip profile application entirely.
 
-Profile is layered *under* the seeded `config.json` fields (provider catalog, sandbox, `checkpoints_enabled`), so the cog's explicit choices always win over the profile.
+Profile is layered *under* the seeded `config.json` fields, so the cog's explicit choices (provider catalog, `checkpoints_enabled`, …) always win over the profile. The cog does **not** seed sandbox fields — that's intentional, so `profile=security`'s workspace restriction + private-network block + shell deny actually take effect when the operator chooses it. The default (`profile=max-build` or any non-security profile) inherits PasClaw's stock `TConfig` sandbox: `RestrictToWorkspace=False`, `ShellDenyEnabled=True`, `BlockPrivateNetworks=True` — appropriate for a cloud container.
 
 **At least one provider must be configured** — either a cloud API key, a local-server URL, or the `custom_provider_*` set.
 

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -293,16 +293,19 @@ class Predictor(BasePredictor):
             default="max-build",
             description="PasClaw config profile applied on top of stock "
             "defaults. `max-build` (default) turns on web_fetch, "
-            "web_search, vector_search, auto_router, prompt_cache, "
-            "task-aware memory orientation, promptware guard, the "
-            "self-improving-skills suite, and bumps tool_output_cap "
-            "to 16 KB -- the richest unattended-build toolset. Other "
-            "choices: `baseline` (everything off, useful for A/B), "
-            "`low-token` (cheaper, smaller context window), "
-            "`security` (workspace restriction + shell deny + "
-            "private-network block), `all-on` (max-build plus every "
-            "remaining flag flipped on). Empty to skip profile "
-            "application.",
+            "vector_search, auto_router, prompt_cache, task-aware "
+            "memory orientation, promptware guard, the self-improving-"
+            "skills suite, and bumps tool_output_cap to 16 KB -- the "
+            "richest unattended-build toolset. (Note: web_search is a "
+            "max-build *flag*, but the tool only registers when "
+            "PasClaw is also configured with a search provider. This "
+            "cog doesn't supply one, so web_search isn't available "
+            "out of the box -- use web_fetch.) Other choices: "
+            "`baseline` (everything off, useful for A/B), `low-token` "
+            "(cheaper, smaller context window), `security` (workspace "
+            "restriction + shell deny + private-network block), "
+            "`all-on` (max-build plus every remaining flag flipped "
+            "on). Empty to skip profile application.",
         ),
     ) -> list[Path]:
         """
@@ -442,6 +445,16 @@ class Predictor(BasePredictor):
         # profile's defaults. We deliberately set checkpoints_enabled
         # outside the profile so /undo + /redo work even under profiles
         # that don't enable them (baseline / security).
+        #
+        # Sandbox fields are NOT seeded here. Codex P2 on PR #304: an
+        # explicit sandbox block would override `profile=security`'s
+        # hardening (which sets restrict_to_workspace / block_private_
+        # networks / etc.). PasClaw's TConfig defaults are already
+        # appropriate for a cloud container -- RestrictToWorkspace=False,
+        # ShellDenyEnabled=True, BlockPrivateNetworks=True -- and the
+        # security profile correctly tightens them when chosen. An
+        # operator who wants a custom sandbox can still author a
+        # user-shadow profile that sets those fields.
         config_data = {
             "default_provider": selected_provider,
             "default_model":    default_model,
@@ -449,15 +462,6 @@ class Predictor(BasePredictor):
             "render_markdown":  False,
             "stats_collection_enabled": False,
             "checkpoints_enabled": True,    # zpaq backend: /undo + /redo survive the zip round-trip
-            "sandbox": {
-                "restrict_to_workspace":      False,
-                "allow_read_outside_workspace": True,
-                "shell_deny_enabled":         True,
-                "block_private_networks":     False,
-                "allow_read_paths":           [],
-                "allow_write_paths":          [],
-                "custom_shell_deny":          [],
-            },
         }
 
         # Apply the profile when non-empty. PasClaw's selection


### PR DESCRIPTION
## Summary

Addresses both Codex P2 findings on PR #304.

### Finding 1 — `predict.py:295-296` — misleading `web_search` claim

The `profile` input description said `max-build` enables `web_search`. The *flag* is in `max-build`'s patch, but tool registration is gated on `HasConfiguredWebSearchProvider(Cfg)` in `NewBuiltinRegistry`. The cog only writes LLM provider entries — no `web_search.provider` block — so the tool never registers. A caller following the default would see no `web_search` despite the description.

**Fix**: rewrite the description to call out `web_fetch` as the available tool and explicitly note that `web_search` needs an out-of-band search-provider config the cog doesn't supply. Same edit in the README's "Profile defaults" section.

### Finding 2 — `predict.py:455-463` — sandbox override defeats `profile=security`

The seeded `config_data` set permissive sandbox values explicitly. `LoadConfig` applies the profile *first*, then the config file overrides — so my explicit fields stomped `security`'s hardening. Operators picking `profile=security` silently got the permissive cog sandbox.

**Fix**: drop the sandbox block from `config_data` entirely. PasClaw's `TConfig` defaults

```
RestrictToWorkspace       := False
AllowReadOutsideWorkspace := False
ShellDenyEnabled          := True
BlockPrivateNetworks      := True
```

are already appropriate for a cloud container — two of the cog's original fields (`AllowReadOutsideWorkspace=True`, `BlockPrivateNetworks=False`) were *more permissive* than the stock defaults without strong motivation. Result table:

| Profile | Effective sandbox |
|---|---|
| `max-build` *(default)* / `baseline` / `low-token` / `all-on` | TConfig defaults (shell deny on, internal-IP block on, workspace-only reads) |
| `security` | Profile's hardening (workspace restriction + allow_read_outside_workspace=False + private-network block + …) takes effect as advertised |
| *(empty)* | TConfig defaults |

A comment block above `config_data` names the Codex P2 finding + PR #304 so the override doesn't get "cleaned up" later. README "Profile defaults" subsection documents the no-sandbox-seed choice and enumerates the inherited values.

### Files

```
cog-build/predict.py    # ~20 LOC delta
cog-build/README.md     # description sentences updated
```

### Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — syntax OK
- [ ] `cog push` with `profile=security` and verify `pasclaw status` (or a quick `fs_read /etc/hostname` attempt) actually fails per the security profile.
- [ ] `cog push` with `profile=max-build` and confirm sandbox is permissive (RestrictToWorkspace=False).

No Pascal-side changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_