### PR TITLE
config: adopt lean-edit shape for stock defaults + hashline opt-in onboarding

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -512,7 +512,8 @@ begin
   Reg := nil;
   if not A.NoTools then
   begin
-    Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled,
+    Reg := NewBuiltinRegistry((not A.NoHashline) and Cfg.HashlineEnabled,
+                              Cfg.VaultToolsEnabled,
                               HasConfiguredWebSearchProvider(Cfg),
                               Cfg.WebFetchEnabled,
                               (Cfg.ToolOutputCap > 0)
@@ -987,7 +988,8 @@ begin
   Reg := nil;
   if not A.NoTools then
   begin
-    Reg := NewBuiltinRegistry(not A.NoHashline, Cfg.VaultToolsEnabled,
+    Reg := NewBuiltinRegistry((not A.NoHashline) and Cfg.HashlineEnabled,
+                              Cfg.VaultToolsEnabled,
                               HasConfiguredWebSearchProvider(Cfg),
                               Cfg.WebFetchEnabled,
                               (Cfg.ToolOutputCap > 0)

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -741,6 +741,47 @@ begin
   end;
 end;
 
+procedure PromptHashline(Cfg: TConfig);
+{ fs_edit_hashline + fs_grep tool registrations. On by default --
+  surgical patches are useful and the format is well-documented in
+  the tool description. The reason this is asked at all is the
+  bench/swe finding (bench/swe/README.md): smaller models
+  (Haiku-class) reach for fs_edit_hashline on tasks fs_write would
+  handle and then fail the anchor/payload format, burning turns
+  recovering. Operators on small-model deployments save measurable
+  per-task turns by opting out -- equivalent to the --no-hashline
+  CLI flag but persisted in config.json. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'fs_edit_hashline + fs_grep' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Surgical-patch toolchain: hashline-format edits with built-in skip ' +
+    'rules' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'for grep. Works great with Opus / Sonnet / GPT-4-tier models; smaller ' +
+    'models' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '(Haiku, gpt-4o-mini, Llama 3.x 8B) sometimes mis-author the hashline ' +
+    'format' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'and waste turns. Opt out to drop them; the model falls back on ' +
+    'fs_write + shell_exec grep.' + Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable hashline tools [Y/n]: ')));
+  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.HashlineEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' fs_edit_hashline + fs_grep enabled');
+  end
+  else
+  begin
+    Cfg.HashlineEnabled := False;
+    PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses fs_write + shell_exec grep)' + Ansi.Reset);
+  end;
+end;
+
 procedure PromptSelfImprovingSkills(Cfg: TConfig);
 { Four nested toggles for the Hermes-style self-improving skills
   (PR #288). Each defaults N because the feature touches:
@@ -1440,6 +1481,7 @@ begin
         who said yes to the previous one, so a quick "enter, enter,
         enter" leaves the minimal-surprise defaults in place. }
       PromptWebFetch(Cfg);
+      PromptHashline(Cfg);
       PromptPromptware(Cfg);
       PromptCondenseReversible(Cfg);
       PromptToolOutputCap(Cfg);

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -742,24 +742,16 @@ begin
 end;
 
 procedure PromptHashline(Cfg: TConfig);
-{ fs_edit_hashline tool registration. PLATFORM-CONDITIONAL default
-  (Y on Windows, N on Linux / macOS) per the bench finding -- smaller
+{ fs_edit_hashline tool registration. Default Y (matches TConfig.Create);
+  Enter-through keeps the surgical-patch tool. Small-model operators
+  (Haiku-class) answer N to drop the tool -- the bench found those
   models mis-author the anchor/payload format and burn turns recovering.
-  Big-model operators answer Y to keep the surgical-patch tool. NOTE:
-  fs_grep is NOT gated by this -- it registers unconditionally because
-  its ripgrep-inspired optimisations win on real codebases and on
-  Windows there's no shell grep at all. }
+  NOTE: fs_grep is NOT gated by this -- it registers unconditionally
+  because its ripgrep-inspired optimisations win on real codebases and
+  on Windows there's no shell grep at all. }
 var
-  Choice, DefaultHint, Prompt: string;
-  DefaultOn: Boolean;
+  Choice: string;
 begin
-  {$IFDEF MSWINDOWS}
-  DefaultOn   := True;
-  DefaultHint := '[Y/n]';
-  {$ELSE}
-  DefaultOn   := False;
-  DefaultHint := '[y/N]';
-  {$ENDIF}
   PrintLn;
   PrintLn(Ansi.Bold + 'fs_edit_hashline (surgical patches)' + Ansi.Reset);
   PrintLn(Ansi.Dim +
@@ -769,25 +761,23 @@ begin
     'correctly; smaller models (Haiku, gpt-4o-mini, Llama 3.x 8B) sometimes ' +
     'mis-author' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'the anchor/payload format and waste turns. Default Y on Windows, N ' +
-    'on Linux/macOS.' + Ansi.Reset);
+    'the anchor/payload format and waste turns. Answer N on small-model ' +
+    'deployments;' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'When disabled the model uses fs_write rewrites instead. fs_grep is ' +
-    'always on.' + Ansi.Reset);
+    'the agent then uses fs_write rewrites instead. fs_grep is always on.' +
+    Ansi.Reset);
   PrintLn;
-  Prompt := '  Enable fs_edit_hashline ' + DefaultHint + ': ';
-  Choice := Trim(LowerCase(ReadLineEcho(Prompt)));
-  if Choice = '' then
-    { Enter-through: take the platform default. }
-    Cfg.HashlineEnabled := DefaultOn
-  else if (Choice = 'y') or (Choice = 'yes') then
-    Cfg.HashlineEnabled := True
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable fs_edit_hashline [Y/n]: ')));
+  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.HashlineEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' fs_edit_hashline enabled');
+  end
   else
+  begin
     Cfg.HashlineEnabled := False;
-  if Cfg.HashlineEnabled then
-    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' fs_edit_hashline enabled')
-  else
     PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses fs_write rewrites)' + Ansi.Reset);
+  end;
 end;
 
 procedure PromptSelfImprovingSkills(Cfg: TConfig);

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -742,43 +742,52 @@ begin
 end;
 
 procedure PromptHashline(Cfg: TConfig);
-{ fs_edit_hashline + fs_grep tool registrations. OFF by default per
-  the bench finding (bench/swe/README.md): smaller models
-  (Haiku-class) mis-author the hashline anchor/payload format and
-  burn turns recovering. The question defaults Y so operators on
-  Opus / Sonnet / GPT-4-tier models restore the surgical-patch
-  toolchain in one keystroke -- those models use it correctly when
-  present. CLI --no-hashline still works as a per-run override;
-  config OFF supersedes CLI ON. }
+{ fs_edit_hashline tool registration. PLATFORM-CONDITIONAL default
+  (Y on Windows, N on Linux / macOS) per the bench finding -- smaller
+  models mis-author the anchor/payload format and burn turns recovering.
+  Big-model operators answer Y to keep the surgical-patch tool. NOTE:
+  fs_grep is NOT gated by this -- it registers unconditionally because
+  its ripgrep-inspired optimisations win on real codebases and on
+  Windows there's no shell grep at all. }
 var
-  Choice: string;
+  Choice, DefaultHint, Prompt: string;
+  DefaultOn: Boolean;
 begin
+  {$IFDEF MSWINDOWS}
+  DefaultOn   := True;
+  DefaultHint := '[Y/n]';
+  {$ELSE}
+  DefaultOn   := False;
+  DefaultHint := '[y/N]';
+  {$ENDIF}
   PrintLn;
-  PrintLn(Ansi.Bold + 'fs_edit_hashline + fs_grep' + Ansi.Reset);
+  PrintLn(Ansi.Bold + 'fs_edit_hashline (surgical patches)' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'Surgical-patch toolchain: hashline-format edits with built-in skip ' +
-    'rules' + Ansi.Reset);
+    'Hashline-format anchored edits. Big models (Opus / Sonnet / GPT-4) ' +
+    'use it' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'for grep. Works great with Opus / Sonnet / GPT-4-tier models; smaller ' +
-    'models' + Ansi.Reset);
+    'correctly; smaller models (Haiku, gpt-4o-mini, Llama 3.x 8B) sometimes ' +
+    'mis-author' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    '(Haiku, gpt-4o-mini, Llama 3.x 8B) sometimes mis-author the hashline ' +
-    'format' + Ansi.Reset);
+    'the anchor/payload format and waste turns. Default Y on Windows, N ' +
+    'on Linux/macOS.' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'and waste turns. Opt out to drop them; the model falls back on ' +
-    'fs_write + shell_exec grep.' + Ansi.Reset);
+    'When disabled the model uses fs_write rewrites instead. fs_grep is ' +
+    'always on.' + Ansi.Reset);
   PrintLn;
