### PR TITLE
tools: model-callable cron tool (opt-in, schedules installed skills)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -317,6 +317,12 @@ test-model-discovery: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/model_discovery_tests.pas -o$(BUILDDIR)/model_discovery_tests
 	@$(BUILDDIR)/model_discovery_tests
+
+# Model-callable cron tool: config.json crons[] add/list/remove + validation.
+test-cron-tool: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/cron_tool_tests.pas -o$(BUILDDIR)/cron_tool_tests
+	@PASCLAW_HOME=$(BUILDDIR)/cron-tool-test-home $(BUILDDIR)/cron_tool_tests
 
 # Provider catalog rows + ChatPath override (Perplexity uses /chat/completions).
 test-provider-catalog: | $(BUILDDIR)
@@ -716,4 +722,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -38,6 +38,7 @@ uses
   PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
+  PasClaw.Tools.Cron,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
@@ -233,7 +234,8 @@ function NewBuiltinRegistry(UseHashline: Boolean = True;
                             EnableVault: Boolean = False;
                             EnableWebSearch: Boolean = False;
                             EnableWebFetch: Boolean = False;
-                            EnableOutputCache: Boolean = False): TToolRegistry;
+                            EnableOutputCache: Boolean = False;
+                            EnableCron: Boolean = False): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
@@ -277,6 +279,11 @@ begin
     operator has flipped on Cfg.ToolOutputCap. The tool's only
     useful while truncation is active, so the flag gates both. }
   if EnableOutputCache then RegisterOutputCacheTool(Result);
+  { cron tool: opt-in (Cfg.CronToolEnabled). Lets the model schedule an
+    existing skill on a cron; off by default since it grants background
+    autonomy. In `agent` there's no live scheduler, so additions apply the
+    next time serve/gateway runs. }
+  if EnableCron then RegisterCronTool(Result);
   (* send_message gates itself: it registers only when config.json
      declares named channels (a "channels" array of name/kind/target
      entries), so there's no flag to thread through here. The model
@@ -509,7 +516,7 @@ begin
                               HasConfiguredWebSearchProvider(Cfg),
                               Cfg.WebFetchEnabled,
                               (Cfg.ToolOutputCap > 0)
-                                or Cfg.CondenseReversible);
+                                or Cfg.CondenseReversible, Cfg.CronToolEnabled);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;
@@ -984,7 +991,7 @@ begin
                               HasConfiguredWebSearchProvider(Cfg),
                               Cfg.WebFetchEnabled,
                               (Cfg.ToolOutputCap > 0)
-                                or Cfg.CondenseReversible);
+                                or Cfg.CondenseReversible, Cfg.CronToolEnabled);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -285,8 +285,12 @@ begin
     if (not Args.NoMCP) and (Reg <> nil) then
       MCPClients := ConnectMCPServers(Cfg, Reg);
 
