### PR TITLE
plan: introduce `pasclaw plan` + `pasclaw build` PLAN.md pickup + --goal Ralph loop + cog mode Input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,6 +457,15 @@ test-config-profile: | $(BUILDDIR)
 	  trap "rm -rf $$PASCLAW_HOME" EXIT ; \
 	  PASCLAW_HOME=$$PASCLAW_HOME $(BUILDDIR)/config_profile_tests
 
+# Active Plan section -- pins BuildActivePlanSection's gating cases
+# (NoPlan / pmPlan / missing) and the happy-path PLAN.md injection.
+test-active-plan-section: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/active_plan_section_tests.pas -o$(BUILDDIR)/active_plan_section_tests
+	@PASCLAW_HOME=$$(mktemp -d) ; \
+	  trap "rm -rf $$PASCLAW_HOME" EXIT ; \
+	  PASCLAW_HOME=$$PASCLAW_HOME $(BUILDDIR)/active_plan_section_tests
+
 # PasClaw.MCP.Disclosure -- Hermes-style progressive disclosure + Claude
 # Code-style tool_search for MCP tools. Hermetic: synthetic TTool records
 # only, no actual MCP server started.

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -289,6 +289,29 @@ class Predictor(BasePredictor):
             default="",
             description="Override model id. Empty = provider's catalog default.",
         ),
+        mode: str = Input(
+            description=(
+                "What to run. "
+                "'build' (default) runs `pasclaw build` -- one-shot multi-iter "
+                "agent run with workspace.zip handshake (the historical "
+                "behavior of this cog). "
+                "'plan' runs `pasclaw plan` -- generates workspace/PLAN.md as "
+                "a structured markdown deliverable (Goal / Files / Steps / "
+                "Open questions / Risks) and stops. The PLAN.md is inside the "
+                "returned workspace zip. "
+                "'plan build' chains the two: first generates PLAN.md, then "
+                "runs build with PLAN.md auto-loaded into the system prompt "
+                "as authoritative guidance. After the build succeeds, the "
+                "plan is archived to workspace/memory/plans/<timestamp>.md "
+                "and you get a browsable history alongside the artifact. "
+                "'plan build goal' is the same as 'plan build' but the build "
+                "step uses the Ralph judge loop (parses '## Goal' from "
+                "PLAN.md as the objective; iterations pump until the judge "
+                "model says MET / FAILED, capped by --goal-max-iters)."
+            ),
+            choices=["build", "plan", "plan build", "plan build goal"],
+            default="build",
+        ),
         profile: str = Input(
             default="max-build",
             description="PasClaw config profile applied on top of stock "
@@ -516,55 +539,108 @@ class Predictor(BasePredictor):
             env["PASCLAW_HOME"]   = home_dir
             env["PASCLAW_CONFIG"] = config_path
 
-            # NOTE: `-q` is forwarded so the early-exit banner scan in
-            # PasClaw.dpr's IsQuietInvocation skips PrintBanner.
-            # Without it, the ASCII PASCLAW banner ends up in
-            # result.stdout and pollutes reply.txt.
-            cmd = [
-                self.binary_path, "build",
-                "-q",
-                "-d", message,
-                "--max-iters", str(max_iters),
-                "--home", home_dir,
-                "--workspace-out", out_zip_path,
-            ]
-            if in_zip is not None:
-                cmd += ["--workspace-in", in_zip]
+            # Phase 4 of the plan/build pairing: dispatch on `mode` to
+            # decide which pasclaw subcommand(s) to invoke.
+            #
+            # build              -> pasclaw build
+            # plan               -> pasclaw plan
+            # plan build         -> pasclaw plan then pasclaw build
+            # plan build goal    -> pasclaw plan then pasclaw build --goal
+            #
+            # For the chained variants, an intermediate "mid_zip"
+            # carries PLAN.md from plan -> build through the existing
+            # workspace.zip handshake. The build step's workspace-out
+            # becomes the cog's final return artifact.
+            mode_norm = mode.strip().lower()
+            mid_zip_path = os.path.join(scratch, "workspace_mid.zip")
+            do_plan  = mode_norm in ("plan", "plan build", "plan build goal")
+            do_build = mode_norm in ("build", "plan build", "plan build goal")
+            do_goal  = mode_norm == "plan build goal"
 
-            print(
-                f"build: invoking {self.binary_path} build "
-                f"max_iters={max_iters} timeout={timeout_seconds}s "
-                f"provider={selected_provider} model={default_model} "
-                f"profile={profile_normalised or '(none)'} "
-                f"workspace_in={'yes' if in_zip else 'no'}"
-            )
+            def invoke_pasclaw(subcmd, extra_args, in_zip_arg, out_zip_arg,
+                                label):
+                """One pasclaw <subcmd> invocation with consistent error
+                surfacing. -q suppresses the ASCII banner (else PrintBanner
+                would land in reply.txt). Returns the captured stdout text;
+                raises on non-zero exit or timeout. """
+                cmd_ = [
+                    self.binary_path, subcmd,
+                    "-q",
+                    "-d", message,
+                    "--home", home_dir,
+                ] + extra_args
+                if in_zip_arg is not None:
+                    cmd_ += ["--workspace-in", in_zip_arg]
+                if out_zip_arg is not None:
+                    cmd_ += ["--workspace-out", out_zip_arg]
 
-            try:
-                result = subprocess.run(
-                    cmd, env=env, capture_output=True, text=True,
-                    check=True, timeout=timeout_seconds,
+                print(
+                    f"{label}: invoking {self.binary_path} {subcmd} "
+                    f"timeout={timeout_seconds}s "
+                    f"provider={selected_provider} model={default_model} "
+                    f"profile={profile_normalised or '(none)'} "
+                    f"workspace_in={'yes' if in_zip_arg else 'no'}"
                 )
-                text_out = result.stdout.strip()
-            except subprocess.CalledProcessError as e:
-                # Surface stdout (model's partial reply, if any) +
-                # stderr (PasClaw's diagnostic log lines) so the
-                # operator can debug from Replicate logs.
-                raise RuntimeError(
-                    "pasclaw build exited non-zero.\n"
-                    f"STDOUT:\n{e.stdout}\n"
-                    f"STDERR:\n{e.stderr}"
-                )
-            except subprocess.TimeoutExpired:
-                raise RuntimeError(
-                    f"pasclaw build timed out after {timeout_seconds}s. "
-                    "Re-run with a higher timeout_seconds, or split the "
-                    "build into smaller calls and re-feed workspace_in."
-                )
+                try:
+                    res = subprocess.run(
+                        cmd_, env=env, capture_output=True, text=True,
+                        check=True, timeout=timeout_seconds,
+                    )
+                    return res.stdout.strip()
+                except subprocess.CalledProcessError as e:
+                    raise RuntimeError(
+                        f"pasclaw {subcmd} exited non-zero (mode={mode_norm}).\n"
+                        f"STDOUT:\n{e.stdout}\n"
+                        f"STDERR:\n{e.stderr}"
+                    )
+                except subprocess.TimeoutExpired:
+                    raise RuntimeError(
+                        f"pasclaw {subcmd} timed out after {timeout_seconds}s. "
+                        "Re-run with a higher timeout_seconds, or split into "
+                        "smaller calls."
+                    )
+
+            text_out = ""
+
+            # --- Plan step (runs first for plan / plan build / plan build goal).
+            #
+            # When chaining, plan writes to mid_zip; build later reads it as
+            # workspace-in. For "plan" alone, plan writes directly to the
+            # cog's final out_zip.
+            if do_plan:
+                plan_args = []
+                # plan uses its own Pascal-side default max-iters (12); the
+                # operator's max_iters input is build's budget, NOT plan's.
+                plan_in   = in_zip
+                plan_out  = mid_zip_path if do_build else out_zip_path
+                text_out  = invoke_pasclaw("plan", plan_args, plan_in,
+                                            plan_out, "plan")
+
+            # --- Build step.
+            #
+            # When chained with plan, reads mid_zip as input. When standalone,
+            # reads the original workspace_in. --goal forwards PLAN.md's
+            # parsed Goal as the Ralph objective (Phase 3 wiring).
+            if do_build:
+                build_args = ["--max-iters", str(max_iters)]
+                if do_goal:
+                    build_args.append("--goal")
+                build_in = mid_zip_path if do_plan else in_zip
+                # When build runs after plan, the mid_zip is what was just
+                # produced -- pass it explicitly. When build runs standalone,
+                # in_zip may be None (fresh run).
+                if do_plan and not os.path.exists(mid_zip_path):
+                    raise RuntimeError(
+                        "pasclaw plan claimed to finish but produced no "
+                        "intermediate workspace zip; cannot proceed with build."
+                    )
+                text_out = invoke_pasclaw("build", build_args, build_in,
+                                          out_zip_path, "build")
 
             if not os.path.exists(out_zip_path):
                 raise RuntimeError(
-                    "pasclaw build did not produce workspace_out.zip "
-                    "(build flag missed? out path unwritable?)."
+                    f"pasclaw {mode_norm} did not produce workspace_out.zip "
+                    f"(missing flag? out path unwritable?)."
                 )
 
             # --- persist both outputs outside scratch ---

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,248 @@
+# `pasclaw plan` and the plan/build pairing
+
+`pasclaw plan` is a sibling command to `pasclaw build`. It produces a
+structured markdown plan as `workspace/PLAN.md` instead of executing
+the work. The plan becomes input for a subsequent `pasclaw build` —
+either as system-prompt context (plain build) or as the objective for
+the Ralph judge loop (`build --goal`).
+
+## Quick start
+
+Local:
+
+```
+pasclaw plan -d "Add a --version flag to the CLI"
+# review workspace/PLAN.md, edit if you want
+pasclaw build -d "Add a --version flag to the CLI"
+```
+
+On the Replicate cog (`cog-build`), the same flow is selected via the
+`mode` Input — see [the cog matrix](#cog-build-mode-input-matrix) below.
+
+## The two commands
+
+### `pasclaw plan -d "<task>"`
+
+Generates `workspace/PLAN.md`. Runs the agent in `pmPlan` mode
+(read-only tool surface — `fs_read`, `fs_grep`, `memory_search`,
+`shell_exec` reads, etc. all work; `fs_write`, `fs_edit_hashline`,
+`shell_exec` mutations, etc. are refused at the dispatch layer).
+
+A dedicated `plan_write` tool is auto-registered when `--mode plan` is
+set; the model calls it once with the finalized markdown body, and the
+tool writes to `<home>/workspace/PLAN.md` (the path is hard-coded so
+`plan_write` can't be turned into a general write primitive by clever
+arguments).
+
+The planner directive in the system prompt requires this structure:
+
+```
+## Goal
+<one-sentence verb-prefixed objective>
+
+## Files
+- src/...
+- src/...
+
+## Steps
+1. ...
+2. ...
+
+## Open questions
+- ...
+
+## Risks
+- ...
+```
+
+The Goal section's opening line is constrained to a single sentence
+starting with a verb so a subsequent `pasclaw build --goal` can parse
+it as the Ralph objective.
+
+#### Incremental updates
+
+If `workspace/PLAN.md` already exists when `pasclaw plan` runs, the
+existing body is injected into the planner's system prompt with a
+**"revise / extend, don't replace"** directive. The model writes the
+revised plan back (full markdown — not a diff). Operators wanting
+per-revision history can `git log workspace/PLAN.md`.
+
+#### Flags
+
+```
+pasclaw plan -d "<task>"
+             [--max-iters N]                 # default 12 (plan is short)
+             [--workspace-in <zip>]          # optional
+             [--workspace-out <zip>]         # optional; carries PLAN.md
+             [--cwd <dir>]
+             [--home <dir>]
+             [--keep-home]
+             ... agent flags forwarded (--provider, --model, ...)
+```
+
+`--mode` is NOT forwarded — plan mode is forced. Use `pasclaw agent
+--mode plan` for an interactive plan session.
+
+### `pasclaw build -d "<task>"`
+
+The existing one-shot multi-iteration agent command, with two new
+behaviors added by the plan pairing:
+
+**Phase 2 — PLAN.md auto-pickup.** If `workspace/PLAN.md` exists at
+the start of the run, its body is injected into the system prompt as
+`## Active Plan` and treated as authoritative guidance. A stale plan
+(mtime > 24h) appends a `(stale: N hours)` note to the header so the
+model treats it skeptically. After a successful build, PLAN.md is
+archived to `workspace/memory/plans/<timestamp>.md` so the next build
+doesn't re-consume the same plan.
+
+Opt out with `--no-plan` — the file stays in place and is ignored for
+the run. The archival is also skipped (opt-out of pickup means
+opt-out of archival).
+
+**Phase 3 — `--goal`.** When set, `pasclaw build` reads PLAN.md's
+`## Goal` line and uses it as the objective for the Ralph judge loop
+(`PasClaw.Agent.Goals.TGoalRunner`). Iterations pump until the judge
+model returns MET / FAILED, or the `--goal-max-iters` budget runs out
+(default 5).
+
+`--goal` requires a parseable Goal section in PLAN.md. Missing
+PLAN.md or a missing/empty Goal section produces a clean error:
+
+```
+$ pasclaw build -d "task" --goal
+build: --goal was set but workspace/PLAN.md has no parseable "## Goal"
+section (run `pasclaw plan -d ...` first to produce one)
+```
+
+Exit code:
+
+| Verdict           | Exit |
+|-------------------|-----:|
+| MET               | 0    |
+| BUDGET-EXHAUSTED  | 0    |
+| FAILED            | 1    |
+| ABORTED           | 1    |
+
+`BUDGET-EXHAUSTED` is treated as a successful best-effort run — the
+agent kept making progress but ran out of turns. Operators wanting a
+strict "did it finish" gate should check the verbose-mode `— verdict —`
+banner instead of just `$?`.
+
+#### New flags on `pasclaw build`
+
+```
+--goal                    Drive the run via the Ralph judge loop
+                          against workspace/PLAN.md's "## Goal" line.
+--goal-max-iters N        Override the Ralph budget (default 5).
+                          Ignored when --goal is absent.
+--no-plan                 Ignore workspace/PLAN.md for this run
+                          (skip both pickup and archival).
+```
+
+## cog-build `mode` Input matrix
+
+The `cog-build` Replicate cog exposes a `mode` Input with four choices:
+
+| `mode` value         | Commands run                                                  |
+|----------------------|---------------------------------------------------------------|
+| `build` (default)    | `pasclaw build`                                               |
+| `plan`               | `pasclaw plan`                                                |
+| `plan build`         | `pasclaw plan` → `pasclaw build` (intermediate workspace zip) |
+| `plan build goal`    | `pasclaw plan` → `pasclaw build --goal` (Ralph judge loop)    |
+
+For `plan build` and `plan build goal`, the cog chains the two
+subprocesses through an intermediate workspace zip in its scratch
+directory — `pasclaw plan`'s `--workspace-out` becomes
+`pasclaw build`'s `--workspace-in`. The final `workspace_out.zip` ships
+PLAN.md (archived if the build succeeded) alongside the rest of
+`$PASCLAW_HOME`.
+
+The `max_iters` Input applies to the build step; plan uses its own
+Pascal-side default (12). Both subprocesses share `timeout_seconds`.
+
+### When to use which mode
+
+- **`build`** — no plan needed. Same behavior as before this pairing.
+- **`plan`** — produce a plan to review or share. Common in a CI step
+  before approval workflows.
+- **`plan build`** — autonomous pipeline. The plan is system-prompt
+  guidance for the build, but the build doesn't strictly verify
+  against it.
+- **`plan build goal`** — autonomous pipeline with judge-driven
+  verification. The plan's Goal line is the success criterion; the
+  Ralph loop keeps iterating until the judge says MET. Best for
+  tasks where "done" is checkable from a model's reply alone.
+
+## File layout
+
+```
+$PASCLAW_HOME/
+├── workspace/
+│   ├── PLAN.md                                  ← active plan
+│   └── memory/
+│       └── plans/
+│           ├── 2026-06-21-101502.md             ← archived plans
+│           └── 2026-06-21-143007.md
+├── sessions/
+├── checkpoints/
+└── ...
+```
+
+PLAN.md lives at the workspace root for visibility (easy to find,
+easy to `cat`, easy to edit by hand). Archives go under `workspace/
+memory/plans/` so they become part of the workspace.zip round-trip
+and the operator gets browsable history.
+
+## How `/goal` ties in
+
+The interactive `/goal` slash command (`pasclaw agent` REPL) and
+`pasclaw build --goal` both drive `PasClaw.Agent.Goals.TGoalRunner` —
+the same Ralph judge-loop machinery. The difference is purely
+where the objective comes from:
+
+- **Interactive**: operator types `/goal "<text>"` in the REPL.
+- **Build**: objective is parsed from `workspace/PLAN.md`'s `## Goal`
+  section.
+
+Same dispatch, same judge prompt, same verdict tokens, same exit
+semantics. The Ralph loop pumps:
+
+1. Agent runs one tool-loop iteration.
+2. Judge model evaluates the latest assistant reply against the
+   objective.
+3. On `MET` or `FAILED`, stop. On `CONTINUE`, the judge's suggested
+   next action becomes the next user message and we loop back.
+4. Capped at `--goal-max-iters` iterations.
+
+## Implementation notes
+
+- `plan_write` is the only tool in the codebase labelled `tcReadOnly`
+  while writing to disk. It passes the `pmPlan` dispatch gate because
+  the gate only refuses `tcMutating`; the safety argument is that
+  `plan_write` writes to a single hard-coded file (`workspace/PLAN.md`)
+  and cannot be turned into a general primitive by a model crafting
+  clever arguments.
+- `ExtractGoalFromPlanFile` accepts an explicit `HomeOverride` because
+  `libc_setenv`'s `PASCLAW_HOME` isn't always visible to a same-process
+  `GetEnvironmentVariable` read on FPC. `Cmd.Build` passes its own
+  `Home` local var rather than round-tripping through the env table.
+- The goal-driven one-shot path (`RunSingleTurnGoalDriven`) deliberately
+  skips per-iteration session persistence and the post-turn skill
+  distiller. Future work can re-add per-iteration `workspace/sessions/`
+  writes; the distiller is a harder fit (it assumes one coherent task
+  per turn, and goal loops produce N iterations).
+- `pasclaw build` archives PLAN.md to `workspace/memory/plans/` BEFORE
+  packing `workspace-out.zip`, so cog callers get the plan history in
+  their output artifact.
+
+## Related commands
+
+- `pasclaw agent` — interactive REPL. Supports `/goal "<text>"` for
+  the same Ralph loop driven from the chat surface.
+- `pasclaw runbook` — tool-driven AGENTS.md bootstrap (companion to
+  `pasclaw init`'s Pascal-driven variant). Different concept: AGENTS.md
+  is persistent project guidance; PLAN.md is per-task.
+- `pasclaw learn --write-scars` — emits/refreshes `workspace/memory/
+  SCARS.md` with anchor IDs per recurring failure. Plans and scars
+  compose: scars surface recurring traps; plans propose work.

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -37,6 +37,7 @@ uses
   PasClaw.Tools.KB,
   PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
+  PasClaw.Tools.PlanWrite,
   PasClaw.Tools.SendMessage,
   PasClaw.Tools.Cron,
   PasClaw.Tools.WebSearch,
@@ -235,7 +236,8 @@ function NewBuiltinRegistry(UseHashline: Boolean = True;
                             EnableWebSearch: Boolean = False;
                             EnableWebFetch: Boolean = False;
                             EnableOutputCache: Boolean = False;
-                            EnableCron: Boolean = False): TToolRegistry;
+                            EnableCron: Boolean = False;
+                            EnablePlanWrite: Boolean = False): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
@@ -284,6 +286,11 @@ begin
     autonomy. In `agent` there's no live scheduler, so additions apply the
     next time serve/gateway runs. }
   if EnableCron then RegisterCronTool(Result);
+  { plan_write registers when running in pmPlan mode (Cmd.Plan and
+    `pasclaw agent --mode plan` both arrive here with the flag set).
+    The tool is tcReadOnly even though it writes the one plan-meta
+    file -- see PasClaw.Tools.PlanWrite for the rationale. }
+  if EnablePlanWrite then RegisterPlanWriteTool(Result);
   (* send_message gates itself: it registers only when config.json
      declares named channels (a "channels" array of name/kind/target
      entries), so there's no flag to thread through here. The model
@@ -517,7 +524,13 @@ begin
                               HasConfiguredWebSearchProvider(Cfg),
                               Cfg.WebFetchEnabled,
                               (Cfg.ToolOutputCap > 0)
-                                or Cfg.CondenseReversible, Cfg.CronToolEnabled);
+                                or Cfg.CondenseReversible,
+                              Cfg.CronToolEnabled,
+                              { EnablePlanWrite -- only when --mode plan
+                                was selected; auto-includes the dedicated
+                                plan_write tool the `pasclaw plan`
+                                command relies on. }
+                              A.Mode = pmPlan);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;
@@ -993,7 +1006,13 @@ begin
                               HasConfiguredWebSearchProvider(Cfg),
                               Cfg.WebFetchEnabled,
                               (Cfg.ToolOutputCap > 0)
-                                or Cfg.CondenseReversible, Cfg.CronToolEnabled);
+                                or Cfg.CondenseReversible,
+                              Cfg.CronToolEnabled,
+                              { EnablePlanWrite -- only when --mode plan
+                                was selected; auto-includes the dedicated
+                                plan_write tool the `pasclaw plan`
+                                command relies on. }
+                              A.Mode = pmPlan);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -89,6 +89,12 @@ type
     NoTools:       Boolean;
     NoMCP:         Boolean;
     NoHashline:    Boolean;