-  Choice := Trim(LowerCase(ReadLineEcho('  Enable hashline tools [Y/n]: ')));
-  if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
-  begin
-    Cfg.HashlineEnabled := True;
-    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' fs_edit_hashline + fs_grep enabled');
-  end
+  Prompt := '  Enable fs_edit_hashline ' + DefaultHint + ': ';
+  Choice := Trim(LowerCase(ReadLineEcho(Prompt)));
+  if Choice = '' then
+    { Enter-through: take the platform default. }
+    Cfg.HashlineEnabled := DefaultOn
+  else if (Choice = 'y') or (Choice = 'yes') then
+    Cfg.HashlineEnabled := True
   else
-  begin
     Cfg.HashlineEnabled := False;
-    PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses fs_write + shell_exec grep)' + Ansi.Reset);
-  end;
+  if Cfg.HashlineEnabled then
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' fs_edit_hashline enabled')
+  else
+    PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses fs_write rewrites)' + Ansi.Reset);
 end;
 
 procedure PromptSelfImprovingSkills(Cfg: TConfig);

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -742,15 +742,14 @@ begin
 end;
 
 procedure PromptHashline(Cfg: TConfig);
-{ fs_edit_hashline + fs_grep tool registrations. On by default --
-  surgical patches are useful and the format is well-documented in
-  the tool description. The reason this is asked at all is the
-  bench/swe finding (bench/swe/README.md): smaller models
-  (Haiku-class) reach for fs_edit_hashline on tasks fs_write would
-  handle and then fail the anchor/payload format, burning turns
-  recovering. Operators on small-model deployments save measurable
-  per-task turns by opting out -- equivalent to the --no-hashline
-  CLI flag but persisted in config.json. }
+{ fs_edit_hashline + fs_grep tool registrations. OFF by default per
+  the bench finding (bench/swe/README.md): smaller models
+  (Haiku-class) mis-author the hashline anchor/payload format and
+  burn turns recovering. The question defaults Y so operators on
+  Opus / Sonnet / GPT-4-tier models restore the surgical-patch
+  toolchain in one keystroke -- those models use it correctly when
+  present. CLI --no-hashline still works as a per-run override;
+  config OFF supersedes CLI ON. }
 var
   Choice: string;
 begin

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -216,7 +216,7 @@ begin
     if not Args.NoTools then
     begin
       Reg := TToolRegistry.Create;
-      RegisterFSTools(Reg, not Args.NoHashline);
+      RegisterFSTools(Reg, (not Args.NoHashline) and Cfg.HashlineEnabled);
       RegisterShellTool(Reg);
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -160,7 +160,7 @@ begin
     if not A.NoTools then
     begin
       Reg := TToolRegistry.Create;
-      RegisterFSTools(Reg, not A.NoHashline);
+      RegisterFSTools(Reg, (not A.NoHashline) and Cfg.HashlineEnabled);
       RegisterShellTool(Reg);
       RegisterExecuteCodeTool(Reg);
       RegisterMemoryTools(Reg);

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -14,20 +14,17 @@
                 them on via onboarding when they actually use them); the
                 six zero-prompt-cost behavioral toggles (orient_task_aware,
                 checkpoints, stats, 1h prompt cache, distiller, auto-
-                router) ON by default. fs_edit_hashline is PLATFORM-
-                CONDITIONAL by default: OFF on Linux / macOS (bench
-                finding -- smaller models mis-author the anchor/payload
-                format and burn turns recovering), ON on Windows.
+                router) ON by default. fs_edit_hashline ON by default
+                (small-model operators opt out via onboarding's
+                PromptHashline question or the --no-hashline CLI flag);
                 fs_grep registers UNCONDITIONALLY -- its six ripgrep-
                 inspired optimisations (skip lists, BMH, binary
                 detection, byte-walking, file-size cap, deferred
                 hashing) make it 10-50x faster than shell_exec grep on
                 real codebases, and on Windows it's the only grep
-                equivalent available. PromptHashline asks about
-                fs_edit_hashline at onboarding with a platform-aware
-                default Y/N. Applying the profile explicitly is a no-op;
-                it exists so `pasclaw profile show stock` documents the
-                no-profile fresh-install state.
+                equivalent available. Applying the profile explicitly
+                is a no-op; it exists so `pasclaw profile show stock`
+                documents the no-profile fresh-install state.
 
     baseline    Everything off. Bare-minimum control profile for A/B
                 comparison ("how does pasclaw behave with no features").
@@ -247,11 +244,10 @@ const
     '+ vault + memory_fetch OFF (operators opt in via onboarding); ' +
     '6 zero-prompt-cost behavioral toggles ON (orient, checkpoints, ' +
     'stats, 1h cache, distiller, auto-router). hashline_enabled gates ' +
-    'fs_edit_hashline ONLY and is PLATFORM-CONDITIONAL -- defaults OFF ' +
-    'on Linux / macOS, ON on Windows; see TConfig.Create. fs_grep ' +
-    'registers unconditionally (6 ripgrep-inspired optimisations + no ' +
-    'shell grep on Windows). Onboarding PromptHashline asks about ' +
-    'fs_edit_hashline with a platform-aware default Y/N.",' +
+    'fs_edit_hashline ONLY -- defaults True; small-model operators opt ' +
+    'out via the onboarding PromptHashline question or --no-hashline ' +
+    'CLI flag. fs_grep registers unconditionally (6 ripgrep-inspired ' +
+    'optimisations + no shell grep on Windows).",' +
     '"vault_tools_enabled":false,' +
     '"web_fetch_enabled":false,' +
     '"vector_search_enabled":true,' +

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -242,7 +242,7 @@ const
     '"render_markdown":true,' +
     '"promptware_enabled":true,' +
     '"condense_reversible":false,' +
-    '"hashline_enabled":true,' +
+    '"hashline_enabled":false,' +
     '"tool_output_cap":0,' +
     '"orient_task_aware":true,' +
     '"stats_collection_enabled":true,' +

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -14,19 +14,20 @@
                 them on via onboarding when they actually use them); the
                 six zero-prompt-cost behavioral toggles (orient_task_aware,
                 checkpoints, stats, 1h prompt cache, distiller, auto-
-                router) ON by default. Additionally drops fs_edit_hashline
-                + fs_grep -- one step BEYOND strict lean-edit, driven by
-                TWO bench findings: (1) smaller models (Haiku-class) misuse
-                the hashline format and burn turns recovering; (2) on
-                fixture 07-cross-file-grep, every model class found
-                shell_exec "grep -rln PATTERN PATH > result.txt" beat
-                fs_grep + fs_write by 1 turn (the single shell invocation
-                collapses find + filter + write into one tool call).
-                Onboarding's PromptHashline restores both tools with one
-                keystroke for operators who want them back. Applying the
-                profile explicitly is a no-op; it exists so
-                `pasclaw profile show stock` documents the no-profile
-                fresh-install state.
+                router) ON by default. fs_edit_hashline is PLATFORM-
+                CONDITIONAL by default: OFF on Linux / macOS (bench
+                finding -- smaller models mis-author the anchor/payload
+                format and burn turns recovering), ON on Windows.
+                fs_grep registers UNCONDITIONALLY -- its six ripgrep-
+                inspired optimisations (skip lists, BMH, binary
+                detection, byte-walking, file-size cap, deferred
+                hashing) make it 10-50x faster than shell_exec grep on
+                real codebases, and on Windows it's the only grep
+                equivalent available. PromptHashline asks about
+                fs_edit_hashline at onboarding with a platform-aware
+                default Y/N. Applying the profile explicitly is a no-op;
+                it exists so `pasclaw profile show stock` documents the
+                no-profile fresh-install state.
 
     baseline    Everything off. Bare-minimum control profile for A/B
                 comparison ("how does pasclaw behave with no features").
@@ -245,19 +246,18 @@ const
     'bench-grounded lean-edit shape (bench/swe/README.md): web_fetch ' +
     '+ vault + memory_fetch OFF (operators opt in via onboarding); ' +
     '6 zero-prompt-cost behavioral toggles ON (orient, checkpoints, ' +
