### PR TITLE
providers: add Cloudflare AI Gateway as a catalog row

### DIFF
--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -112,7 +112,7 @@ end;
   change required for OpenAI-compatible endpoints. }
 function BuildCatalog: TProviderSpecArray;
 begin
-  SetLength(Result, 23);
+  SetLength(Result, 25);
   Result[0]  := MkSpec('anthropic',  'Anthropic',
                        pfAnthropic,  'https://api.anthropic.com',
                        'claude-opus-4-7',
@@ -283,6 +283,38 @@ begin
                        MkAuth(asBearer),
                        'Workers AI direct or AI Gateway proxy (set api_base; Bearer = CLOUDFLARE_API_TOKEN; @cf/ model prefix for Workers AI)',
                        '/chat/completions');
+  (* Cloudflare AI Gateway -- Anthropic passthrough. Routes Anthropic-
+     shaped requests through a named gateway for caching / rate
+     limiting / analytics, then forwards to api.anthropic.com upstream.
+     The pfAnthropic provider appends /v1/messages to api_base, so:
+
+       api_base = https://gateway.ai.cloudflare.com/v1/{ACCT}/{GW}/anthropic
+       URL      = .../anthropic/v1/messages
+
+     Auth is the operator's ANTHROPIC api key in x-api-key (Cloudflare
+     forwards the upstream auth header unmodified). Operators with
+     "Authenticated Gateway" set on their CF gateway also need a
+     `cf-aig-authorization` header -- not supported here in V1, so
+     leave the gateway unauthenticated or wait for follow-up. *)
+  Result[23] := MkSpec('cloudflare-anthropic', 'Cloudflare AI Gateway (Anthropic)',
+                       pfAnthropic,  '',
+                       'claude-opus-4-7',
+                       MkAuth(asHeader, 'x-api-key'),
+                       'AI Gateway proxy to Anthropic (set api_base to .../gateway/anthropic; x-api-key = your Anthropic key)');
+  (* Cloudflare AI Gateway -- Gemini passthrough. Same pattern as the
+     Anthropic row but the upstream slug is "google-ai-studio" and
+     the path the pfGemini provider appends is
+     /v1beta/models/<model>:generateContent:
+
+       api_base = https://gateway.ai.cloudflare.com/v1/{ACCT}/{GW}/google-ai-studio
+       URL      = .../google-ai-studio/v1beta/models/<model>:generateContent
+
+     Auth is the operator's GEMINI api key in x-goog-api-key. *)
+  Result[24] := MkSpec('cloudflare-gemini',    'Cloudflare AI Gateway (Gemini)',
+                       pfGemini,     '',
+                       'gemini-3.5-flash',
+                       MkAuth(asHeader, 'x-goog-api-key'),
+                       'AI Gateway proxy to Gemini (set api_base to .../gateway/google-ai-studio; x-goog-api-key = your Gemini key)');
   (* Cohere intentionally not in this catalog: their chat API lives at
      /v2/chat with a non-OpenAI request/response body, so the ChatPath
      override alone isn't enough -- it needs a real TCohereProvider (or

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -252,15 +252,18 @@ begin
   (* Cloudflare AI Gateway. Two URL shapes operators paste into
      api_base, both OpenAI Chat Completions compatible:
 
-       Workers AI direct (no gateway features):
-         https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1
-         + ChatPath /chat/completions
-         => POST .../ai/v1/chat/completions
-
-       AI Gateway proxy (caching, rate limits, analytics, fallback):
+       AI Gateway compat proxy (caching, rate limits, analytics,
+       multi-provider routing -- the headline feature, and what this
+       catalog row is named after):
          https://gateway.ai.cloudflare.com/v1/{ACCOUNT_ID}/{GATEWAY_ID}/compat
          + ChatPath /chat/completions
          => POST .../{GATEWAY_ID}/compat/chat/completions
+
+       Workers AI direct (no gateway features; bypasses the AI Gateway
+       entirely and hits Workers AI's own OpenAI-compat endpoint):
+         https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1
+         + ChatPath /chat/completions
+         => POST .../ai/v1/chat/completions
 
      Both expect Authorization: Bearer <CLOUDFLARE_API_TOKEN>; both
      return the same OpenAI-shaped response. ChatPath is /chat/completions
@@ -269,19 +272,24 @@ begin
      because the URL embeds the operator's account_id (same as mimo /
      litellm).
 
-     DefaultModel is a Workers AI flagship: Llama 3.3 70B FP8 fast.
-     Operators wanting a different upstream (gpt-oss-120b, Mistral, an
-     Anthropic passthrough through the AI Gateway, etc.) override via
-     the model field per request -- Workers AI prefixes models with
-     `@cf/<vendor>/<name>`; AI Gateway passthroughs use the upstream
-     provider's native model id. Docs:
-     https://developers.cloudflare.com/ai-gateway/ +
-     https://developers.cloudflare.com/workers-ai/. *)
+     DefaultModel uses the compat endpoint's {provider}/{model} routing
+     format (Codex P2 on PR #316 -- the bare `@cf/...` form the row
+     shipped with works for the direct path but the compat path
+     rejects unprefixed model ids because it has to pick which upstream
+     to forward to). `workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast`
+     routes through Workers AI on the compat path AND is overridable
+     to any other compat-supported upstream (openai/gpt-5.2,
+     anthropic/claude-sonnet-4-5, google-ai-studio/gemini-2.5-flash,
+     etc.) via the per-request model field. Operators on the direct
+     Workers AI path override the model to bare `@cf/...` (or use the
+     cloudflare-workers-ai sibling row if one ever lands). Docs:
+     https://developers.cloudflare.com/ai-gateway/usage/chat-completion/
+     + https://developers.cloudflare.com/workers-ai/. *)
   Result[22] := MkSpec('cloudflare', 'Cloudflare AI Gateway',
                        pfOpenAI,     '',
-                       '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+                       'workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast',
                        MkAuth(asBearer),
-                       'Workers AI direct or AI Gateway proxy (set api_base; Bearer = CLOUDFLARE_API_TOKEN; @cf/ model prefix for Workers AI)',
+                       'AI Gateway proxy (set api_base to .../compat; Bearer = CLOUDFLARE_API_TOKEN; model uses {provider}/{model} routing -- workers-ai/@cf/..., openai/..., anthropic/..., google-ai-studio/...)',
                        '/chat/completions');
   (* Cloudflare AI Gateway -- Anthropic passthrough. Routes Anthropic-
      shaped requests through a named gateway for caching / rate

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -112,7 +112,7 @@ end;
   change required for OpenAI-compatible endpoints. }
 function BuildCatalog: TProviderSpecArray;
 begin
-  SetLength(Result, 22);
+  SetLength(Result, 23);
   Result[0]  := MkSpec('anthropic',  'Anthropic',
                        pfAnthropic,  'https://api.anthropic.com',
                        'claude-opus-4-7',
@@ -248,6 +248,40 @@ begin
                        'sonar',
                        MkAuth(asBearer),
                        'Sonar / Sonar Pro / Sonar Reasoning (web-grounded)',
+                       '/chat/completions');
+  (* Cloudflare AI Gateway. Two URL shapes operators paste into
+     api_base, both OpenAI Chat Completions compatible:
+
+       Workers AI direct (no gateway features):
+         https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1
+         + ChatPath /chat/completions
+         => POST .../ai/v1/chat/completions
+
+       AI Gateway proxy (caching, rate limits, analytics, fallback):
+         https://gateway.ai.cloudflare.com/v1/{ACCOUNT_ID}/{GATEWAY_ID}/compat
+         + ChatPath /chat/completions
+         => POST .../{GATEWAY_ID}/compat/chat/completions
+
+     Both expect Authorization: Bearer <CLOUDFLARE_API_TOKEN>; both
+     return the same OpenAI-shaped response. ChatPath is /chat/completions
+     (no /v1) -- like Perplexity -- because the /v1 segment is part of
+     the Cloudflare URL prefix, not the OpenAI path. DefaultBase empty
+     because the URL embeds the operator's account_id (same as mimo /
+     litellm).
+
+     DefaultModel is a Workers AI flagship: Llama 3.3 70B FP8 fast.
+     Operators wanting a different upstream (gpt-oss-120b, Mistral, an
+     Anthropic passthrough through the AI Gateway, etc.) override via
+     the model field per request -- Workers AI prefixes models with
+     `@cf/<vendor>/<name>`; AI Gateway passthroughs use the upstream
+     provider's native model id. Docs:
+     https://developers.cloudflare.com/ai-gateway/ +
+     https://developers.cloudflare.com/workers-ai/. *)
+  Result[22] := MkSpec('cloudflare', 'Cloudflare AI Gateway',
+                       pfOpenAI,     '',
+                       '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+                       MkAuth(asBearer),
+                       'Workers AI direct or AI Gateway proxy (set api_base; Bearer = CLOUDFLARE_API_TOKEN; @cf/ model prefix for Workers AI)',
                        '/chat/completions');
   (* Cohere intentionally not in this catalog: their chat API lives at
      /v2/chat with a non-OpenAI request/response body, so the ChatPath

--- a/src/tests/provider_catalog_tests.pas
+++ b/src/tests/provider_catalog_tests.pas
@@ -48,18 +48,24 @@ begin
   Expect(Spec.ChatPath = '/v1/chat/completions',
          'groq ChatPath default regressed: ' + Spec.ChatPath);
 
-  { Cloudflare AI Gateway: OpenAI family, Bearer auth, /chat/completions
-    (no /v1 -- the /v1 lives in the operator-supplied api_base prefix).
-    DefaultBase empty because the URL embeds the operator's account id
-    (same pattern as mimo / litellm). DefaultModel is a Workers AI
-    flagship with the @cf/ prefix. }
+  (* Cloudflare AI Gateway: OpenAI family, Bearer auth, /chat/completions
+     (no /v1 -- the /v1 lives in the operator-supplied api_base prefix).
+     DefaultBase empty because the URL embeds the operator's account id
+     (same pattern as mimo / litellm). DefaultModel uses the AI Gateway
+     compat endpoint's {provider}/{model} routing format -- the bare
+     `@cf/...` form the row originally shipped with would 4xx on the
+     compat path (Codex P2 on PR #316). The compat-prefixed form routes
+     through Workers AI by default AND is overridable to any other
+     compat-supported upstream (openai/..., anthropic/...,
+     google-ai-studio/...). *)
   Expect(LookupProvider('cloudflare', Spec), 'cloudflare not in catalog');
   Expect(Spec.Family = pfOpenAI,             'cloudflare should be pfOpenAI');
   Expect(Spec.Auth.Kind = asBearer,          'cloudflare should be bearer auth');
   Expect(Spec.DefaultBase = '',
          'cloudflare DefaultBase must be empty (operator supplies URL): ' + Spec.DefaultBase);
-  Expect(Spec.DefaultModel = '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
-         'cloudflare DefaultModel wrong: ' + Spec.DefaultModel);
+  Expect(Spec.DefaultModel = 'workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+         'cloudflare DefaultModel must use AI Gateway compat <provider>/<model> routing format: '
+         + Spec.DefaultModel);
   Expect(Spec.ChatPath = '/chat/completions',
          'cloudflare ChatPath must be /chat/completions (no /v1), got: ' + Spec.ChatPath);
   Expect(Spec.DisplayName = 'Cloudflare AI Gateway',

--- a/src/tests/provider_catalog_tests.pas
+++ b/src/tests/provider_catalog_tests.pas
@@ -69,5 +69,43 @@ begin
   Expect(LookupProvider('Cloudflare', Spec),
          'cloudflare lookup not case-insensitive');
 
+  { Cloudflare AI Gateway -- Anthropic passthrough. Family pfAnthropic
+    because the wire shape is Anthropic's /v1/messages, not OpenAI's.
+    Auth is asHeader 'x-api-key' (forwarded to api.anthropic.com
+    upstream by the gateway). DefaultBase empty because the URL embeds
+    the operator's account id and gateway id. }
+  Expect(LookupProvider('cloudflare-anthropic', Spec),
+         'cloudflare-anthropic not in catalog');
+  Expect(Spec.Family = pfAnthropic,
+         'cloudflare-anthropic should be pfAnthropic');
+  Expect(Spec.Auth.Kind = asHeader,
+         'cloudflare-anthropic should be asHeader auth');
+  Expect(Spec.Auth.HeaderName = 'x-api-key',
+         'cloudflare-anthropic header name wrong: ' + Spec.Auth.HeaderName);
+  Expect(Spec.DefaultBase = '',
+         'cloudflare-anthropic DefaultBase must be empty: ' + Spec.DefaultBase);
+  Expect(Spec.DefaultModel = 'claude-opus-4-7',
+         'cloudflare-anthropic DefaultModel wrong: ' + Spec.DefaultModel);
+  Expect(Spec.DisplayName = 'Cloudflare AI Gateway (Anthropic)',
+         'cloudflare-anthropic DisplayName wrong: ' + Spec.DisplayName);
+
+  { Cloudflare AI Gateway -- Gemini passthrough. Family pfGemini, auth
+    asHeader 'x-goog-api-key' (Gemini's own auth, forwarded by the
+    gateway). DefaultBase empty (operator URL embeds the account id). }
+  Expect(LookupProvider('cloudflare-gemini', Spec),
+         'cloudflare-gemini not in catalog');
+  Expect(Spec.Family = pfGemini,
+         'cloudflare-gemini should be pfGemini');
+  Expect(Spec.Auth.Kind = asHeader,
+         'cloudflare-gemini should be asHeader auth');
+  Expect(Spec.Auth.HeaderName = 'x-goog-api-key',
+         'cloudflare-gemini header name wrong: ' + Spec.Auth.HeaderName);
+  Expect(Spec.DefaultBase = '',
+         'cloudflare-gemini DefaultBase must be empty: ' + Spec.DefaultBase);
+  Expect(Spec.DefaultModel = 'gemini-3.5-flash',
+         'cloudflare-gemini DefaultModel wrong: ' + Spec.DefaultModel);
+  Expect(Spec.DisplayName = 'Cloudflare AI Gateway (Gemini)',
+         'cloudflare-gemini DisplayName wrong: ' + Spec.DisplayName);
+
   WriteLn('provider_catalog_tests: OK');
 end.

--- a/src/tests/provider_catalog_tests.pas
+++ b/src/tests/provider_catalog_tests.pas
@@ -48,5 +48,26 @@ begin
   Expect(Spec.ChatPath = '/v1/chat/completions',
          'groq ChatPath default regressed: ' + Spec.ChatPath);
 
+  { Cloudflare AI Gateway: OpenAI family, Bearer auth, /chat/completions
+    (no /v1 -- the /v1 lives in the operator-supplied api_base prefix).
+    DefaultBase empty because the URL embeds the operator's account id
+    (same pattern as mimo / litellm). DefaultModel is a Workers AI
+    flagship with the @cf/ prefix. }
+  Expect(LookupProvider('cloudflare', Spec), 'cloudflare not in catalog');
+  Expect(Spec.Family = pfOpenAI,             'cloudflare should be pfOpenAI');
+  Expect(Spec.Auth.Kind = asBearer,          'cloudflare should be bearer auth');
+  Expect(Spec.DefaultBase = '',
+         'cloudflare DefaultBase must be empty (operator supplies URL): ' + Spec.DefaultBase);
+  Expect(Spec.DefaultModel = '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+         'cloudflare DefaultModel wrong: ' + Spec.DefaultModel);
+  Expect(Spec.ChatPath = '/chat/completions',
+         'cloudflare ChatPath must be /chat/completions (no /v1), got: ' + Spec.ChatPath);
+  Expect(Spec.DisplayName = 'Cloudflare AI Gateway',
+         'cloudflare DisplayName wrong: ' + Spec.DisplayName);
+
+  { Case-insensitive lookup works for the new row too. }
+  Expect(LookupProvider('Cloudflare', Spec),
+         'cloudflare lookup not case-insensitive');
+
   WriteLn('provider_catalog_tests: OK');
 end.


### PR DESCRIPTION
## Summary

Adds **Cloudflare AI Gateway** as a new `pfOpenAI` catalog row. The gateway exposes an OpenAI Chat Completions compatible surface for both Workers AI direct and the AI Gateway proxy (which adds caching, rate limiting, analytics, and provider fallback in front of upstream OpenAI / Anthropic / Mistral / Workers AI / etc.).

One-row catalog change — no new provider unit needed. The existing `TOpenAIProvider` already handles every entry in the `pfOpenAI` family transparently once `Kind` / `DefaultBase` / `Auth` / `ChatPath` are wired up.

## URL shapes operators paste into `api_base`

Both OpenAI-shaped, both expect `Authorization: Bearer <CLOUDFLARE_API_TOKEN>`:

| Mode | `api_base` | Full chat URL |
|---|---|---|
| Workers AI direct (no gateway features) | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1` | `…/ai/v1/chat/completions` |
| AI Gateway proxy (caching, rate limits, analytics, fallback) | `https://gateway.ai.cloudflare.com/v1/{ACCOUNT_ID}/{GATEWAY_ID}/compat` | `…/{GATEWAY_ID}/compat/chat/completions` |

## Catalog row

| Field | Value |
|---|---|
| `Kind` | `cloudflare` |
| `DisplayName` | `Cloudflare AI Gateway` |
| `Family` | `pfOpenAI` |
| `DefaultBase` | `''` (operator supplies — URL embeds `account_id`, same pattern as `mimo` / `litellm`) |
| `DefaultModel` | `@cf/meta/llama-3.3-70b-instruct-fp8-fast` (Workers AI flagship) |
| `Auth` | `asBearer` |
| `ChatPath` | `/chat/completions` (no `/v1` — the `/v1` is part of the operator's `api_base` prefix, same trick the Perplexity row uses) |

Operators wanting a different upstream (e.g. `@cf/openai/gpt-oss-120b`, an OpenAI passthrough through the gateway, Mistral, etc.) override per-request via the `model` field.

## Onboarding

`PromptProvider`'s catalog menu reads `AllProviderSpecs` and sorts by `DisplayName`, so the new "Cloudflare AI Gateway" row appears automatically in the picker — no onboarding plumbing needed.

## Test plan

- [x] `make` passes
- [x] `make test-provider-catalog` passes
- [x] `LookupProvider('cloudflare')` returns the row with the expected `Family` / `Auth` / `ChatPath` / `DefaultBase` / `DefaultModel` / `DisplayName`
- [x] No-`/v1` `ChatPath` regression check (same shape as Perplexity's existing pin)
- [x] Case-insensitive lookup: `LookupProvider('Cloudflare')` works
- [ ] Manual: real Cloudflare account + `pasclaw mcp install`-style workflow against a live gateway (followup; needs an operator with a Cloudflare account)

## Docs referenced

- https://developers.cloudflare.com/ai-gateway/
- https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/

## Followups (not in this PR)

- A `cf-aig-gateway-id` header surface so operators using the universal `api.cloudflare.com/.../ai/v1` endpoint can route through a named gateway without changing `api_base`. Out of scope here — the existing AI Gateway URL (`gateway.ai.cloudflare.com/.../compat`) covers the routing case via path-based selection.
- Separate `cloudflare-anthropic` / `cloudflare-gemini` catalog rows if operators want Anthropic-shaped or Gemini-shaped passthroughs through the gateway. Doable as additional one-row changes if there's demand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_