+    { --no-plan -- opt out of the workspace/PLAN.md auto-pickup
+      added in PR-cycle "pasclaw plan / pasclaw build" Phase 2.
+      Default False; when True, BuildActivePlanSection emits empty
+      so PLAN.md is ignored for this run. Cmd.Build also reads this
+      from A.Forwarded to skip its post-success archival step. }
+    NoPlan:        Boolean;
     { Session id to resume. Empty (the default) = interactive mode
       auto-allocates a fresh id and persists from turn 1, so a Ctrl-C
       / crash never drops the conversation. Non-empty AND existing on
@@ -171,6 +177,7 @@ begin
   Result.NoTools       := False;
   Result.NoMCP         := False;
   Result.NoHashline    := False;
+  Result.NoPlan        := False;
   Result.Quiet         := False;
 end;
 
@@ -197,6 +204,7 @@ begin
     if Argv[i] = '--no-tools'    then begin A.NoTools    := True; Inc(i); Continue; end;
     if Argv[i] = '--no-mcp'      then begin A.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline' then begin A.NoHashline := True; Inc(i); Continue; end;
+    if Argv[i] = '--no-plan'     then begin A.NoPlan     := True; Inc(i); Continue; end;
     if (Argv[i] = '--quiet') or (Argv[i] = '-q') then begin A.Quiet := True; Inc(i); Continue; end;
     if Argv[i] = '--session'     then begin if i = High(Argv) then Exit(False); A.Session := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--backend'     then begin if i = High(Argv) then Exit(False); A.BackendOverride := Argv[i + 1]; Inc(i, 2); Continue; end;
@@ -375,7 +383,8 @@ begin
     the MEMORY section slices to task-relevant sections instead of
     whole files. }
   Result.Options.SystemPrompt  := BuildSystemPrompt(Cfg, A.SystemPrompt,
-                                                    Reg <> nil, TaskHint, A.Mode);
+                                                    Reg <> nil, TaskHint,
+                                                    A.Mode, A.NoPlan);
   Result.Mode := A.Mode;
   Result.Options.ThinkingLevel := A.Thinking;
   if A.MaxTokens > 0 then Result.Options.MaxTokens := A.MaxTokens;
@@ -1141,7 +1150,8 @@ begin
               keeps the model's own behaviour aligned. }
             LoopCfg.Mode := A.Mode;
             LoopCfg.Options.SystemPrompt :=
-              BuildSystemPrompt(Cfg, A.SystemPrompt, Reg <> nil, '', A.Mode);
+              BuildSystemPrompt(Cfg, A.SystemPrompt, Reg <> nil, '',
+                                A.Mode, A.NoPlan);
             PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
                     ' mode -> ' + ModeName(A.Mode));
           end;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -95,6 +95,19 @@ type
       so PLAN.md is ignored for this run. Cmd.Build also reads this
       from A.Forwarded to skip its post-success archival step. }
     NoPlan:        Boolean;
