### PR TITLE
windows: fix cmd.exe quoting bugs in shell_exec + execute_code

### DIFF
--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -444,8 +444,32 @@ begin
   M := TMemoryStream.Create;
   try
     {$IFDEF MSWINDOWS}
-    P.Executable := 'cmd.exe';
-    P.Parameters.Add('/C'); P.Parameters.Add(Cmd);
+    (* cmd.exe quoting workaround. TProcess.Parameters builds the
+       Windows lpCommandLine via FPC's MSVCRT-style escape pass --
+       embedded `"` becomes `\"`. cmd.exe does NOT recognise `\"`;
+       its escape for an embedded quote is `""` (doubled). When the
+       model sends `python -c "..."` containing literal quotes, the
+       FPC-escaped `\"` confuses cmd's parser, which splits the
+       argument at the wrong boundary and Python receives a
+       truncated `-c` value -- the well-known cmd.exe-vs-MSVCRT
+       quoting mismatch.
+
+       Bypass FPC's escape pass by setting CommandLine directly.
+       cmd.exe's `cmd /C "<stuff>"` outer-quote-strip rule then
+       handles the common case cleanly:
+
+         CommandLine := 'cmd.exe /C "python -c "with open(...)""'
+                        ^                                     ^
+                        +-- cmd strips these (first + last char) -+
+         -> cmd executes: python -c "with open(...)"
+
+       Limitation: if `Cmd` contains an unquoted shell operator
+       (`&&`, `|`, `>`) AND no internal quotes, cmd's strip rule
+       may still apply incorrectly. The model rarely emits such
+       commands -- and the FPC.Parameters path's mangling was a
+       guaranteed bug for every quoted command, so this is a
+       net improvement. *)
+    P.CommandLine := 'cmd.exe /C "' + Cmd + '"';
     {$ELSE}
     P.Executable := '/bin/sh';
     P.Parameters.Add('-c'); P.Parameters.Add(Cmd);
@@ -534,8 +558,32 @@ begin
       end;
     P.Environment := EnvList;
     {$IFDEF MSWINDOWS}
-    P.Executable := 'cmd.exe';
-    P.Parameters.Add('/C'); P.Parameters.Add(Cmd);
+    (* cmd.exe quoting workaround. TProcess.Parameters builds the
+       Windows lpCommandLine via FPC's MSVCRT-style escape pass --
+       embedded `"` becomes `\"`. cmd.exe does NOT recognise `\"`;
+       its escape for an embedded quote is `""` (doubled). When the
+       model sends `python -c "..."` containing literal quotes, the
+       FPC-escaped `\"` confuses cmd's parser, which splits the
+       argument at the wrong boundary and Python receives a
+       truncated `-c` value -- the well-known cmd.exe-vs-MSVCRT
+       quoting mismatch.
+
+       Bypass FPC's escape pass by setting CommandLine directly.
+       cmd.exe's `cmd /C "<stuff>"` outer-quote-strip rule then
+       handles the common case cleanly:
+
+         CommandLine := 'cmd.exe /C "python -c "with open(...)""'
+                        ^                                     ^
+                        +-- cmd strips these (first + last char) -+
+         -> cmd executes: python -c "with open(...)"
+
+       Limitation: if `Cmd` contains an unquoted shell operator
+       (`&&`, `|`, `>`) AND no internal quotes, cmd's strip rule
+       may still apply incorrectly. The model rarely emits such
+       commands -- and the FPC.Parameters path's mangling was a
+       guaranteed bug for every quoted command, so this is a
+       net improvement. *)
+    P.CommandLine := 'cmd.exe /C "' + Cmd + '"';
     {$ELSE}
     P.Executable := '/bin/sh';
     P.Parameters.Add('-c'); P.Parameters.Add(Cmd);

--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -92,6 +92,13 @@ function BuildExecuteCodeArgv(const Lang, ScriptPath: string;
    hardcoding pwsh and silently breaking on stock Windows. *)
 function ResolvePowerShellExe: string;
 