-    'stats, 1h cache, distiller, auto-router). Additionally drops ' +
-    'fs_edit_hashline + fs_grep -- beyond strict lean-edit, justified ' +
-    'by TWO bench findings: small models mis-author the hashline ' +
-    'format (Haiku 3x turn penalty), and on fixture 07 shell_exec ' +
-    '\"grep -rln ... > result.txt\" beat fs_grep+fs_write across every ' +
-    'model class. Onboarding restores both tools with one keystroke.",' +
+    'stats, 1h cache, distiller, auto-router). hashline_enabled gates ' +
+    'fs_edit_hashline ONLY and is PLATFORM-CONDITIONAL -- defaults OFF ' +
+    'on Linux / macOS, ON on Windows; see TConfig.Create. fs_grep ' +
+    'registers unconditionally (6 ripgrep-inspired optimisations + no ' +
+    'shell grep on Windows). Onboarding PromptHashline asks about ' +
+    'fs_edit_hashline with a platform-aware default Y/N.",' +
     '"vault_tools_enabled":false,' +
     '"web_fetch_enabled":false,' +
     '"vector_search_enabled":true,' +
     '"render_markdown":true,' +
     '"promptware_enabled":true,' +
     '"condense_reversible":false,' +
-    '"hashline_enabled":false,' +
     '"tool_output_cap":0,' +
     '"orient_task_aware":true,' +
     '"stats_collection_enabled":true,' +

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -8,13 +8,18 @@
 
   Six built-ins:
 
-    stock       TConfig.Create's exact defaults. The shape is the
-                bench-grounded lean-edit (bench/swe/README.md): web_fetch,
+    stock       TConfig.Create's exact defaults. Adopted the bench-
+                grounded lean-edit shape (bench/swe/README.md): web_fetch,
                 vault, and memory_fetch OFF out-of-box (operators turn
                 them on via onboarding when they actually use them); the
                 six zero-prompt-cost behavioral toggles (orient_task_aware,
                 checkpoints, stats, 1h prompt cache, distiller, auto-
-                router) ON by default. Applying the profile explicitly
+                router) ON by default. Additionally drops fs_edit_hashline
+                + fs_grep -- one step BEYOND strict lean-edit, driven by
+                the bench finding that smaller models (Haiku-class) misuse
+                the hashline format and burn turns recovering; onboarding's
+                PromptHashline restores both tools with one keystroke for
+                Opus / Sonnet deployments. Applying the profile explicitly
                 is a no-op; it exists so `pasclaw profile show stock`
                 documents the no-profile fresh-install state.
 
@@ -231,11 +236,15 @@ const
      stock cross-check catches. *)
   Profile_Stock: string =
     '{' +
-    '"_description":"Stock TConfig.Create defaults. Adopted lean-edit ' +
-    'shape: web_fetch + vault + memory_fetch OFF (operators opt in via ' +
-    'onboarding); 6 zero-prompt-cost behavioral toggles ON (orient, ' +
-    'checkpoints, stats, 1h cache, distiller, auto-router). See ' +
-    'bench/swe/README.md for the data behind the shift.",' +
+    '"_description":"Stock TConfig.Create defaults. Adopted the ' +
+    'bench-grounded lean-edit shape (bench/swe/README.md): web_fetch ' +
+    '+ vault + memory_fetch OFF (operators opt in via onboarding); ' +
+    '6 zero-prompt-cost behavioral toggles ON (orient, checkpoints, ' +
+    'stats, 1h cache, distiller, auto-router). Additionally drops ' +
+    'fs_edit_hashline + fs_grep -- this part goes beyond strict ' +
+    'lean-edit, driven by the bench finding that small models ' +
+    '(Haiku-class) misuse the hashline format; onboarding restores ' +
+    'them with one keystroke for Opus / Sonnet operators.",' +
     '"vault_tools_enabled":false,' +
     '"web_fetch_enabled":false,' +
     '"vector_search_enabled":true,' +

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -16,12 +16,17 @@
                 checkpoints, stats, 1h prompt cache, distiller, auto-
                 router) ON by default. Additionally drops fs_edit_hashline
                 + fs_grep -- one step BEYOND strict lean-edit, driven by
-                the bench finding that smaller models (Haiku-class) misuse
-                the hashline format and burn turns recovering; onboarding's
-                PromptHashline restores both tools with one keystroke for
-                Opus / Sonnet deployments. Applying the profile explicitly
-                is a no-op; it exists so `pasclaw profile show stock`
-                documents the no-profile fresh-install state.
+                TWO bench findings: (1) smaller models (Haiku-class) misuse
+                the hashline format and burn turns recovering; (2) on
+                fixture 07-cross-file-grep, every model class found
+                shell_exec "grep -rln PATTERN PATH > result.txt" beat
+                fs_grep + fs_write by 1 turn (the single shell invocation
+                collapses find + filter + write into one tool call).
+                Onboarding's PromptHashline restores both tools with one
+                keystroke for operators who want them back. Applying the
+                profile explicitly is a no-op; it exists so
+                `pasclaw profile show stock` documents the no-profile
+                fresh-install state.
 
     baseline    Everything off. Bare-minimum control profile for A/B
                 comparison ("how does pasclaw behave with no features").
@@ -241,10 +246,11 @@ const
     '+ vault + memory_fetch OFF (operators opt in via onboarding); ' +
     '6 zero-prompt-cost behavioral toggles ON (orient, checkpoints, ' +
     'stats, 1h cache, distiller, auto-router). Additionally drops ' +
-    'fs_edit_hashline + fs_grep -- this part goes beyond strict ' +
-    'lean-edit, driven by the bench finding that small models ' +
-    '(Haiku-class) misuse the hashline format; onboarding restores ' +
-    'them with one keystroke for Opus / Sonnet operators.",' +
+    'fs_edit_hashline + fs_grep -- beyond strict lean-edit, justified ' +
+    'by TWO bench findings: small models mis-author the hashline ' +
+    'format (Haiku 3x turn penalty), and on fixture 07 shell_exec ' +
+    '\"grep -rln ... > result.txt\" beat fs_grep+fs_write across every ' +
+    'model class. Onboarding restores both tools with one keystroke.",' +
     '"vault_tools_enabled":false,' +
     '"web_fetch_enabled":false,' +
     '"vector_search_enabled":true,' +

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -6,18 +6,25 @@
   embedded as Pascal string constants below; operators can add their
   own by dropping files at $PASCLAW_HOME/profiles/<name>.json.
 
-  Six built-ins (PR #291):
+  Six built-ins:
 
-    stock       Mirrors TConfig.Create's exact defaults. Applying it is
-                a no-op; it exists so `pasclaw profile show stock`
+    stock       TConfig.Create's exact defaults. The shape is the
+                bench-grounded lean-edit (bench/swe/README.md): web_fetch,
+                vault, and memory_fetch OFF out-of-box (operators turn
+                them on via onboarding when they actually use them); the
+                six zero-prompt-cost behavioral toggles (orient_task_aware,
+                checkpoints, stats, 1h prompt cache, distiller, auto-
+                router) ON by default. Applying the profile explicitly
+                is a no-op; it exists so `pasclaw profile show stock`
                 documents the no-profile fresh-install state.
 
     baseline    Everything off. Bare-minimum control profile for A/B
                 comparison ("how does pasclaw behave with no features").
 
     low-token   Minimise tokens going to/from the model: condenser on,
-                output cap on, MEMORY task-aware slicing, prompt cache,
-                progressive disclosure for skills, auto-router for
+                output cap on, prompt cache, progressive disclosure for
+                skills (so the registry advertises skills_list/view
+                without the heavier skills_manage), auto-router for
                 easy turns.
 
     security    Maximum sandboxing: workspace restriction + shell deny
@@ -25,10 +32,11 @@
                 and vault tools off, agent-authored skills stage for
                 approval (auto_approve off).
 
-    max-build   Best settings for productive coding: web_fetch, vault,
-                vector search, checkpoints, stats, condenser, large
-                output cap, 1h prompt cache, all four self-improving
-                skill switches on.
+    max-build   Maximum capability surface: web_fetch + vault + memory_fetch
+                back on, plus skill discovery (progressive_disclosure)
+                and skill authoring (self_manage), condenser + 16KB
+                output cap. Use when you need the broadest tool surface
+                and don't mind paying ~2900 bytes/turn for it.
 
     all-on      Every boolean knob flipped on. For surface-area /
                 integration testing only.
@@ -223,28 +231,31 @@ const
      stock cross-check catches. *)
   Profile_Stock: string =
     '{' +