+    { Start the scheduler when there are crons OR the model can add them
+      (cron_tool_enabled) -- otherwise an empty-config server with the cron
+      tool on would accept an add but never fire it until restart. Codex P2
+      on PR #310. }
     Scheduler := nil;
-    if (Reg <> nil) and (Length(Cfg.Crons) > 0) then
+    if (Reg <> nil) and ((Length(Cfg.Crons) > 0) or Cfg.CronToolEnabled) then
     begin
       Scheduler := TCronScheduler.Create(Cfg, Reg);
       Scheduler.Start;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -37,6 +37,7 @@ uses
   PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
+  PasClaw.Tools.Cron,             { cron tool -- gated on cron_tool_enabled }
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
@@ -271,6 +272,7 @@ begin
         RegisterOutputCacheTool(Reg);
       { send_message self-gates on Cfg.Channels. Codex P2 on PR #230. }
       RegisterSendMessageTool(Reg);
+      if Cfg.CronToolEnabled then RegisterCronTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       RegisterSkillManageTool(Reg, Cfg);

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -76,6 +76,7 @@ uses
   PasClaw.Skills.Loader,
   PasClaw.Skills.Manage,
   PasClaw.Skills.Disclosure,
+  PasClaw.Cron.Scheduler,
   PasClaw.Stream.Reliability,
   PasClaw.Gateway.Server;
 
@@ -138,6 +139,7 @@ var
   Reg: TToolRegistry;
   MCPClients: TMCPClientList;
   Server, MCPServer: TGatewayServer;
+  Scheduler: TCronScheduler;
   Skills: TSkillSpecArray;
   BaseURL: string;
   KindSelected: TShellBackendKind;
@@ -157,6 +159,7 @@ begin
   Cfg := LoadConfig(ProfileName);
   ConfigureSandbox(Cfg.Sandbox, '');
   ShellSessionId := '';
+  Scheduler := nil;   { so the finally is safe if we Exit before starting it }
   try
     Args := ParseServe(Argv, Cfg);
     { Install the active shell backend so shell_exec / execute_code run on
@@ -252,6 +255,16 @@ begin
     if (not Args.NoMCP) and (Reg <> nil) then
       MCPClients := ConnectMCPServers(Cfg, Reg);
 
+    { Cron scheduler: serve had none before. Start it when crons exist OR
+      the model can add them (cron_tool_enabled), so a cron the model
+      schedules actually fires in this process. Codex P2 on PR #310. }
+    Scheduler := nil;
+    if (Reg <> nil) and ((Length(Cfg.Crons) > 0) or Cfg.CronToolEnabled) then
+    begin
+      Scheduler := TCronScheduler.Create(Cfg, Reg);
+      Scheduler.Start;
+    end;
+
     Server := TGatewayServer.Create(Cfg, Provider, Reg);
     Server.DebugIO := Args.Debug;
     Server.MaxIter := Args.MaxIter;
@@ -312,6 +325,9 @@ begin
       if MCPServer <> nil then MCPServer.Stop;
       Server.Free;
       if MCPServer <> nil then MCPServer.Free;
+      { Stop the cron thread before tearing down the registry it fires
+        jobs through (Free -> Destroy joins the thread). }
+      if Scheduler <> nil then Scheduler.Free;
       FreeMCPClients(MCPClients);
       if Reg <> nil then Reg.Free;
     end;

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -59,6 +59,7 @@ uses
   PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.SendMessage,
+  PasClaw.Tools.Cron,             { cron tool -- gated on cron_tool_enabled }
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
   PasClaw.Tools.WebFetch,
@@ -236,6 +237,9 @@ begin
         RegisterOutputCacheTool(Reg);
       { send_message self-gates on Cfg.Channels. Codex P2 on PR #230. }
       RegisterSendMessageTool(Reg);
+      { cron tool: opt-in (model-scheduled background jobs). Runs existing
+        skills only; the running scheduler picks up its config edits live. }
+      if Cfg.CronToolEnabled then RegisterCronTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
       RegisterSkillManageTool(Reg, Cfg);

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -532,6 +532,15 @@ type
        the default is now on. Onboarding asks (default Y); operators
        who don't want outbound HTTP from the agent flip it off. *)
     WebFetchEnabled:   Boolean;
+    (* OFF by default: when True, the model gets a `cron` tool that can
+       list/add/remove scheduled jobs by editing config.json's crons[].
+       Bounded by design -- a cron entry only runs an EXISTING operator-
+       installed skill on a schedule, so the model can schedule but not
+       author the work. Off by default because letting the model schedule
+       background execution is an autonomy step operators should opt into;
+       flip cron_tool_enabled=true in config.json. The running scheduler
+       picks up the model's edits within one tick (config mtime watch). *)
+    CronToolEnabled:   Boolean;
     (* On-by-default: when True, memory_search uses a hybrid keyword
        (FTS5 BM25) + vector (sqlite-vec ANN) index over
        workspace/memory/ files, fused via Reciprocal Rank Fusion.
@@ -865,6 +874,7 @@ begin
   PromptCache.TTL      := '';    { default 5m via empty }
   VaultToolsEnabled    := True;  { on by default -- vault_search/get are read-only HTTP GETs against pasclaw.dev. Onboarding asks (default Y). }
   WebFetchEnabled      := True;  { on by default -- onboarding asks (default Y); operators not wanting outbound HTTP from the agent flip it off. }
+  CronToolEnabled      := False; { off by default -- model-scheduled background jobs are an opt-in autonomy step (runs existing skills only). }
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   ToolOutputCap        := 0;     { off by default; operators opt in. See TConfig.ToolOutputCap. }
   StatsCollectionEnabled := False; { opt-in via onboarding; see TConfig.StatsCollectionEnabled. }
@@ -1098,6 +1108,10 @@ begin
       Root.PutBool('vault_tools_enabled', False);
     if not WebFetchEnabled then
       Root.PutBool('web_fetch_enabled', False);
+    { cron_tool_enabled defaults OFF; emit only the explicit-on so an
+      operator who opted into model-scheduled jobs round-trips. }
+    if CronToolEnabled then
+      Root.PutBool('cron_tool_enabled', True);
     { RenderMarkdown defaults to True; emit only when operator
       explicitly disabled it so they can flip it back via config.json
       and we round-trip correctly. }
@@ -1488,6 +1502,7 @@ begin
 
     VaultToolsEnabled   := Root.GetBool('vault_tools_enabled',   VaultToolsEnabled);
     WebFetchEnabled     := Root.GetBool('web_fetch_enabled',     WebFetchEnabled);
+    CronToolEnabled     := Root.GetBool('cron_tool_enabled',     CronToolEnabled);
     RenderMarkdown      := Root.GetBool('render_markdown',       RenderMarkdown);
     VectorSearchEnabled := Root.GetBool('vector_search_enabled', VectorSearchEnabled);
     ToolOutputCap       := Integer(Root.GetInt('tool_output_cap', ToolOutputCap));

--- a/src/pkg/cron/PasClaw.Cron.Scheduler.pas
+++ b/src/pkg/cron/PasClaw.Cron.Scheduler.pas
@@ -22,6 +22,12 @@ uses
   PasClaw.Tools.Registry;
 
 type
+  { Owned-by-the-scheduler-thread copy of the cron entries, so the model's
+    cron tool can edit config.json and have new jobs picked up live without
+    any cross-thread mutation of the shared TConfig (which the gateway's
+    /v1/cron handler also reads). See ReloadCronsIfChanged. }
+  TCronEntryArray = array of TCronEntry;
+
   TCronScheduler = class
   private
     FCfg:      TConfig;
@@ -30,6 +36,10 @@ type
     FStopEvt:  TEvent;
     FStop:     Boolean;
     FState:    TObject;   { TCronState -- opaque to avoid uses-cycle at decl time }
+    FCrons:      TCronEntryArray;  { private copy RunOnce iterates }
+    FCronsPath:  string;           { config.json path we watch }
+    FCronsMtime: TDateTime;        { last-seen config mtime; 0 = unknown }
+    procedure ReloadCronsIfChanged;
     procedure RunOnce;
   public
     constructor Create(Cfg: TConfig; Registry: TToolRegistry);
@@ -95,6 +105,36 @@ begin
   State := TCronState.Create(DefaultCronStatePath);
   State.Load;
   FState := State;
+  { Seed our private entry list from the startup config, and remember the
+    config file's mtime so ReloadCronsIfChanged can pick up later edits
+    (the model's cron tool writes config.json). }
+  FCrons      := Copy(Cfg.Crons);
+  FCronsPath  := GetConfigPath;
+  FCronsMtime := 0;
+  FileAge(FCronsPath, FCronsMtime);
+end;
+
+procedure TCronScheduler.ReloadCronsIfChanged;
+{ Cheap mtime poll: when config.json changed since we last loaded it,
+  re-read and replace our private FCrons. Runs only on the scheduler
+  thread, so FCrons is never touched concurrently -- no lock needed, and
+  we never mutate the shared FCfg the gateway also reads. }
+var
+  Mtime: TDateTime;
+  Fresh: TConfig;
+begin
+  if FCronsPath = '' then Exit;
+  Mtime := 0;
+  if not FileAge(FCronsPath, Mtime) then Exit;   { file gone -- keep current }
+  if (FCronsMtime <> 0) and (Mtime <= FCronsMtime) then Exit;
+  Fresh := LoadConfig;
+  try
+    FCrons := Copy(Fresh.Crons);
+    FCronsMtime := Mtime;
+    LogInfo('cron: reloaded %d entr(ies) after config change', [Length(FCrons)]);
+  finally
+    Fresh.Free;
+  end;
 end;
 
 destructor TCronScheduler.Destroy;
@@ -144,9 +184,13 @@ begin
   State := TCronState(FState);
   Dirty := False;
 
-  for i := 0 to High(FCfg.Crons) do
+  { Pick up any config.json edits (e.g. the model's cron tool) before the
+    sweep, so new jobs go live within one tick instead of needing a restart. }
+  ReloadCronsIfChanged;
+
+  for i := 0 to High(FCrons) do
   begin
-    Entry := FCfg.Crons[i];
+    Entry := FCrons[i];
     if not Entry.Enabled then Continue;
     if not ParseCronExpr(Entry.Spec, Expr) then
     begin

--- a/src/pkg/tools/PasClaw.Tools.Cron.pas
+++ b/src/pkg/tools/PasClaw.Tools.Cron.pas
@@ -54,6 +54,14 @@ type
   end;
   TCronRows = array of TCronRow;
 
+var
+  { The registry the scheduler will run jobs through. Set by
+    RegisterCronTool; the SAME instance serve/gateway hand to
+    TCronScheduler, so validating against it matches exactly what the
+    running process can fire. nil in unit tests (they call Tool_Cron
+    directly) -> SkillExists falls back to the on-disk manifest set. }
+  GCronRegistry: TToolRegistry = nil;
+
 { Read config.json (raw) into a TJsonObject. Missing file -> empty object so
   a first add can create it. Returns False with Err on a parse failure. }
 function LoadConfigRoot(out Root: TJsonObject; out Err: string): Boolean;
@@ -140,8 +148,18 @@ function SkillExists(const Name: string): Boolean;
 var
   Skills: TSkillSpecArray;
   i: Integer;
+  T: TTool;
 begin
   Result := False;
+  { Validate against the registry the scheduler actually runs jobs through
+    (skills register as skill_<name> at startup, fired via Reg.RunTool).
+    This rejects a skill that's on disk but not in THIS running process --
+    one the scheduler couldn't fire until restart anyway. Codex P2 on
+    PR #310. }
+  if GCronRegistry <> nil then
+    Exit(GCronRegistry.Find('skill_' + Name, T));
+  { No registry wired (unit tests call Tool_Cron directly) -- fall back to
+    the on-disk manifest set. }
   Skills := LoadSkillManifests(GetHome);
   for i := 0 to High(Skills) do
     if SameText(Skills[i].Name, Name) then Exit(True);
@@ -263,6 +281,7 @@ var
   T: TTool;
 begin
   if R = nil then Exit;
+  GCronRegistry := R;   { validate add's skill against what this process can fire }
   T.Name        := 'cron';
   T.Description :=
     'Schedule background jobs that run an installed skill on a cron schedule. ' +

--- a/src/pkg/tools/PasClaw.Tools.Cron.pas
+++ b/src/pkg/tools/PasClaw.Tools.Cron.pas
@@ -1,0 +1,287 @@
+(*
+  PasClaw.Tools.Cron - the model-callable `cron` tool.
+
+  Lets the model schedule background work the same way picoclaw / nanobot /
+  openclaw do, but bounded: a cron entry only runs an EXISTING operator-
+  installed skill on a schedule (it cannot author the work, only schedule
+  it), and the tool is OFF unless the operator sets cron_tool_enabled=true.
+
+  Mechanism: the tool edits config.json's `crons[]` array directly (raw
+  JSON -- NOT LoadConfig/SaveConfig, which would bake any active profile's
+  resolved values into the file). The running TCronScheduler watches
+  config.json's mtime and reloads within one tick (~30s), so additions go
+  live without a restart; in `pasclaw agent` (no scheduler) they apply the
+  next time `serve`/`gateway` runs.
+
+  Actions:
+    {"action":"list"}
+    {"action":"add","spec":"0 9 * * *","skill":"daily-digest","args":"..."}
+    {"action":"remove","id":"cron-..."}
+*)
+unit PasClaw.Tools.Cron;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+interface
+
+uses
+  PasClaw.Tools.Registry;
+
+procedure RegisterCronTool(R: TToolRegistry);
+
+{ The tool handler: action=list|add|remove against config.json's crons[].
+  Exposed for tests. }
+function Tool_Cron(const ArgsJSON: string; out ErrMsg: string): string;
+
+implementation
+
+uses
+  SysUtils, DateUtils,
+  PasClaw.Tools.Types,   { TTool / TToolCategory / tcMutating }
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Logger,
+  PasClaw.Config,
+  PasClaw.Cron.Expr,
+  PasClaw.Skills.Loader;
+
+type
+  TCronRow = record
+    Id, Spec, Skill, Args, ChannelKind, ChannelTarget: string;
+    Enabled: Boolean;
+  end;
+  TCronRows = array of TCronRow;
+
+{ Read config.json (raw) into a TJsonObject. Missing file -> empty object so
+  a first add can create it. Returns False with Err on a parse failure. }
+function LoadConfigRoot(out Root: TJsonObject; out Err: string): Boolean;
+var
+  Path, Body: string;
+begin
+  Root := nil; Err := '';
+  Path := GetConfigPath;
+  if FileExists(Path) then
+  begin
+    try
+      Body := ReadFileText(Path);
+    except
+      on E: Exception do begin Err := 'read config: ' + E.Message; Exit(False); end;
+    end;
+    Root := TJsonObject.Parse(Body);
+    if Root = nil then begin Err := 'config.json is not valid JSON'; Exit(False); end;
+  end
+  else
+    Root := TJsonObject.Create;
+  Result := True;
+end;
+
+function ReadCrons(Root: TJsonObject): TCronRows;
+var
+  Arr: TJsonArray;
+  Item: TJsonObject;
+  i, N: Integer;
+begin
+  SetLength(Result, 0);
+  Arr := Root.ChildArray('crons');
+  if Arr = nil then Exit;
+  try
+    N := 0;
+    SetLength(Result, Arr.Count);
+    for i := 0 to Arr.Count - 1 do
+    begin
+      Item := Arr.ItemObject(i);
+      if Item = nil then Continue;
+      try
+        Result[N].Id            := Item.GetStr ('id',             '');
+        Result[N].Spec          := Item.GetStr ('spec',           '');
+        Result[N].Skill         := Item.GetStr ('skill',          '');
+        Result[N].Args          := Item.GetStr ('args',           '');
+        Result[N].Enabled       := Item.GetBool('enabled',        True);
+        Result[N].ChannelKind   := Item.GetStr ('channel_kind',   '');
+        Result[N].ChannelTarget := Item.GetStr ('channel_target', '');
+        Inc(N);
+      finally
+        Item.Free;
+      end;
+    end;
+    SetLength(Result, N);
+  finally
+    Arr.Free;
+  end;
+end;
+
+{ Replace Root's crons[] with Rows and write config.json back. }
+procedure WriteCrons(Root: TJsonObject; const Rows: TCronRows);
+var
+  Arr: TJsonArray;
+  Item: TJsonObject;
+  i: Integer;
+begin
+  Arr := TJsonArray.Create;
+  for i := 0 to High(Rows) do
+  begin
+    Item := TJsonObject.Create;
+    Item.PutStr ('id',      Rows[i].Id);
+    Item.PutStr ('spec',    Rows[i].Spec);
+    Item.PutStr ('skill',   Rows[i].Skill);
+    Item.PutStr ('args',    Rows[i].Args);
+    Item.PutBool('enabled', Rows[i].Enabled);
+    if Rows[i].ChannelKind   <> '' then Item.PutStr('channel_kind',   Rows[i].ChannelKind);
+    if Rows[i].ChannelTarget <> '' then Item.PutStr('channel_target', Rows[i].ChannelTarget);
+    Arr.AddObject(Item);
+  end;
+  Root.PutArray('crons', Arr);   { overwrites the existing key }
+  WriteFileText(GetConfigPath, Root.ToJSON);
+end;
+
+function SkillExists(const Name: string): Boolean;
+var
+  Skills: TSkillSpecArray;
+  i: Integer;
+begin
+  Result := False;
+  Skills := LoadSkillManifests(GetHome);
+  for i := 0 to High(Skills) do
+    if SameText(Skills[i].Name, Name) then Exit(True);
+end;
+
+function GenCronId: string;
+begin
+  Result := 'cron-' + FormatDateTime('yyyymmdd-hhnnss', Now) +
+            '-' + IntToHex(Random(1 shl 16), 4);
+end;
+
+function FmtRows(const Rows: TCronRows): string;
+var
+  i: Integer;
+begin
+  if Length(Rows) = 0 then Exit('(no cron jobs scheduled)');
+  Result := IntToStr(Length(Rows)) + ' cron job(s):'#10;
+  for i := 0 to High(Rows) do
+  begin
+    Result := Result + Format('  %s  [%s]  skill=%s  args=%s',
+      [Rows[i].Id, Rows[i].Spec, Rows[i].Skill, Rows[i].Args]);
+    if not Rows[i].Enabled then Result := Result + ' (disabled)';
+    Result := Result + #10;
+  end;
+end;
+
+function Tool_Cron(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Obj, Root: TJsonObject;
+  Action, Spec, Skill, SkArgs, Id: string;
+  Rows: TCronRows;
+  Expr: TCronExpr;
+  i, KeptN: Integer;
+  Found: Boolean;
+  Err: string;
+begin
+  ErrMsg := ''; Result := '';
+  Action := ''; Spec := ''; Skill := ''; SkArgs := ''; Id := '';
+  if Trim(ArgsJSON) <> '' then
+  begin
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj <> nil then
+    try
+      Action := LowerCase(Trim(Obj.GetStr('action', '')));
+      Spec   := Trim(Obj.GetStr('spec',  ''));
+      Skill  := Trim(Obj.GetStr('skill', ''));
+      SkArgs := Obj.GetStr('args', '');
+      Id     := Trim(Obj.GetStr('id',    ''));
+    finally
+      Obj.Free;
+    end;
+  end;
+  if Action = '' then begin ErrMsg := 'missing "action" (list | add | remove)'; Exit; end;
+
+  if not LoadConfigRoot(Root, Err) then begin ErrMsg := Err; Exit; end;
+  try
+    Rows := ReadCrons(Root);
+
+    if Action = 'list' then
+      Result := FmtRows(Rows)
+
+    else if Action = 'add' then
+    begin
+      if (Spec = '') or (Skill = '') then
+      begin ErrMsg := 'add requires "spec" (cron expression) and "skill"'; Exit; end;
+      if not ParseCronExpr(Spec, Expr) then
+      begin ErrMsg := 'invalid cron expression: "' + Spec + '"'; Exit; end;
+      if not SkillExists(Skill) then
+      begin
+        ErrMsg := 'unknown skill "' + Skill + '" -- cron runs existing ' +
+                  'installed skills only; install it first';
+        Exit;
+      end;
+      if Id = '' then Id := GenCronId;
+      for i := 0 to High(Rows) do
+        if SameText(Rows[i].Id, Id) then
+        begin ErrMsg := 'a cron with id "' + Id + '" already exists'; Exit; end;
+      SetLength(Rows, Length(Rows) + 1);
+      Rows[High(Rows)].Id      := Id;
+      Rows[High(Rows)].Spec    := Spec;
+      Rows[High(Rows)].Skill   := Skill;
+      Rows[High(Rows)].Args    := SkArgs;
+      Rows[High(Rows)].Enabled := True;
+      WriteCrons(Root, Rows);
+      LogInfo('cron tool: scheduled %s (skill=%s spec=%s)', [Id, Skill, Spec]);
+      Result := Format('Scheduled cron "%s": skill "%s" on "%s". A running ' +
+        'serve/gateway picks it up within ~30s; otherwise it activates on the ' +
+        'next start.', [Id, Skill, Spec]);
+    end
+
+    else if Action = 'remove' then
+    begin
+      if Id = '' then begin ErrMsg := 'remove requires "id"'; Exit; end;
+      Found := False; KeptN := 0;
+      for i := 0 to High(Rows) do
+        if SameText(Rows[i].Id, Id) then
+          Found := True
+        else
+        begin
+          Rows[KeptN] := Rows[i];
+          Inc(KeptN);
+        end;
+      if not Found then begin ErrMsg := 'no cron with id "' + Id + '"'; Exit; end;
+      SetLength(Rows, KeptN);
+      WriteCrons(Root, Rows);
+      LogInfo('cron tool: removed %s', [Id]);
+      Result := Format('Removed cron "%s".', [Id]);
+    end
+
+    else
+      ErrMsg := 'unknown action "' + Action + '" (want list | add | remove)';
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure RegisterCronTool(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if R = nil then Exit;
+  T.Name        := 'cron';
+  T.Description :=
+    'Schedule background jobs that run an installed skill on a cron schedule. ' +
+    'action="list" shows current jobs; action="add" needs a 5-field cron ' +
+    '"spec" and an installed "skill" name (optional "args"); action="remove" ' +
+    'needs the job "id". Jobs run existing skills only -- you cannot schedule ' +
+    'arbitrary commands. A running server applies changes within ~30s.';
+  T.Schema      :=
+    '{"type":"object","properties":{' +
+    '"action":{"type":"string","enum":["list","add","remove"]},' +
+    '"spec":{"type":"string","description":"5-field cron expression, e.g. \"0 9 * * *\" (add)."},' +
+    '"skill":{"type":"string","description":"Name of an installed skill to run (add)."},' +
+    '"args":{"type":"string","description":"Arguments passed to the skill (optional)."},' +
+    '"id":{"type":"string","description":"Job id (required for remove; auto-generated on add)."}' +
+    '},"required":["action"]}';
+  T.Handler     := Tool_Cron;
+  T.IsCore      := False;
+  T.Category    := tcMutating;   { edits config.json + schedules execution }
+  R.Register(T);
+end;
+
+end.

--- a/src/tests/cron_tool_tests.pas
+++ b/src/tests/cron_tool_tests.pas
@@ -1,0 +1,114 @@
+program cron_tool_tests;
+(*
+  Pins the model-callable `cron` tool: it edits config.json's crons[] to
+  list/add/remove jobs, validates the cron spec and that the skill exists,
+  and refuses bad input. Runs against a temp PASCLAW_HOME with one seeded
+  skill. (The live-scheduler mtime reload that activates additions on a
+  running server is verified by inspection -- no socket/thread here.)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils,
+  PasClaw.Config,        { GetConfigPath, GetHome }
+  PasClaw.Utils,         { ReadFileText / WriteFileText / JoinPath }
+  PasClaw.Tools.Cron;    { Tool_Cron }
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+function Cron(const Args: string; out Err: string): string;
+begin
+  Result := Tool_Cron(Args, Err);
+end;
+
+procedure ExpectOK(const Args, Needle, Msg: string);
+var Out_, Err: string;
+begin
+  Out_ := Cron(Args, Err);
+  if Err <> '' then Fail_(Msg + ' -- unexpected error: ' + Err);
+  if (Needle <> '') and (Pos(Needle, Out_) = 0) then
+    Fail_(Msg + ' -- output missing "' + Needle + '": ' + Out_);
+end;
+
+procedure ExpectErr(const Args, ErrNeedle, Msg: string);
+var Out_, Err: string;
+begin
+  Out_ := Cron(Args, Err);
+  if Err = '' then Fail_(Msg + ' -- expected an error, got: ' + Out_);
+  if (ErrNeedle <> '') and (Pos(ErrNeedle, Err) = 0) then
+    Fail_(Msg + ' -- error missing "' + ErrNeedle + '": ' + Err);
+end;
+
+procedure ConfigContains(const Needle, Msg: string);
+var Body: string;
+begin
+  if not FileExists(GetConfigPath) then Fail_(Msg + ' -- config.json missing');
+  Body := ReadFileText(GetConfigPath);
+  if Pos(Needle, Body) = 0 then
+    Fail_(Msg + ' -- config.json missing "' + Needle + '": ' + Body);
+end;
+
+procedure ConfigMissing(const Needle, Msg: string);
+var Body: string;
+begin
+  if not FileExists(GetConfigPath) then Exit;
+  Body := ReadFileText(GetConfigPath);
+  if Pos(Needle, Body) > 0 then
+    Fail_(Msg + ' -- config.json still has "' + Needle + '"');
+end;
+
+var
+  SkillDir: string;
+begin
+  { Seed one installed skill so add's skill-existence check passes. }
+  SkillDir := JoinPath(JoinPath(JoinPath(GetHome, 'workspace'), 'skills'), 'hello');
+  ForceDirectories(SkillDir);
+  WriteFileText(JoinPath(SkillDir, 'SKILL.md'),
+    '---'#10 + 'name: hello'#10 + 'description: test skill'#10 + '---'#10 + 'body'#10);
+
+  { Empty to start. }
+  ExpectOK('{"action":"list"}', 'no cron jobs', 'list empty');
+
+  { Add a valid job. }
+  ExpectOK('{"action":"add","spec":"0 9 * * *","skill":"hello","id":"job1"}',
+           'Scheduled', 'add valid');
+  ConfigContains('job1', 'config has job id');
+  ConfigContains('hello', 'config has skill');
+
+  { It shows up in the list. }
+  ExpectOK('{"action":"list"}', 'job1', 'list shows the job');
+
+  { Duplicate id is refused. }
+  ExpectErr('{"action":"add","spec":"0 9 * * *","skill":"hello","id":"job1"}',
+            'already exists', 'duplicate id refused');
+
+  { Invalid cron expression is refused (before the skill check). }
+  ExpectErr('{"action":"add","spec":"not a cron","skill":"hello"}',
+            'invalid cron', 'bad spec refused');
+
+  { Unknown skill is refused. }
+  ExpectErr('{"action":"add","spec":"0 9 * * *","skill":"does-not-exist"}',
+            'unknown skill', 'unknown skill refused');
+
+  { Missing required fields. }
+  ExpectErr('{"action":"add"}', 'requires', 'add missing fields');
+
+  { Remove the job. }
+  ExpectOK('{"action":"remove","id":"job1"}', 'Removed', 'remove existing');
+  ConfigMissing('job1', 'config no longer has the job');
+
+  { Remove a non-existent job. }
+  ExpectErr('{"action":"remove","id":"nope"}', 'no cron', 'remove missing');
+
+  { Unknown / missing action. }
+  ExpectErr('{"action":"frobnicate"}', 'unknown action', 'unknown action');
+  ExpectErr('{}', 'action', 'missing action');
+
+  WriteLn('cron_tool_tests: OK');
+end.


### PR DESCRIPTION
Closes the capability gap from the tool comparison: picoclaw / nanobot / openclaw let the **model** schedule jobs, but PasClaw's cron was operator-config-only. This adds a model-callable `cron` tool — **opt-in and bounded**.

## The tool
`cron` with `action`: `list` / `add` / `remove`.
- **add** `{spec, skill, args?, id?}` — validates the cron expression (`ParseCronExpr`) and that `skill` is an **installed** skill, generates an id, and persists.
- **list** / **remove** as expected.

**Bounded by design:** a cron entry only runs an *existing, operator-installed skill* on a schedule — the model can *schedule* work but can't *author* it (no arbitrary commands). And the whole tool is **off unless `cron_tool_enabled=true`** (model-scheduled background execution is an autonomy step operators should opt into). It's registered in `serve`/`gateway`/`agent`, gated on that flag.

## Live activation without a lock or restart
The tool edits `config.json`'s `crons[]` via **raw JSON** (deliberately *not* `LoadConfig`/`SaveConfig`, which would bake an active profile's resolved values into the file). The scheduler now keeps its **own private copy** of the entries and reloads it when `config.json`'s mtime changes — picked up within one ~30s tick on a running `serve`/`gateway`. Because the reload happens only on the scheduler thread and never mutates the shared `TConfig` the gateway also reads, there's **no cross-thread mutation and no lock**. In `agent` (no scheduler) additions simply apply the next time a server runs.

## Tests
New `cron_tool_tests` (in `make test`) seeds a temp `PASCLAW_HOME` with one skill and pins: empty list, add (→ config.json gains the entry), list shows it, duplicate-id refused, invalid cron-expression refused, unknown-skill refused, missing-fields refused, remove (→ entry gone), remove-missing refused, unknown/missing action. Full binary builds clean.

**Caveat:** the live scheduler reload (mtime watch on its background thread) is verified by inspection, not a runtime test — this sandbox can't run the scheduler thread/server. The tool's config-mutation logic is fully unit-tested. A manual check on a running `serve` with `cron_tool_enabled=true` is worth doing before merge.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_