+(* True when Arg must be wrapped in `"..."` for `cmd /C` or `/bin/sh -c`
+   not to mis-parse it. Bareword-safe tokens (no whitespace, no shell
+   metacharacters) pass through unquoted. Exposed so a unit test can
+   pin the regression for the "'\"powershell\"' is not recognized"
+   cmd.exe bug without spawning anything. *)
+function ArgvNeedsQuoting(const Arg: string): Boolean;
+
 (* The tool handler itself. Exposed (rather than only registered)
    so a regression test can drive it without standing up a full
    agent + provider. Same calling convention as every other
@@ -317,6 +324,34 @@ begin
   if Lang = 'powershell' then Result := '.ps1' else Result := '.sh';
 end;
 
+function ArgvNeedsQuoting(const Arg: string): Boolean;
+{ True when Arg must be wrapped in quotes for `cmd /C` or `sh -c`
+  not to mis-parse it. Bareword-safe tokens (no whitespace, no
+  shell metacharacters) can pass through unquoted, which matters
+  on Windows where quoting the executable name itself breaks
+  cmd.exe's command lookup (`'"powershell"' is not recognized`).
+
+  The metacharacter set covers what either shell treats specially:
+  whitespace + shell-operator chars + quote chars themselves.
+  Conservative: false positives just produce unnecessary quoting,
+  not incorrect parsing. }
+var
+  i: Integer;
+begin
+  if Arg = '' then Exit(True);    { empty arg needs explicit "" }
+  for i := 1 to Length(Arg) do
+    case Arg[i] of
+      ' ', #9, #10, #13,
+      '"', '''',
+      '&', '|', '<', '>', '^',
+      '(', ')',
+      '*', '?', ';',
+      '$', '`':
+        Exit(True);
+    end;
+  Result := False;
+end;
+
 function MakeTempScript(const Lang, Code: string; out Path: string;
                        out ErrMsg: string): Boolean;
 { Materialise the model's script body to disk under
@@ -460,15 +495,26 @@ begin
 
       { Compose the spawn command. RunOneShotWithEnv wants a single
         command string it can hand to /bin/sh -c (or cmd /c on
-        Windows) -- we don't have a direct argv-vector API. Quote
-        each argument so spaces or special chars in $PASCLAW_HOME
-        don't fragment the script-path argument; the script body
-        itself is in the file and isn't touched by this quoting. }
+        Windows) -- we don't have a direct argv-vector API.
+
+        Quote each argument that contains whitespace or shell
+        special chars; leave bareword-safe tokens (the executable
+        name like `bash` / `pwsh` / `powershell`) unquoted. Earlier
+        revisions unconditionally wrapped every element in `"..."`
+        -- on Windows that produced `cmd /C ""powershell" "-File"
+        "C:\..\.ps1""` which cmd.exe's parser misreads as a request
+        for a program literally named `"powershell"` (with quotes),
+        failing with "'\"powershell\"' is not recognized". The
+        script path under $PASCLAW_HOME/tmp/ does still need
+        quoting on hosts where the user profile name has spaces. }
       Cmd := '';
       for i := 0 to High(Argv) do
       begin
         if Cmd <> '' then Cmd := Cmd + ' ';
-        Cmd := Cmd + '"' + StringReplace(Argv[i], '"', '\"', [rfReplaceAll]) + '"';
+        if ArgvNeedsQuoting(Argv[i]) then
+          Cmd := Cmd + '"' + StringReplace(Argv[i], '"', '\"', [rfReplaceAll]) + '"'
+        else
+          Cmd := Cmd + Argv[i];
       end;
 
       if RestrictionActive then

--- a/src/tests/execute_code_tests.pas
+++ b/src/tests/execute_code_tests.pas
@@ -228,6 +228,61 @@ begin
   AssertContains(Err, 'code', 'error mentions the missing arg');
 end;
 
+procedure TestArgvNeedsQuoting;
+{ Regression for the Windows cmd-quoting bug that produced
+  "'\"powershell\"' is not recognized as an internal or external
+  command". Argv[0] is always a bareword executable name on every
+  current code path (bash / pwsh / powershell), so the quoting
+  helper must NOT wrap it. The script-path argument can contain
+  spaces when $PASCLAW_HOME sits under a profile with spaces, so
+  it must still get quoted. }
+begin
+  { Bareword executable names: must NOT be quoted. }
+  AssertTrue(not ArgvNeedsQuoting('bash'),
+             'bash bareword unquoted');
+  AssertTrue(not ArgvNeedsQuoting('powershell'),
+             'powershell bareword unquoted');
+  AssertTrue(not ArgvNeedsQuoting('pwsh'),
+             'pwsh bareword unquoted');
+
+  { Bareword flags: also unquoted. }
+  AssertTrue(not ArgvNeedsQuoting('-File'),
+             '-File flag unquoted');
+  AssertTrue(not ArgvNeedsQuoting('-NoProfile'),
+             '-NoProfile flag unquoted');
+  AssertTrue(not ArgvNeedsQuoting('Bypass'),
+             'Bypass policy value unquoted');
+
+  { Paths without spaces -- safe unquoted. }
+  AssertTrue(not ArgvNeedsQuoting('/tmp/x.ps1'),
+             'simple POSIX path unquoted');
+  AssertTrue(not ArgvNeedsQuoting('/home/u/.pasclaw/tmp/exec.sh'),
+             'real-shape POSIX path unquoted');
+
+  { Windows paths without spaces -- safe unquoted. Backslash is not a
+    shell metacharacter on either cmd or sh, so a bareword Windows
+    path passes through clean. }
+  AssertTrue(not ArgvNeedsQuoting('C:\Users\anony\.pasclaw\tmp\exec.ps1'),
+             'plain Windows path unquoted (no spaces, no specials)');
+
+  { Paths WITH spaces -- must be quoted. This is the realistic case
+    that makes Cmd_Build_Run keep the quoting code path at all. }
+  AssertTrue(ArgvNeedsQuoting('C:\Program Files\thing\x.ps1'),
+             'Windows path with literal space must be quoted');
+  AssertTrue(ArgvNeedsQuoting('/path with space/script.sh'),
+             'POSIX path with space must be quoted');
+
+  { Empty string -- needs explicit "" so the arg slot isn't lost. }
+  AssertTrue(ArgvNeedsQuoting(''), 'empty arg needs "" wrapping');
+
+  { Shell-special chars in the body. }
+  AssertTrue(ArgvNeedsQuoting('a && b'),  '&& metacharacter');
+  AssertTrue(ArgvNeedsQuoting('a | b'),   '| pipe');
+  AssertTrue(ArgvNeedsQuoting('a"b'),     'embedded quote');
+  AssertTrue(ArgvNeedsQuoting('a$b'),     '$ dollar');
+  AssertTrue(ArgvNeedsQuoting('a`b'),     '` backtick');
+end;
+
 begin
   TestResolveLangDispatch;
   TestBuildArgvBash;
@@ -237,5 +292,6 @@ begin
   TestEndToEndRoundTrip;
   TestDenylistRejectsScriptBody;
   TestMissingCodeArg;
+  TestArgvNeedsQuoting;
   WriteLn('execute_code_tests: OK');
 end.


### PR DESCRIPTION
Two layered Windows quoting bugs surfaced from real prediction logs.  Both reproduce on every Windows build that hits a command with internal quotes, which is essentially every model call that runs Python / Node / any -c-style one-liner.

BUG 1 -- execute_code over-quoted the executable name.

  PasClaw.Tools.ExecuteCode.pas:467-472 unconditionally wrapped
  every argv element in `"..."` before joining for cmd /C, so the
  command line ended up:

      "powershell" "-NoProfile" "-ExecutionPolicy" "Bypass" \
                                "-File" "C:\Users\...\exec.ps1"

  cmd.exe's command lookup looks for an executable literally named
  `"powershell"` (with the surrounding quotes interpreted as part
  of the name in a cmd quirk), doesn't find one, and fails with

      '"powershell"' is not recognized as an internal or external
      command, operable program or batch file.

  Fix: new ArgvNeedsQuoting helper that returns True only for
  args containing whitespace or shell metacharacters
  (space / tab / quote / & / | / < / > / ^ / ( ) / * ? ; / $ / `).
  Argv[0] -- always a bareword like `bash` / `pwsh` / `powershell`
  on every current code path -- passes through unquoted; the
  script path under $PASCLAW_HOME/tmp/ still gets quoted when the
  operator profile has a space in it.

BUG 2 -- shell_exec mangled internal quotes via MSVCRT escaping.

  PasClaw.Platform.pas (both RunOneShot and RunOneShotWithEnv on
  the Windows branch) did:

      P.Executable := 'cmd.exe';
      P.Parameters.Add('/C');
      P.Parameters.Add(Cmd);

  FPC's TProcess can't pass an "array of params" to Windows --
  CreateProcess takes a single lpCommandLine string -- so it
  builds that string from Parameters by applying its own
  MSVCRT-style escape pass: embedded `"` becomes `\"`.

  cmd.exe does NOT recognise `\"`. Its escape for an embedded
  quote is `""` (doubled) or `^"` (caret-escape). When the model
  sent `python -c "with open(...)"`, FPC turned that into
  `python -c \"with open(...)\"`, cmd's parser split at the wrong
  boundary, and Python received a truncated `-c` argument:

      File "<string>", line 1
          "with
          ^
      SyntaxError: unterminated string literal

  Fix: bypass FPC's escape pass by setting TProcess.CommandLine
  directly.  cmd.exe's `cmd /C "<stuff>"` outer-quote-strip rule
  then handles the common case cleanly --

      P.CommandLine := 'cmd.exe /C "' + Cmd + '"';

  ->  cmd /C "python -c "with open(...)""
                                          ^ cmd strips first/last
      ->  python -c "with open(...)"      "

  Documented limitation: if Cmd contains an unquoted shell
  operator (&&, |, >) AND no internal quotes, cmd's strip rule
  may misapply.  The model rarely emits such commands and the
  FPC.Parameters path's mangling was a guaranteed bug for every
  quoted command, so this is a net improvement.  Block comments
  on both code paths spell out the trade-off so a future cleanup
  doesn't reintroduce the Parameters call.

Tests:

  src/tests/execute_code_tests.pas grows TestArgvNeedsQuoting
  with 14 assertions:
    * bareword executables (bash / powershell / pwsh) unquoted
    * bareword flags (-File / -NoProfile / Bypass) unquoted
    * plain Windows paths (no spaces) unquoted
    * plain POSIX paths unquoted
    * Windows path WITH space quoted
    * POSIX path with space quoted
    * empty string quoted (so the slot isn't lost)
    * each metacharacter triggers quoting (&&, |, ", $, `)

  All existing suites still pass: test-execute-code,
  test-shell-backend, test-shell-filters, test-run-timeout.

  Sandbox here is FPC/linux; the Windows fixes are verified by
  inspection and unit-tests against the helper.  Real validation
  on a Windows box is the next step.