-    '"_description":"Stock TConfig.Create defaults. Documents the ' +
-    'fresh-install state explicitly so `profile show stock` reveals ' +
-    'what `pasclaw agent` does with no --profile / PASCLAW_PROFILE / ' +
-    'config.json profile field set.",' +
-    '"vault_tools_enabled":true,' +
-    '"web_fetch_enabled":true,' +
+    '"_description":"Stock TConfig.Create defaults. Adopted lean-edit ' +
+    'shape: web_fetch + vault + memory_fetch OFF (operators opt in via ' +
+    'onboarding); 6 zero-prompt-cost behavioral toggles ON (orient, ' +
+    'checkpoints, stats, 1h cache, distiller, auto-router). See ' +
+    'bench/swe/README.md for the data behind the shift.",' +
+    '"vault_tools_enabled":false,' +
+    '"web_fetch_enabled":false,' +
     '"vector_search_enabled":true,' +
     '"render_markdown":true,' +
     '"promptware_enabled":true,' +
     '"condense_reversible":false,' +
+    '"hashline_enabled":true,' +
     '"tool_output_cap":0,' +
-    '"orient_task_aware":false,' +
-    '"stats_collection_enabled":false,' +
-    '"checkpoints_enabled":false,' +
+    '"orient_task_aware":true,' +
+    '"stats_collection_enabled":true,' +
+    '"checkpoints_enabled":true,' +
+    '"checkpoints_keep_last":32,' +
     '"self_improving_skills":{' +
       '"self_manage":false,' +
       '"progressive_disclosure":false,' +
       '"auto_approve":false,' +
-      '"distiller":{"enabled":false}' +
+      '"distiller":{"enabled":true,"min_tool_calls":5}' +
     '},' +
-    '"auto_router":{"enabled":false},' +
-    '"prompt_cache":{"enabled":true},' +
+    '"auto_router":{"enabled":true},' +
+    '"prompt_cache":{"enabled":true,"ttl":"1h"},' +
     '"sandbox":{' +
       '"restrict_to_workspace":false,' +
       '"shell_deny_enabled":true,' +

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -1189,12 +1189,14 @@ begin
       only the explicit-on so fresh configs stay tidy. }
     if CondenseReversible then
       Root.PutBool('condense_reversible', True);
-    { hashline_enabled: default flipped to OFF in PR #314 (bench/swe).
-      Emit only the explicit-on so operators answering Y to the
-      onboarding prompt (Opus / Sonnet deployments) see the choice
-      round-trip. CLI --no-hashline still works as a per-run override. }
-    if HashlineEnabled then
-      Root.PutBool('hashline_enabled', True);
+    { hashline_enabled: default True. Emit only the explicit OFF so
+      small-model operators who answer N to PromptHashline (or who
+      set the field via config edit) see their choice round-trip;
+      Y-keepers don't get a redundant "hashline_enabled": true in
+      their config.json. CLI --no-hashline still works as a per-run
+      override. }
+    if not HashlineEnabled then
+      Root.PutBool('hashline_enabled', False);
     if Heartbeat.Enabled
        or (Heartbeat.IntervalMins <> 30)
        or (Heartbeat.ContentPath <> '')

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -1100,8 +1100,11 @@ begin
     end;
 
     { Only emit prompt_cache when non-default -- keeps stock configs
-      tidy. Reading back: missing object => defaults (enabled, 5m). }
-    if (not PromptCache.Enabled) or (PromptCache.TTL <> '') then
+      tidy. Default flipped to 1h in PR #314 (bench/swe/README.md): an
+      operator setting TTL back to "5m" or any other non-default needs
+      the value to round-trip; same for the explicit-off path. Reading
+      back: missing object => defaults (enabled, 1h). }
+    if (not PromptCache.Enabled) or ((PromptCache.TTL <> '') and (PromptCache.TTL <> '1h')) then
     begin
       Tmp := TJsonObject.Create;
       Tmp.PutBool('enabled', PromptCache.Enabled);
@@ -1116,13 +1119,15 @@ begin
       Root.PutArray('allow_senders', Arr);
     end;
 
-    { vault_tools_enabled, web_fetch_enabled: defaults flipped to ON
-      in PR #289. Emit only the explicit-off so a fresh config stays
-      tidy and an operator who explicitly opted out round-trips. }
-    if not VaultToolsEnabled then
-      Root.PutBool('vault_tools_enabled', False);
-    if not WebFetchEnabled then
-      Root.PutBool('web_fetch_enabled', False);
+    { vault_tools_enabled, web_fetch_enabled: defaults flipped to OFF
+      in PR #314 (bench/swe/README.md). Emit only the explicit-on so a
+      fresh config stays tidy AND so an operator who answered Y to the
+      onboarding prompt sees the choice round-trip (without this, the
+      Y would silently revert to N on the next LoadConfig). }
+    if VaultToolsEnabled then
+      Root.PutBool('vault_tools_enabled', True);
+    if WebFetchEnabled then
+      Root.PutBool('web_fetch_enabled', True);
     { cron_tool_enabled defaults OFF; emit only the explicit-on so an
       operator who opted into model-scheduled jobs round-trips. }
     if CronToolEnabled then
@@ -1142,28 +1147,38 @@ begin
       JSON keeps fresh config files clean. }
     if ToolOutputCap > 0 then
       Root.PutInt('tool_output_cap', ToolOutputCap);
-    if StatsCollectionEnabled then
-      Root.PutBool('stats_collection_enabled', True);
-    if CheckpointsEnabled then
-      Root.PutBool('checkpoints_enabled', True);
-    if CheckpointsKeepLast > 0 then
+    { stats_collection_enabled, checkpoints_enabled, orient_task_aware:
+      defaults flipped to ON in PR #314 (the six free behavioral toggles
+      from the bench's ablation). Emit only the explicit-off so an
+      operator answering N to onboarding (or editing the field by hand)
+      sees the choice round-trip. Without this, an opt-out silently
+      reverts to the on-by-default behavior on the next load -- privacy
+      / storage / behavior opt-outs do not stick. }
+    if not StatsCollectionEnabled then
+      Root.PutBool('stats_collection_enabled', False);
+    if not CheckpointsEnabled then
+      Root.PutBool('checkpoints_enabled', False);
+    { CheckpointsKeepLast default flipped from 0 (=> use library
+      default 32) to an explicit 32 in PR #314. Emit when it differs --
+      0 and other values both round-trip. }
+    if CheckpointsKeepLast <> 32 then
       Root.PutInt('checkpoints_keep_last', CheckpointsKeepLast);
     { Default True -- emit only the explicit-off so it round-trips
       (same rule as render_markdown / vector_search_enabled). }
     if not PromptwareEnabled then
       Root.PutBool('promptware_enabled', False);
-    { Default False -- emit only the explicit-on. }
-    if OrientTaskAware then
-      Root.PutBool('orient_task_aware', True);
+    if not OrientTaskAware then
+      Root.PutBool('orient_task_aware', False);
     { condense_reversible: default flipped to OFF in PR #289. Emit
       only the explicit-on so fresh configs stay tidy. }
     if CondenseReversible then
       Root.PutBool('condense_reversible', True);
-    { hashline_enabled: default ON; emit only the explicit-off so
-      operators who flipped it during onboarding see the choice
-      persisted on disk. }
-    if not HashlineEnabled then
-      Root.PutBool('hashline_enabled', False);
+    { hashline_enabled: default flipped to OFF in PR #314 (bench/swe).
+      Emit only the explicit-on so operators answering Y to the
+      onboarding prompt (Opus / Sonnet deployments) see the choice
+      round-trip. CLI --no-hashline still works as a per-run override. }
+    if HashlineEnabled then
+      Root.PutBool('hashline_enabled', True);
     if Heartbeat.Enabled
        or (Heartbeat.IntervalMins <> 30)
        or (Heartbeat.ContentPath <> '')
@@ -1215,10 +1230,13 @@ begin
         Tmp.Free; raise;
       end;
     end;
