### PR TITLE
cron: fix dcc64 E2010 (named TCronEntryArray vs anonymous array of TCronEntry)

### DIFF
--- a/src/pkg/cron/PasClaw.Cron.Scheduler.pas
+++ b/src/pkg/cron/PasClaw.Cron.Scheduler.pas
@@ -94,6 +94,20 @@ end;
 
 (* ---- TCronScheduler ---- *)
 
+{ Element-wise copy into the named TCronEntryArray. dcc64 (Delphi 12) won't
+  assign Copy(Cfg.Crons) -- an anonymous `array of TCronEntry` -- to the
+  named type (E2010 strict named-type matching; FPC is lenient). An open-
+  array param accepts either shape, and per-element record assignment is
+  always compatible. }
+procedure CopyCronEntries(const Src: array of TCronEntry; out Dst: TCronEntryArray);
+var
+  i: Integer;
+begin
+  SetLength(Dst, Length(Src));
+  for i := 0 to High(Src) do
+    Dst[i] := Src[i];
+end;
+
 constructor TCronScheduler.Create(Cfg: TConfig; Registry: TToolRegistry);
 var
   State: TCronState;
@@ -108,7 +122,7 @@ begin
   { Seed our private entry list from the startup config, and remember the
     config file's mtime so ReloadCronsIfChanged can pick up later edits
     (the model's cron tool writes config.json). }
-  FCrons      := Copy(Cfg.Crons);
+  CopyCronEntries(Cfg.Crons, FCrons);
   FCronsPath  := GetConfigPath;
   FCronsMtime := 0;
   FileAge(FCronsPath, FCronsMtime);
@@ -129,7 +143,7 @@ begin
   if (FCronsMtime <> 0) and (Mtime <= FCronsMtime) then Exit;
   Fresh := LoadConfig;
   try
-    FCrons := Copy(Fresh.Crons);
+    CopyCronEntries(Fresh.Crons, FCrons);
     FCronsMtime := Mtime;
     LogInfo('cron: reloaded %d entr(ies) after config change', [Length(FCrons)]);
   finally


### PR DESCRIPTION
## Symptom (dcc64 / Delphi 12)
```
[dcc64 Error] PasClaw.Cron.Scheduler.pas(111): E2010 Incompatible types: 'TCronEntryArray' and 'Dynamic array'
[dcc64 Error] PasClaw.Cron.Scheduler.pas(132): E2010 Incompatible types: 'TCronEntryArray' and 'Dynamic array'
[dcc64 Fatal Error] PasClaw.Cmd.Gateway.pas(57): F2063 Could not compile used unit 'PasClaw.Cron.Scheduler.pas'
```

## Cause
The cron scheduler (from #310) seeds its private entry list with `FCrons := Copy(Cfg.Crons)`. `Cfg.Crons` is an **anonymous** `array of TCronEntry`; `FCrons` is the **named** `TCronEntryArray`. Delphi 12's `dcc64` enforces strict named-type matching on dynamic-array assignment, so `Copy()`'s anonymous result won't assign to the named type (E2010) — the same trap the codebase already documents for `TLLMProviderArray`. FPC is lenient, so it built green there and the issue only surfaced under RAD Studio (cascading to F2063 in the units that use the scheduler).

## Fix
Replace both `Copy()` calls (the `Create` seed and `ReloadCronsIfChanged`) with a small `CopyCronEntries` helper:
```pascal
procedure CopyCronEntries(const Src: array of TCronEntry; out Dst: TCronEntryArray);
var i: Integer;
begin
  SetLength(Dst, Length(Src));
  for i := 0 to High(Src) do Dst[i] := Src[i];
end;
```
An **open-array** parameter accepts either array shape, and per-element record assignment into a `SetLength`'d `TCronEntryArray` is always type-compatible — so no `Copy()` of an anonymous array, no E2010. Pure refactor, no behavior change.

## Verification
FPC build clean; `make test-cron-tool` still passes. I can't run `dcc64` in this sandbox, but the change removes the exact construct that triggered E2010 and uses only assignment-compatible operations — please confirm it clears under RAD Studio.

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_