+    { --goal-objective "<text>" -- Phase 3 of the plan/build pairing.
+      When non-empty in the one-shot -m path, RunSingleTurnGoalDriven
+      drives the Ralph judge loop (PasClaw.Agent.Goals.TGoalRunner)
+      against the objective instead of doing a single-shot turn. Empty
+      -> single-shot. Set by Cmd.Build --goal after parsing PLAN.md's
+      "## Goal" section. Interactive mode does NOT consume this --
+      operators in REPL use the /goal slash command instead. }
+    GoalObjective: string;
+    { --goal-max-iters N -- override the Ralph budget for the
+      --goal-objective driver. Defaults to
+      PasClaw.Agent.Goals.DefaultGoalMaxIter. Ignored when
+      GoalObjective is empty. }
+    GoalMaxIters:  Integer;
     { Session id to resume. Empty (the default) = interactive mode
       auto-allocates a fresh id and persists from turn 1, so a Ctrl-C
       / crash never drops the conversation. Non-empty AND existing on
@@ -178,6 +191,8 @@ begin
   Result.NoMCP         := False;
   Result.NoHashline    := False;
   Result.NoPlan        := False;
+  Result.GoalObjective := '';
+  Result.GoalMaxIters  := 0;  { 0 = use DefaultGoalMaxIter }
   Result.Quiet         := False;
 end;
 
@@ -205,6 +220,8 @@ begin
     if Argv[i] = '--no-mcp'      then begin A.NoMCP      := True; Inc(i); Continue; end;
     if Argv[i] = '--no-hashline' then begin A.NoHashline := True; Inc(i); Continue; end;
     if Argv[i] = '--no-plan'     then begin A.NoPlan     := True; Inc(i); Continue; end;
+    if Argv[i] = '--goal-objective' then begin if i = High(Argv) then Exit(False); A.GoalObjective := Argv[i + 1]; Inc(i, 2); Continue; end;
+    if Argv[i] = '--goal-max-iters' then begin if i = High(Argv) then Exit(False); A.GoalMaxIters := StrToIntDef(Argv[i + 1], A.GoalMaxIters); Inc(i, 2); Continue; end;
     if (Argv[i] = '--quiet') or (Argv[i] = '-q') then begin A.Quiet := True; Inc(i); Continue; end;
     if Argv[i] = '--session'     then begin if i = High(Argv) then Exit(False); A.Session := Argv[i + 1]; Inc(i, 2); Continue; end;
     if Argv[i] = '--backend'     then begin if i = High(Argv) then Exit(False); A.BackendOverride := Argv[i + 1]; Inc(i, 2); Continue; end;
@@ -656,6 +673,225 @@ begin
     FreeMCPClients(MCPClients);
     if Spawn <> nil then Spawn.Free;
     Reg.Free;
+  end;
+end;
+
+{ ============================================================
+  Goal-driven one-shot path (Phase 3 of plan/build pairing).
+
+  RunSingleTurnGoalDriven wraps the one-shot RunToolLoop call in a
+  PasClaw.Agent.Goals.TGoalRunner instead of running it once. The
+  Ralph judge loop pumps turns: agent runs -> judge verdicts
+  (MET / CONTINUE / FAILED) -> next iteration with the judge's
+  suggestion as the new user message, up to MaxIters.
+
+  Cmd.Build --goal sets A.GoalObjective to PLAN.md's parsed Goal
+  line, and `pasclaw agent --goal-objective "<text>"` lets operators
+  drive the same machinery directly. Interactive mode does NOT
+  consume A.GoalObjective -- REPL operators use /goal instead.
+
+  Deliberately skipped vs the regular RunSingleTurn:
+    - Session persistence: a goal-driven run doesn't write to
+      workspace/sessions/. Operators wanting goal results in their
+      session history can re-pipe via `pasclaw agent --session <id>`
+      after the fact. Future work could add per-iteration persistence.
+    - SkillDistiller post-turn hook: the distiller assumes one
+      coherent task per turn; goal loops produce N iterations and
+      the right distillation moment is unclear. Skipped for V1.
+    - Auto-router per-iteration: goal CONTINUE turns are mid-task
+      and shouldn't route to a cheaper tier. Stays on the primary
+      model. Mirrors the interactive /goal handler.
+  ============================================================ }
+
+type
+  TOneShotGoalCallbacks = class
+    Cfg:      TConfig;
+    A:        TAgentArgs;
+    Provider: ILLMProvider;
+    Reg:      TToolRegistry;
+    Model:    string;
+    Handlers: TLoopHandlers;
+    function  TurnFn(const UserMsg: string;
+                      var Hist: TMessageArray;
+                      out Reply: string): Boolean;
+    procedure Progress(IterNo, MaxIter: Integer; const Reply: string);
+  end;
+
+function TOneShotGoalCallbacks.TurnFn(const UserMsg: string;
+                                       var Hist: TMessageArray;
+                                       out Reply: string): Boolean;
+{ TGoalTurnFn implementation -- one agent turn during the Ralph loop.
+  Slimmed-down counterpart to TGoalCmdCallbacks.TurnFn in the
+  interactive path: no session, no background-spawn drain key, no
+  systems-prompt-override threading (the goal-driven one-shot doesn't
+  persist across turns by design). }
+var
+  Loop:    TToolLoopResult;
+  LoopCfg: TToolLoopConfig;
+begin
+  Result := False;
+  Reply  := '';
+  SetLength(Hist, Length(Hist) + 1);
+  Hist[High(Hist)] := MakeMessage(mrUser, UserMsg);
+
+  LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers, UserMsg);
+  if not RunToolLoop(LoopCfg, Hist, Loop) then Exit;
+
+  { Mirror the RunSingleTurn / interactive convention: RunToolLoop
+    returns Hist with tool transcripts but the final assistant text
+    in Loop.Content -- append it explicitly so the judge call (which
+    reads the most recent assistant message) sees it. Codex P1 on
+    PR #223 covers the original interactive fix; same shape here. }
+  Hist := Loop.FinalMessages;
+  if Trim(Loop.Content) <> '' then
+  begin
+    SetLength(Hist, Length(Hist) + 1);
+    Hist[High(Hist)] := MakeMessage(mrAssistant, Loop.Content);
+  end;
+  Reply := Loop.Content;
+  if Trim(Reply) = '' then Reply := '(no reply)';
+  Result := True;
+end;
+
+procedure TOneShotGoalCallbacks.Progress(IterNo, MaxIter: Integer;
+                                          const Reply: string);
+begin
+  { Quiet mode: no per-iteration chatter, just the final reply.
+    Verbose mode: per-iteration banner so a long goal loop doesn't
+    sit silent for tens of seconds. }
+  if A.Quiet then Exit;
+  PrintLn;
+  PrintLn(Ansi.Dim + Format('— goal iter %d/%d —', [IterNo, MaxIter]) + Ansi.Reset);
+  if Trim(Reply) <> '' then
+    PrintLn(MaybeRender(Cfg, Reply));
+end;
+
+function VerdictName(V: TGoalVerdict): string;
+begin
+  case V of
+    gvMet:              Result := 'MET';
+    gvFailed:           Result := 'FAILED';
+    gvBudgetExhausted:  Result := 'BUDGET-EXHAUSTED';
+    gvAborted:          Result := 'ABORTED';
+  else
+    Result := 'UNKNOWN';
+  end;
+end;
+
+function RunSingleTurnGoalDriven(const Cfg: TConfig; const A: TAgentArgs;
+                                  const Prompt: string): Boolean;
+{ Goal-driven counterpart to RunSingleTurn. Setup mirrors the regular
+  one-shot path but the per-iteration RunToolLoop call is wrapped in
+  TGoalRunner.
+
+  Returns True when the loop ended with MET or BUDGET-EXHAUSTED (the
+  latter is "we tried hard but ran out of turns" -- still a successful
+  best-effort run). Returns False on FAILED, ABORTED, or any
+  setup-time failure (no provider, etc.) so Cmd_Agent_Run maps it to
+  exit 1. Phase 3 of the plan/build pairing. }
+var
+  Provider:   ILLMProvider;
+  Err, Model: string;
+  Reg:        TToolRegistry;
+  Handlers:   TLoopHandlers;
+  MCPClients: TMCPClientList;
+  Spawn:      TSpawnTool;
+  BgCoord:    TBackgroundSpawnCoordinator;
+  Msgs:       TMessageArray;
+  Callbacks:  TOneShotGoalCallbacks;
+  Runner:     TGoalRunner;
+  MaxIter:    Integer;
+  R:          TGoalResult;
+  OneShotSessionId: string;
+begin
+  Result := False;
+  if not PickProvider(Cfg, A, Provider, Err) then
+  begin
+    PrintErr(Err);
+    Exit;
+  end;
+  if A.Model <> '' then Model := A.Model else Model := Cfg.DefaultModel;
+
+  Reg := nil;
+  if not A.NoTools then
+  begin
+    Reg := NewBuiltinRegistry((not A.NoHashline) and Cfg.HashlineEnabled,
+                              Cfg.VaultToolsEnabled,
+                              HasConfiguredWebSearchProvider(Cfg),
+                              Cfg.WebFetchEnabled,
+                              (Cfg.ToolOutputCap > 0)
+                                or Cfg.CondenseReversible,
+                              Cfg.CronToolEnabled,
+                              A.Mode = pmPlan);
+    RegisterSkillManageTool(Reg, Cfg);
+    RegisterSkillDisclosureTools(Reg, Cfg);
+  end;
+  MCPClients := ConnectMCP(Cfg, Reg, A.NoMCP);
+  Spawn      := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
+  BgCoord    := MaybeRegisterBackgroundSpawnTools(Cfg, Provider, Reg, Model);
+  Handlers   := TLoopHandlers.Create;
+
+  { Per-process shell-backend session id, same shape as RunSingleTurn.
+    Lazy docker container -- only spawned on the first shell tool call. }
+  OneShotSessionId := 'oneshot-goal-' + FormatDateTime('yyyymmdd-hhnnss', Now) +
+                      '-' + IntToHex(Random(1 shl 24), 6);
+  SetCurrentSessionId(OneShotSessionId);
+
+  try
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, Prompt);
+
+    MaxIter := A.GoalMaxIters;
+    if MaxIter <= 0 then MaxIter := DefaultGoalMaxIter;
+
+    if not A.Quiet then
+    begin
+      PrintLn(Ansi.Bold + '— goal —' + Ansi.Reset + ' ' + A.GoalObjective +
+              Ansi.Dim + Format('  (budget=%d)', [MaxIter]) + Ansi.Reset);
+      PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset +
+              ' (' + Provider.GetName + '/' + Model + '):');
+    end;
+
+    Callbacks := TOneShotGoalCallbacks.Create;
+    Callbacks.Cfg      := Cfg;
+    Callbacks.A        := A;
+    Callbacks.Provider := Provider;
+    Callbacks.Reg      := Reg;
+    Callbacks.Model    := Model;
+    Callbacks.Handlers := Handlers;
+    try
+      Runner := TGoalRunner.Create(Provider, Model, MaxIter, Callbacks.TurnFn);
+      try
+        Runner.OnProgress := Callbacks.Progress;
+        R := Runner.Run(A.GoalObjective, Msgs);
+      finally
+        Runner.Free;
+      end;
+    finally
+      Callbacks.Free;
+    end;
+
+    { Final reply. Quiet mode emits the last assistant text only (cog
+      caller pipes it); verbose mode emits a verdict banner + reason. }
+    if A.Quiet then
+      PrintLn(R.LastReply)
+    else
+    begin
+      PrintLn;
+      PrintLn(Ansi.Bold + '— verdict —' + Ansi.Reset + ' ' + VerdictName(R.Verdict) +
+              ' (iterations=' + IntToStr(R.Iterations) + ')');
+      if R.Reason <> '' then
+        PrintLn(Ansi.Dim + R.Reason + Ansi.Reset);
+    end;
+
+    Result := R.Verdict in [gvMet, gvBudgetExhausted];
+  finally
+    CloseShellSession(OneShotSessionId);
+    SetCurrentSessionId('');
+    Handlers.Free;
+    FreeMCPClients(MCPClients);
+    if Spawn <> nil then Spawn.Free;
+    if Reg <> nil then Reg.Free;
   end;
 end;
 
@@ -1520,8 +1756,21 @@ begin
         `pasclaw agent --quiet -m "..."` callers checking $? see real
         failures instead of a silently-zero exit code that lies about
         success. PR #243 P2. Interactive mode has no equivalent
-        return -- session lifecycle is the user's signal there. }
-      if RunSingleTurn(Cfg, A, A.Message) then
+        return -- session lifecycle is the user's signal there.
+
+        Phase 3 of plan/build: --goal-objective (set by Cmd.Build
+        --goal after parsing PLAN.md's Goal line) routes the one-shot
+        path through RunSingleTurnGoalDriven instead, wrapping
+        RunToolLoop in TGoalRunner so the Ralph judge loop pumps
+        iterations until MET / FAILED / BUDGET-EXHAUSTED. }
+      if A.GoalObjective <> '' then
+      begin
+        if RunSingleTurnGoalDriven(Cfg, A, A.Message) then
+          Result := 0
+        else
+          Result := 1;
+      end
+      else if RunSingleTurn(Cfg, A, A.Message) then
         Result := 0
       else
         Result := 1;

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -830,6 +830,17 @@ begin
   Spawn      := MaybeRegisterSpawnTool(Cfg, Provider, Reg, Model);
   BgCoord    := MaybeRegisterBackgroundSpawnTools(Cfg, Provider, Reg, Model);
   Handlers   := TLoopHandlers.Create;
+  { Propagate --quiet so per-tool decoration fired through
+    OnToolCall / OnToolResult no-ops. Mirrors RunSingleTurn at
+    Cmd.Agent.pas:572. Codex P2 reviewer on PR #317: without this,
+    pasclaw build --goal would print tool-call/result previews to
+    stdout during each Ralph iteration even though Cmd.Build always
+    injects -q, polluting cog reply.txt and other subprocess
+    consumers that rely on -q meaning "only the final assistant
+    reply". The verbose banner + verdict lines are still gated on
+    `not A.Quiet` further down so non-quiet operators still see
+    them. }
+  Handlers.Quiet := A.Quiet;
 
   { Per-process shell-backend session id, same shape as RunSingleTurn.
     Lazy docker container -- only spawned on the first shell tool call. }

--- a/src/cmd/PasClaw.Cmd.Build.pas
+++ b/src/cmd/PasClaw.Cmd.Build.pas
@@ -419,6 +419,75 @@ begin
   for i := 0 to L.Count - 1 do Result[i] := L[i];
 end;
 
