### PR TITLE
bench: LOCOMO-shaped memory-retrieval harness for memory_search

### DIFF
--- a/bench/locomo/.gitignore
+++ b/bench/locomo/.gitignore
@@ -1,0 +1,7 @@
+# Built helper -- compiled per-host, not tracked.  Build via the
+# fpc invocation in the README.
+memory_recall
+
+# Per-persona retrieval dumps.  These are run artifacts, not code;
+# keep them out of git.  Real-LOCOMO runs produce ~50 of these.
+results/

--- a/bench/locomo/README.md
+++ b/bench/locomo/README.md
@@ -1,0 +1,112 @@
+# LOCOMO memory-retrieval bench
+
+Self-contained harness that measures PasClaw's `memory_search` retrieval quality on [LOCOMO](https://github.com/snap-stanford/locomo)-shaped multi-session conversations. Designed to run **without a real LLM provider** — the harness only exercises the retrieval layer, which is the upper bound on agent performance.
+
+## What it measures
+
+For each question in a persona, the harness:
+
+1. Writes the persona's multi-session conversations into `$PASCLAW_HOME/workspace/memory/` as date-stamped markdown files.
+2. Calls PasClaw's `memory_search` (via the `memory_recall` helper here) for the question text.
+3. Scores the top-K results two ways:
+   - **Snippet-level**: did the gold answer (or any alias) appear in the FTS5-bounded snippet text? This is what the model sees in *one* `memory_search` call.
+   - **Doc-level**: did it appear anywhere in the full document body of the top-K hits' source files? This is what an agent reaches with a follow-up `fs_read` on the cited path.
+
+Both numbers tell different parts of the story. Snippet-level is the agent's *first* round of retrieval; doc-level is what an iterating agent can recover.
+
+## What it does NOT measure
+
+- Agent-loop reasoning, multi-step tool use, hallucination on missing facts.
+- The model's ability to *synthesize* across multiple retrieved chunks (multi-hop questions get credit for retrieving each constituent fact separately, not for the synthesis).
+
+Those need a full LLM in the loop. For PasClaw the natural extension is to run [`pasclaw build`](../../docs/commands.md#build) with a real provider and tally end-to-end answer accuracy.
+
+## Running
+
+### Smoke test (bundled fixture, no LOCOMO download)
+
+```sh
+# Compile the Pascal helper once.  Uses PasClaw's standard
+# FPCFLAGS so unit paths resolve.
+make build/pasclaw      # ensures dependencies are already built
+
+fpc -MDelphi -Sh -O2 -Xs -XX \
+    $(...the same -Fu list `make` uses; see the build commands the
+    Makefile prints for the full set...) \
+    -FEbench/locomo -FUbuild/lib \
+    bench/locomo/memory_recall.pas
+
+# Run.
+python3 bench/locomo/run.py
+```
+
+Output goes to `bench/locomo/results/<persona_id>.json` plus a console summary.
+
+### Against real LOCOMO
+
+```sh
+git clone https://github.com/snap-stanford/locomo /tmp/locomo
+# write a small adapter that maps LOCOMO's session_summary + conversation
+# fields into the shape this harness expects -- see load_persona() in
+# run.py.  Then:
+python3 bench/locomo/run.py --persona /tmp/locomo/data/locomo10.json
+```
+
+The shape adapter is a few dozen lines because LOCOMO's raw format names the same content differently ("date" → "session_date", "messages" → "dialogue", etc.). Not bundled here because the dataset license has its own download terms.
+
+## Persona JSON schema
+
+```json
+{
+  "persona_id": "string -- unique label, used as the tempdir + results filename",
+  "sessions": [
+    {
+      "session_id": "string",
+      "date": "YYYY-MM-DD",
+      "messages": [
+        {"role": "user" | "assistant", "content": "string"}
+      ]
+    }
+  ],
+  "questions": [
+    {
+      "id": "string",
+      "category": "single-hop" | "multi-hop" | "temporal" | "adversarial" | "open-domain",
+      "question": "string",
+      "answer": "string -- the gold answer",
+      "answer_aliases": ["string", ...],   // optional; defaults to [answer]
+      "source_session": "string or comma-separated"   // optional, for debugging
+    }
+  ]
+}
+```
+
+A `score_question` hit is **any case-insensitive substring match** of any alias against the snippet/doc body. Substring is generous — it gives credit for noisy snippets that contain the answer somewhere — and matches what most LOCOMO baselines do.
+
+## Ablation knobs
+
+Set `vector_search_enabled` in the seeded `config.json` (see `write_config()` in `run.py`) to compare:
+
+- **FTS5-only**: `vector_search_enabled: false`. PasClaw skips the hybrid path; just BM25.
+- **Hybrid (default)**: `vector_search_enabled: true` *and* the vector runtime is on disk (`pasclaw memory provision`). Hybrid FTS5 + sqlite-vec via RRF.
+
+For a quick FTS-only run, edit `write_config()` to flip the flag and re-run.
+
+## Files
+
+```
+bench/locomo/
+├── README.md            you're here
+├── fixture/
+│   └── alice_synthetic.json    1 persona, 3 sessions, 8 questions
+├── memory_recall.pas    Pascal CLI helper -- calls PasClaw.Memory.Index.Search
+├── memory_recall        compiled binary (gitignored)
+├── run.py               main harness -- load persona, recall per Q, score
+└── results/             per-persona JSON dumps (gitignored)
+```
+
+## Honest caveats
+
+- **The bundled fixture is hand-rolled**, not a LOCOMO sample. It exists to smoke-test the harness end-to-end without the dataset download. Real LOCOMO has 10+ personas with 35+ sessions each; expect lower numbers (more distractor content per persona).
+- **No automatic consolidation.** PasClaw treats memory as operator-curated notebooks (`MEMORY.md`, daily notes). The bench writes raw conversation content directly; an "automatic episode → semantic fact" pass like [Mem0](https://github.com/mem0ai/mem0) or the [Elastic agent-memory architecture](https://www.elastic.co/search-labs/blog/agent-memory-elasticsearch) would change these numbers materially. The harness can serve as the regression target if/when such a pass lands in PasClaw.
+- **The adversarial category is currently a single question** in the fixture and isn't representative. Real LOCOMO has dozens; that's where supersession + confidence scoring would show up in the numbers (or their absence in PasClaw's current memory model).

--- a/bench/locomo/fixture/alice_synthetic.json
+++ b/bench/locomo/fixture/alice_synthetic.json
@@ -1,0 +1,120 @@
+{
+  "persona_id": "alice_synthetic",
+  "description": "LOCOMO-shaped synthetic persona with three sessions and 8 questions across categories. Multi-session content with explicit facts (single-hop), facts that cross sessions (multi-hop), and dates (temporal). Used to smoke-test the bench harness against PasClaw's memory_search retrieval layer without requiring the real LOCOMO download.",
+  "sessions": [
+    {
+      "session_id": "s1",
+      "date": "2024-01-15",
+      "messages": [
+        {"role": "user", "content": "Hi! Long time. I've been thinking about getting a dog."},
+        {"role": "assistant", "content": "Welcome back. What breed are you considering?"},
+        {"role": "user", "content": "Almost certainly a Border Collie. They're intense but I've wanted one since I was a kid."},
+        {"role": "assistant", "content": "They need a lot of exercise. Is your living situation compatible?"},
+        {"role": "user", "content": "Yeah I just moved to Portland Oregon, got a place near Forest Park so trail running is right there."},
+        {"role": "assistant", "content": "Sounds ideal. Any names picked out yet?"},
+        {"role": "user", "content": "Probably Luna. My sister Jenna says it's overused but I don't care."},
+        {"role": "assistant", "content": "Luna is a great name. When are you picking her up?"},
+        {"role": "user", "content": "Breeder said end of February. Pups are 8 weeks then."},
+        {"role": "assistant", "content": "Exciting. Anything else going on?"},
+        {"role": "user", "content": "Job search is wrapping up. Have a final interview Thursday at a robotics company called Acme Robotics."}
+      ]
+    },
+    {
+      "session_id": "s2",
+      "date": "2024-02-28",
+      "messages": [
+        {"role": "user", "content": "I got the job at Acme Robotics! Starting March 11."},
+        {"role": "assistant", "content": "Congratulations! What's your role?"},
+        {"role": "user", "content": "Senior software engineer on the motion planning team. Lots of C++."},
+        {"role": "assistant", "content": "Sounds great. And Luna?"},
+        {"role": "user", "content": "Picked her up two days ago. She's a black-and-white tri color. Already chewed through one shoe."},
+        {"role": "assistant", "content": "Border Collie puppy energy is real. How's the Portland adjustment?"},
+        {"role": "user", "content": "Loving it. Bought a Trek FX3 bike last weekend to commute to Acme's office in Beaverton."},
+        {"role": "assistant", "content": "Smart choice. Any travel plans?"},
+        {"role": "user", "content": "Thinking Japan in June. My friend David lives in Kyoto now, last time I saw him was 2021."}
+      ]
+    },
+    {
+      "session_id": "s3",
+      "date": "2024-04-10",
+      "messages": [
+        {"role": "user", "content": "Quick update. Luna passed her puppy class!"},
+        {"role": "assistant", "content": "Nice. How's work at the new job?"},
+        {"role": "user", "content": "Good. The motion planning team uses ROS 2 plus their own state estimator. Steep ramp."},
+        {"role": "assistant", "content": "And Japan?"},
+        {"role": "user", "content": "Booked. June 8-22. Two weeks. Mostly Kyoto with side trips to Nara and Osaka."},
+        {"role": "assistant", "content": "Two weeks is generous. Staying with David?"},
+        {"role": "user", "content": "First week with him, second week at a ryokan in Hakone."},
+        {"role": "assistant", "content": "Sounds great. Anything else?"},
+        {"role": "user", "content": "Sister Jenna's wedding is in October. I'm in the wedding party."}
+      ]
+    }
+  ],
+  "questions": [
+    {
+      "id": "q1",
+      "category": "single-hop",
+      "question": "What breed of dog does Alice have?",
+      "answer": "Border Collie",
+      "answer_aliases": ["border collie", "Border Collie"],
+      "source_session": "s1"
+    },
+    {
+      "id": "q2",
+      "category": "single-hop",
+      "question": "Where does Alice work?",
+      "answer": "Acme Robotics",
+      "answer_aliases": ["Acme Robotics", "Acme"],
+      "source_session": "s2"
+    },
+    {
+      "id": "q3",
+      "category": "single-hop",
+      "question": "What city did Alice move to?",
+      "answer": "Portland",
+      "answer_aliases": ["Portland", "Portland Oregon", "Portland, Oregon"],
+      "source_session": "s1"
+    },
+    {
+      "id": "q4",
+      "category": "single-hop",
+      "question": "What is Alice's dog's name?",
+      "answer": "Luna",
+      "answer_aliases": ["Luna"],
+      "source_session": "s1"
+    },
+    {
+      "id": "q5",
+      "category": "temporal",
+      "question": "When is Alice traveling to Japan?",
+      "answer": "June 8-22",
+      "answer_aliases": ["June 8-22", "June 8", "June 22", "June"],
+      "source_session": "s3"
+    },
+    {
+      "id": "q6",
+      "category": "multi-hop",
+      "question": "What is the name of the dog Alice bought before starting at her new robotics job?",
+      "answer": "Luna",
+      "answer_aliases": ["Luna"],
+      "source_session": "s1,s2"
+    },
+    {
+      "id": "q7",
+      "category": "multi-hop",
+      "question": "Where does Alice's friend David live, and how is Alice planning to visit him?",
+      "answer": "Kyoto / Japan trip in June",
+      "answer_aliases": ["Kyoto", "Japan"],
+      "source_session": "s2,s3"
+    },
+    {
+      "id": "q8",
+      "category": "adversarial",
+      "question": "What breed of cat does Alice have?",
+      "answer": "Alice does not have a cat",
+      "answer_aliases": ["no cat", "does not have", "doesn't have", "Border Collie"],
+      "source_session": "none",
+      "note": "Alice has a Border Collie, not a cat. The retrieval should surface the dog information; a correct answer requires the model to NOT confabulate a cat."
+    }
+  ]
+}

--- a/bench/locomo/memory_recall.pas
+++ b/bench/locomo/memory_recall.pas
@@ -1,0 +1,173 @@
+program memory_recall;
+(*
+  bench/locomo/memory_recall -- thin CLI shim over PasClaw.Memory.Index
+  for the LOCOMO retrieval bench. Not part of pasclaw proper; lives
+  here so the harness can ask the same Search() the agent's
+  memory_search tool would, without spawning the agent loop.
+
+  Usage:
+    memory_recall --home <path> --query "<question>" --k <N>
+
+  Output: a single JSON object on stdout:
+    { "hits": [
+        { "path": "<file>", "snippet": "<txt>", "score": <float> },
+        ...
+      ]
+    }
+
+  Errors go to stderr; exit code is 0 on success / 1 on any failure
+  so the Python harness can subprocess this cleanly.
+
+  Resolution order for $PASCLAW_HOME:
+    1. --home <path>          (the bench harness always sets this)
+    2. PASCLAW_HOME env var   (so a manual run is easy too)
+    3. default GetHome        (last resort)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Memory.Index,
+  PasClaw.Memory.Vector,
+  PasClaw.Config,
+  PasClaw.Utils;
+
+{$IFDEF UNIX}
+function libc_setenv(const Name, Value: PAnsiChar; Overwrite: Integer): Integer;
+  cdecl; external 'c' name 'setenv';
+{$ENDIF}
+
+procedure SetEnv(const Name, Value: string);
+begin
+  {$IFDEF UNIX}
+  libc_setenv(PAnsiChar(AnsiString(Name)), PAnsiChar(AnsiString(Value)), 1);
+  {$ENDIF}
+end;
+
+function JsonEscape(const S: string): string;
+var
+  i: Integer;
+  c: Char;
+begin
+  Result := '';
+  for i := 1 to Length(S) do
+  begin
+    c := S[i];
+    case c of
+      '"':  Result := Result + '\"';
+      '\':  Result := Result + '\\';
+      #8:   Result := Result + '\b';
+      #9:   Result := Result + '\t';
+      #10:  Result := Result + '\n';
+      #12:  Result := Result + '\f';
+      #13:  Result := Result + '\r';
+    else
+      if Ord(c) < 32 then
+        Result := Result + Format('\u%4.4x', [Ord(c)])
+      else
+        Result := Result + c;
+    end;
+  end;
+end;
+
+procedure Die(const Msg: string);
+begin
+  Writeln(StdErr, 'memory_recall: ', Msg);
+  Halt(1);
+end;
+
+var
+  i, K: Integer;
+  Query, Home: string;
+  Cfg: TConfig;
+  Idx: IMemoryIndex;
+  Hits: TMemoryHitArray;
+  DbPath, MemDir: string;
+  First: Boolean;
+begin
+  Home  := '';
+  Query := '';
+  K     := 10;
+  i := 1;
+  while i <= ParamCount do
+  begin
+    if ParamStr(i) = '--home' then
+    begin
+      if i = ParamCount then Die('--home needs a value');
+      Inc(i); Home := ParamStr(i);
+    end
+    else if ParamStr(i) = '--query' then
+    begin
+      if i = ParamCount then Die('--query needs a value');
+      Inc(i); Query := ParamStr(i);
+    end
+    else if ParamStr(i) = '--k' then
+    begin
+      if i = ParamCount then Die('--k needs a value');
+      Inc(i); K := StrToIntDef(ParamStr(i), 10);
+    end
+    else
+      Die('unknown arg: ' + ParamStr(i));
+    Inc(i);
+  end;
+
+  if Query = '' then Die('--query is required');
+  if Home <> '' then SetEnv('PASCLAW_HOME', Home);
+
+  { Sync the memory store so any newly-written .md files we wrote
+    in load_persona.py land in the FTS5 / vec indexes before we
+    Search. The bench writes files then immediately queries; without
+    a SyncDir, FTS5 sees zero rows.
+
+    Index paths match PasClaw.Tools.Memory.IndexDbPath:
+      FTS5     : $PASCLAW_HOME/workspace/memory/.index.db
+      Vector   : $PASCLAW_HOME/workspace/memory/.index.db.vec  }
+  Cfg := LoadConfig;
+  try
+    MemDir := JoinPath(GetHome, 'workspace/memory');
+    ForceDirectories(MemDir);
+    DbPath := JoinPath(MemDir, '.index.db');
+
+    Idx := nil;
+    if Cfg.VectorSearchEnabled then
+    begin
+      Idx := NewVectorMemoryIndex;
+      if not Idx.Open(DbPath + '.vec') then
+        Idx := nil;
+    end;
+    if Idx = nil then
+    begin
+      Idx := NewMemoryIndex;
+      if not Idx.Open(DbPath) then
+        Die('Open ' + DbPath + ' failed (libsqlite3 missing?)');
+    end;
+    try
+      Idx.SyncDir(MemDir);
+      Hits := Idx.Search(Query, K);
+    finally
+      Idx.Close;
+    end;
+  finally
+    Cfg.Free;
+  end;
+
+  { Emit as JSON. Manual emission so we don't drag in a builder for
+    one object -- the shape is fixed and small. }
+  Write('{"hits":[');
+  First := True;
+  for i := 0 to High(Hits) do
+  begin
+    if not First then Write(',');
+    First := False;
+    Write(Format('{"path":"%s","score":%.6f,"snippet":"%s"}',
+                 [JsonEscape(Hits[i].Path),
+                  Hits[i].Score,
+                  JsonEscape(Hits[i].Snippet)]));
+  end;
+  Writeln(']}');
+end.

--- a/bench/locomo/run.py
+++ b/bench/locomo/run.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+LOCOMO memory-retrieval bench for PasClaw.
+
+What this measures
+------------------
+Just the memory retrieval layer -- given a question, does
+PasClaw's memory_search surface a snippet that contains the
+gold answer? This is the upper bound on agent performance:
+if the right facts don't make it into the model's context,
+no amount of reasoning recovers them.
+
+What this does NOT measure
+--------------------------
+Agent-loop reasoning, multi-hop synthesis across retrieved
+snippets, hallucination on missing facts. Those are downstream
+of retrieval and require a full LLM in the loop.
+
+Pipeline
+--------
+1. Per persona, set up a fresh $PASCLAW_HOME tempdir.
+2. Write each conversation session as one markdown file under
+   workspace/memory/ (date-stamped naming so PasClaw's daily-
+   note injection conventions apply).
+3. Invoke bench/locomo/memory_recall (Pascal helper) per
+   question. It calls Idx.SyncDir on first invocation, which
+   builds the FTS5 + vec indexes; subsequent calls reuse them.
+4. Dump top-K retrievals to results/<persona>.json.
+5. Score: for each question, did the gold answer (or any
+   alias) appear in the snippet text of the top-K hits?
+6. Tally R@1 / R@5 / R@10 per category and overall.
+
+Real LOCOMO
+-----------
+The bundled fixture is a hand-rolled LOCOMO-shaped persona for
+smoke-testing without the dataset download. To run against the
+real LOCOMO benchmark:
+
+    git clone https://github.com/snap-stanford/locomo
+    python bench/locomo/run.py --persona locomo/data/locomo10.json
+
+The shape adapter is straightforward -- LOCOMO's session_summary
++ conversation field map onto the loader's "messages" array. See
+load_persona() for the exact contract.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+RECALL_BINARY = HERE / "memory_recall"
+
+
+def load_persona(path):
+    """Load a LOCOMO-shaped persona JSON.
+
+    Expected shape (matches the bundled fixture):
+      { "persona_id": str,
+        "sessions": [ { "session_id", "date", "messages": [
+                         {"role", "content"} ] } ],
+        "questions": [ { "id", "category", "question",
+                         "answer", "answer_aliases"? } ] }
+
+    For real-LOCOMO files, write a tiny shim that produces this
+    shape -- LOCOMO's raw format has the same content, just
+    different field names.
+    """
+    with open(path) as f:
+        return json.load(f)
+
+
+def write_sessions_to_memory(home, persona):
+    """Convert persona sessions to PasClaw memory markdown files.
+
+    Strategy: each session lands as a single .md under
+    workspace/memory/ with the session date as the filename
+    (so PasClaw's "yesterday's daily note" injection has a
+    chance to surface it). The session content is rendered as
+    a transcript with explicit speaker tags so FTS5 has clean
+    token boundaries and vector embedding sees readable text.
+    """
+    mem_dir = home / "workspace" / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    pid = persona["persona_id"]
+    for sess in persona["sessions"]:
+        date = sess["date"]
+        sid = sess["session_id"]
+        path = mem_dir / f"{pid}_{date}_{sid}.md"
+        with open(path, "w") as f:
+            f.write(f"# {pid} session {sid} ({date})\n\n")
+            for msg in sess["messages"]:
+                speaker = "user" if msg["role"] == "user" else "assistant"
+                f.write(f"**{speaker}**: {msg['content']}\n\n")
+    return mem_dir
+
+
+def write_config(home):
+    """Seed a minimal config.json. memory_recall only reads
+    Cfg.VectorSearchEnabled; everything else PasClaw defaults
+    are fine for a bench run."""
+    cfg_path = home / "config.json"
+    # Vector backend is opt-in -- if the host hasn't run
+    # `pasclaw memory provision`, the runtime artifacts aren't
+    # on disk and Open will fail back to FTS-only. Leave the
+    # flag on; the helper handles graceful fallback.
+    cfg = {
+        "default_provider": "bench",
+        "default_model": "n/a",
+        "providers": [],
+        "vector_search_enabled": True,
+        "render_markdown": False,
+    }
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f, indent=2)
+    return cfg_path
+
+
+def recall(home, query, k):
+    """Invoke the Pascal helper. Returns the parsed JSON.
+
+    Each call shells out so we don't have to hand-import a
+    Pascal-callable Python binding; the per-query overhead is
+    fork/exec + one SQLite open which is fast enough at bench
+    scale. SyncDir is run on every call but it's mtime-keyed
+    so only the first call does real work."""
+    cmd = [
+        str(RECALL_BINARY),
+        "--home", str(home),
+        "--query", query,
+        "--k", str(k),
+    ]
+    env = os.environ.copy()
+    env["PASCLAW_HOME"] = str(home)
+    res = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=False,
+        timeout=60,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"memory_recall failed (exit={res.returncode}):\n"
+            f"stderr: {res.stderr}\nstdout: {res.stdout}"
+        )
+    return json.loads(res.stdout)
+
+
+def _read_doc(path):
+    """Best-effort full-doc read for the document-level score. The
+    memory_recall snippet column is FTS5's bounded window (~30 tokens
+    of context); a real agent would see the snippet, decide a hit
+    looks relevant, and call fs_read on the path to expand. We
+    measure both layers so the bench distinguishes 'retrieval found
+    the right doc but snippet missed the answer line' (fixable with
+    a follow-up read) from 'retrieval missed entirely' (fatal)."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read().lower()
+    except (FileNotFoundError, PermissionError, UnicodeDecodeError):
+        return ""
+
+
+def score_question(q, hits):
+    """For each k in {1, 5, 10}, two layers:
+
+      snippet_r@k -- did any alias appear in the FTS5-bounded
+                     snippet text of the top-k hits? This is what
+                     the model sees in one memory_search call,
+                     before any follow-up fs_read.
+      doc_r@k     -- did any alias appear in the FULL document
+                     body of the top-k hits' source files? An
+                     agent following up with fs_read would
+                     surface this content.
+
+    Real LOCOMO scoring uses chunked retrieval where the chunk IS
+    the model's window; PasClaw's tool surface has the cite-then-
+    read split, so both numbers tell different parts of the story."""
+    aliases = q.get("answer_aliases") or [q["answer"]]
+    aliases = [a.lower() for a in aliases]
+    out = {}
+    docs_seen = {}  # cache: path -> lowered body
+    for k in (1, 5, 10):
+        snippet_hit = False
+        doc_hit = False
+        for entry in hits[:k]:
+            snippet = entry["snippet"].lower()
+            if any(alias in snippet for alias in aliases):
+                snippet_hit = True
+                doc_hit = True
+                break
+            # snippet missed; check the full doc as the
+            # follow-up-fs_read upper bound.
+            path = entry["path"]
+            if path not in docs_seen:
+                docs_seen[path] = _read_doc(path)
+            if any(alias in docs_seen[path] for alias in aliases):
+                doc_hit = True
+        out[f"snippet_r@{k}"] = 1 if snippet_hit else 0
+        out[f"doc_r@{k}"]     = 1 if doc_hit else 0
+    return out
+
+
+def run(persona_path, out_dir, k=10, keep_home=False):
+    persona = load_persona(persona_path)
+    pid = persona["persona_id"]
+
+    home = Path(tempfile.mkdtemp(prefix=f"locomo_{pid}_"))
+    try:
+        write_config(home)
+        write_sessions_to_memory(home, persona)
+        print(f"[bench] persona={pid} home={home}", file=sys.stderr)
+        print(f"[bench] {len(persona['sessions'])} sessions, "
+              f"{len(persona['questions'])} questions", file=sys.stderr)
+
+        results = []
+        for q in persona["questions"]:
+            try:
+                r = recall(home, q["question"], k)
+            except Exception as e:
+                print(f"[bench] FAIL on {q['id']}: {e}", file=sys.stderr)
+                r = {"hits": []}
+            scored = score_question(q, r["hits"])
+            results.append({
+                "question": q,
+                "hits": r["hits"],
+                "score": scored,
+            })
+            print(f"[bench] {q['id']} ({q['category']}): "
+                  f"snippet={scored['snippet_r@1']}/{scored['snippet_r@5']}/{scored['snippet_r@10']} "
+                  f"doc={scored['doc_r@1']}/{scored['doc_r@5']}/{scored['doc_r@10']}",
+                  file=sys.stderr)
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{pid}.json"
+        with open(out_path, "w") as f:
+            json.dump({
+                "persona_id": pid,
+                "results": results,
+                "summary": summarize(results),
+            }, f, indent=2)
+        print(f"[bench] wrote {out_path}", file=sys.stderr)
+        print(format_summary(summarize(results)))
+        return out_path
+    finally:
+        if not keep_home:
+            shutil.rmtree(home, ignore_errors=True)
+
+
+def _mean(scores, key):
+    return sum(s[key] for s in scores) / len(scores)
+
+
+def summarize(results):
+    by_cat = {}
+    for r in results:
+        cat = r["question"]["category"]
+        by_cat.setdefault(cat, []).append(r["score"])
+    keys = ["snippet_r@1", "snippet_r@5", "snippet_r@10",
+            "doc_r@1",     "doc_r@5",     "doc_r@10"]
+    summary = {"by_category": {}, "overall": {}}
+    for cat, scores in by_cat.items():
+        m = {"n": len(scores)}
+        for k in keys:
+            m[k] = _mean(scores, k)
+        summary["by_category"][cat] = m
+    all_scores = [r["score"] for r in results]
+    o = {"n": len(all_scores)}
+    for k in keys:
+        o[k] = _mean(all_scores, k)
+    summary["overall"] = o
+    return summary
+
+
+def format_summary(summary):
+    lines = ["",
+             "                       ----- snippet-level -----   ----- doc-level -------",
+             "category         n    R@1    R@5    R@10           R@1    R@5    R@10",
+             "--------------- ---   -----  -----  -----          -----  -----  -----"]
+    def row(label, m):
+        return (f"{label:<15} {m['n']:>3}   "
+                f"{m['snippet_r@1']:>.3f}  {m['snippet_r@5']:>.3f}  {m['snippet_r@10']:>.3f}"
+                f"          "
+                f"{m['doc_r@1']:>.3f}  {m['doc_r@5']:>.3f}  {m['doc_r@10']:>.3f}")
+    for cat, m in sorted(summary["by_category"].items()):
+        lines.append(row(cat, m))
+    lines.append("--------------- ---   -----  -----  -----          -----  -----  -----")
+    lines.append(row("overall", summary["overall"]))
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--persona", default=str(HERE / "fixture" / "alice_synthetic.json"),
+                   help="path to a LOCOMO-shaped persona JSON")
+    p.add_argument("--out", default=str(HERE / "results"),
+                   help="output directory for per-persona results")
+    p.add_argument("--k", type=int, default=10,
+                   help="top-K snippets to retrieve (default 10)")
+    p.add_argument("--keep-home", action="store_true",
+                   help="don't clean up the temp PASCLAW_HOME (debug)")
+    args = p.parse_args()
+
+    if not RECALL_BINARY.exists():
+        sys.exit(f"missing helper: {RECALL_BINARY}\n"
+                 "Build it with:\n"
+                 "  fpc <PasClaw FPCFLAGS> bench/locomo/memory_recall.pas")
+
+    run(Path(args.persona), Path(args.out), k=args.k,
+        keep_home=args.keep_home)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Self-contained adapter that runs LOCOMO-shaped multi-session personas through PasClaw's `memory_search` and reports retrieval scores. **Does not need a real LLM provider** — it exercises the retrieval layer only, which is the upper bound on agent performance (no LLM can answer if the right facts don't surface).

This is the "I act as the provider/judge inside myself" setup you asked for: the harness writes conversations into PasClaw's memory store, queries `memory_search`, dumps snippets — I read the dumps and judge whether the gold answer is present. No external API calls, no per-turn LLM costs.

## Two-layer scoring

For each top-K result set:

- **snippet-level** — did the gold answer (or any alias) appear in the FTS5-bounded snippet text? This is what the model sees in **one** `memory_search` call.
- **doc-level** — did it appear anywhere in the full document body of the top-K hits' source files? This is what an agent reaches with a follow-up `fs_read` on the cited path.

Both numbers tell different parts of the story. Snippet-level is the agent's first round; doc-level is what an iterating agent can recover.

## Files

```
bench/locomo/
├── README.md            design + run procedure + real-LOCOMO adapter notes
├── fixture/
│   └── alice_synthetic.json    1 persona, 3 sessions, 8 questions
├── memory_recall.pas    Pascal CLI shim over PasClaw.Memory.Index.Search
├── run.py               main harness (loader / scorer / summariser)
└── .gitignore           compiled binary + per-run results
```

`memory_recall.pas` falls back from `NewVectorMemoryIndex` → `NewMemoryIndex` when the vector runtime isn't provisioned, so the harness works on any FPC build without first running `pasclaw memory provision`.

## Smoke result on the bundled persona

```
category         n    snippet R@10    doc R@10
adversarial      1    0.000           1.000
multi-hop        2    1.000           1.000
single-hop       4    0.750           1.000
temporal         1    1.000           1.000
---------------  ---  ------------    --------
overall          8    0.750           1.000
```

**Read**: PasClaw's `memory_search` lands the right *document* almost always (doc R@10 ~ 1.0 on this synthetic), but the FTS5 snippet window often clips the answer line (snippet R@10 ~ 0.75). Actionable: either widen snippet windows in `PasClaw.Memory.Index`, or train the agent to follow up with `fs_read` on retrieved citations more aggressively.

These numbers are from a synthetic persona designed to be recoverable. Real LOCOMO will be lower because of:

- More distractor content per persona (35+ sessions vs 3)
- More cross-session synthesis required for multi-hop
- Real adversarial cases (negation, supersession) that PasClaw's no-consolidation memory model doesn't address

## Running against real LOCOMO

```sh
git clone https://github.com/snap-stanford/locomo /tmp/locomo
# write a ~30-line shape adapter mapping LOCOMO's session_summary +
# dialogue field names to this harness's loader contract -- see
# load_persona() in run.py.
python3 bench/locomo/run.py --persona /tmp/locomo/data/locomo10.json
```

Not bundled because LOCOMO has its own download terms.

## Why no Pascal source changes

The helper compiles against PasClaw's existing `PasClaw.Memory.Index` / `PasClaw.Memory.Vector` units. The whole adapter is bench-shaped scaffolding around the existing memory API — no internal PasClaw behavior change.

## Test plan

- [x] Harness runs end-to-end on the bundled fixture (results above).
- [x] Two-layer scoring distinguishes "retrieval missed entirely" from "retrieval found doc but snippet too narrow."
- [ ] Real LOCOMO run with a shape adapter — left as a follow-up since the dataset has its own license terms.

The harness is also the regression target for future memory work (Gauss decay, auto-consolidation, supersession) — these numbers can be tracked over time as the layer evolves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_