### PR TITLE
memory/kb: widen FTS5 snippet window 24 → 60 + nudge agent to follow up with fs_read

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -472,7 +472,13 @@ begin
     '/{today}.md (e.g. ' + FormatDateTime('yyyy-mm-dd', Now) +
     '.md) for episodic context. Use `memory_search` before answering ' +
     'questions about prior conversations or project facts you might ' +
-    'have written down on an earlier turn.' + sLineBreak +
+    'have written down on an earlier turn. **`memory_search` / ' +
+    '`kb_search` return bounded snippets (a token window centred on the ' +
+    'matched terms) -- if the answer line might fall just outside the ' +
+    'window, follow up with `fs_read` (or `kb_get` for the KB) on the ' +
+    'cited path to surface the surrounding paragraphs. A snippet that ' +
+    'shows the right file but not quite the right line is a hit, not a ' +
+    'miss.**' + sLineBreak +
     sLineBreak +
     '6. **Think in code, not in transcripts** -- when a question needs ' +
     'numbers, summaries, or filtered results across many files, prefer ' +

--- a/src/pkg/kb/PasClaw.KB.Index.pas
+++ b/src/pkg/kb/PasClaw.KB.Index.pas
@@ -144,7 +144,7 @@ uses
   PasClaw.Utils,
   PasClaw.Config,
   PasClaw.Logger,
-  PasClaw.Memory.Index,        { SanitizeFtsQuery }
+  PasClaw.Memory.Index,        { SanitizeFtsQuery, FTS5_SNIPPET_TOKENS }
   PasClaw.KB.PDF,              { ExtractPDFText for .pdf ingest }
   LocalVector.VectorStore,
   LocalVector.Embedder,
@@ -1259,7 +1259,8 @@ begin
   try
     Q.Database := FConn;
     Q.SQL.Text :=
-      'SELECT path, chunk_no, snippet(kb_fts, 2, ''«'', ''»'', ''…'', 24), bm25(kb_fts) ' +
+      'SELECT path, chunk_no, snippet(kb_fts, 2, ''«'', ''»'', ''…'', ' +
+      IntToStr(FTS5_SNIPPET_TOKENS) + '), bm25(kb_fts) ' +
       'FROM kb_fts WHERE kb_fts MATCH :q ORDER BY bm25(kb_fts) LIMIT :k';
     Q.Params.ParamByName('q').AsString  := Sanitized;
     Q.Params.ParamByName('k').AsInteger := K;
@@ -1292,7 +1293,8 @@ begin
   try
     Q.Connection := FConn;
     Q.SQL.Text :=
-      'SELECT path, chunk_no, snippet(kb_fts, 2, ''«'', ''»'', ''…'', 24), bm25(kb_fts) ' +
+      'SELECT path, chunk_no, snippet(kb_fts, 2, ''«'', ''»'', ''…'', ' +
+      IntToStr(FTS5_SNIPPET_TOKENS) + '), bm25(kb_fts) ' +
       'FROM kb_fts WHERE kb_fts MATCH :q ORDER BY bm25(kb_fts) LIMIT :k';
     Q.ParamByName('q').AsString  := Sanitized;
     Q.ParamByName('k').AsInteger := K;

--- a/src/pkg/memory/PasClaw.Memory.Index.pas
+++ b/src/pkg/memory/PasClaw.Memory.Index.pas
@@ -67,6 +67,16 @@ type
 
 function NewMemoryIndex: IMemoryIndex;
 
+const
+  (* Token budget for the FTS5 snippet() window. 64 is FTS5's hard
+     ceiling; 60 leaves a sliver of slack for the «...» highlight
+     markup. The historical width of 24 routinely clipped the actual
+     answer line out of the returned snippet (LOCOMO bench: snippet
+     R@10 ≈ 0.75 with width=24 vs 1.0 with width=60). Exposed in the
+     interface so PasClaw.KB.Index can pin its kb_search snippets to
+     the same width. *)
+  FTS5_SNIPPET_TOKENS = 60;
+
 (* Turn a natural-language query into an FTS5-safe MATCH expression
    (OR-ed quoted tokens; ASCII punctuation stripped; UTF-8 token
    bytes preserved). Exposed so PasClaw.Session.Search can reuse the
@@ -583,7 +593,8 @@ begin
   try
     Q.Database := FConn;
     Q.SQL.Text :=
-      'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', 24), bm25(memory_fts) ' +
+      'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', ' +
+      IntToStr(FTS5_SNIPPET_TOKENS) + '), bm25(memory_fts) ' +
       'FROM memory_fts WHERE memory_fts MATCH :q ' +
       'ORDER BY bm25(memory_fts) LIMIT :k';
     Q.Params.ParamByName('q').AsString := Sanitized;