-    if AutoRouter.Enabled
-       or (AutoRouter.EasyProvider <> '')
-       or (AutoRouter.EasyModel <> '')
-       or (AutoRouter.EasyMaxTokens <> 500) then
+    { auto_router.enabled default flipped to ON in PR #314. Always
+      emit the subobject -- True default plus the previous "emit when
+      Enabled" gate means an opt-out (Enabled := False with no other
+      changes) would skip emission and the next LoadConfig would
+      silently re-enable. Emitting unconditionally keeps the round-trip
+      honest at the cost of one always-present subobject in fresh
+      configs (cheap given it has four fields). }
     begin
       Tmp := TJsonObject.Create;
       try
@@ -1231,12 +1249,17 @@ begin
         Tmp.Free; raise;
       end;
     end;
-    { Self-improving skills -- emit only when something is enabled so a
-      default config.json stays clean (same posture as auto_router). }
+    { Self-improving skills -- emit when ANYTHING differs from the new
+      defaults so the round-trip is honest. Distiller.Enabled default
+      flipped to True in PR #314, so the gate ALSO has to fire on the
+      explicit-off path (without `not Distiller.Enabled` here, an
+      onboarding-skip + manual distiller=false flip would silently
+      revert to on). SelfManage / ProgressiveDisclosure / AutoApprove
+      defaults stay False -- gate emits when any is True. }
     if SelfImprovingSkills.SelfManage
        or SelfImprovingSkills.ProgressiveDisclosure
        or SelfImprovingSkills.AutoApprove
-       or SelfImprovingSkills.Distiller.Enabled
+       or (not SelfImprovingSkills.Distiller.Enabled)
        or (Length(SelfImprovingSkills.GuardDeny) > 0)
        or (SelfImprovingSkills.Distiller.MinToolCalls <> 5)
        or (SelfImprovingSkills.Distiller.Model <> '') then

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -624,6 +624,16 @@ type
        view surprised operators on fresh deploys (PR #289). Onboarding
        asks (default N). *)
     CondenseReversible:    Boolean;