+function ContainsNoPlanFlag(Forwarded: TStringList): Boolean;
+{ Cmd.Build doesn't parse --no-plan -- it just forwards every unknown
+  flag to Cmd.Agent. For archival we need to know whether the operator
+  opted out, so scan A.Forwarded for the bare flag. Match is exact:
+  we don't expand prefixes the way some parsers do. }
+var
+  i: Integer;
+begin
+  Result := False;
+  for i := 0 to Forwarded.Count - 1 do
+    if Forwarded[i] = '--no-plan' then Exit(True);
+end;
+
+procedure ArchivePlanMaybe(const Home: string; AgentRc: Integer;
+                            Forwarded: TStringList);
+{ Move <home>/workspace/PLAN.md to <home>/workspace/memory/plans/
+  <timestamp>.md when the build that just consumed it succeeded.
+
+  Skipped silently when:
+    - --no-plan was in the operator's argv (they opted out of
+      auto-pickup; respect that and don't touch the file)
+    - PLAN.md doesn't exist (no plan, nothing to archive)
+    - The agent exited with non-zero status (the build failed; the
+      plan is still relevant for whatever retry comes next, and
+      destroying it would force the operator to re-plan from
+      scratch).
+
+  Failures (mkdir / rename) are logged but don't override AgentRc
+  -- a failed archival shouldn't sink an otherwise-successful build. }
+var
+  PlanPath, ArchiveDir, Stamp, ArchivePath: string;
+begin
+  if AgentRc <> 0 then Exit;
+  if ContainsNoPlanFlag(Forwarded) then
+  begin
+    LogInfo('build: --no-plan set, leaving PLAN.md in place');
+    Exit;
+  end;
+  PlanPath := JoinPath(JoinPath(Home, 'workspace'), 'PLAN.md');
+  if not SysUtils.FileExists(PlanPath) then Exit;
+
+  ArchiveDir := JoinPath(JoinPath(JoinPath(Home, 'workspace'), 'memory'), 'plans');
+  if not ForceDirectories(ArchiveDir) then
+  begin
+    LogWarn('build: cannot create plan archive dir %s -- leaving PLAN.md in place',
+            [ArchiveDir]);
+    Exit;
+  end;
+
+  Stamp := FormatDateTime('yyyy-mm-dd-hhnnss', Now);
+  ArchivePath := JoinPath(ArchiveDir, Stamp + '.md');
+  try
+    if not RenameFile(PlanPath, ArchivePath) then
+    begin
+      LogWarn('build: PLAN.md archive RenameFile failed (%s -> %s); leaving in place',
+              [PlanPath, ArchivePath]);
+      Exit;
+    end;
+  except
+    on E: Exception do
+    begin
+      LogWarn('build: PLAN.md archive raised %s: %s; leaving in place',
+              [E.ClassName, E.Message]);
+      Exit;
+    end;
+  end;
+  LogInfo('build: archived PLAN.md -> %s', [ArchivePath]);
+end;
+
 function Cmd_Build_Run(const Argv: array of string): Integer;
 const
   ExcludeFromZip: array[0..3] of string = (
@@ -521,6 +590,21 @@ begin
       end;
       if Rc <> 0 then
         LogWarn('build: agent exited with status %d', [Rc]);
+
+      { 3.5 PLAN.md archival. If a prior `pasclaw plan` left a
+        workspace/PLAN.md the model just consumed as system-prompt
+        context (Phase 2), move it to workspace/memory/plans/
+        <timestamp>.md so the next `pasclaw build` doesn't re-load
+        the same plan and the operator gets a browsable history of
+        what was planned.
+
+        Skipped if --no-plan was in the operator's argv (opt-out
+        of the auto-pickup also means opt-out of archival -- if you
+        ignored PLAN.md, leave it alone) OR if the agent exited
+        with a non-zero status (a failed build's plan is still
+        relevant for the retry). }
+      ArchivePlanMaybe(Home, Rc, A.Forwarded);
+
 
       { 4. Zip out. Failure to pack is logged but doesn't override
         the agent's exit code -- the operator can still inspect

--- a/src/cmd/PasClaw.Cmd.Build.pas
+++ b/src/cmd/PasClaw.Cmd.Build.pas
@@ -92,7 +92,8 @@ uses
   PasClaw.Logger,
   PasClaw.Utils,
   PasClaw.Skills.Zip,
-  PasClaw.Cmd.Agent;
+  PasClaw.Cmd.Agent,
+  PasClaw.Agent.Prompt;  { ExtractGoalFromPlanFile for --goal flag }
 
 {$IFDEF UNIX}
 { libc setenv is POSIX-portable across glibc / musl / macOS / BSD --
@@ -176,11 +177,26 @@ type
     HomeOverride:  string;
     KeepHome:      Boolean;
     HelpRequested: Boolean;
+    { --goal -- Phase 3 of the plan/build pairing. When True, Cmd.Build
+      reads <home>/workspace/PLAN.md, parses the "## Goal" line, and
+      forwards it to Cmd.Agent as --goal-objective. Cmd.Agent then
+      routes the one-shot run through RunSingleTurnGoalDriven (the
+      Ralph judge loop) instead of single-shot. Fails fast if --goal
+      is set but PLAN.md is missing or has no parseable Goal section
+      -- silently falling back to a regular build would defeat the
+      operator's intent. }
+    Goal:          Boolean;
+    { --goal-max-iters N -- override the Ralph iteration budget when
+      --goal is set. Defaults to 0 = use Cmd.Agent's
+      DefaultGoalMaxIter. Ignored when --goal is False. }
+    GoalMaxIters:  Integer;
     Forwarded:     TStringList;  { remaining flags handed to Cmd_Agent_Run }
   end;
 
 procedure InitArgs(out A: TBuildArgs);
 begin
+  A.Goal          := False;
+  A.GoalMaxIters  := 0;
   A.Description   := '';
   A.MaxIters      := PASCLAW_BUILD_DEFAULT_MAX_ITERS;
   A.WorkspaceIn   := '';
@@ -205,6 +221,11 @@ begin
   PrintLn('Build flags:');
   PrintLn('  -d, --describe <text>      The task to perform (REQUIRED).');
   PrintLn('  --max-iters N              Iteration budget (default 50).');
+  PrintLn('  --goal                     Drive the run via the Ralph judge loop');
+  PrintLn('                             against workspace/PLAN.md''s "## Goal"');
+  PrintLn('                             line. Requires a prior `pasclaw plan`.');
+  PrintLn('  --goal-max-iters N         Override the Ralph budget (default 5);');
+  PrintLn('                             ignored when --goal is absent.');
   PrintLn('  --workspace-in <zip>       Unzip this into PASCLAW_HOME first.');
   PrintLn('  --workspace-out <zip>      Zip PASCLAW_HOME here after the run.');
   PrintLn('  --cwd <dir>                cwd for fs_write (default: ');
@@ -290,6 +311,21 @@ begin
     begin
       if i = High(Argv) then begin ErrMsg := '--home needs a path'; Exit; end;
       Inc(i); A.HomeOverride := Argv[i];
+    end
+    else if Token = '--goal' then
+    begin
+      A.Goal := True;
+    end
+    else if Token = '--goal-max-iters' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--goal-max-iters needs a value'; Exit; end;
+      Inc(i);
+      A.GoalMaxIters := StrToIntDef(Argv[i], A.GoalMaxIters);
+      if A.GoalMaxIters <= 0 then
+      begin
+        ErrMsg := '--goal-max-iters must be positive (got ' + Argv[i] + ')';
+        Exit;
+      end;
     end
     else if Token = '--keep-home' then
     begin
@@ -395,11 +431,14 @@ begin
 end;
 
 function BuildForwardedArgv(const A: TBuildArgs;
+                            const GoalObjective: string;
                             out Argv: TStringList): Boolean;
 { Construct the argv pasclaw agent will see. Always inject -q
   (machine-friendly stdout), -m (the description), and
-  --max-iterations (the operator's choice or our default 50). Then
-  append whatever flags survived our parser. }
+  --max-iterations (the operator's choice or our default 50). When
+  GoalObjective is non-empty, also forward --goal-objective so
+  Cmd.Agent routes through the Ralph goal-driver instead of single-
+  shot. Then append whatever flags survived our parser. }
 begin
   Result := True;
   Argv := TStringList.Create;
@@ -408,6 +447,16 @@ begin
   Argv.Add(A.Description);
   Argv.Add('--max-iterations');
   Argv.Add(IntToStr(A.MaxIters));
+  if GoalObjective <> '' then
+  begin
+    Argv.Add('--goal-objective');
+    Argv.Add(GoalObjective);
+    if A.GoalMaxIters > 0 then
+    begin
+      Argv.Add('--goal-max-iters');
+      Argv.Add(IntToStr(A.GoalMaxIters));
+    end;
+  end;
   Argv.AddStrings(A.Forwarded);
 end;
 
@@ -498,7 +547,7 @@ const
   );
 var
   A: TBuildArgs;
-  ErrMsg, Home, Cwd, SavedHomeEnv, SavedCwd: string;
+  ErrMsg, Home, Cwd, SavedHomeEnv, SavedCwd, GoalObjective: string;
   AgentArgv: TStringList;
   Argv_: TArray<string>;
   HomeIsTemp: Boolean;
@@ -575,9 +624,35 @@ begin
       end;
       LogInfo('build: cwd=%s', [Cwd]);
 
+      { 2.5 Phase 3 of plan/build: when --goal is set, parse
+        <home>/workspace/PLAN.md's "## Goal" line and forward it to
+        Cmd.Agent as --goal-objective. Fail fast on missing PLAN.md
+        or empty Goal section -- silently falling back to a regular
+        build would defeat the operator's intent. ExtractGoalFromPlanFile
+        reads PLAN.md via GetHome, which honors the PASCLAW_HOME we
+        just set. }
+      GoalObjective := '';
+      if A.Goal then
+      begin
+        { Pass Home explicitly: libc_setenv's PASCLAW_HOME isn't
+          always visible to a same-process GetEnvironmentVariable
+          read on FPC, and Cmd.Build already owns the home path
+          locally -- no reason to round-trip through env. }
+        GoalObjective := ExtractGoalFromPlanFile(Home);
+        if GoalObjective = '' then
+        begin
+          PrintErr('build: --goal was set but workspace/PLAN.md has no ' +
+                   'parseable "## Goal" section (run `pasclaw plan -d ...` ' +
+                   'first to produce one)');
+          Exit(1);
+        end;
+        LogInfo('build: goal-driven run -- objective from PLAN.md: %s',
+                [GoalObjective]);
+      end;
+
       { 3. Run the agent. Its stdout becomes our stdout under -q --
         Replicate (and any subprocess.run caller) captures that. }
-      if not BuildForwardedArgv(A, AgentArgv) then
+      if not BuildForwardedArgv(A, GoalObjective, AgentArgv) then
       begin
         PrintErr('build: failed to build agent argv');
         Exit(1);

--- a/src/cmd/PasClaw.Cmd.Plan.pas
+++ b/src/cmd/PasClaw.Cmd.Plan.pas
@@ -1,0 +1,569 @@
+unit PasClaw.Cmd.Plan;
+(*
+  PasClaw.Cmd.Plan - the `pasclaw plan` subcommand. Companion to
+  `pasclaw build`: produces `workspace/PLAN.md` as a deliverable that
+  the operator (or a follow-up `pasclaw build`) can consume.
+
+  How it works
+  ============
+
+  This unit mirrors `pasclaw build`'s lifecycle (workspace.zip
+  handshake + PASCLAW_HOME orchestration) and adds a planner-specific
+  layer on top:
+
+    1. Parse plan-specific args (mirrors Cmd.Build's argv surface).
+    2. Resolve PASCLAW_HOME + unzip the workspace-in if provided.
+    3. If <home>/workspace/PLAN.md exists, read its body for incremental
+       update (model gets the existing plan in its system prompt with a
+       "revise / extend, don't replace" directive).
+    4. Build a planner system-prompt addendum -- a strong directive that
+       says "produce a structured plan; call plan_write once; end your
+       turn."
+    5. Forward to Cmd_Agent_Run with: -q -m <description>
+       --mode plan --system <planner directive> --max-iterations N.
+    6. The agent runs in pmPlan mode. Read-only tools (fs_read,
+       fs_grep, memory_search, etc.) work normally; mutating tools are
+       refused at dispatch. The dedicated `plan_write` tool
+       (PasClaw.Tools.PlanWrite) is auto-registered when --mode plan is
+       set; it's tcReadOnly-tagged so it passes the gate, but only
+       writes the one plan-meta file.
+    7. The model calls plan_write with the finalized markdown body;
+       it lands at <home>/workspace/PLAN.md.
+    8. Workspace-out zip (if requested) captures PLAN.md alongside the
+       rest of $PASCLAW_HOME, identical to `pasclaw build`.
+
+  Why mirror build's lifecycle rather than call into it
+  =====================================================
+
+  Cmd_Build_Run unpacks workspace-in early, runs the agent, then
+  packs workspace-out. Cmd.Plan needs to peek at PLAN.md BEFORE the
+  agent runs (for the incremental-update directive) and AFTER (to
+  verify the model wrote it), which means we need our own lifecycle
+  with hooks. Helpers (ResolveHome, SetEnv, etc.) are duplicated as
+  internals rather than exposed from Cmd.Build's interface --
+  Cmd.Build is heavily used and its public surface is best left
+  unchanged.
+
+  Usage
+  -----
+
+    pasclaw plan -d "<task>"
+                 [--max-iters N]                (default 12)
+                 [--workspace-in <zip>]         optional
+                 [--workspace-out <zip>]        optional
+                 [--cwd <dir>]
+                 [--home <dir>]
+                 [--keep-home]
+                 ... forwarded agent flags (--provider, --model, ...)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+{$ENDIF}
+
+interface
+
+function Cmd_Plan_Run(const Argv: array of string): Integer;
+
+const
+  { Default iteration budget for `pasclaw plan`. Lower than build's 50
+    -- planning involves reading code and producing one document; it
+    shouldn't take dozens of tool-loop rounds. Calibrated so a
+    Sonnet/Opus run on a medium-sized codebase has headroom for ~5
+    fs_read + ~3 fs_grep + 1 plan_write before hitting the cap. }
+  PASCLAW_PLAN_DEFAULT_MAX_ITERS = 12;
+
+implementation
+
+uses
+  SysUtils, Classes,
+  {$IFDEF MSWINDOWS}Windows,{$ENDIF}
+  PasClaw.CliUI,
+  PasClaw.Logger,
+  PasClaw.Utils,
+  PasClaw.Skills.Zip,
+  PasClaw.Cmd.Agent,
+  PasClaw.Cmd.Build,         { for PASCLAW_WORKSPACE_ZIP_CAP + MakeUniqueTempDir }
+  PasClaw.Tools.PlanWrite;
+
+{$IFDEF UNIX}
+function libc_setenv(const Name, Value: PAnsiChar; Overwrite: Integer): Integer;
+  cdecl; external 'c' name 'setenv';
+function libc_unsetenv(const Name: PAnsiChar): Integer;
+  cdecl; external 'c' name 'unsetenv';
+{$ENDIF}
+
+procedure RemoveTree(const Path: string);
+{ Best-effort rm -rf. Mirror of Cmd.Build.RemoveTree -- same SysUtils.
+  qualification rationale (Windows unit shadowing). Local copy because
+  Cmd.Build keeps it implementation-private. }
+var
+  SR: SysUtils.TSearchRec;
+  Child: string;
+begin
+  if (Path = '') or (not SysUtils.DirectoryExists(Path)) then
+  begin
+    if SysUtils.FileExists(Path) then SysUtils.DeleteFile(Path);
+    Exit;
+  end;
+  if SysUtils.FindFirst(JoinPath(Path, '*'),
+                        faAnyFile or faDirectory, SR) = 0 then
+  try
+    repeat
+      if (SR.Name = '.') or (SR.Name = '..') then Continue;
+      Child := JoinPath(Path, SR.Name);
+      if (SR.Attr and faDirectory) <> 0 then
+        RemoveTree(Child)
+      else
+        SysUtils.DeleteFile(Child);
+    until SysUtils.FindNext(SR) <> 0;
+  finally
+    SysUtils.FindClose(SR);
+  end;
+  SysUtils.RemoveDir(Path);
+end;
+
+function FileSizeOf(const Path: string): Int64;
+{ Mirror of Cmd.Build.GetFileSize -- that function is implementation-
+  private so we can't share it without expanding Cmd.Build's interface.
+  Same code, local copy. }
+var
+  SR: SysUtils.TSearchRec;
+begin
+  Result := -1;
+  if SysUtils.FindFirst(Path, faAnyFile, SR) = 0 then
+  begin
+    Result := SR.Size;
+    SysUtils.FindClose(SR);
+  end;
+end;
+
+procedure SetEnvVar(const Name, Value: string);
+begin
+  {$IFDEF UNIX}
+  if Value = '' then
+    libc_unsetenv(PAnsiChar(AnsiString(Name)))
+  else
+    libc_setenv(PAnsiChar(AnsiString(Name)),
+                PAnsiChar(AnsiString(Value)), 1);
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  if Value = '' then
+    Windows.SetEnvironmentVariable(PChar(Name), nil)
+  else
+    Windows.SetEnvironmentVariable(PChar(Name), PChar(Value));
+  {$ENDIF}
+end;
+
+type
+  TPlanArgs = record
+    Description:   string;
+    MaxIters:      Integer;
+    WorkspaceIn:   string;
+    WorkspaceOut:  string;
+    Cwd:           string;
+    HomeOverride:  string;
+    KeepHome:      Boolean;
+    HelpRequested: Boolean;
+    Forwarded:     TStringList;
+  end;
+
+procedure InitArgs(out A: TPlanArgs);
+begin
+  A.Description   := '';
+  A.MaxIters      := PASCLAW_PLAN_DEFAULT_MAX_ITERS;
+  A.WorkspaceIn   := '';
+  A.WorkspaceOut  := '';
+  A.Cwd           := '';
+  A.HomeOverride  := '';
+  A.KeepHome      := False;
+  A.HelpRequested := False;
+  A.Forwarded     := TStringList.Create;
+end;
+
+procedure PrintHelp;
+begin
+  PrintLn('Usage: pasclaw plan -d "<task>" [flags] [agent flags]');
+  PrintLn;
+  PrintLn('Generate a structured plan as workspace/PLAN.md without');
+  PrintLn('changing any project files. Runs the agent in plan mode');
+  PrintLn('(read-only tool surface) with a planner directive that');
+  PrintLn('produces a markdown document via the plan_write tool.');
+  PrintLn;
+  PrintLn('Plan structure: ## Goal, ## Files, ## Steps,');
+  PrintLn('                ## Open questions, ## Risks');
+  PrintLn;
+  PrintLn('Plan flags:');
+  PrintLn('  -d, --describe <text>      The task to plan (REQUIRED).');
+  PrintLn('  --max-iters N              Iteration budget (default 12).');
+  PrintLn('  --workspace-in <zip>       Unzip this into PASCLAW_HOME first.');
+  PrintLn('  --workspace-out <zip>      Zip PASCLAW_HOME here after the run');
+  PrintLn('                             (the zip carries PLAN.md).');
+  PrintLn('  --cwd <dir>                cwd for tools (default:');
+  PrintLn('                             $PASCLAW_HOME/workspace).');
+  PrintLn('  --home <dir>               Override PASCLAW_HOME.');
+  PrintLn('  --keep-home                Don''t delete the tempdir on exit.');
+  PrintLn;
+  PrintLn('Plan mode is forced; --mode is NOT forwarded (use `pasclaw');
+  PrintLn('agent --mode plan` for an interactive plan session).');
+  PrintLn;
+  PrintLn('Output:');
+  PrintLn('  <workspace>/PLAN.md  -- markdown plan written by the model.');
+  PrintLn('  stdout               -- final agent reply (short confirmation).');
+  PrintLn('  stderr               -- progress + workspace.zip size.');
+end;
+
+function ParseArgs(const Argv: array of string;
+                   var A: TPlanArgs;
+                   out ErrMsg: string): Boolean;
+var
+  i: Integer;
+  Token: string;
+begin
+  Result := False;
+  ErrMsg := '';
+  i := Low(Argv);
+  while i <= High(Argv) do
+  begin
+    Token := Argv[i];
+    if (Token = '-h') or (Token = '--help') then
+    begin
+      A.HelpRequested := True;
+      Exit(True);
+    end
+    else if (Token = '-d') or (Token = '--describe') or (Token = '-m') then
+    begin
+      if i = High(Argv) then begin ErrMsg := Token + ' needs a value'; Exit; end;
+      Inc(i);
+      A.Description := Argv[i];
+    end
+    else if Token = '--max-iters' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--max-iters needs a value'; Exit; end;
+      Inc(i);
+      A.MaxIters := StrToIntDef(Argv[i], A.MaxIters);
+      if A.MaxIters <= 0 then
+      begin
+        ErrMsg := '--max-iters must be positive (got ' + Argv[i] + ')';
+        Exit;
+      end;
+    end
+    else if Token = '--workspace-in' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--workspace-in needs a path'; Exit; end;
+      Inc(i); A.WorkspaceIn := Argv[i];
+    end
+    else if Token = '--workspace-out' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--workspace-out needs a path'; Exit; end;
+      Inc(i); A.WorkspaceOut := Argv[i];
+    end
+    else if Token = '--cwd' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--cwd needs a path'; Exit; end;
+      Inc(i); A.Cwd := Argv[i];
+    end
+    else if Token = '--home' then
+    begin
+      if i = High(Argv) then begin ErrMsg := '--home needs a path'; Exit; end;
+      Inc(i); A.HomeOverride := Argv[i];
+    end
+    else if Token = '--keep-home' then
+    begin
+      A.KeepHome := True;
+    end
+    else if (Token = '--mode') or (Token = '--plan') or (Token = '--build') then
+    begin
+      { plan forces --mode plan; refusing the flag here means an
+        operator who passes --mode build by accident gets a clear
+        error instead of silently switching the run to build mode. }
+      ErrMsg := Token + ' is not allowed in `pasclaw plan` (mode is forced to plan)';
+      Exit;
+    end
+    else
+    begin
+      A.Forwarded.Add(Token);
+    end;
+    Inc(i);
+  end;
+  if A.Description = '' then
+  begin
+    ErrMsg := '-d / --describe is required (see -h for usage)';
+    Exit;
+  end;
+  Result := True;
+end;
+
+function ResolveHome(const A: TPlanArgs; out IsTemp: Boolean): string;
+{ Resolution order matches Cmd.Build:
+    1. --home <dir>                  (operator override)
+    2. existing PASCLAW_HOME env var (cog already sets one)
+    3. fresh tempdir                 (cleaned on exit unless --keep-home) }
+var
+  Env: string;
+begin
+  IsTemp := False;
+  if A.HomeOverride <> '' then
+    Exit(A.HomeOverride);
+  Env := GetEnvironmentVariable('PASCLAW_HOME');
+  if Env <> '' then
+    Exit(Env);
+  IsTemp := True;
+  Result := MakeUniqueTempDir('pasclaw_plan');
+end;
+
+procedure CleanupTempHome(const Home: string);
+begin
+  try
+    if DirectoryExists(Home) then
+      RemoveTree(Home);
+  except
+    on E: Exception do
+      LogWarn('plan: cleanup of tempdir failed: %s: %s',
+              [E.ClassName, E.Message]);
+  end;
+end;
+
+function ReadExistingPlanBody: string;
+var
+  Path: string;
+begin
+  Result := '';
+  Path := ResolvePlanPath;
+  if not FileExists(Path) then Exit;
+  try
+    Result := Trim(ReadFileText(Path));
+  except
+    on E: Exception do
+    begin
+      LogWarn('plan: existing PLAN.md unreadable (%s); generating fresh plan',
+              [E.Message]);
+      Result := '';
+    end;
+  end;
+end;
+
+const
+  { The planner directive. Stuffed into --system so it lands at the
+    end of the system prompt (BuildSystemPrompt appends UserSys last,
+    so it gets the "most authoritative" slot ahead of model defaults
+    and skills). Opinionated on structure so plans are comparable
+    across runs and a follow-up `pasclaw build --goal` (Phase 3) can
+    parse the Goal section cleanly. }
+  PlanDirectiveHeader =
+    'You are running under `pasclaw plan` -- your deliverable is a ' +
+    'markdown plan, NOT actually doing the work. Read the codebase as ' +
+    'needed (fs_read, fs_grep, memory_search), then SAVE the plan via ' +
+    'the `plan_write` tool with the full markdown as the `content` ' +
+    'argument. After plan_write returns, end your turn with a short ' +
+    'confirmation -- do NOT restate the plan in your reply.' + sLineBreak + sLineBreak +
+    'Plan structure (use these exact headings, in this order):' + sLineBreak +
+    '  ## Goal' + sLineBreak +
+    '    One paragraph: what success looks like. The first line should' + sLineBreak +
+    '    be a single-sentence objective starting with a verb (so a' + sLineBreak +
+    '    follow-up `pasclaw build --goal` can parse it cleanly).' + sLineBreak +
+    '  ## Files' + sLineBreak +
+    '    Bullet list of files that will change, one line each.' + sLineBreak +
+    '  ## Steps' + sLineBreak +
+    '    Numbered list of concrete actions, in order.' + sLineBreak +
+    '  ## Open questions' + sLineBreak +
+    '    Anything the operator needs to decide. Omit if none.' + sLineBreak +
+    '  ## Risks' + sLineBreak +
+    '    Things that could go wrong + mitigation. Omit if none.';
+
+  PlanDirectiveFreshTail =
+    sLineBreak + sLineBreak +
+    'No existing PLAN.md was found -- write a fresh plan.';
+
+  PlanDirectiveIncrementalTail =
+    sLineBreak + sLineBreak +
+    'An EXISTING PLAN.md is shown below. Your job is to REVISE / EXTEND ' +
+    'it based on the new task description. Keep sections that still ' +
+    'apply, drop what no longer fits, add what''s missing. Preserve the ' +
+    'overall structure. Output the FULL revised plan via plan_write -- ' +
+    'do not output a diff.' + sLineBreak + sLineBreak +
+    '=== Existing plan ===' + sLineBreak;
+
+function BuildPlannerDirective(const ExistingPlan: string): string;
+begin
+  Result := PlanDirectiveHeader;
+  if Trim(ExistingPlan) = '' then
+    Result := Result + PlanDirectiveFreshTail
+  else
+    Result := Result + PlanDirectiveIncrementalTail + ExistingPlan;
+end;
+
+function ToDynArray(L: TStringList): TArray<string>;
+var
+  i: Integer;
+begin
+  SetLength(Result, L.Count);
+  for i := 0 to L.Count - 1 do Result[i] := L[i];
+end;
+
+function Cmd_Plan_Run(const Argv: array of string): Integer;
+var
+  A: TPlanArgs;
+  ErrMsg, Home, Cwd, Directive, ExistingPlan, PlanPath: string;
+  SavedHomeEnv: string;
+  AgentArgv: TStringList;
+  Argv_: TArray<string>;
+  Rc: Integer;
+  HomeIsTemp, PlanExisted: Boolean;
+  Bytes, FinalSize: Int64;
+  PreviousAge, FinalAge: Integer;
+begin
+  Result := 1;
+  InitArgs(A);
+  try
+    if not ParseArgs(Argv, A, ErrMsg) then
+    begin
+      PrintErr('plan: ' + ErrMsg);
+      Exit(2);
+    end;
+    if A.HelpRequested then
+    begin
+      PrintHelp;
+      Exit(0);
+    end;
+
+    Home := ResolveHome(A, HomeIsTemp);
+    if not ForceDirectories(Home) then
+    begin
+      PrintErr('plan: cannot create home dir: ' + Home);
+      Exit(1);
+    end;
+
+    SavedHomeEnv := GetEnvironmentVariable('PASCLAW_HOME');
+    SetEnvVar('PASCLAW_HOME', Home);
+    LogInfo('plan: PASCLAW_HOME=%s (temp=%s)',
+            [Home, BoolToStr(HomeIsTemp, True)]);
+
+    try
+      { 1. Unzip in. }
+      if A.WorkspaceIn <> '' then
+      begin
+        if not SysUtils.FileExists(A.WorkspaceIn) then
+        begin
+          PrintErr('plan: workspace-in not found: ' + A.WorkspaceIn);
+          Exit(1);
+        end;
+        Bytes := FileSizeOf(A.WorkspaceIn);
+        if Bytes > PASCLAW_WORKSPACE_ZIP_CAP then
+        begin
+          PrintErr(Format('plan: workspace-in is %d bytes (> %d cap)',
+                          [Bytes, PASCLAW_WORKSPACE_ZIP_CAP]));
+          Exit(1);
+        end;
+        LogInfo('plan: unpacking %s (%d bytes) -> %s',
+                [A.WorkspaceIn, Bytes, Home]);
+        if not ExtractZipToDir(A.WorkspaceIn, Home, ErrMsg) then
+        begin
+          PrintErr('plan: unzip failed: ' + ErrMsg);
+          Exit(1);
+        end;
+      end;
+
+      { 2. cwd. }
+      Cwd := A.Cwd;
+      if Cwd = '' then
+        Cwd := JoinPath(Home, 'workspace');
+      if not ForceDirectories(Cwd) then
+      begin
+        PrintErr('plan: cannot create cwd: ' + Cwd);
+        Exit(1);
+      end;
+      if not SetCurrentDir(Cwd) then
+      begin
+        PrintErr('plan: SetCurrentDir failed: ' + Cwd);
+        Exit(1);
+      end;
+      LogInfo('plan: cwd=%s', [Cwd]);
+
+      { 3. Read existing PLAN.md (if any) for incremental update.
+        Snapshot its FileAge so we can detect post-run whether the
+        model actually rewrote it. }
+      ExistingPlan := ReadExistingPlanBody;
+      PlanPath := ResolvePlanPath;
+      PlanExisted := FileExists(PlanPath);
+      PreviousAge := 0;
+      if PlanExisted then
+        PreviousAge := FileAge(PlanPath);
+
+      Directive := BuildPlannerDirective(ExistingPlan);
+
+      { 4. Run the agent in plan mode with the directive folded into
+        --system. plan_write registers automatically because Cmd.Agent
+        sees --mode plan and threads EnablePlanWrite=True into
+        NewBuiltinRegistry. }
+      AgentArgv := TStringList.Create;
+      try
+        AgentArgv.Add('-q');
+        AgentArgv.Add('-m');
+        AgentArgv.Add(A.Description);
+        AgentArgv.Add('--mode');
+        AgentArgv.Add('plan');
+        AgentArgv.Add('--system');
+        AgentArgv.Add(Directive);
+        AgentArgv.Add('--max-iterations');
+        AgentArgv.Add(IntToStr(A.MaxIters));
+        AgentArgv.AddStrings(A.Forwarded);
+        Argv_ := ToDynArray(AgentArgv);
+        Rc := Cmd_Agent_Run(Argv_);
+      finally
+        AgentArgv.Free;
+      end;
+      if Rc <> 0 then
+        LogWarn('plan: agent exited with status %d', [Rc]);
+
+      { 5. Sanity check: did the model actually write PLAN.md? An empty
+        run (model decided not to call plan_write) should surface as a
+        failure rather than silently produce no artifact. }
+      if not FileExists(PlanPath) then
+      begin
+        PrintErr('plan: model did not call plan_write -- no PLAN.md produced');
+        Exit(1);
+      end;
+      FinalSize := FileSizeOf(PlanPath);
+      FinalAge  := FileAge(PlanPath);
+      if PlanExisted and (FinalAge = PreviousAge) then
+      begin
+        { FileAge unchanged -- the model didn't update PLAN.md.
+          Surface as failure unless the agent itself reported a
+          nonzero exit (in which case the user already sees the
+          underlying error). }
+        if Rc = 0 then
+        begin
+          PrintErr('plan: PLAN.md not updated -- model did not call plan_write');
+          Exit(1);
+        end;
+      end;
+      LogInfo('plan: PLAN.md at %s (%d bytes)', [PlanPath, FinalSize]);
+
+      { 6. Zip out. PLAN.md is captured by the whole-home pack just
+        like every other file under $PASCLAW_HOME. Exclusion list
+        matches Cmd.Build's so the two commands produce zips with
+        the same shape. }
+      if A.WorkspaceOut <> '' then
+      begin
+        LogInfo('plan: packing %s -> %s', [Home, A.WorkspaceOut]);
+        if not PackDirToZip(Home, A.WorkspaceOut,
+                            ['.git', '.DS_Store', 'Thumbs.db', 'kb.db-journal'],
+                            ErrMsg, '') then
+          LogWarn('plan: zip-out failed: %s', [ErrMsg]);
+      end;
+
+      Result := Rc;
+    finally
+      SetEnvVar('PASCLAW_HOME', SavedHomeEnv);
+      if HomeIsTemp and (not A.KeepHome) then
+        CleanupTempHome(Home);
+    end;
+  finally
+    A.Forwarded.Free;
+  end;
+end;
+
+end.

--- a/src/cmd/PasClaw.Cmd.Plan.pas
+++ b/src/cmd/PasClaw.Cmd.Plan.pas
@@ -81,6 +81,7 @@ uses
   SysUtils, Classes,
   {$IFDEF MSWINDOWS}Windows,{$ENDIF}
   PasClaw.CliUI,
+  PasClaw.Config,            { GetHome -- ResolveHome's local-default fallback }
   PasClaw.Logger,
   PasClaw.Utils,
   PasClaw.Skills.Zip,
@@ -297,10 +298,23 @@ begin
 end;
 
 function ResolveHome(const A: TPlanArgs; out IsTemp: Boolean): string;
-{ Resolution order matches Cmd.Build:
-    1. --home <dir>                  (operator override)
-    2. existing PASCLAW_HOME env var (cog already sets one)
-    3. fresh tempdir                 (cleaned on exit unless --keep-home) }
+{ Resolution order, mirroring Cmd.Build for the override and env-var
+  paths but DIVERGING on the fallback because `pasclaw plan`'s
+  deliverable IS a file in the workspace (workspace/PLAN.md). If we
+  fell back to a fresh tempdir like build does, the finally-block
+  cleanup below would delete PLAN.md before the operator could
+  review it -- a local `pasclaw plan -d "..."` with no flags would
+  silently produce nothing. Codex P2 reviewer on PR #317.
+
+  Order:
+    1. --home <dir>                  (explicit override)
+    2. existing PASCLAW_HOME env var (cog or shell-exported)
+    3. --workspace-out <zip>         (caller is using the zip
+                                      handshake; tempdir is fine
+                                      because the artifact ships out
+                                      via the zip)
+    4. GetHome (= ~/.pasclaw)        (local default; PLAN.md persists
+                                      where the operator can find it) }
 var
   Env: string;
 begin
@@ -310,8 +324,17 @@ begin
   Env := GetEnvironmentVariable('PASCLAW_HOME');
   if Env <> '' then
     Exit(Env);
-  IsTemp := True;
-  Result := MakeUniqueTempDir('pasclaw_plan');
+  if A.WorkspaceOut <> '' then
+  begin
+    { Zip-handshake flow: the artifact survives in the output zip, so
+      destroying the tempdir is fine. Mirrors cog usage. }
+    IsTemp := True;
+    Result := MakeUniqueTempDir('pasclaw_plan');
+    Exit;
+  end;
+  { Local default: persist to ~/.pasclaw/workspace/PLAN.md so the
+    operator can review or hand it off to `pasclaw build`. }
+  Result := GetHome;
 end;
 
 procedure CleanupTempHome(const Home: string);
@@ -545,14 +568,22 @@ begin
       { 6. Zip out. PLAN.md is captured by the whole-home pack just
         like every other file under $PASCLAW_HOME. Exclusion list
         matches Cmd.Build's so the two commands produce zips with
-        the same shape. }
+        the same shape.
+
+        Failure promoted to non-zero exit (Codex P2 reviewer on PR
+        #317): the tempdir-default cleanup below would otherwise
+        destroy PLAN.md while the caller saw exit 0 -- silently
+        producing nothing. Cmd.Build does the same promotion. }
       if A.WorkspaceOut <> '' then
       begin
         LogInfo('plan: packing %s -> %s', [Home, A.WorkspaceOut]);
         if not PackDirToZip(Home, A.WorkspaceOut,
                             ['.git', '.DS_Store', 'Thumbs.db', 'kb.db-journal'],
                             ErrMsg, '') then
-          LogWarn('plan: zip-out failed: %s', [ErrMsg]);
+        begin
+          PrintErr('plan: zip-out failed: ' + ErrMsg);
+          if Rc = 0 then Rc := 1;
+        end;
       end;
 
       Result := Rc;

--- a/src/cmd/PasClaw.Cmd.Root.pas
+++ b/src/cmd/PasClaw.Cmd.Root.pas
@@ -62,6 +62,8 @@ uses
                                Cmd.Runbook's tool-driven variant *)
   PasClaw.Cmd.Build,        (* `pasclaw build` -- one-shot multi-iter agent
                                with workspace.zip handshake *)
+  PasClaw.Cmd.Plan,         (* `pasclaw plan` -- plan-mode sibling to build,
+                               writes workspace/PLAN.md via plan_write *)
   PasClaw.Cmd.Runbook,
   PasClaw.Cmd.Heartbeat,
   PasClaw.Cmd.TUI;
@@ -136,7 +138,7 @@ const
 var
   Sub, Fl: array of string;
 begin
-  SetLength(Sub, 29);
+  SetLength(Sub, 30);
   Sub[0]  := 'config       View/edit configuration';
   Sub[1]  := 'onboard      Initialize config & workspace';
   Sub[2]  := 'agent        Chat with the assistant (line-by-line)';
@@ -164,8 +166,9 @@ begin
   Sub[24] := 'init         Scan cwd and ask the model for a starter AGENTS.md (one-shot, no tool loop)';
   Sub[25] := 'runbook      Tool-driven variant of init: agent loop probes the repo via execute_code';
   Sub[26] := 'build        One-shot multi-iter agent run with workspace.zip handshake (for cog / CI)';
-  Sub[27] := 'heartbeat    Run the proactive periodic wake-up daemon (off by default; opt in via onboard)';
-  Sub[28] := 'version      Show version info';
+  Sub[27] := 'plan         Plan-mode sibling to build; writes workspace/PLAN.md via plan_write tool';
+  Sub[28] := 'heartbeat    Run the proactive periodic wake-up daemon (off by default; opt in via onboard)';
+  Sub[29] := 'version      Show version info';
 
   SetLength(Fl, 2);
   Fl[0] := '--no-color   Disable colored output (also: NO_COLOR env)';
@@ -196,6 +199,7 @@ begin
   else if Cmd = 'export'   then Result := Cmd_Export_Run(Argv)
   else if Cmd = 'init'     then Result := Cmd_Init_Run(Argv)
   else if Cmd = 'build'    then Result := Cmd_Build_Run(Argv)
+  else if Cmd = 'plan'     then Result := Cmd_Plan_Run(Argv)
   else if Cmd = 'runbook'  then Result := Cmd_Runbook_Run(Argv)
   { resume <id> is shorthand for `agent --session <id>` -- wire it
     here so `pasclaw resume foo` works as a top-level shortcut. }

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -107,6 +107,30 @@ function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
   through BuildSystemPrompt. }
 function BuildActivePlanSection(NoPlan: Boolean; Mode: TPasClawMode): string;
 
+{ Extract the "## Goal" objective line from workspace/PLAN.md.
+
+  Looks for the first markdown H2 heading equal to "Goal" (or "Goal:"),
+  then returns the next non-empty, non-heading content line (trimmed).
+  That line is the planner's single-sentence verb-prefixed objective
+  per `pasclaw plan`'s opinionated structure.
+
+  Returns '' when PLAN.md is missing, unreadable, or has no parseable
+  Goal section. Caller decides whether '' is a soft fall-through (skip
+  the goal driver) or hard error (fail the build).
+
+  Two overloads:
+    - No-arg version uses GetHome (PASCLAW_HOME env) to resolve the
+      workspace root. Suitable for tests and any caller whose
+      PASCLAW_HOME is reliably set in the OS env table.
+    - HomeOverride version takes an explicit home dir. Used by
+      Cmd.Build where the libc_setenv just-set PASCLAW_HOME isn't
+      always visible to a same-process GetEnvironmentVariable read --
+      passing Home explicitly bypasses the env round-trip and is
+      strictly more correct anyway (Cmd.Build owns the home path; no
+      reason to round-trip it through env). }
+function ExtractGoalFromPlanFile: string; overload;
+function ExtractGoalFromPlanFile(const HomeOverride: string): string; overload;
+
 { Locate the nearest AGENTS.md walking up from StartDir to the
   filesystem root, stopping at the first git working tree boundary
   (a directory containing a `.git` entry) once that boundary is
@@ -514,6 +538,105 @@ begin
   if Trim(Section) = '' then Exit(Acc);
   if Acc = '' then Exit(Section);
   Result := Acc + SectionSep + Section;
+end;
+
+function ExtractGoalFromPlanFile: string; overload;
+begin
+  Result := ExtractGoalFromPlanFile(GetHome);
+end;
+
+function ExtractGoalFromPlanFile(const HomeOverride: string): string; overload;
+{ Phase 3 helper: parse the "## Goal" section of <home>/workspace/PLAN.md
+  and return the first content line as the Ralph objective. The planner
+  directive constrains plans to open the Goal section with a single-
+  sentence verb-prefixed objective, so the first non-empty, non-heading
+  line after the header IS the objective.
+
+  Tolerances:
+    - Heading can be "## Goal", "## Goal:", "##Goal", "## GOAL", etc.
+      (case-insensitive on the word, optional trailing colon and
+      whitespace).
+    - Blank lines between heading and content are skipped.
+    - The objective itself may be wrapped across multiple lines; we
+      return only the first line (the planner is opinionated on
+      single-sentence objectives, and the rest is treated as
+      explanation).
+
+  Returns '' for any read failure or missing/empty Goal section. }
+const
+  HeaderToken = 'GOAL';
+var
+  Path, Body, Line, Stripped: string;
+  Lines: TStringList;
+  i: Integer;
+  InGoal: Boolean;
+
+  function StripHeader(const S: string): string;
+  { Strip leading '#' chars + whitespace + a trailing colon, uppercase
+    what's left. Used to recognise heading lines as "## Goal" without
+    being picky about exact formatting. }
+  var
+    Trimmed: string;
+  begin
+    Trimmed := Trim(S);
+    while (Trimmed <> '') and (Trimmed[1] = '#') do
+      Delete(Trimmed, 1, 1);
+    Trimmed := Trim(Trimmed);
+    if (Trimmed <> '') and (Trimmed[Length(Trimmed)] = ':') then
+      SetLength(Trimmed, Length(Trimmed) - 1);
+    Result := UpperCase(Trim(Trimmed));
+  end;
+
+  function IsHeading(const S: string): Boolean;
+  begin
+    Result := (Trim(S) <> '') and (Trim(S)[1] = '#');
+  end;
+
+begin
+  Result := '';
+  Path := JoinPath(JoinPath(HomeOverride, 'workspace'), 'PLAN.md');
+  if not FileExists(Path) then Exit;
+  try
+    Body := ReadFileText(Path);
+  except
+    on E: Exception do
+    begin
+      LogWarn('plan-goal: PLAN.md unreadable (%s)', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Trim(Body) = '' then Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := Body;
+    InGoal := False;
+    for i := 0 to Lines.Count - 1 do
+    begin
+      Line := Lines[i];
+      Stripped := Trim(Line);
+
+      if not InGoal then
+      begin
+        { Looking for the Goal header. }
+        if IsHeading(Line) and (StripHeader(Line) = HeaderToken) then
+          InGoal := True;
+      end
+      else
+      begin
+        { In the Goal section. Skip blanks; on the first non-blank
+          non-heading line, return its trimmed text. A heading here
+          means we walked off the end of the Goal section without
+          finding content (e.g., "## Goal\n## Files"); give up. }
+        if Stripped = '' then Continue;
+        if IsHeading(Line) then Exit;
+        Result := Stripped;
+        Exit;
+      end;
+    end;
+  finally
+    Lines.Free;
+  end;
 end;
 
 function BuildActivePlanSection(NoPlan: Boolean; Mode: TPasClawMode): string;

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -84,11 +84,28 @@ function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
   block is prepended so the model knows mutating tools will refuse and
   it should produce analysis / a proposed plan rather than calling
   write/exec tools. The dispatch gate in PasClaw.Tools.ToolLoop is the
-  authority -- the prompt block is belt-and-braces / model-honesty. }
+  authority -- the prompt block is belt-and-braces / model-honesty.
+
+  NoPlan -- opt out of the workspace/PLAN.md auto-pickup. When False
+  (default) and Mode = pmBuild, an "## Active Plan" section is read
+  from <home>/workspace/PLAN.md and injected as authoritative guidance.
+  Plan-mode runs always skip this section -- Cmd.Plan handles existing
+  PLAN.md via a planner --system directive, so auto-pickup would
+  double-inject. }
 function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
                            ToolsEnabled: Boolean;
                            const TaskHint: string;
-                           Mode: TPasClawMode): string; overload;
+                           Mode: TPasClawMode;
+                           NoPlan: Boolean = False): string; overload;
+
+{ Active-plan section -- reads <home>/workspace/PLAN.md (the output of
+  a prior `pasclaw plan`) and returns it wrapped in a "## Active Plan"
+  block for injection into the build's system prompt. Returns '' when
+  NoPlan is True (opt-out), when Mode = pmPlan (plan command handles
+  its own PLAN.md context via --system), or when PLAN.md is missing /
+  unreadable / empty. Exposed for unit tests; production callers go
+  through BuildSystemPrompt. }
+function BuildActivePlanSection(NoPlan: Boolean; Mode: TPasClawMode): string;
 
 { Locate the nearest AGENTS.md walking up from StartDir to the
   filesystem root, stopping at the first git working tree boundary
@@ -121,6 +138,7 @@ implementation
 uses
   Classes,
   PasClaw.Utils,
+  PasClaw.Logger,         { LogWarn for BuildActivePlanSection's PLAN.md read failures }
   PasClaw.Skills.Loader,
   PasClaw.Agent.Orient,   { task-aware MEMORY slicing (Cfg.OrientTaskAware) }
   PasClaw.MCP.Disclosure; { deferred-tools section (Cfg.MCPProgressiveDisclosure) }
@@ -498,6 +516,81 @@ begin
   Result := Acc + SectionSep + Section;
 end;
 
+function BuildActivePlanSection(NoPlan: Boolean; Mode: TPasClawMode): string;
+{ Phase 2 of the `pasclaw plan` / `pasclaw build` pairing. Reads
+  <home>/workspace/PLAN.md (the output of a prior `pasclaw plan`
+  run) and injects it as authoritative guidance for the build.
+
+  Suppressed in three cases:
+    1. NoPlan True -- operator passed --no-plan to opt out.
+    2. Mode = pmPlan -- the planner command's own --system directive
+       handles existing PLAN.md as "revise" context; auto-pickup here
+       would double-inject the same body and confuse the model.
+    3. PLAN.md is missing or unreadable -- the auto-pickup is
+       opportunistic, not required.
+
+  Stale guidance: when PLAN.md hasn't been touched in over 24h, a
+  "(stale: N hours)" note is appended to the section header so the
+  model treats it with appropriate skepticism. We DO NOT block the
+  load -- cog / non-TTY runs would deadlock on an interactive prompt,
+  and an operator who wanted to ignore it would pass --no-plan or
+  archive the file. }
+const
+  StaleHours = 24.0;
+var
+  Path, Body, StaleNote: string;
+  AgeRaw: Integer;
+  Hours: Double;
+begin
+  Result := '';
+  if NoPlan then Exit;
+  if Mode = pmPlan then Exit;
+
+  Path := JoinPath(JoinPath(GetHome, 'workspace'), 'PLAN.md');
+  if not FileExists(Path) then Exit;
+  try
+    Body := Trim(ReadFileText(Path));
+  except
+    on E: Exception do
+    begin
+      { Surface the read failure to the log but don't fail the agent
+        run -- PLAN.md being unreadable shouldn't break an
+        otherwise-valid build. }
+      LogWarn('build: PLAN.md present but unreadable (%s); skipping ' +
+              'active-plan section', [E.Message]);
+      Exit;
+    end;
+  end;
+  if Body = '' then Exit;
+
+  StaleNote := '';
+  AgeRaw := FileAge(Path);
+  if AgeRaw <> -1 then
+  begin
+    try
+      Hours := (Now - FileDateToDateTime(AgeRaw)) * 24.0;
+      if Hours > StaleHours then
+        StaleNote := Format(' (stale: %.0f hours old -- ' +
+                            'pass --no-plan to ignore PLAN.md)', [Hours]);
+    except
+      { FileDateToDateTime can raise on a corrupt time stamp on some
+        filesystems. Fall through with no stale note rather than
+        failing the whole section. }
+      StaleNote := '';
+    end;
+  end;
+
+  Result :=
+    '## Active Plan' + StaleNote + sLineBreak + sLineBreak +
+    'A prior `pasclaw plan` run produced the plan below at ' +
+    '`' + Path + '`. Treat it as authoritative guidance for what to ' +
+    'do this turn. The plan''s `## Goal` section opens with a single-' +
+    'sentence objective -- that''s the success criterion. Pass ' +
+    '`--no-plan` on the build command to ignore PLAN.md entirely.' +
+    sLineBreak + sLineBreak +
+    Body;
+end;
+
 function BuildPlanModeSection: string;
 begin
   (* The plan-safe / plan-refused lists must match the actual
@@ -546,7 +639,8 @@ end;
 
 function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
                            ToolsEnabled: Boolean; const TaskHint: string;
-                           Mode: TPasClawMode): string;
+                           Mode: TPasClawMode;
+                           NoPlan: Boolean = False): string;
 begin
   Result := '';
   if Mode = pmPlan then
@@ -562,6 +656,12 @@ begin
     ToolsEnabled): even a chat-only session benefits from "in this
     project, prefer X". }
   Result := AppendSection(Result, BuildProjectRulesSection);
+  { Active plan auto-pickup. Emitted between project rules and skills
+    so the plan can reference both above it (memory + AGENTS.md) and
+    below (skills, deferred MCP tools, behaviour rules). pmPlan mode
+    suppresses this -- Cmd.Plan handles existing PLAN.md via its
+    --system directive, not auto-pickup. See BuildActivePlanSection. }
+  Result := AppendSection(Result, BuildActivePlanSection(NoPlan, Mode));
   { Skills are only callable when the tool registry was actually built.
     --no-tools (and component UseTools=False) bypass RegisterSkills, so
     advertising the catalog would be a lie. }

--- a/src/pkg/tools/PasClaw.Tools.PlanWrite.pas
+++ b/src/pkg/tools/PasClaw.Tools.PlanWrite.pas
@@ -1,0 +1,216 @@
+(*
+  PasClaw.Tools.PlanWrite - the `plan_write` tool used by `pasclaw plan`.
+
+  Why this exists
+  ===============
+
+  `pasclaw plan` runs the agent in `pmPlan` mode (read-only safety gate
+  -- no fs_write, no shell mutations, no edits). For the command to
+  produce a deliverable, SOMETHING has to write the model's finalized
+  plan to `<PASCLAW_HOME>/workspace/PLAN.md`. Two options:
+
+    a) Have the wrapper capture stdout and tee to PLAN.md. Fragile --
+       FPC's Output redirection is finicky, and the agent prints
+       progress alongside the final reply so we'd have to parse out
+       the plan text.
+
+    b) Give the model a tool that writes specifically to PLAN.md.
+       Transactional, transparent, the model decides when the plan
+       is "done" by calling the tool. This is the chosen path.
+
+  The tool is registered ONLY when `Cmd.Agent` builds the registry
+  with `EnablePlanWrite := True`, which happens iff `--mode plan` was
+  passed. `pasclaw agent --mode plan` (without the `plan` subcommand)
+  also gets the tool -- it's a sensible default for plan-mode
+  sessions.
+
+  Why category tcReadOnly even though it writes
+  ============================================
+
+  `pmPlan`'s dispatch gate refuses tcMutating tools. `plan_write`
+  writes exactly one file at a fixed path (workspace/PLAN.md) -- it's
+  meta-state describing intent, not project code. Marking it
+  tcReadOnly lets it pass the plan-mode gate without weakening the
+  gate's protection on real mutation tools (fs_write, shell_exec,
+  fs_edit_hashline, etc.) which stay refused.
+
+  This is the only tool in the codebase that's labeled tcReadOnly
+  while writing to disk. The justification is the scope: a single
+  hard-coded file with no path argument. The tool cannot be turned
+  into a general-purpose write primitive by a model crafting clever
+  arguments -- the path is not parameterised.
+
+  Sandbox interaction
+  ====================
+
+  Workspace sandbox (PasClaw.Tools.Sandbox) still applies on the
+  write, so an operator's `sandbox.restrict_to_workspace` setting
+  is honoured. The plan file lives under <home>/workspace/ which
+  IS the workspace root, so the sandbox check passes in the normal
+  case. Operators who've narrowed the workspace below the home dir
+  get a sandbox-refused error and the model retries with the
+  configured workspace.
+*)
+unit PasClaw.Tools.PlanWrite;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry;
+
+procedure RegisterPlanWriteTool(R: TToolRegistry);
+
+{ Returns the canonical absolute path the tool writes to.
+  <PASCLAW_HOME>/workspace/PLAN.md. Exposed for tests and for
+  Cmd.Plan's post-run sanity check. }
+function ResolvePlanPath: string;
+
+const
+  PLAN_FILENAME = 'PLAN.md';
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Logger,
+  PasClaw.Tools.Sandbox;
+
+function ResolvePlanPath: string;
+begin
+  Result := JoinPath(JoinPath(GetHome, 'workspace'), PLAN_FILENAME);
+end;
+
+function ParseContentArg(const ArgsJSON: string;
+                         out Content: string;
+                         out ErrMsg: string): Boolean;
+var
+  Obj: TJsonObject;
+begin
+  Result := False;
+  Content := '';
+  ErrMsg := '';
+  if Trim(ArgsJSON) = '' then
+  begin
+    ErrMsg := 'plan_write: missing arguments';
+    Exit;
+  end;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then
+    begin
+      ErrMsg := 'plan_write: invalid JSON arguments';
+      Exit;
+    end;
+    try
+      if not Obj.Has('content') then
+      begin
+        { Treat a missing `content` key the same way fs_write does -- it
+          almost always means the provider truncated mid-tool_call. The
+          model gets the error and retries on the next iteration; we do
+          NOT silently write an empty plan. }
+        ErrMsg := 'plan_write: missing required argument `content` ' +
+                  '(provider may have truncated; please retry with the ' +
+                  'full plan body)';
+        Exit;
+      end;
+      Content := Obj.GetStr('content', '');
+    finally
+      Obj.Free;
+    end;
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'plan_write: ' + E.ClassName + ': ' + E.Message;
+      Exit;
+    end;
+  end;
+  Result := True;
+end;
+
+function Tool_PlanWrite(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Content, PlanPath, Reason: string;
+begin
+  ErrMsg := '';
+  Result := '';
+  if not ParseContentArg(ArgsJSON, Content, ErrMsg) then Exit;
+
+  PlanPath := ResolvePlanPath;
+
+  { Sandbox check: even though the path is hard-coded, the operator
+    may have narrowed the workspace below the default. Surface the
+    refusal to the model so it can ask the operator to widen it. }
+  if not CanWritePath(PlanPath, Reason) then
+  begin
+    ErrMsg := 'plan_write: refused by sandbox: ' + Reason;
+    Exit;
+  end;
+
+  if not ForceDirectories(ExtractFilePath(PlanPath)) then
+  begin
+    ErrMsg := 'plan_write: cannot create directory for ' + PlanPath;
+    Exit;
+  end;
+
+  try
+    WriteFileText(PlanPath, Content);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'plan_write: write failed: ' + E.ClassName + ': ' + E.Message;
+      Exit;
+    end;
+  end;
+
+  LogInfo('plan_write: wrote %d byte(s) to %s',
+          [Length(Content), PlanPath]);
+  Result := Format('wrote %d byte(s) to %s', [Length(Content), PlanPath]);
+end;
+
+const
+  PlanWriteDesc =
+    'Save the finalized plan to workspace/PLAN.md. ONE call per ' +
+    '`pasclaw plan` run -- when the plan is complete, call this once ' +
+    'with the full markdown body and end your turn. Content should ' +
+    'follow the structure: ## Goal, ## Files, ## Steps, ' +
+    '## Open questions, ## Risks. The file path is hard-coded; do not ' +
+    'pass a path argument.';
+
+  PlanWriteSchema =
+    '{"type":"object","properties":{' +
+    '"content":{"type":"string","description":"Full markdown body of the plan."}' +
+    '},"required":["content"]}';
+
+procedure RegisterPlanWriteTool(R: TToolRegistry);
+var
+  T: TTool;
+begin
+  if R = nil then Exit;
+  FillChar(T, SizeOf(T), 0);
+  T.Name        := 'plan_write';
+  T.Description := PlanWriteDesc;
+  T.Schema      := PlanWriteSchema;
+  T.Handler     := Tool_PlanWrite;
+  T.HandlerObj  := nil;
+  T.IsCore      := False;
+  { tcReadOnly -- see unit comment. Passes the pmPlan dispatch gate
+    even though the handler writes a file. Justified by the fixed
+    target path; the tool is not a general write primitive. }
+  T.Category    := tcReadOnly;
+  R.Register(T);
+  LogInfo('plan_write: registered (plan mode)');
+end;
+
+end.

--- a/src/tests/active_plan_section_tests.pas
+++ b/src/tests/active_plan_section_tests.pas
@@ -1,0 +1,131 @@
+program active_plan_section_tests;
+(*
+  Pins BuildActivePlanSection's three gating cases (NoPlan opt-out,
+  pmPlan suppression, missing file) and the happy-path injection of
+  PLAN.md as system-prompt context. Belt-and-braces guard against
+  someone refactoring BuildSystemPrompt and silently dropping the
+  Phase-2 wiring.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Config,        { GetHome }
+  PasClaw.Utils,
+  PasClaw.Agent.Mode,
+  PasClaw.Agent.Prompt;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin if Pos(Needle, Haystack) = 0 then
+  Fail_(Msg + ' (no "' + Needle + '" in section)'); end;
+
+procedure AssertEmpty(const S, Msg: string);
+begin if Trim(S) <> '' then Fail_(Msg + ' (got "' + S + '")'); end;
+
+procedure WritePlanInHome(const Body: string);
+var
+  Path, Dir: string;
+begin
+  Dir := JoinPath(GetHome, 'workspace');
+  ForceDirectories(Dir);
+  Path := JoinPath(Dir, 'PLAN.md');
+  WriteFileText(Path, Body);
+end;
+
+procedure DeletePlanInHome;
+var
+  Path: string;
+begin
+  Path := JoinPath(JoinPath(GetHome, 'workspace'), 'PLAN.md');
+  if FileExists(Path) then SysUtils.DeleteFile(Path);
+end;
+
+procedure TestEmptyWhenNoPlanTrue;
+var
+  Section: string;
+begin
+  WritePlanInHome('## Goal' + sLineBreak + 'Test goal.' + sLineBreak);
+  Section := BuildActivePlanSection({NoPlan=}True, pmBuild);
+  AssertEmpty(Section, 'NoPlan=True must suppress the section');
+  WriteLn('  ok: NoPlan=True suppresses (opt-out)');
+end;
+
+procedure TestEmptyWhenPlanMode;
+var
+  Section: string;
+begin
+  WritePlanInHome('## Goal' + sLineBreak + 'Test goal.' + sLineBreak);
+  Section := BuildActivePlanSection({NoPlan=}False, pmPlan);
+  AssertEmpty(Section, 'Mode=pmPlan must suppress the section ' +
+                       '(Cmd.Plan handles PLAN.md via --system)');
+  WriteLn('  ok: pmPlan mode suppresses (planner handles it)');
+end;
+
+procedure TestEmptyWhenPlanMissing;
+var
+  Section: string;
+begin
+  DeletePlanInHome;
+  Section := BuildActivePlanSection({NoPlan=}False, pmBuild);
+  AssertEmpty(Section, 'missing PLAN.md must produce empty section');
+  WriteLn('  ok: missing PLAN.md -> empty');
+end;
+
+procedure TestInjectsBody;
+var
+  Section: string;
+begin
+  WritePlanInHome('## Goal' + sLineBreak +
+                  'Add a flag.' + sLineBreak + sLineBreak +
+                  '## Files' + sLineBreak +
+                  '- src/main.pas' + sLineBreak);
+  Section := BuildActivePlanSection({NoPlan=}False, pmBuild);
+  AssertTrue(Section <> '', 'happy path produces a non-empty section');
+  AssertContains(Section, '## Active Plan',
+                 'section starts with the Active Plan header');
+  AssertContains(Section, 'Add a flag.',
+                 'section includes the plan body verbatim');
+  AssertContains(Section, '## Files',
+                 'section preserves plan subheadings');
+  AssertContains(Section, '--no-plan',
+                 'section mentions the opt-out flag');
+  WriteLn('  ok: happy path injects PLAN.md body');
+end;
+
+procedure TestStaleNoteWhenOver24h;
+var
+  Section: string;
+  Path: string;
+begin
+  WritePlanInHome('## Goal' + sLineBreak + 'Stale plan.' + sLineBreak);
+  Path := JoinPath(JoinPath(GetHome, 'workspace'), 'PLAN.md');
+  { Backdate mtime to 48h ago. FileSetDate takes a Unix-style age int. }
+  FileSetDate(Path, DateTimeToFileDate(Now - 2.0));
+  Section := BuildActivePlanSection({NoPlan=}False, pmBuild);
+  AssertTrue(Section <> '', 'stale PLAN.md still loads');
+  AssertContains(Section, 'stale:',
+                 'stale plan picks up the "stale:" note');
+  WriteLn('  ok: stale (>24h) PLAN.md gets a stale: note');
+end;
+
+begin
+  { The Makefile sets PASCLAW_HOME to a fresh tempdir before invoking
+    this binary, so each test run is isolated from the operator's
+    real config. GetHome reads $PASCLAW_HOME and returns the
+    Makefile-supplied path. }
+  TestEmptyWhenNoPlanTrue;
+  TestEmptyWhenPlanMode;
+  TestEmptyWhenPlanMissing;
+  TestInjectsBody;
+  TestStaleNoteWhenOver24h;
+  WriteLn('ok - active plan section tests passed');
+end.

--- a/src/tests/active_plan_section_tests.pas
+++ b/src/tests/active_plan_section_tests.pas
@@ -101,6 +101,93 @@ begin
   WriteLn('  ok: happy path injects PLAN.md body');
 end;
 
+procedure TestGoalExtractHappyPath;
+var
+  Goal: string;
+begin
+  WritePlanInHome(
+    '## Goal' + sLineBreak +
+    'Add a --version flag to the CLI.' + sLineBreak + sLineBreak +
+    '## Files' + sLineBreak +
+    '- src/cmd/PasClaw.Cmd.Root.pas' + sLineBreak);
+  Goal := ExtractGoalFromPlanFile;
+  AssertTrue(Goal = 'Add a --version flag to the CLI.',
+             'Goal extraction picks the first content line ' +
+             '(got "' + Goal + '")');
+  WriteLn('  ok: ExtractGoalFromPlanFile happy path');
+end;
+
+procedure TestGoalExtractColonHeader;
+var
+  Goal: string;
+begin
+  { Some models write "## Goal:" instead of "## Goal". The parser
+    should tolerate the trailing colon. }
+  WritePlanInHome(
+    '## Goal:' + sLineBreak +
+    'Tighten config validation.' + sLineBreak);
+  Goal := ExtractGoalFromPlanFile;
+  AssertTrue(Goal = 'Tighten config validation.',
+             'Goal heading with trailing colon parses (got "' + Goal + '")');
+  WriteLn('  ok: ExtractGoalFromPlanFile tolerates "## Goal:"');
+end;
+
+procedure TestGoalExtractSkipsBlankLines;
+var
+  Goal: string;
+begin
+  WritePlanInHome(
+    '## Goal' + sLineBreak +
+    sLineBreak +
+    sLineBreak +
+    'Build it.' + sLineBreak);
+  Goal := ExtractGoalFromPlanFile;
+  AssertTrue(Goal = 'Build it.',
+             'Goal extraction skips blank lines between header and ' +
+             'content (got "' + Goal + '")');
+  WriteLn('  ok: ExtractGoalFromPlanFile skips blanks');
+end;
+
+procedure TestGoalExtractEmptyWhenMissing;
+var
+  Goal: string;
+begin
+  DeletePlanInHome;
+  Goal := ExtractGoalFromPlanFile;
+  AssertEmpty(Goal, 'missing PLAN.md returns empty');
+  WriteLn('  ok: ExtractGoalFromPlanFile returns "" when PLAN.md missing');
+end;
+
+procedure TestGoalExtractEmptyWhenNoGoalSection;
+var
+  Goal: string;
+begin
+  WritePlanInHome(
+    '## Files' + sLineBreak +
+    '- foo.pas' + sLineBreak +
+    sLineBreak +
+    '## Steps' + sLineBreak +
+    '1. Do the thing.' + sLineBreak);
+  Goal := ExtractGoalFromPlanFile;
+  AssertEmpty(Goal, 'PLAN.md without a "## Goal" section returns ""');
+  WriteLn('  ok: ExtractGoalFromPlanFile returns "" when no Goal section');
+end;
+
+procedure TestGoalExtractEmptyWhenHeaderHasNoContent;
+var
+  Goal: string;
+begin
+  { ## Goal followed by ## Files with no content between -- parser
+    should bail rather than picking up the next heading as the goal. }
+  WritePlanInHome(
+    '## Goal' + sLineBreak +
+    '## Files' + sLineBreak +
+    '- foo.pas' + sLineBreak);
+  Goal := ExtractGoalFromPlanFile;
+  AssertEmpty(Goal, 'PLAN.md with empty Goal section returns ""');
+  WriteLn('  ok: ExtractGoalFromPlanFile returns "" when Goal is empty');
+end;
+
 procedure TestStaleNoteWhenOver24h;
 var
   Section: string;
@@ -127,5 +214,11 @@ begin
   TestEmptyWhenPlanMissing;
   TestInjectsBody;
   TestStaleNoteWhenOver24h;
-  WriteLn('ok - active plan section tests passed');
+  TestGoalExtractHappyPath;
+  TestGoalExtractColonHeader;
+  TestGoalExtractSkipsBlankLines;
+  TestGoalExtractEmptyWhenMissing;
+  TestGoalExtractEmptyWhenNoGoalSection;
+  TestGoalExtractEmptyWhenHeaderHasNoContent;
+  WriteLn('ok - active plan section + goal extract tests passed');
 end.


### PR DESCRIPTION
## Summary

Five-phase build-out of the `pasclaw plan` / `pasclaw build` pairing. The goal: structured planning as a deliverable, with the plan flowing automatically into a subsequent build (either as system-prompt context or as a Ralph-judge objective).

### Workflow

Local:
```bash
pasclaw plan -d "Add a --version flag"   # writes workspace/PLAN.md
pasclaw build -d "Add a --version flag"  # auto-picks up PLAN.md
```

With judge-driven completion:
```bash
pasclaw build -d "Add a --version flag" --goal   # Ralph loop using PLAN.md's "## Goal"
```

On the Replicate cog (`cog-build`), the same pipeline via a `mode` Input.

## Five phases

### Phase 1 — `pasclaw plan` + `plan_write` tool
- New `pasclaw plan -d "<task>"` subcommand mirroring `pasclaw build`'s lifecycle (workspace.zip handshake, PASCLAW_HOME orchestration)
- Forces `pmPlan` mode (read-only safety gate). Mutating tools refused at dispatch
- New `plan_write` tool (`PasClaw.Tools.PlanWrite`) — the only `tcReadOnly`-labelled tool that writes to disk. Hard-coded target `workspace/PLAN.md`; can't be turned into a general write primitive
- Planner directive in `--system` requires the structure `## Goal / ## Files / ## Steps / ## Open questions / ## Risks`
- Incremental updates: when PLAN.md already exists, model gets it as `## Existing Plan` context with a "revise / extend, don't replace" directive

### Phase 2 — `pasclaw build` PLAN.md auto-pickup
- `BuildActivePlanSection` reads `workspace/PLAN.md` and injects as `## Active Plan` system-prompt context
- Three suppressions: `--no-plan` opt-out, `Mode = pmPlan` (planner handles it via `--system`), missing/empty file
- Stale check: PLAN.md older than 24h appends a `(stale: N hours)` note to the section header
- After successful build, PLAN.md is archived to `workspace/memory/plans/<timestamp>.md` (skipped on non-zero agent exit; the plan stays relevant for the retry)

### Phase 3 — `pasclaw build --goal` (Ralph judge loop)
- `ExtractGoalFromPlanFile` parses PLAN.md's `## Goal` section. Tolerates `## Goal`, `## Goal:`, blank-line separation. Two overloads (default uses `GetHome`; `HomeOverride` for Cmd.Build because `libc_setenv`'s PASCLAW_HOME isn't always visible to a same-process `GetEnvironmentVariable` on FPC)
- `RunSingleTurnGoalDriven` in `Cmd.Agent` wraps the per-iteration `RunToolLoop` in `TGoalRunner` — same Ralph judge-loop machinery the interactive `/goal` command uses
- `TAgentArgs.GoalObjective` field + `--goal-objective <text>` flag for direct entry
- Exit codes: MET / BUDGET-EXHAUSTED → 0, FAILED / ABORTED → 1
- `Cmd.Build --goal` reads PLAN.md, parses Goal, forwards `--goal-objective`. Fails fast with clear error if PLAN.md missing or no parseable Goal section

### Phase 4 — cog-build `mode` Input
- 4-choice Input on `cog-build/predict.py`:

| `mode` | Commands |
|---|---|
| `build` (default) | `pasclaw build` |
| `plan` | `pasclaw plan` |
| `plan build` | `pasclaw plan` → `pasclaw build` (chained via intermediate workspace zip) |
| `plan build goal` | `pasclaw plan` → `pasclaw build --goal` |

- `invoke_pasclaw()` helper extracts the subprocess call with consistent error surfacing
- Intermediate workspace zip in scratch dir carries PLAN.md between the two subprocesses

### Phase 5 — `docs/plan.md`
End-to-end walkthrough covering the workflow, both commands' new flags, the cog matrix with "when to use which mode" guidance, file layout, how `/goal` ties in, and implementation notes (the `tcReadOnly`-but-writes `plan_write` rationale, the FPC env-var workaround, deliberate omissions in the goal-driver).

## Test plan

- [x] `make clean && make` passes
- [x] `make test-active-plan-section` passes all 11 cases (5 BuildActivePlanSection gating + happy-path + stale; 6 ExtractGoalFromPlanFile parser cases)
- [x] `python3 -c "import ast; ast.parse(open('cog-build/predict.py').read())"` passes
- [x] `pasclaw plan -h`, `pasclaw build -h --goal` print expected help
- [x] `pasclaw plan` without `-d` exits 2 with clear error
- [x] `pasclaw plan -d X --mode build` refused (mode-forced gate)
- [x] `pasclaw build --goal` without PLAN.md exits 1 with "no parseable Goal section" error
- [x] `pasclaw build --goal` with valid PLAN.md extracts and forwards the objective
- [x] `pasclaw agent --goal-objective "X" -m "go"` drives the Ralph loop without going through Cmd.Build
- [ ] Manual: full end-to-end run against a real provider (follow-up — requires API key in a non-sandboxed environment)
- [ ] Manual: cog `plan build goal` round-trip against Replicate (follow-up — needs a cog runtime)

## Files

| File | Status |
|---|---|
| `src/pkg/tools/PasClaw.Tools.PlanWrite.pas` | new |
| `src/cmd/PasClaw.Cmd.Plan.pas` | new |
| `src/cmd/PasClaw.Cmd.Agent.pas` | modified (NewBuiltinRegistry param, --no-plan, --goal-objective, RunSingleTurnGoalDriven) |
| `src/cmd/PasClaw.Cmd.Build.pas` | modified (ArchivePlanMaybe, --goal, --goal-max-iters) |
| `src/cmd/PasClaw.Cmd.Root.pas` | modified (registers `plan` subcommand) |
| `src/pkg/agent/PasClaw.Agent.Prompt.pas` | modified (BuildActivePlanSection, ExtractGoalFromPlanFile, NoPlan param) |
| `src/tests/active_plan_section_tests.pas` | new (11 cases) |
| `Makefile` | new test target |
| `cog-build/predict.py` | modified (mode Input + dispatch) |
| `docs/plan.md` | new |

## Risks worth flagging

- **`plan_write` as `tcReadOnly` despite writing**: justified by the hard-coded target path (cannot be turned into a general primitive), but it IS the only tool labelled this way. Future reviewers should understand the rationale before adding others.
- **`libc_setenv` / `GetEnvironmentVariable` mismatch**: hit when wiring `ExtractGoalFromPlanFile` — the same issue likely affects other places in the codebase that depend on cross-routine env propagation. Fixed locally with an explicit `HomeOverride` parameter; broader audit could be a follow-up.
- **`RunSingleTurnGoalDriven` deliberate omissions**: no per-iteration session persistence, no skill distiller. Both have unclear semantics inside a goal loop. Documented in `docs/plan.md` so the gap is visible to future contributors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_