@@ -628,7 +639,8 @@ begin
   try
     Q.Connection := FConn;
     Q.SQL.Text :=
-      'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', 24), bm25(memory_fts) ' +
+      'SELECT path, snippet(memory_fts, 1, ''«'', ''»'', ''…'', ' +
+      IntToStr(FTS5_SNIPPET_TOKENS) + '), bm25(memory_fts) ' +
       'FROM memory_fts WHERE memory_fts MATCH :q ' +
       'ORDER BY bm25(memory_fts) LIMIT :k';
     Q.ParamByName('q').AsString  := Sanitized;


### PR DESCRIPTION
## Summary

Addresses the actionable finding from PR #308's LOCOMO bench results:

> FTS5-bounded snippet window often clips the actual answer line (snippet R@10 ≈ 0.75). That's an actionable finding — either widen snippet windows in `PasClaw.Memory.Index` or train the agent to follow up with `fs_read` on retrieved citations more aggressively.

Does **both** — the two fixes are complementary, not alternatives.

## Bench delta

Re-running the PR #308 harness against the bundled `alice_synthetic` persona with this branch applied:

| metric         | before (width=24) | after (width=60) |
| -------------- | ----------------- | ---------------- |
| snippet R@10   | 0.75              | **1.0**          |
| snippet R@1    | 0.375             | **0.875**        |
| doc R@10       | 1.0               | 1.0 (unchanged)  |

Doc-level recall was already optimal — the layer found the right *file*; it just wasn't showing the right *line* in the snippet. Widening the window closes that gap on this synthetic. The remaining `snippet R@1 = 0.875` (1 out of 8 missed) is a BM25 ranking artifact, not a snippet-width issue — leaving for a follow-up that tunes the hybrid ranker.

## Changes

### 1. `PasClaw.Memory.Index` — lift the magic number, widen to 60

Adds `FTS5_SNIPPET_TOKENS = 60` as an **interface-section** const so `PasClaw.KB.Index` can reuse it (memory_search and kb_search should agree on snippet width — they share a tokenizer and they share the bench). 64 is FTS5's hard ceiling per call; 60 leaves a sliver of slack for the «...» highlight markup. Both `Search()` overloads (FPC sqldb and Delphi FireDAC) now interpolate `IntToStr(FTS5_SNIPPET_TOKENS)`.

### 2. `PasClaw.KB.Index` — reuse the same const

Two `snippet(kb_fts, 2, ...)` queries now reference `FTS5_SNIPPET_TOKENS` (picked up from the existing `uses PasClaw.Memory.Index`). The `uses` comment is updated so the cross-unit dependency is grep-able.

### 3. `PasClaw.Agent.Prompt.BuildRulesSection` — nudge for citation follow-up

Rule #5 (the memory rule) now explicitly tells the model that `memory_search` / `kb_search` return *bounded* snippets, and that if the cited file is right but the answer line might fall just outside the window, follow up with `fs_read` (or `kb_get` for the KB) on the cited path. Frames it as: a snippet showing the right file but not quite the right line is **a hit, not a miss** — i.e. drive the agent toward iteration on citations instead of giving up.

## Why both fixes

- **Wider window** lifts the common case — short answer lines that used to fall just outside a 24-token window now show up in the first hit. Cheap and zero-token cost to the model.
- **Prompt nudge** handles long-context documents where even 60 tokens can't centre on the right line (e.g. a multi-paragraph note where the relevant fact is several sentences from the search term that anchored the hit). The model now knows to read the underlying file instead of treating the snippet as the final answer.

## Test plan

- [x] `make` clean — no new warnings/errors introduced
- [x] `make test-kb-index` passes
- [x] `make test-agents-md` passes
- [x] Re-ran PR #308's harness — numbers above
- [ ] Real LOCOMO run (gated on PR #308 + a shape adapter — separate follow-up)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_