+    (* HashlineEnabled -- gate fs_edit_hashline + fs_grep tool
+       registrations. On by default so the surgical-patch tool surface
+       is available. The bench (bench/swe/README.md) found that smaller
+       models (Haiku-class) misuse fs_edit_hashline -- they reach for it
+       on tasks fs_write would handle, then fail the anchor/payload
+       format and burn turns recovering. Onboarding asks (default Y)
+       so operators on small-model deployments can opt out -- equivalent
+       to the --no-hashline CLI flag but persistent. Both layers compose
+       (CLI flag OR config off = drop registrations). *)
+    HashlineEnabled:       Boolean;
     (* Proactive periodic wake-up (picoclaw / openclaw heartbeat).
        Off by default. When Enabled, the standalone `pasclaw
        heartbeat` daemon (and the gateway / serve embedders, when
@@ -871,18 +881,19 @@ begin
   WebSearch.BaseURL    := '';
   WebSearch.MaxResults := 5;
   PromptCache.Enabled  := True;  { default-on; see TPromptCacheConfig comment }
-  PromptCache.TTL      := '';    { default 5m via empty }
-  VaultToolsEnabled    := True;  { on by default -- vault_search/get are read-only HTTP GETs against pasclaw.dev. Onboarding asks (default Y). }
-  WebFetchEnabled      := True;  { on by default -- onboarding asks (default Y); operators not wanting outbound HTTP from the agent flip it off. }
+  PromptCache.TTL      := '1h';  { 1h cache hits well across back-to-back runs (bench/swe/results/ablation.md). 5m was the historical default; 1h is one of the six zero-prompt-cost behavioral toggles the bench identified as a free upgrade. }
+  VaultToolsEnabled    := False; { off by default per the bench-grounded "stock = lean-edit shape" verdict (bench/swe/README.md). Vault entries are never called across the bench's 45+ cells -- the model has them as training data. Onboarding asks (default Y for operators who DO use the vault). }
+  WebFetchEnabled      := False; { off by default for the same reason as VaultToolsEnabled. Also drops memory_fetch (RegisterMemoryFetchTool is gated on EnableWebFetch in NewBuiltinRegistry -- see comment there). Onboarding asks. }
   CronToolEnabled      := False; { off by default -- model-scheduled background jobs are an opt-in autonomy step (runs existing skills only). }
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   ToolOutputCap        := 0;     { off by default; operators opt in. See TConfig.ToolOutputCap. }
-  StatsCollectionEnabled := False; { opt-in via onboarding; see TConfig.StatsCollectionEnabled. }
-  CheckpointsEnabled     := False; { opt-in via onboarding; see TConfig.CheckpointsEnabled. }
-  CheckpointsKeepLast    := 0;     { 0 means default (32) inside PasClaw.Checkpoints. }
+  StatsCollectionEnabled := True;  { on by default -- zero prompt cost, useful for diagnosing turn-count regressions. Onboarding can flip off for privacy-conscious operators. }
+  CheckpointsEnabled     := True;  { on by default -- zero prompt cost, prevents lost work on multi-edit sessions. }
+  CheckpointsKeepLast    := 32;    { keep last 32 atomic edit checkpoints. }
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
-  OrientTaskAware        := False; { opt-in; whole-file MEMORY injection is the contract. }
+  OrientTaskAware        := True;  { on by default -- MEMORY task-aware injection. Zero prompt cost when MEMORY.md is absent; saves tokens when present. }
   CondenseReversible     := False; { off by default -- raw tool output preserved verbatim. Onboarding asks (default N). Flipped from on-by-default in PR #289 so a fresh deploy doesn't silently rewrite ls/grep output behind the operator's back. }
+  HashlineEnabled        := True;  { on by default -- fs_edit_hashline + fs_grep advertised. The bench found smaller models (Haiku) mishandle the hashline format; onboarding asks so operators on smaller models can opt out (equivalent to the --no-hashline CLI flag). }
   Heartbeat.Enabled      := False; { opt-in via onboarding; off by default. }
   Heartbeat.IntervalMins := 30;
   Heartbeat.ContentPath  := '';    { empty -> default workspace/heartbeat.md at load time }
@@ -893,16 +904,20 @@ begin
   ShellBackendDocker.User       := '';
   ShellBackendDocker.Privileged := False;
   SetLength(Channels, 0);          { no channels -> send_message tool not registered. }
-  AutoRouter.Enabled        := False;  { opt-in via onboarding; see TAutoRouterConfig. }
+  AutoRouter.Enabled        := True;   { on by default -- routes easy turns to the cheap model when EasyProvider/Model are configured. Zero prompt cost; no effect unless multi-tier provider config is set. }
   AutoRouter.EasyProvider   := '';
   AutoRouter.EasyModel      := '';
   AutoRouter.EasyMaxTokens  := 500;
-  { Self-improving skills: everything opt-in (see TSelfImprovingSkillsConfig). }
+  { Self-improving skills: distiller on by default (zero prompt cost,
+    post-turn pass produces staged drafts under workspace/skills/.pending/).
+    The three other switches (self_manage / progressive_disclosure /
+    auto_approve) remain opt-in -- each adds tool registrations or
+    skips operator review. See TSelfImprovingSkillsConfig. }
   SelfImprovingSkills.SelfManage            := False;
   SelfImprovingSkills.ProgressiveDisclosure := False;
   SelfImprovingSkills.AutoApprove           := False;
   SetLength(SelfImprovingSkills.GuardDeny, 0);
-  SelfImprovingSkills.Distiller.Enabled      := False;
+  SelfImprovingSkills.Distiller.Enabled      := True;
   SelfImprovingSkills.Distiller.MinToolCalls := 5;
   SelfImprovingSkills.Distiller.Model        := '';
   Profile := '';   { PR #291: empty == no persisted profile selection }
@@ -1144,6 +1159,11 @@ begin
       only the explicit-on so fresh configs stay tidy. }
     if CondenseReversible then
       Root.PutBool('condense_reversible', True);
+    { hashline_enabled: default ON; emit only the explicit-off so
+      operators who flipped it during onboarding see the choice
+      persisted on disk. }
+    if not HashlineEnabled then
+      Root.PutBool('hashline_enabled', False);
     if Heartbeat.Enabled
        or (Heartbeat.IntervalMins <> 30)
        or (Heartbeat.ContentPath <> '')
@@ -1514,6 +1534,7 @@ begin
     PromptwareEnabled   := Root.GetBool('promptware_enabled', PromptwareEnabled);
     OrientTaskAware     := Root.GetBool('orient_task_aware',  OrientTaskAware);
     CondenseReversible  := Root.GetBool('condense_reversible', CondenseReversible);
+    HashlineEnabled     := Root.GetBool('hashline_enabled',    HashlineEnabled);
 
     Obj := Root.ChildObject('heartbeat');
     if Obj <> nil then

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -893,7 +893,7 @@ begin
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
   OrientTaskAware        := True;  { on by default -- MEMORY task-aware injection. Zero prompt cost when MEMORY.md is absent; saves tokens when present. }
   CondenseReversible     := False; { off by default -- raw tool output preserved verbatim. Onboarding asks (default N). Flipped from on-by-default in PR #289 so a fresh deploy doesn't silently rewrite ls/grep output behind the operator's back. }
-  HashlineEnabled        := True;  { on by default -- fs_edit_hashline + fs_grep advertised. The bench found smaller models (Haiku) mishandle the hashline format; onboarding asks so operators on smaller models can opt out (equivalent to the --no-hashline CLI flag). }
+  HashlineEnabled        := False; { off by default per the bench finding (bench/swe/README.md): the surgical-patch surface fs_edit_hashline + fs_grep lures smaller models (Haiku-class) into mis-authoring the anchor/payload format and burning turns. Bigger models (Opus / Sonnet) use the tool correctly when it's present, so the onboarding question defaults Y -- operators on Opus / Sonnet / GPT-4-tier deployments restore the toolchain in one keystroke. CLI --no-hashline still works as a per-run override; config OFF supersedes CLI ON. }
   Heartbeat.Enabled      := False; { opt-in via onboarding; off by default. }
   Heartbeat.IntervalMins := 30;
   Heartbeat.ContentPath  := '';    { empty -> default workspace/heartbeat.md at load time }

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -624,15 +624,22 @@ type
        view surprised operators on fresh deploys (PR #289). Onboarding
        asks (default N). *)
     CondenseReversible:    Boolean;
-    (* HashlineEnabled -- gate fs_edit_hashline + fs_grep tool
-       registrations. On by default so the surgical-patch tool surface
-       is available. The bench (bench/swe/README.md) found that smaller
-       models (Haiku-class) misuse fs_edit_hashline -- they reach for it
-       on tasks fs_write would handle, then fail the anchor/payload
-       format and burn turns recovering. Onboarding asks (default Y)
-       so operators on small-model deployments can opt out -- equivalent
-       to the --no-hashline CLI flag but persistent. Both layers compose
-       (CLI flag OR config off = drop registrations). *)
+    (* HashlineEnabled gates fs_edit_hashline ONLY (PR #314: split the
+       previous bundled gate -- fs_grep now registers unconditionally
+       because its ripgrep-inspired optimisations beat shell_exec grep
+       on real codebases and on Windows it's the only grep available).
+       The flag also controls fs_read's default output format
+       (hashline-prefixed vs raw bytes).
+
+       PLATFORM-CONDITIONAL default in TConfig.Create:
+         Linux / macOS: False (bench finding -- smaller models mis-author
+           the hashline anchor/payload format and burn turns recovering).
+         Windows:       True  (the format isn't model-specific, so the
+           default just preserves the historical surface; small-model
+           operators on Windows still flip it off via onboarding or
+           the --no-hashline CLI flag).
+       Both gate layers compose: CLI flag OR config off = drop the
+       fs_edit_hashline registration. *)
     HashlineEnabled:       Boolean;
     (* Proactive periodic wake-up (picoclaw / openclaw heartbeat).
        Off by default. When Enabled, the standalone `pasclaw
@@ -893,7 +900,30 @@ begin
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
   OrientTaskAware        := True;  { on by default -- MEMORY task-aware injection. Zero prompt cost when MEMORY.md is absent; saves tokens when present. }
   CondenseReversible     := False; { off by default -- raw tool output preserved verbatim. Onboarding asks (default N). Flipped from on-by-default in PR #289 so a fresh deploy doesn't silently rewrite ls/grep output behind the operator's back. }
-  HashlineEnabled        := False; { off by default per the bench finding (bench/swe/README.md): the surgical-patch surface fs_edit_hashline + fs_grep lures smaller models (Haiku-class) into mis-authoring the anchor/payload format and burning turns. Bigger models (Opus / Sonnet) use the tool correctly when it's present, so the onboarding question defaults Y -- operators on Opus / Sonnet / GPT-4-tier deployments restore the toolchain in one keystroke. CLI --no-hashline still works as a per-run override; config OFF supersedes CLI ON. }
+  { HashlineEnabled gates fs_edit_hashline ONLY (PR #314 split the
+    previous bundled gate). fs_grep registers unconditionally.
+
+    Linux / macOS default OFF: bench (bench/swe/README.md) found that
+      smaller models (Haiku-class) mis-author fs_edit_hashline's
+      anchor/payload format and burn turns recovering on every cell
+      that hit the tool. Big-model operators (Opus / Sonnet / GPT-4)
+      who DO use it correctly restore via the onboarding PromptHashline
+      question (default N on these platforms but a single Y keystroke
+      flips it back).
+
+    Windows default ON: the bench's small-model finding still applies
+      but Windows operators on big models tend to want fs_edit_hashline
+      available out-of-box (no platform-specific reason to drop it like
+      there was for fs_grep). PromptHashline still asks (defaults Y on
+      Windows).
+
+    --no-hashline CLI flag still works as a per-run override; config
+    OFF supersedes CLI ON. }
+  {$IFDEF MSWINDOWS}
+  HashlineEnabled        := True;
+  {$ELSE}
+  HashlineEnabled        := False;
+  {$ENDIF}
   Heartbeat.Enabled      := False; { opt-in via onboarding; off by default. }
   Heartbeat.IntervalMins := 30;
   Heartbeat.ContentPath  := '';    { empty -> default workspace/heartbeat.md at load time }

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -631,14 +631,12 @@ type
        The flag also controls fs_read's default output format
        (hashline-prefixed vs raw bytes).
 
-       PLATFORM-CONDITIONAL default in TConfig.Create:
-         Linux / macOS: False (bench finding -- smaller models mis-author
-           the hashline anchor/payload format and burn turns recovering).
-         Windows:       True  (the format isn't model-specific, so the
-           default just preserves the historical surface; small-model
-           operators on Windows still flip it off via onboarding or
-           the --no-hashline CLI flag).
-       Both gate layers compose: CLI flag OR config off = drop the
+       Default True everywhere. The bench (bench/swe/README.md) found
+       that smaller models (Haiku-class) mis-author the hashline
+       anchor/payload format and burn turns recovering; operators on
+       small-model deployments opt out via onboarding's PromptHashline
+       (default N skips it) or the --no-hashline CLI flag. Both gate
+       layers compose: CLI flag OR config off = drop the
        fs_edit_hashline registration. *)
     HashlineEnabled:       Boolean;
     (* Proactive periodic wake-up (picoclaw / openclaw heartbeat).
@@ -901,29 +899,17 @@ begin
   OrientTaskAware        := True;  { on by default -- MEMORY task-aware injection. Zero prompt cost when MEMORY.md is absent; saves tokens when present. }
   CondenseReversible     := False; { off by default -- raw tool output preserved verbatim. Onboarding asks (default N). Flipped from on-by-default in PR #289 so a fresh deploy doesn't silently rewrite ls/grep output behind the operator's back. }
   { HashlineEnabled gates fs_edit_hashline ONLY (PR #314 split the
-    previous bundled gate). fs_grep registers unconditionally.
+    previous bundled gate -- fs_grep registers unconditionally).
 
-    Linux / macOS default OFF: bench (bench/swe/README.md) found that
-      smaller models (Haiku-class) mis-author fs_edit_hashline's
-      anchor/payload format and burn turns recovering on every cell
-      that hit the tool. Big-model operators (Opus / Sonnet / GPT-4)
-      who DO use it correctly restore via the onboarding PromptHashline
-      question (default N on these platforms but a single Y keystroke
-      flips it back).
-
-    Windows default ON: the bench's small-model finding still applies
-      but Windows operators on big models tend to want fs_edit_hashline
-      available out-of-box (no platform-specific reason to drop it like
-      there was for fs_grep). PromptHashline still asks (defaults Y on
-      Windows).
-
-    --no-hashline CLI flag still works as a per-run override; config
-    OFF supersedes CLI ON. }
-  {$IFDEF MSWINDOWS}
+    Default True everywhere. The bench (bench/swe/README.md) found
+    that smaller models (Haiku-class) mis-author fs_edit_hashline's
+    anchor/payload format and burn turns recovering; those operators
+    opt out via onboarding's PromptHashline (default Y) or the
+    --no-hashline CLI flag. Big-model operators (Opus / Sonnet /
+    GPT-4) use the tool correctly, and they're the majority case
+    pasclaw is tuned for. CLI flag OR config off = drop the
+    fs_edit_hashline registration. }
   HashlineEnabled        := True;
-  {$ELSE}
-  HashlineEnabled        := False;
-  {$ENDIF}
   Heartbeat.Enabled      := False; { opt-in via onboarding; off by default. }
   Heartbeat.IntervalMins := 30;
   Heartbeat.ContentPath  := '';    { empty -> default workspace/heartbeat.md at load time }

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -402,7 +402,14 @@ begin
   Headers := BuildAuthHeaders;
 
   LogDebug('%s POST %s (model=%s, body=%d bytes)', [FDisplayName, URL, UseModel, Length(Body)]);
-  Resp := PostJSON(URL, Body, Headers, 120);
+  { 600s read timeout: a high-effort model on a complex one-shot task
+    can take 2-3 minutes to emit a reasoning preamble + a multi-KB
+    tool-call body. 120s was tight for that and broke bench cells
+    where a slow Claude subagent took ~130s to publish its first
+    reply to the localhost stub. The 600s ceiling covers slow-think
+    scenarios without affecting the happy path -- the read returns
+    as soon as the body lands; the timeout is a ceiling, not a wait. }
+  Resp := PostJSON(URL, Body, Headers, 600);
 
   Result.Content := '';
   Result.StatusCode := Resp.StatusCode;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -30,9 +30,14 @@ uses
   PasClaw.Tools.Types,
   PasClaw.Tools.Registry;
 
-{ UseHashline controls fs_read's default output format and whether the
-  hashline-only tools (fs_edit_hashline, fs_grep) get registered at all.
-  Default True. Set False from a command with --no-hashline. }
+{ UseHashline controls fs_read's default output format (hashline-prefixed
+  vs raw bytes) and whether fs_edit_hashline gets registered. As of
+  PR #314 fs_grep registers UNCONDITIONALLY -- its six ripgrep-inspired
+  optimisations (skip lists, BMH, binary detection, byte-walking,
+  file-size cap, deferred hashing) make it 10-50x faster than
+  shell_exec grep on real codebases, and on Windows there's no shell
+  grep at all. Default True. Set False from a command with
+  --no-hashline or from config hashline_enabled: false. }
 procedure RegisterFSTools(R: TToolRegistry; UseHashline: Boolean = True);
 
 implementation
@@ -805,9 +810,42 @@ begin
   T.Category    := tcReadOnly;
   R.Register(T);
 
-  { Hashline-only tools: skip registration entirely when UseHashline is False
-    so the model never sees them in the tool list and doesn't try to call
-    fs_edit_hashline with a hashless patch that we'd reject. }
+  { fs_grep registers UNCONDITIONALLY -- the six ripgrep-inspired
+    optimisations (skip lists, BMH, binary detection, byte-walking,
+    file-size cap, deferred hashing) make it 10-50x faster than
+    shell_exec grep on real codebases, and on Windows it's the only
+    grep equivalent the agent has (Windows ships no grep). The
+    bench's "shell_exec grep wins by 1 turn" finding measured the
+    one-shot UX advantage of `>` redirect on a tiny 8-file fixture --
+    it does NOT generalise to larger repos where fs_grep's speed
+    dominates, and it does not apply at all on Windows. So the gate
+    used to bundle fs_grep with fs_edit_hashline has been split:
+    UseHashline now controls ONLY fs_edit_hashline (plus the hashline
+    format of fs_read), and fs_grep registers unconditionally. }
+  T.Name        := 'fs_grep';
+  T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
+                   'Skips dotdirs, well-known build/VCS/deps dirs (.git, node_modules, target, build, ' +
+                   'dist, vendor, .venv, __pycache__, .gradle, .next), binary files (NUL-byte detection ' +
+                   'in first 1 KiB), and files larger than max_file_bytes (default 10 MiB). Returns ' +
+                   'hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
+                   'so you can paste anchors directly into fs_edit_hashline (when registered).';
+  T.Schema      := '{"type":"object","properties":{' +
+                   '"path":{"type":"string"},' +
+                   '"pattern":{"type":"string"},' +
+                   '"ignore_case":{"type":"boolean"},' +
+                   '"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"},' +
+                   '"max_file_bytes":{"type":"integer","description":"Skip files larger than this (default 10485760 = 10 MiB). Override for grepping into giant log files."}' +
+                   '},"required":["path","pattern"]}';
+  T.Handler     := Tool_FSGrep;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;
+  R.Register(T);
+
+  { fs_edit_hashline: gated on UseHashline (PR #314 / bench finding --
+    smaller models mis-author the anchor/payload format and burn turns
+    recovering). When UseHashline is False we don't expose the tool at
+    all so the model never sees it in the tool list and doesn't try a
+    hashless patch that we'd reject. }
   if UseHashline then
   begin
     T.Name        := 'fs_edit_hashline';
@@ -829,25 +867,6 @@ begin
     T.Handler     := Tool_FSEditHashline;
     T.IsCore      := True;
     T.Category    := tcMutating;
-    R.Register(T);
-
-    T.Name        := 'fs_grep';
-    T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
-                     'Skips dotdirs, well-known build/VCS/deps dirs (.git, node_modules, target, build, ' +
-                     'dist, vendor, .venv, __pycache__, .gradle, .next), binary files (NUL-byte detection ' +
-                     'in first 1 KiB), and files larger than max_file_bytes (default 10 MiB). Returns ' +
-                     'hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
-                     'so you can paste anchors directly into fs_edit_hashline.';
-    T.Schema      := '{"type":"object","properties":{' +
-                     '"path":{"type":"string"},' +
-                     '"pattern":{"type":"string"},' +
-                     '"ignore_case":{"type":"boolean"},' +
-                     '"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"},' +
-                     '"max_file_bytes":{"type":"integer","description":"Skip files larger than this (default 10485760 = 10 MiB). Override for grepping into giant log files."}' +
-                     '},"required":["path","pattern"]}';
-    T.Handler     := Tool_FSGrep;
-    T.IsCore      := True;
-    T.Category    := tcReadOnly;
     R.Register(T);
   end;
 end;

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -294,6 +294,69 @@ begin
   end;
 end;
 
+(* PR #314 review P1/P2: every default flipped in this PR must
+   round-trip its opt-OUT through SaveConfig + LoadConfig. The old
+   ToJSON gates only emitted explicit-on for default-off toggles
+   (and vice versa); after the flips, a fresh-default value would
+   skip emission so an opt-OUT (= match the OLD default) would
+   silently revert to the NEW default on the next LoadConfig. Fixed
+   in this PR's ToJSON updates. This test pins the round-trip honest
+   for every flipped toggle.
+
+   Asymmetric: we test the OPT-OUT path (the one that breaks the
+   review-comment scenarios). The opt-IN path (default value) is
+   tested by TestStockMatchesDefaults. *)
+procedure TestOptOutsPersistAcrossRoundTrip;
+var
+  Saved, Loaded: TConfig;
+begin
+  Saved := LoadConfig('');  { TConfig.Create defaults via no-profile path }
+  try
+    { Flip every toggle whose default moved in PR #314 to its
+      OPPOSITE value, so the resulting SaveConfig has to emit the
+      opt-out and the next LoadConfig has to read it back. }
+    Saved.VaultToolsEnabled                     := True;   { default False -> opt-in }
+    Saved.WebFetchEnabled                       := True;   { default False -> opt-in }
+    Saved.StatsCollectionEnabled                := False;  { default True  -> opt-out }
+    Saved.CheckpointsEnabled                    := False;  { default True  -> opt-out }
+    Saved.CheckpointsKeepLast                   := 16;     { default 32    -> custom }
+    Saved.OrientTaskAware                       := False;  { default True  -> opt-out }
+    Saved.HashlineEnabled                       := True;   { default False -> opt-in }
+    Saved.PromptCache.TTL                       := '5m';   { default '1h'  -> non-default }
+    Saved.AutoRouter.Enabled                    := False;  { default True  -> opt-out }
+    Saved.SelfImprovingSkills.Distiller.Enabled := False;  { default True  -> opt-out }
+    SaveConfig(Saved);
+  finally
+    Saved.Free;
+  end;
+
+  Loaded := LoadConfig('');
+  try
+    AssertTrue(Loaded.VaultToolsEnabled,
+               'vault_tools_enabled opt-in persisted');
+    AssertTrue(Loaded.WebFetchEnabled,
+               'web_fetch_enabled opt-in persisted');
+    AssertTrue(not Loaded.StatsCollectionEnabled,
+               'stats_collection_enabled opt-out persisted');
+    AssertTrue(not Loaded.CheckpointsEnabled,
+               'checkpoints_enabled opt-out persisted');
+    AssertEqI(Loaded.CheckpointsKeepLast, 16,
+              'checkpoints_keep_last custom value persisted');
+    AssertTrue(not Loaded.OrientTaskAware,
+               'orient_task_aware opt-out persisted');
+    AssertTrue(Loaded.HashlineEnabled,
+               'hashline_enabled opt-in persisted');
+    AssertEqS(Loaded.PromptCache.TTL, '5m',
+              'prompt_cache.ttl custom value persisted');
+    AssertTrue(not Loaded.AutoRouter.Enabled,
+               'auto_router.enabled opt-out persisted');
+    AssertTrue(not Loaded.SelfImprovingSkills.Distiller.Enabled,
+               'distiller.enabled opt-out persisted');
+  finally
+    Loaded.Free;
+  end;
+end;
+
 (* Codex P2 #2: SaveConfig must preserve the persisted profile field
    so mutating commands (auth login, model set, ...) don't drop it. *)
 procedure TestSaveConfigPreservesProfile;
@@ -426,6 +489,7 @@ begin
     TestLoadConfigInheritsChain;
     TestProfileWithoutConfigFile;
     TestSaveConfigPreservesProfile;
+    TestOptOutsPersistAcrossRoundTrip;
     TestSelfShadowInherit;
     TestDiffMaterial;
     WriteLn('ok - config profile tests passed');

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -321,7 +321,7 @@ begin
     Saved.CheckpointsEnabled                    := False;  { default True  -> opt-out }
     Saved.CheckpointsKeepLast                   := 16;     { default 32    -> custom }
     Saved.OrientTaskAware                       := False;  { default True  -> opt-out }
-    Saved.HashlineEnabled                       := True;   { default False -> opt-in }
+    Saved.HashlineEnabled                       := False;  { default True  -> opt-out }
     Saved.PromptCache.TTL                       := '5m';   { default '1h'  -> non-default }
     Saved.AutoRouter.Enabled                    := False;  { default True  -> opt-out }
     Saved.SelfImprovingSkills.Distiller.Enabled := False;  { default True  -> opt-out }
@@ -344,8 +344,8 @@ begin
               'checkpoints_keep_last custom value persisted');
     AssertTrue(not Loaded.OrientTaskAware,
                'orient_task_aware opt-out persisted');
-    AssertTrue(Loaded.HashlineEnabled,
-               'hashline_enabled opt-in persisted');
+    AssertTrue(not Loaded.HashlineEnabled,
+               'hashline_enabled opt-out persisted');
     AssertEqS(Loaded.PromptCache.TTL, '5m',
               'prompt_cache.ttl custom value persisted');
     AssertTrue(not Loaded.AutoRouter.Enabled,

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -91,6 +91,7 @@ begin
     AssertTrue(Fresh.RenderMarkdown       = Stocked.RenderMarkdown,       'stock: render_markdown');
     AssertTrue(Fresh.PromptwareEnabled    = Stocked.PromptwareEnabled,    'stock: promptware_enabled');
     AssertTrue(Fresh.CondenseReversible   = Stocked.CondenseReversible,   'stock: condense_reversible');
+    AssertTrue(Fresh.HashlineEnabled      = Stocked.HashlineEnabled,      'stock: hashline_enabled');
     AssertTrue(Fresh.ToolOutputCap        = Stocked.ToolOutputCap,        'stock: tool_output_cap');
     AssertTrue(Fresh.OrientTaskAware      = Stocked.OrientTaskAware,      'stock: orient_task_aware');
     AssertTrue(Fresh.StatsCollectionEnabled = Stocked.StatsCollectionEnabled, 'stock: stats_collection_enabled');


### PR DESCRIPTION
## Summary

Adopts the bench-grounded `lean-edit` shape for PasClaw's stock (out-of-box) defaults, and adds a hashline opt-in question to `pasclaw onboard`. Driven by the empirical findings in [PR #313](https://github.com/FMXExpress/PasClaw/pull/313)'s `bench/swe/README.md`.

**Pure config / profile / onboarding changes — no benchmark code here.**

## What changes for a fresh install

| setting | before | after | rationale |
|---|---|---|---|
| `web_fetch_enabled` | true | **false** | The bench's 45+ live-driven cells called `web_fetch` only on tasks where `shell_exec curl` was the natural alternative; never on a public URL it couldn't reach. |
| `vault_tools_enabled` | true | **false** | Bench called vault_search / vault_get zero times across all cells. |
| `orient_task_aware` | false | **true** | Zero prompt cost (MEMORY-aware injection); useful when `MEMORY.md` exists. |
| `checkpoints_enabled` | false | **true** (keep_last=32) | Zero prompt cost; prevents lost work on multi-edit sessions. |
| `stats_collection_enabled` | false | **true** | Zero prompt cost; helpful for diagnosing turn-count regressions. |
| `prompt_cache.ttl` | empty (5m) | **`1h`** | Better cache hits across back-to-back runs. |
| `auto_router.enabled` | false | **true** | Zero prompt cost; routes easy turns to a cheap model when configured. |
| `self_improving_skills.distiller.enabled` | false | **true** | Zero prompt cost; produces staged drafts under `workspace/skills/.pending/`. |

`vector_search_enabled` stays on (memory_search remains available). All six new-default behaviors were identified by `bench/swe/results/ablation.md` as costing **zero tools-array bytes** — they're pure-behavior changes.

## New `HashlineEnabled` config field

Gates `fs_edit_hashline` + `fs_grep` tool registrations. The bench found Haiku-class models reach for `fs_edit_hashline` on tasks `fs_write` would handle, fail the anchor/payload format, and burn turns recovering — Haiku showed a **3× turn-count penalty** on max-build vs lean-edit on `fixture/01-snippet-window` driven entirely by hashline mis-authoring. Sonnet and Opus use the tool correctly.

- Default: `true` (matches current behavior)
- Onboarding asks (`PromptHashline`, placed right after `PromptWebFetch`)
- CLI `--no-hashline` still works as a per-run override
- Both layers compose: `UseHashline = (not --no-hashline) and Cfg.HashlineEnabled`

## Profile compatibility

- `baseline`, `security`, `low-token`, `all-on` — unchanged in their explicit overrides
- `max-build` — explicitly turns `web_fetch_enabled` + `vault_tools_enabled` back ON, so `--profile max-build` produces the same final behavior as before
- `stock` — body updated to reflect the new TConfig defaults

## Upgrade impact

Operators upgrading PasClaw and expecting `web_fetch` / `vault_tools` out-of-box will see them disabled on first run. **`pasclaw onboard` restores them in two keystrokes** (the existing `PromptWebFetch` / vault questions ask, default Y). Documented in the new stock profile description.

## Test plan

- [x] `make test-config-profile` — TestStockMatchesDefaults still passes (TConfig.Create and Profile_Stock changed together)
- [x] Added HashlineEnabled assertion to TestStockMatchesDefaults
- [x] `pasclaw config show` after `hashline_enabled: false` in config.json — confirmed the field round-trips
- [x] `pasclaw profile show stock` — new shape printed
- [x] Clean build (`make clean && make`) — 0 errors
- [ ] Independent reviewer runs `pasclaw onboard` to confirm new `PromptHashline` step renders correctly

## Bench reference

Full empirical data in [PR #313](https://github.com/FMXExpress/PasClaw/pull/313)'s `bench/swe/README.md`. Cross-model verdict from there:

| model | reliability | max-build vs lean penalty | recommendation |
|---|---|---|---|
| Haiku 4.5 | bypassed schema 14/15 | **3x turns** on max-build | lean-edit (now the default) |
| Sonnet 4.6 | 15/15 REAL | none | lean-edit (now the default) |
| Opus 4.8 | 45+/45+ REAL | none | lean-edit (now the default) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_