### PR TITLE
relay: V1 provider — pull-worker pattern, queue + provider + catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,13 @@ test-active-plan-section: | $(BUILDDIR)
 	  trap "rm -rf $$PASCLAW_HOME" EXIT ; \
 	  PASCLAW_HOME=$$PASCLAW_HOME $(BUILDDIR)/active_plan_section_tests
 
+# Relay queue + provider envelope tests. Hermetic -- in-process
+# synchronisation only; no HTTP, no real workers.
+test-relay-queue: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/relay_queue_tests.pas -o$(BUILDDIR)/relay_queue_tests
+	@$(BUILDDIR)/relay_queue_tests
+
 # PasClaw.MCP.Disclosure -- Hermes-style progressive disclosure + Claude
 # Code-style tool_search for MCP tools. Hermetic: synthetic TTool records
 # only, no actual MCP server started.

--- a/docs/providers-relay.md
+++ b/docs/providers-relay.md
@@ -28,10 +28,15 @@ Three flows this unblocks that none of the existing catalog providers do:
 - Non-streaming. Worker returns one POST with the full completion.
   Streaming (chunks back through PasClaw to the agent loop's caller) is
   a V2 feature.
-- Tool calls are **text-parsed** from the model's reply. The worker
-  serves raw text; PasClaw's existing tool-call extraction does the
-  rest. Smaller local models without strong tool-calling capability get
-  text-only chat.
+- Tool calls flow through the response envelope's **`tool_calls`
+  array** (OpenAI shape: `id`, `type`, `function.name`,
+  `function.arguments`). Workers using libraries that emit structured
+  tool calls (WebLLM, mlc-llm, llama.cpp grammar mode) populate this;
+  workers that emit only text omit the array and the agent gets
+  text-only chat through the relay. There is **no text-extraction
+  fallback** -- worker libraries that can't emit structured output
+  yield text-only relay sessions. Most modern small-model runtimes
+  support structured tool calls; this is the right floor for V1.
 - Capability matching is **exact case-insensitive string match** on the
   model id. Glob / semver matching is V2.
 - Single-process. One in-process queue, one set of workers.
@@ -160,12 +165,31 @@ on receipt.
   "usage": {                       // optional; best-effort token accounting
     "prompt_tokens":     47,
     "completion_tokens": 12
-  }
+  },
+  "tool_calls": [                  // optional; OpenAI shape. Omit when the model
+                                   // produced only text (e.g., smaller models
+                                   // without tool-calling support). Workers
+                                   // that support tool calling -- WebLLM,
+                                   // mlc-llm, llama.cpp grammar mode --
+                                   // populate this; PasClaw forwards verbatim
+                                   // into TLLMResponse.ToolCalls and
+                                   // RunToolLoop dispatches.
+    {
+      "id":   "call_0",
+      "type": "function",
+      "function": {
+        "name":      "fs_read",
+        "arguments": "{\"path\":\"foo.pas\"}"
+      }
+    }
+  ]
 }
 ```
 
 Workers without a token counter can omit `usage`; PasClaw estimates via
-its tokenizer if needed.
+its tokenizer if needed. Workers without tool-calling support omit
+`tool_calls` entirely and the agent gets text-only chat through the
+relay.
 
 ## Multi-worker semantics (this is important)
 
@@ -247,6 +271,10 @@ sees the relay layer.
         content:       completion.choices[0].message.content,
         finish_reason: completion.choices[0].finish_reason,
         usage:         completion.usage,
+        // Forward tool_calls if WebLLM produced them. PasClaw's
+        // RunToolLoop dispatches verbatim. Omit (or null) for
+        // text-only models.
+        tool_calls:    completion.choices[0].message.tool_calls,
       }),
     });
   };

--- a/docs/providers-relay.md
+++ b/docs/providers-relay.md
@@ -1,0 +1,329 @@
+# Relay provider (pull-worker pattern)
+
+The relay provider inverts the usual PasClaw → LLM-API relationship.
+Instead of PasClaw making outbound HTTP calls to a hosted LLM, an
+**external worker app** (a WebGPU browser tab, a phone with mlc-llm, a
+desktop with llama.cpp, anything that speaks HTTP+SSE) connects
+**inbound** to PasClaw's gateway, advertises which models it can serve,
+pulls pending inference requests off PasClaw's queue, runs them on its
+own hardware, and POSTs results back.
+
+## Why
+
+Three flows this unblocks that none of the existing catalog providers do:
+
+- **WebGPU on your laptop without exposing ports.** Open a browser tab
+  with WebLLM / Transformers.js / mlc-llm pointing at your PasClaw URL.
+  The tab connects outbound; PasClaw never reaches the laptop. Closes
+  when you close the tab.
+- **Cog / Replicate-hosted PasClaw served by your phone.** PasClaw
+  runs on Replicate (no GPU), inference happens on a phone in your
+  pocket. The cog never talks to a paid LLM API.
+- **Share a home GPU across devices.** Each device runs its own
+  PasClaw; one home server runs the queue; the GPU machine connects as
+  a worker.
+
+## V1 scope
+
+- Non-streaming. Worker returns one POST with the full completion.
+  Streaming (chunks back through PasClaw to the agent loop's caller) is
+  a V2 feature.
+- Tool calls are **text-parsed** from the model's reply. The worker
+  serves raw text; PasClaw's existing tool-call extraction does the
+  rest. Smaller local models without strong tool-calling capability get
+  text-only chat.
+- Capability matching is **exact case-insensitive string match** on the
+  model id. Glob / semver matching is V2.
+- Single-process. One in-process queue, one set of workers.
+
+## Wire protocol
+
+Two HTTP endpoints on `pasclaw gateway`, both auth'd with the existing
+`PASCLAW_GATEWAY_TOKEN`:
+
+### `GET /v1/relay/poll` — SSE stream
+
+The worker opens this once and keeps it alive. Each `data:` event ships
+one pending inference request.
+
+```http
+GET /v1/relay/poll HTTP/1.1
+Authorization: Bearer <PASCLAW_GATEWAY_TOKEN>
+Accept: text/event-stream
+X-Relay-Worker-Id: web-tab-abc123
+X-Relay-Capabilities: llama-3.2-3b-instruct,phi-3-mini
+```
+
+Response stream:
+
+```
+data: {"id":"req_...", "model":"llama-3.2-3b-instruct", "messages":[...], "tools":[...], "options":{"max_tokens":8192,"system_prompt":"..."}}
+
+data: {"id":"req_...", ...}
+```
+
+The first poll connection acts as the worker's **registration**: the
+`X-Relay-Worker-Id` is the worker's identity, and `X-Relay-Capabilities`
+is the comma-separated list of model ids it can serve. Re-connecting
+with the same worker id updates capabilities (so a worker page reload
+with a different model swap is transparent).
+
+A worker with empty capabilities (no header, or empty string) is
+treated as a **wildcard** — it accepts any model. Useful for "I'll
+serve whatever you throw at me" workers without explicit capability
+tracking.
+
+The queue does first-come-first-served dispatch: pending requests go to
+the first connected worker whose capabilities match the request's
+model. If no matching worker is connected, the request stays in the
+queue until one shows up or the caller's timeout expires.
+
+### `POST /v1/relay/respond/:id` — worker submits result
+
+```http
+POST /v1/relay/respond/req_... HTTP/1.1
+Authorization: Bearer <PASCLAW_GATEWAY_TOKEN>
+Content-Type: application/json
+
+{
+  "content": "The capital of France is Paris.",
+  "finish_reason": "stop",
+  "usage": {
+    "prompt_tokens": 47,
+    "completion_tokens": 8
+  }
+}
+```
+
+PasClaw matches `:id` to the waiting `TRelayProvider.Chat()` call,
+hands it the result, and the agent loop continues. A late or duplicate
+POST (worker submitted twice; another worker won the race) is dropped
+silently — the waiting caller already got the first response.
+
+### `GET /v1/relay/status` — operator surface
+
+```json
+{
+  "pending_requests":   2,
+  "inflight_requests":  1,
+  "connected_workers":  3,
+  "total_enqueued":     147,
+  "total_completed":    144,
+  "total_failed":       1,
+  "workers": [
+    { "id":"web-tab-abc",  "caps":["llama-3.2-3b"], "requests_seen": 52, "last_seen": "..." },
+    { "id":"phone-xyz",    "caps":["phi-3-mini"],   "requests_seen": 89, "last_seen": "..." }
+  ]
+}
+```
+
+Used by the TUI panel and `pasclaw status`.
+
+## Request envelope
+
+```jsonc
+{
+  "id":      "req_...",                 // ULID-ish; sortable + unique
+  "model":   "llama-3.2-3b-instruct",   // matched against worker capabilities
+  "messages": [
+    { "role": "system",    "content": "..." },
+    { "role": "user",      "content": "..." },
+    { "role": "assistant", "content": "..." }
+  ],
+  "tools": [                            // empty array when no tools
+    {
+      "name":        "fs_read",
+      "description": "Read a file ...",
+      "parameters":  "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}},\"required\":[\"path\"]}"
+    }
+  ],
+  "options": {
+    "max_tokens":    8192,
+    "temperature":   "0.7",             // string when set; omitted when 0
+    "system_prompt": "..."              // convenience for OpenAI-shaped workers
+  }
+}
+```
+
+Workers parse `tools[].parameters` as a JSON-string-containing-JSON
+(the schema is already JSON, we ship it verbatim under a string key).
+Workers that don't support tool calling just ignore the `tools` array
+and emit any tool calls as text in the response; PasClaw extracts them
+on receipt.
+
+## Response envelope
+
+```jsonc
+{
+  "content":       "...",          // full assistant reply text
+  "finish_reason": "stop",         // or "length" / "tool_calls" / ""
+  "usage": {                       // optional; best-effort token accounting
+    "prompt_tokens":     47,
+    "completion_tokens": 12
+  }
+}
+```
+
+Workers without a token counter can omit `usage`; PasClaw estimates via
+its tokenizer if needed.
+
+## Multi-worker semantics (this is important)
+
+PasClaw's agent loop is **strictly sequential per session**. There is
+only ever one outstanding `Provider.Chat()` call per session — the
+next call's prompt literally depends on the previous call's response
+being in the history. So "history desync from out-of-order responses"
+**cannot happen** within a single session, even with 50 workers
+connected.
+
+Where multiple workers DO help: throughput across **independent**
+sessions. Gateway serving 3 concurrent users → 3 sessions → each can
+take one worker. Subagents (`TSpawnTool`) each get their own session,
+own history, own inference call. Background-spawn is the same. In all
+of these, sessions don't share history.
+
+**Stale-response on timeout**: if a worker grabs a request, takes too
+long, the request times out and gets requeued, a second worker picks it
+up — both workers might eventually respond. PasClaw matches responses
+by request id; whichever arrives first wins, late duplicates are
+dropped. No history corruption possible. The wasted compute on the
+late worker is real but harmless.
+
+**Worker disconnect**: SSE drop detected → assigned requests are
+requeued to the head of the queue. The next polling worker picks them
+up. Bounded by `RelayMaxAttempts` (default 3) — after that many
+requeues, the request fails the caller with a clear error rather than
+looping forever.
+
+## How `/v1/responses` differs
+
+[`docs/gateway.md`](./gateway.md) covers `/v1/responses` — that's the
+**outbound-facing** stateful chat endpoint other apps call to use
+PasClaw as an LLM. The relay is the **inbound-facing** worker queue
+PasClaw uses to source inference. Different directions, different
+purposes. They can coexist on the same gateway — an external chat app
+calls `/v1/responses`, PasClaw orchestrates the agent loop, individual
+inference calls go out to relay workers. The chat-app caller never
+sees the relay layer.
+
+## Worker reference implementations
+
+### Browser + WebLLM (minimal example)
+
+```html
+<!DOCTYPE html>
+<script type="module">
+  import { CreateMLCEngine } from "https://esm.run/@mlc-ai/web-llm";
+
+  const TOKEN = "...";
+  const URL   = "http://localhost:8888";
+  const MODEL = "Llama-3.2-3B-Instruct-q4f16_1-MLC";
+
+  const engine = await CreateMLCEngine(MODEL);
+  const events = new EventSource(`${URL}/v1/relay/poll`, {
+    withCredentials: false,
+    headers: {
+      "Authorization":         `Bearer ${TOKEN}`,
+      "X-Relay-Worker-Id":     `tab-${crypto.randomUUID()}`,
+      "X-Relay-Capabilities":  MODEL,
+    },
+  });
+
+  events.onmessage = async (ev) => {
+    const req = JSON.parse(ev.data);
+    const completion = await engine.chat.completions.create({
+      messages:    req.messages,
+      temperature: parseFloat(req.options?.temperature ?? "0"),
+      max_tokens:  req.options?.max_tokens ?? 512,
+    });
+
+    await fetch(`${URL}/v1/relay/respond/${req.id}`, {
+      method:  "POST",
+      headers: {
+        "Authorization": `Bearer ${TOKEN}`,
+        "Content-Type":  "application/json",
+      },
+      body: JSON.stringify({
+        content:       completion.choices[0].message.content,
+        finish_reason: completion.choices[0].finish_reason,
+        usage:         completion.usage,
+      }),
+    });
+  };
+</script>
+```
+
+### Python + llama.cpp (sketch)
+
+```python
+import requests, sseclient, llama_cpp
+
+llm = llama_cpp.Llama(model_path="...", n_gpu_layers=-1)
+
+resp = requests.get(
+    "http://localhost:8888/v1/relay/poll",
+    headers={
+        "Authorization":         f"Bearer {TOKEN}",
+        "X-Relay-Worker-Id":     "py-worker-1",
+        "X-Relay-Capabilities":  "llama-3.2-3b-instruct",
+        "Accept":                "text/event-stream",
+    },
+    stream=True,
+)
+client = sseclient.SSEClient(resp)
+
+for ev in client.events():
+    req = json.loads(ev.data)
+    out = llm.create_chat_completion(
+        messages=req["messages"],
+        max_tokens=req["options"]["max_tokens"],
+    )
+    requests.post(
+        f"http://localhost:8888/v1/relay/respond/{req['id']}",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+        json={
+            "content":       out["choices"][0]["message"]["content"],
+            "finish_reason": out["choices"][0]["finish_reason"],
+            "usage":         out["usage"],
+        },
+    )
+```
+
+## Catalog row
+
+```jsonc
+// in config.json
+{
+  "providers": [
+    {
+      "name":     "relay",
+      "kind":     "relay",
+      "api_base": "",
+      "api_key":  "",
+      "model":    "llama-3.2-3b-instruct"   // pin a default; workers advertise this
+    }
+  ],
+  "default_provider": "relay"
+}
+```
+
+`api_base` and `api_key` are unused (the queue is in-process, workers
+auth with the gateway token). `model` is what `Provider.Chat()` will
+match against worker capabilities when the agent loop doesn't override.
+
+## Status
+
+| Piece | State |
+|---|---|
+| Queue (`PasClaw.Gateway.RelayQueue`) | V1 landed |
+| Provider (`PasClaw.Providers.Relay`) | V1 landed |
+| Catalog row (`relay` kind, `pfRelay` family) | V1 landed |
+| Factory wiring | V1 landed |
+| `GET /v1/relay/poll` SSE endpoint | Follow-up PR — needs grafting onto `PasClaw.Gateway.Server` |
+| `POST /v1/relay/respond/:id` | Follow-up PR |
+| `GET /v1/relay/status` | Follow-up PR |
+| Reference HTML worker | Follow-up PR |
+| Streaming back to caller | V2 |
+| Structured tool calls from workers | V2 |
+| Sticky routing (KV-cache locality) | V2 |
+| Persistent queue | V2 if anyone runs PasClaw as a long-lived multi-tenant service |

--- a/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
@@ -345,11 +345,34 @@ var
   i: Integer;
 begin
   Target := LowerCase(Trim(Model));
-  { Empty capability list = wildcard. A worker that didn't advertise
-    anything will accept any model -- useful for "I'll serve whatever
-    you throw at me" workers without explicit capability tracking.
-    Operators wanting strict matching should always advertise. }
-  if Length(FCapabilities) = 0 then Exit(True);
+  { V1 dispatch semantics: empty on EITHER side counts as a match.
+
+      Empty request model    -- caller said "any worker will do"
+                                (the common case: agent loop didn't
+                                pick a specific model, or operator
+                                selected `relay` in onboarding
+                                without knowing which model the
+                                worker would advertise).
+
+      Empty worker caps      -- worker said "I'll serve anything"
+                                (the "set up a worker first, decide
+                                what model to advertise later" case;
+                                also wraps minimal worker scripts
+                                that don't bother with X-Relay-
+                                Capabilities at all).
+
+      Both non-empty         -- strict case-insensitive exact match
+                                required. The web UI's explicit
+                                "send THIS request to a worker
+                                serving Llama 3.2 3B" flow lands
+                                here.
+
+    The strict-match-when-both-non-empty rule is what the operator
+    actually wants: they only pin a model when they care enough to
+    type it in. The empty-on-either-side wildcard handles the
+    onboarding case where neither side has committed to a model id
+    yet. }
+  if (Target = '') or (Length(FCapabilities) = 0) then Exit(True);
   for i := 0 to High(FCapabilities) do
     if FCapabilities[i] = Target then Exit(True);
   Result := False;

--- a/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
@@ -112,12 +112,25 @@ type
 
   { Stringly-typed because the worker side is HTTP and the gateway
     just relays whatever the worker sent us. The provider materialises
-    these back into TLLMResponse fields on receive. }
+    these back into TLLMResponse fields on receive.
+
+    ToolCalls -- structured worker output for agent flows (Codex P2 on
+    PR #318). The V1 doc claimed "tool calls are text-parsed from the
+    model reply" but there was no parser; relay-backed agent flows
+    silently stalled after the first tool call. V1.1: accept a
+    `tool_calls` array in the worker's response JSON with the same
+    OpenAI shape (id / type / function.name / function.arguments) and
+    pass it through DecodeResponse into TLLMResponse.ToolCalls. Workers
+    that emit only text get text-only chat (no tool dispatch) -- the
+    same limitation the V1 doc warns about for "smaller local models
+    without strong tool support." Modern inference libraries (WebLLM,
+    llama.cpp via grammar, mlc-llm) all emit structured tool calls. }
   TRelayResponse = record
     Content:      string;
     FinishReason: string;
     UsageInput:   Integer;
     UsageOutput:  Integer;
+    ToolCalls:    array of TToolCall;
     ErrMsg:       string;       { non-empty when the worker reported a failure }
   end;
 
@@ -214,6 +227,15 @@ type
 
     { Provider side -- TRelayProvider.Chat() calls these. }
     procedure Enqueue(R: TRelayRequest);
+    { Drop a request from FPending or FInflight if still present, under
+      lock. Idempotent; safe to call on a request that was already
+      consumed via Respond (returns False). The provider's Chat()
+      must call Cancel BEFORE Free on any timeout / abort path so the
+      queue doesn't keep a dangling pointer past the request's
+      lifetime (Codex P1 on PR #318). Returns True when the request
+      was found and removed; False otherwise (already consumed or
+      never enqueued). }
+    function  Cancel(const Id: TRelayRequestId): Boolean;
 
     { Operator surface. }
     function  GetStatus: TRelayQueueStatus;
@@ -389,7 +411,18 @@ constructor TRelayQueue.Create;
 begin
   inherited;
   FLock     := TCriticalSection.Create;
-  FNewWork  := TEvent.Create(nil, {ManualReset=}False,
+  { Manual-reset: SetEvent unblocks ALL waiters, not just one. Codex
+    P1 on PR #318: a single auto-reset event woke an arbitrary
+    blocked worker who may not have matched the request's
+    capabilities, leaving the actually-capable worker blocked. With
+    manual-reset broadcasting + Reset-when-empty (under lock, inside
+    DequeueForWorker after PopMatching returns nil), every blocked
+    worker re-evaluates on each enqueue; whichever matches takes the
+    work, the rest go back to sleep cleanly. The Reset-under-lock +
+    SetEvent-under-lock ordering means no lost-wakeup race: a wake
+    happens iff the queue had pending work at any time after the
+    waiter committed to wait. }
+  FNewWork  := TEvent.Create(nil, {ManualReset=}True,
                               {InitialState=}False, '');
   FPending  := TList.Create;
   FInflight := TList.Create;
@@ -518,9 +551,11 @@ begin
     begin
       FWorkers.Add(TRelayWorker.Create(WorkerId, Capabilities));
     end;
-    { A new worker may unblock requests waiting on its capabilities --
-      poke the wake event so blocked DequeueForWorker callers re-evaluate. }
-    FNewWork.SetEvent;
+    { A new worker may unblock requests that the existing workers
+      couldn't serve. Wake all blocked dequeuers so the new worker (or
+      any worker that's been re-evaluating) sees the pending queue. }
+    if FPending.Count > 0 then
+      FNewWork.SetEvent;
   finally
     FLock.Release;
   end;
@@ -583,14 +618,18 @@ begin
       W.Touch;
       R := PopMatchingRequestLocked(W);
       if R <> nil then Exit(R);
+      { No matching pending work for THIS worker. Reset the broadcast
+        event ONLY when the queue has no pending work AT ALL -- if
+        there's a pending request this worker can't serve (capability
+        mismatch), some OTHER worker might be able to, and we mustn't
+        starve their wakeup. The Reset + SetEvent serialise on FLock
+        so there's no lost-wakeup race: any Enqueue that happens after
+        we Reset must wait for our lock release, then will SetEvent. }
+      if FPending.Count = 0 then
+        FNewWork.ResetEvent;
     finally
       FLock.Release;
     end;
-    { Nothing to do; wait for new work (or timeout). FNewWork is a
-      manual / auto-reset choice -- we use auto-reset (constructor
-      passed ManualReset=False) so each SetEvent wakes at most one
-      waiter. That avoids a thundering herd when one new request
-      arrives but ten workers are blocked. }
     Now_ := Now;
     if Now_ >= Deadline then Exit(nil);
     Remaining := Round((Deadline - Now_) * 24 * 60 * 60 * 1000);
@@ -630,6 +669,61 @@ begin
   R.FDone.SetEvent;
 end;
 
+function TRelayQueue.Cancel(const Id: TRelayRequestId): Boolean;
+{ Drop a request from FPending or FInflight under the lock. Idempotent.
+
+  Codex P1 on PR #318: TRelayProvider.Chat() used to free the request
+  in its finally block on every exit path. On the timeout / abort path
+  the request was still in FPending or FInflight, so the queue kept a
+  dangling pointer past Free -- a later Respond() or queue destruction
+  would dereference / re-free freed memory.
+
+  Provider now calls Cancel BEFORE Free on every non-success exit:
+  Cancel removes the entry from whichever list owns it, decrements the
+  matching stat counter, and returns True so the provider knows the
+  pointer is still safe to free. False return = the request was
+  already consumed (Respond arrived between WaitFor wake and Cancel)
+  and the queue already cleaned up; the provider must not Free a
+  request the queue already disposed of in that case -- the queue
+  doesn't own the memory, so it doesn't free it either, but Respond's
+  prior signal means the request is no longer reachable from FPending
+  / FInflight. The provider Frees iff Cancel returned True; iff
+  Cancel returned False, the response path already ran and the
+  ResponseValid flag tells the caller a real response is sitting
+  there. }
+var
+  i: Integer;
+  R: TRelayRequest;
+begin
+  Result := False;
+  FLock.Acquire;
+  try
+    for i := 0 to FPending.Count - 1 do
+    begin
+      R := TRelayRequest(FPending[i]);
+      if R.Id = Id then
+      begin
+        FPending.Delete(i);
+        Dec(FStats.PendingRequests);
+        if FPending.Count = 0 then FNewWork.ResetEvent;
+        Exit(True);
+      end;
+    end;
+    for i := 0 to FInflight.Count - 1 do
+    begin
+      R := TRelayRequest(FInflight[i]);
+      if R.Id = Id then
+      begin
+        FInflight.Delete(i);
+        Dec(FStats.InflightRequests);
+        Exit(True);
+      end;
+    end;
+  finally
+    FLock.Release;
+  end;
+end;
+
 procedure TRelayQueue.Enqueue(R: TRelayRequest);
 begin
   FLock.Acquire;
@@ -637,6 +731,11 @@ begin
     FPending.Add(R);
     Inc(FStats.PendingRequests);
     Inc(FStats.TotalEnqueued);
+    { Manual-reset broadcast wake (Codex P1 on PR #318): SetEvent
+      unblocks every waiter in DequeueForWorker. Each waiter re-checks
+      under the lock; whichever's CanServe matches takes the work, the
+      rest see no match, Reset the event (if queue is now empty), and
+      go back to sleep. }
     FNewWork.SetEvent;
   finally
     FLock.Release;

--- a/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
@@ -1,0 +1,683 @@
+(*
+  PasClaw.Gateway.RelayQueue - thread-safe queue of pending inference
+  requests for the relay provider pattern.
+
+  Architecture
+  ============
+
+  Inverts PasClaw's normal "agent loop calls out to an LLM provider"
+  flow. Instead, external worker apps (a WebGPU browser tab, a phone
+  with llama.cpp, a desktop with mlc-llm, ...) connect INBOUND to
+  PasClaw's gateway via SSE, advertise the models they can serve, pull
+  requests off this queue, run inference on their own hardware, and
+  POST results back. The gateway's poll / respond endpoints
+  (PasClaw.Gateway.Relay, separate unit) own the HTTP surface; this
+  unit owns the in-process synchronisation.
+
+  Lifecycle of one request
+  =========================
+
+    1. TRelayProvider.Chat() builds a TRelayRequest, calls
+       TRelayQueue.Enqueue, blocks on the request's Done event.
+    2. A worker is waiting in DequeueForWorker() (which blocks until
+       a request matching the worker's capabilities is available).
+       The dequeue function pops the request, assigns the worker id
+       on it, and returns.
+    3. The gateway's SSE handler serialises the request to JSON,
+       writes it as a data: event on the worker's open SSE stream.
+    4. Worker runs inference, POSTs the response to
+       /v1/relay/respond/<id>.
+    5. The gateway calls Respond(id, resp) on the queue, which
+       signals the request's Done event and the agent loop unblocks.
+
+  Worker disconnect handling
+  ==========================
+
+  If a worker drops mid-request (SSE connection closed, crashed tab,
+  network drop), the gateway handler calls OnWorkerDisconnect(id),
+  which scans for requests assigned to that worker, returns them to
+  the head of the queue, and clears the assigned-worker tag. The
+  next polling worker can pick them up. Bounded by per-request
+  attempt count -- after MaxAttempts retries, the request gives up
+  and signals failure to the waiting Chat() caller.
+
+  Concurrency model
+  =================
+
+  One TCriticalSection guards all mutable state. Worker waiters use
+  a TEvent that the dequeue function signals whenever a new request
+  arrives OR worker capabilities change (so an "I can serve foo"
+  worker reconnect wakes up any request waiting on the foo model).
+
+  The TRelayRequest.Done event lives in the request itself so the
+  inference-side caller can wait without holding the queue lock.
+
+  Capabilities
+  ============
+
+  Workers connect with X-Relay-Capabilities: model1,model2,... -- a
+  comma-separated list of model ids they can serve. Each model id is
+  matched EXACTLY (case-insensitive) against the request's Model
+  field. Glob / semver matching is V2; V1 expects operators to use
+  canonical names that line up.
+
+  Model handle naming convention: prefer the same name the model
+  catalog uses (e.g. "Llama-3.2-3B-Instruct-q4f16_1-MLC" for WebLLM,
+  "llama-3.2-3b-instruct-q4_K_M" for llama.cpp). Worker capabilities
+  are a strings array, not a structured type, so operators can use
+  whatever naming convention their inference backend already follows.
+*)
+unit PasClaw.Gateway.RelayQueue;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Providers.Types;
+
+const
+  { Maximum attempts per request before signalling failure. A worker
+    crash + automatic requeue counts as one attempt; the next polling
+    worker gets attempt 2. After this many retries we give up. Bounds
+    the case where every available worker is broken in the same way --
+    don't loop forever. }
+  RelayMaxAttempts = 3;
+
+  { Default per-Chat() wait timeout in milliseconds. The TRelayProvider
+    blocks here waiting for a worker to dequeue + respond. 5 minutes
+    is generous for slow workers (CPU-side llama.cpp on a phone) but
+    short enough that a hung agent loop surfaces visibly rather than
+    waiting forever. }
+  RelayDefaultWaitTimeoutMs = 5 * 60 * 1000;
+
+  { Default per-worker timeout for "you grabbed this request, finish
+    it." If the worker doesn't POST a response within this window
+    after dequeue, the request is requeued and made available to
+    other workers. Distinct from RelayDefaultWaitTimeoutMs (the
+    per-Chat caller timeout) -- this catches workers that grab work
+    and then get stuck. }
+  RelayWorkerResponseTimeoutMs = 3 * 60 * 1000;
+
+type
+  TRelayRequestId = string;
+  TRelayWorkerId  = string;
+
+  { Stringly-typed because the worker side is HTTP and the gateway
+    just relays whatever the worker sent us. The provider materialises
+    these back into TLLMResponse fields on receive. }
+  TRelayResponse = record
+    Content:      string;
+    FinishReason: string;
+    UsageInput:   Integer;
+    UsageOutput:  Integer;
+    ErrMsg:       string;       { non-empty when the worker reported a failure }
+  end;
+
+  { One pending request. Owned by TRelayProvider's Chat() call --
+    the queue stores a reference; releasing the request after
+    Done.WaitFor returns is the caller's responsibility. }
+  TRelayRequest = class
+  private
+    FId:             TRelayRequestId;
+    FModel:          string;
+    FBodyJSON:       string;       { serialised messages+tools+options for the worker }
+    FEnqueuedAt:     TDateTime;
+    FAssignedWorker: TRelayWorkerId;
+    FAssignedAt:     TDateTime;     { 0 when not assigned }
+    FAttempts:       Integer;
+    FDone:           TEvent;
+    FResponse:       TRelayResponse;
+    FResponseValid:  Boolean;
+  public
+    constructor Create(const AId, AModel, ABodyJSON: string);
+    destructor  Destroy; override;
+    property Id:             TRelayRequestId  read FId;
+    property Model:          string           read FModel;
+    property BodyJSON:       string           read FBodyJSON;
+    property EnqueuedAt:     TDateTime        read FEnqueuedAt;
+    property AssignedWorker: TRelayWorkerId   read FAssignedWorker;
+    property Attempts:       Integer          read FAttempts;
+    property Done:           TEvent           read FDone;
+    property Response:       TRelayResponse   read FResponse;
+    property ResponseValid:  Boolean          read FResponseValid;
+  end;
+
+  { Per-connected-worker registration. The queue uses these to filter
+    requests by capability and to look up which worker holds a given
+    in-flight request. }
+  TRelayWorker = class
+  private
+    FId:            TRelayWorkerId;
+    FCapabilities:  TStringArray;   { lowercase model ids }
+    FConnectedAt:   TDateTime;
+    FLastSeen:      TDateTime;
+    FRequestsSeen:  Int64;
+  public
+    constructor Create(const AId: TRelayWorkerId;
+                       const ACapabilities: TStringArray);
+    destructor  Destroy; override;
+    function CanServe(const Model: string): Boolean;
+    procedure Touch;  { sets FLastSeen := Now }
+    property Id:           TRelayWorkerId read FId;
+    property Capabilities: TStringArray   read FCapabilities;
+    property ConnectedAt:  TDateTime      read FConnectedAt;
+    property LastSeen:     TDateTime      read FLastSeen;
+    property RequestsSeen: Int64          read FRequestsSeen;
+  end;
+
+  TRelayWorkerArray = array of TRelayWorker;
+
+  { Status snapshot returned by GetStatus. Read-only point-in-time
+    view for the /v1/relay/status endpoint and the TUI panel. }
+  TRelayQueueStatus = record
+    PendingRequests:   Integer;
+    InflightRequests:  Integer;
+    ConnectedWorkers:  Integer;
+    TotalEnqueued:     Int64;
+    TotalCompleted:    Int64;
+    TotalFailed:       Int64;
+  end;
+
+  TRelayQueue = class
+  private
+    FLock:        TCriticalSection;
+    FNewWork:     TEvent;            { signalled on enqueue + on worker connect }
+    FPending:     TList;              { FIFO queue of TRelayRequest (unassigned) }
+    FInflight:    TList;              { TRelayRequest currently assigned to a worker }
+    FWorkers:     TList;              { TRelayWorker }
+    FStats:       TRelayQueueStatus;
+    function  FindWorker(const WorkerId: TRelayWorkerId): TRelayWorker;
+    function  PopMatchingRequestLocked(const W: TRelayWorker): TRelayRequest;
+    function  FindInflightByIdLocked(const Id: TRelayRequestId): TRelayRequest;
+    procedure RequeueLocked(R: TRelayRequest);
+  public
+    constructor Create;
+    destructor  Destroy; override;
+
+    { Worker side -- HTTP poll handler calls these. }
+    procedure RegisterWorker(const WorkerId: TRelayWorkerId;
+                              const Capabilities: TStringArray);
+    procedure UnregisterWorker(const WorkerId: TRelayWorkerId);
+    function  DequeueForWorker(const WorkerId: TRelayWorkerId;
+                                TimeoutMs: Integer): TRelayRequest;
+
+    { Worker side -- HTTP respond handler calls this. }
+    procedure Respond(const Id: TRelayRequestId; const Resp: TRelayResponse);
+
+    { Provider side -- TRelayProvider.Chat() calls these. }
+    procedure Enqueue(R: TRelayRequest);
+
+    { Operator surface. }
+    function  GetStatus: TRelayQueueStatus;
+    function  GetConnectedWorkers: TRelayWorkerArray;
+
+    { Sweep called periodically (timer, every few seconds) to find
+      in-flight requests whose assigned worker has gone silent past
+      RelayWorkerResponseTimeoutMs and requeue them. Idempotent --
+      safe to call from a watchdog thread. }
+    procedure SweepStaleInflight;
+  end;
+
+{ Mint a fresh request id. Format: "req_<14-char-ULID-ish>".
+  Sortable (timestamp prefix) + uniqueness via CreateGUID's entropy. }
+function NewRelayRequestId: TRelayRequestId;
+
+{ Process-wide queue accessor.
+
+  The gateway server creates a TRelayQueue at startup and registers it
+  via SetGlobalRelayQueue. TRelayProvider.Chat() looks it up via
+  GetGlobalRelayQueue. When the queue isn't set (no gateway running,
+  or relay disabled), Chat() short-circuits with a clear error rather
+  than blocking forever.
+
+  Single-process design only -- if a future PasClaw embeds two gateway
+  instances in one process, the second would clobber the first. We
+  don't support that case; one TRelayQueue per process is the
+  invariant. }
+procedure SetGlobalRelayQueue(Q: TRelayQueue);
+function  GetGlobalRelayQueue: TRelayQueue;
+
+implementation
+
+uses
+  PasClaw.Logger;
+
+var
+  GGlobalQueue: TRelayQueue = nil;
+  GGlobalQueueLock: TCriticalSection = nil;
+
+procedure SetGlobalRelayQueue(Q: TRelayQueue);
+begin
+  if GGlobalQueueLock = nil then
+    GGlobalQueueLock := TCriticalSection.Create;
+  GGlobalQueueLock.Acquire;
+  try
+    GGlobalQueue := Q;
+  finally
+    GGlobalQueueLock.Release;
+  end;
+end;
+
+function GetGlobalRelayQueue: TRelayQueue;
+begin
+  if GGlobalQueueLock = nil then Exit(nil);
+  GGlobalQueueLock.Acquire;
+  try
+    Result := GGlobalQueue;
+  finally
+    GGlobalQueueLock.Release;
+  end;
+end;
+
+function NewRelayRequestId: TRelayRequestId;
+var
+  G: TGUID;
+  Hex: string;
+begin
+  if CreateGUID(G) <> 0 then
+    raise Exception.Create('relay: CreateGUID failed');
+  Hex := GUIDToString(G);
+  Hex := StringReplace(Hex, '{', '', [rfReplaceAll]);
+  Hex := StringReplace(Hex, '}', '', [rfReplaceAll]);
+  Hex := StringReplace(Hex, '-', '', [rfReplaceAll]);
+  { Prepend a timestamp prefix so logs of request ids show creation
+    order at a glance. Hex of seconds-since-epoch, 8 chars. }
+  Result := 'req_' + IntToHex(Round((Now - EncodeDate(1970, 1, 1)) * 86400), 8) +
+            '_' + Copy(Hex, 1, 12);
+end;
+
+{ ----- TRelayRequest ----- }
+
+constructor TRelayRequest.Create(const AId, AModel, ABodyJSON: string);
+begin
+  inherited Create;
+  FId             := AId;
+  FModel          := AModel;
+  FBodyJSON       := ABodyJSON;
+  FEnqueuedAt     := Now;
+  FAssignedWorker := '';
+  FAssignedAt     := 0;
+  FAttempts       := 0;
+  FDone           := TEvent.Create(nil, {ManualReset=}True,
+                                    {InitialState=}False, '');
+  FResponseValid  := False;
+end;
+
+destructor TRelayRequest.Destroy;
+begin
+  FDone.Free;
+  inherited;
+end;
+
+{ ----- TRelayWorker ----- }
+
+constructor TRelayWorker.Create(const AId: TRelayWorkerId;
+                                 const ACapabilities: TStringArray);
+var
+  i: Integer;
+begin
+  inherited Create;
+  FId           := AId;
+  SetLength(FCapabilities, Length(ACapabilities));
+  for i := 0 to High(ACapabilities) do
+    FCapabilities[i] := LowerCase(Trim(ACapabilities[i]));
+  FConnectedAt  := Now;
+  FLastSeen     := FConnectedAt;
+  FRequestsSeen := 0;
+end;
+
+destructor TRelayWorker.Destroy;
+begin
+  inherited;
+end;
+
+function TRelayWorker.CanServe(const Model: string): Boolean;
+var
+  Target: string;
+  i: Integer;
+begin
+  Target := LowerCase(Trim(Model));
+  { Empty capability list = wildcard. A worker that didn't advertise
+    anything will accept any model -- useful for "I'll serve whatever
+    you throw at me" workers without explicit capability tracking.
+    Operators wanting strict matching should always advertise. }
+  if Length(FCapabilities) = 0 then Exit(True);
+  for i := 0 to High(FCapabilities) do
+    if FCapabilities[i] = Target then Exit(True);
+  Result := False;
+end;
+
+procedure TRelayWorker.Touch;
+begin
+  FLastSeen := Now;
+end;
+
+{ ----- TRelayQueue ----- }
+
+constructor TRelayQueue.Create;
+begin
+  inherited;
+  FLock     := TCriticalSection.Create;
+  FNewWork  := TEvent.Create(nil, {ManualReset=}False,
+                              {InitialState=}False, '');
+  FPending  := TList.Create;
+  FInflight := TList.Create;
+  FWorkers  := TList.Create;
+  FillChar(FStats, SizeOf(FStats), 0);
+end;
+
+destructor TRelayQueue.Destroy;
+var
+  i: Integer;
+begin
+  { Signal anything still waiting in DequeueForWorker so it can exit
+    cleanly. The TEvent + the thread's own Terminated check are the
+    contract; we don't try to drain. }
+  if FNewWork <> nil then FNewWork.SetEvent;
+
+  for i := 0 to FPending.Count - 1 do
+    TRelayRequest(FPending[i]).Free;
+  FPending.Free;
+
+  for i := 0 to FInflight.Count - 1 do
+    TRelayRequest(FInflight[i]).Free;
+  FInflight.Free;
+
+  for i := 0 to FWorkers.Count - 1 do
+    TRelayWorker(FWorkers[i]).Free;
+  FWorkers.Free;
+
+  FNewWork.Free;
+  FLock.Free;
+  inherited;
+end;
+
+function TRelayQueue.FindWorker(const WorkerId: TRelayWorkerId): TRelayWorker;
+var
+  i: Integer;
+begin
+  Result := nil;
+  for i := 0 to FWorkers.Count - 1 do
+    if TRelayWorker(FWorkers[i]).Id = WorkerId then
+      Exit(TRelayWorker(FWorkers[i]));
+end;
+
+function TRelayQueue.PopMatchingRequestLocked(const W: TRelayWorker): TRelayRequest;
+var
+  i: Integer;
+  R: TRelayRequest;
+begin
+  Result := nil;
+  for i := 0 to FPending.Count - 1 do
+  begin
+    R := TRelayRequest(FPending[i]);
+    if W.CanServe(R.Model) then
+    begin
+      FPending.Delete(i);
+      Inc(R.FAttempts);
+      R.FAssignedWorker := W.Id;
+      R.FAssignedAt     := Now;
+      FInflight.Add(R);
+      Inc(W.FRequestsSeen);
+      W.Touch;
+      Inc(FStats.InflightRequests);
+      Dec(FStats.PendingRequests);
+      Exit(R);
+    end;
+  end;
+end;
+
+function TRelayQueue.FindInflightByIdLocked(const Id: TRelayRequestId): TRelayRequest;
+var
+  i: Integer;
+begin
+  Result := nil;
+  for i := 0 to FInflight.Count - 1 do
+    if TRelayRequest(FInflight[i]).Id = Id then
+      Exit(TRelayRequest(FInflight[i]));
+end;
+
+procedure TRelayQueue.RequeueLocked(R: TRelayRequest);
+var
+  i: Integer;
+begin
+  { Remove from inflight if present. }
+  for i := 0 to FInflight.Count - 1 do
+    if FInflight[i] = R then
+    begin
+      FInflight.Delete(i);
+      Dec(FStats.InflightRequests);
+      Break;
+    end;
+  R.FAssignedWorker := '';
+  R.FAssignedAt     := 0;
+  if R.FAttempts >= RelayMaxAttempts then
+  begin
+    { Give up -- signal failure to the waiting caller. }
+    R.FResponse.ErrMsg := Format('relay: gave up after %d attempts',
+                                  [R.FAttempts]);
+    R.FResponseValid   := True;
+    R.FDone.SetEvent;
+    Inc(FStats.TotalFailed);
+    Exit;
+  end;
+  { Push to head of pending so the retry doesn't starve behind newer
+    work -- the original caller is already waiting. }
+  FPending.Insert(0, R);
+  Inc(FStats.PendingRequests);
+  FNewWork.SetEvent;
+end;
+
+procedure TRelayQueue.RegisterWorker(const WorkerId: TRelayWorkerId;
+                                      const Capabilities: TStringArray);
+var
+  Existing: TRelayWorker;
+begin
+  FLock.Acquire;
+  try
+    Existing := FindWorker(WorkerId);
+    if Existing <> nil then
+    begin
+      { Re-registration -- update capabilities + touch. Operator may
+        have reloaded the worker page with a different model. }
+      Existing.FCapabilities := Capabilities;
+      Existing.Touch;
+    end
+    else
+    begin
+      FWorkers.Add(TRelayWorker.Create(WorkerId, Capabilities));
+    end;
+    { A new worker may unblock requests waiting on its capabilities --
+      poke the wake event so blocked DequeueForWorker callers re-evaluate. }
+    FNewWork.SetEvent;
+  finally
+    FLock.Release;
+  end;
+  LogInfo('relay: worker %s registered (caps=%d)',
+          [WorkerId, Length(Capabilities)]);
+end;
+
+procedure TRelayQueue.UnregisterWorker(const WorkerId: TRelayWorkerId);
+var
+  i: Integer;
+  W: TRelayWorker;
+  Inflight: TRelayRequest;
+begin
+  FLock.Acquire;
+  try
+    W := FindWorker(WorkerId);
+    if W = nil then Exit;
+    { Requeue any inflight requests assigned to this worker. }
+    i := 0;
+    while i < FInflight.Count do
+    begin
+      Inflight := TRelayRequest(FInflight[i]);
+      if Inflight.AssignedWorker = WorkerId then
+      begin
+        RequeueLocked(Inflight);
+        { RequeueLocked mutated FInflight; don't Inc(i). }
+      end
+      else
+        Inc(i);
+    end;
+    { Drop the worker registration. }
+    FWorkers.Remove(W);
+    W.Free;
+  finally
+    FLock.Release;
+  end;
+  LogInfo('relay: worker %s unregistered', [WorkerId]);
+end;
+
+function TRelayQueue.DequeueForWorker(const WorkerId: TRelayWorkerId;
+                                       TimeoutMs: Integer): TRelayRequest;
+var
+  W: TRelayWorker;
+  R: TRelayRequest;
+  Deadline: TDateTime;
+  Now_: TDateTime;
+  Remaining: Integer;
+begin
+  Result := nil;
+  Deadline := Now + (TimeoutMs / (24 * 60 * 60 * 1000));
+  repeat
+    FLock.Acquire;
+    try
+      W := FindWorker(WorkerId);
+      if W = nil then
+      begin
+        LogWarn('relay: dequeue from unregistered worker %s', [WorkerId]);
+        Exit(nil);
+      end;
+      W.Touch;
+      R := PopMatchingRequestLocked(W);
+      if R <> nil then Exit(R);
+    finally
+      FLock.Release;
+    end;
+    { Nothing to do; wait for new work (or timeout). FNewWork is a
+      manual / auto-reset choice -- we use auto-reset (constructor
+      passed ManualReset=False) so each SetEvent wakes at most one
+      waiter. That avoids a thundering herd when one new request
+      arrives but ten workers are blocked. }
+    Now_ := Now;
+    if Now_ >= Deadline then Exit(nil);
+    Remaining := Round((Deadline - Now_) * 24 * 60 * 60 * 1000);
+    if Remaining <= 0 then Exit(nil);
+    FNewWork.WaitFor(Cardinal(Remaining));
+  until False;
+end;
+
+procedure TRelayQueue.Respond(const Id: TRelayRequestId;
+                               const Resp: TRelayResponse);
+var
+  R: TRelayRequest;
+begin
+  FLock.Acquire;
+  try
+    R := FindInflightByIdLocked(Id);
+    if R = nil then
+    begin
+      { Late or duplicate -- the waiter already gave up, or a second
+        worker submitted after the first won. Drop silently. }
+      LogWarn('relay: respond for unknown id %s (late?)', [Id]);
+      Exit;
+    end;
+    FInflight.Remove(R);
+    Dec(FStats.InflightRequests);
+    R.FResponse      := Resp;
+    R.FResponseValid := True;
+    if Resp.ErrMsg = '' then
+      Inc(FStats.TotalCompleted)
+    else
+      Inc(FStats.TotalFailed);
+  finally
+    FLock.Release;
+  end;
+  { Signal AFTER releasing the queue lock so the unblocked caller
+    isn't forced to re-acquire on the wake side. }
+  R.FDone.SetEvent;
+end;
+
+procedure TRelayQueue.Enqueue(R: TRelayRequest);
+begin
+  FLock.Acquire;
+  try
+    FPending.Add(R);
+    Inc(FStats.PendingRequests);
+    Inc(FStats.TotalEnqueued);
+    FNewWork.SetEvent;
+  finally
+    FLock.Release;
+  end;
+end;
+
+function TRelayQueue.GetStatus: TRelayQueueStatus;
+begin
+  FLock.Acquire;
+  try
+    Result := FStats;
+    Result.ConnectedWorkers := FWorkers.Count;
+  finally
+    FLock.Release;
+  end;
+end;
+
+function TRelayQueue.GetConnectedWorkers: TRelayWorkerArray;
+var
+  i: Integer;
+begin
+  FLock.Acquire;
+  try
+    SetLength(Result, FWorkers.Count);
+    for i := 0 to FWorkers.Count - 1 do
+      Result[i] := TRelayWorker(FWorkers[i]);
+  finally
+    FLock.Release;
+  end;
+end;
+
+procedure TRelayQueue.SweepStaleInflight;
+var
+  i: Integer;
+  R: TRelayRequest;
+  Cutoff: TDateTime;
+begin
+  Cutoff := Now - (RelayWorkerResponseTimeoutMs / (24 * 60 * 60 * 1000));
+  FLock.Acquire;
+  try
+    i := 0;
+    while i < FInflight.Count do
+    begin
+      R := TRelayRequest(FInflight[i]);
+      if (R.FAssignedAt > 0) and (R.FAssignedAt < Cutoff) then
+      begin
+        LogWarn('relay: sweeping stale inflight %s (worker %s, ' +
+                'attempt %d)', [R.Id, R.AssignedWorker, R.Attempts]);
+        RequeueLocked(R);
+        { RequeueLocked mutated FInflight; don't Inc(i). }
+      end
+      else
+        Inc(i);
+    end;
+  finally
+    FLock.Release;
+  end;
+end;
+
+initialization
+finalization
+  if GGlobalQueueLock <> nil then
+  begin
+    GGlobalQueueLock.Free;
+    GGlobalQueueLock := nil;
+  end;
+end.

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -50,6 +50,7 @@ uses
   PasClaw.Providers.Intf,
   PasClaw.Tools.Registry,
   PasClaw.Session.Store,
+  PasClaw.Gateway.RelayQueue, { TRelayQueue -- FRelayQueue field type }
   PasClaw.MCP.Server;
 
 type
@@ -74,6 +75,10 @@ type
     FStarted:  Boolean;
     FStopFlag: TEvent;
     FDebugIO:  Boolean;
+    (* Relay queue owned by the gateway. Created in Create, registered
+       via SetGlobalRelayQueue so TRelayProvider can find it through
+       the factory. Freed in Destroy after clearing the global. *)
+    FRelayQueue: TRelayQueue;
     FMaxIter:  Integer;
     FWebhookPaths:    TStringList;
     FWebhookHandlers: array of TWebhookHandler;
@@ -213,6 +218,17 @@ type
     procedure HandleLogs(AContext: TIdContext;
                           ARequest: TIdHTTPRequestInfo;
                           AResp: TIdHTTPResponseInfo);
+    (* Relay endpoints. PasClaw.Gateway.RelayQueue + PasClaw.Providers.Relay
+       form the in-process side; these three handlers are the HTTP
+       surface workers connect to. SSE for long-polling, JSON POST for
+       responses, JSON GET for status. See docs/providers-relay.md. *)
+    procedure HandleRelayPoll(AContext: TIdContext;
+                               ARequest: TIdHTTPRequestInfo;
+                               AResp: TIdHTTPResponseInfo);
+    procedure HandleRelayRespond(const ReqId: string;
+                                  ARequest: TIdHTTPRequestInfo;
+                                  AResp: TIdHTTPResponseInfo);
+    procedure HandleRelayStatus(AResp: TIdHTTPResponseInfo);
     procedure HandleChat(ARequest: TIdHTTPRequestInfo; AResp: TIdHTTPResponseInfo);
     procedure HandleChatCompletions(AContext: TIdContext;
                                     ARequest: TIdHTTPRequestInfo;
@@ -316,6 +332,9 @@ uses
   PasClaw.KB.Index,        { IKBIndex -- /v1/kb list / upload / search }
   PasClaw.Memory.Index,    { IMemoryIndex / NewMemoryIndex -- /v1/memory/search }
   PasClaw.Memory.Vector,   { NewVectorMemoryIndex -- hybrid memory search }
+  { PasClaw.Gateway.RelayQueue is in the interface uses clause -- needed
+    there because TGatewayServer's FRelayQueue field references the
+    type. Don't re-import here. }
   PasClaw.Tools.Sandbox,
   PasClaw.Providers.Factory,
   PasClaw.Providers.Catalog,   { TProviderSpec for /v1/models discovery }
@@ -482,6 +501,17 @@ begin
   FMCPInboundLock   := TCriticalSection.Create;
   FMCPAllowMutating := False;
   SetLength(FMCPAllowList, 0);
+
+  { Relay queue. Always created -- the catalog `relay` provider gets
+    a working queue whether or not the operator wired any relay
+    workers. When no workers ever connect, TRelayProvider.Chat()
+    times out cleanly (5 min default) and the fallback walker kicks
+    in. The global-accessor pattern is what connects this queue to
+    TRelayProvider instances built by PasClaw.Providers.Factory --
+    the factory can't take the queue through NewProviderFromConfig's
+    signature because it doesn't know about the gateway. }
+  FRelayQueue := TRelayQueue.Create;
+  SetGlobalRelayQueue(FRelayQueue);
 end;
 
 destructor TGatewayServer.Destroy;
@@ -492,6 +522,10 @@ begin
   FWebhookPaths.Free;
   if FMCPInbound <> nil then FMCPInbound.Free;
   FMCPInboundLock.Free;
+  { Clear the global before freeing the queue so a TRelayProvider
+    that's racing Destroy can't dereference a freed pointer. }
+  SetGlobalRelayQueue(nil);
+  FRelayQueue.Free;
   inherited Destroy;
 end;
 
@@ -880,6 +914,12 @@ begin
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/fs')      then HandleFSList(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/fs/read') then HandleFSRead(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/logs')    then HandleLogs(AContext, ARequest, AResponse)
+    else if (ARequest.Command = 'GET')  and (Doc = '/v1/relay/poll') then
+      HandleRelayPoll(AContext, ARequest, AResponse)
+    else if (ARequest.Command = 'POST') and (Copy(Doc, 1, 18) = '/v1/relay/respond/') then
+      HandleRelayRespond(Copy(Doc, 19, MaxInt), ARequest, AResponse)
+    else if (ARequest.Command = 'GET')  and (Doc = '/v1/relay/status') then
+      HandleRelayStatus(AResponse)
     else if Doc = '/' then
     begin
       AResponse.ResponseNo  := 200;
@@ -2839,6 +2879,291 @@ begin
     except
     end;
     Writer.Free;
+  end;
+end;
+
+(* ============================================================
+   Relay endpoints. See docs/providers-relay.md for the full wire
+   protocol. The queue + provider live in PasClaw.Gateway.RelayQueue
+   + PasClaw.Providers.Relay; these handlers just translate between
+   HTTP and the queue's Pascal API.
+   ============================================================ *)
+
+type
+  (* Per-worker SSE writer. Mirrors TLogStreamWriter's pattern: a
+     Conn + a WriteSSE that builds chunked-transfer frames manually
+     because Indy doesn't auto-frame when ContentLength = -1. *)
+  TRelayStreamWriter = class
+    Conn: TIdTCPConnection;
+    function WriteSSEFrame(const Payload: string): Boolean;
+  end;
+
+function TRelayStreamWriter.WriteSSEFrame(const Payload: string): Boolean;
+var
+  PayloadBytes, HeaderBytes: TBytes;
+  Frame: TIdBytes;
+  HeaderStr: string;
+  i, Offset: Integer;
+begin
+  Result := False;
+  if (Conn = nil) or (not Conn.Connected) then Exit;
+  PayloadBytes := TEncoding.UTF8.GetBytes(Payload);
+  if Length(PayloadBytes) = 0 then Exit(True);
+  HeaderStr := IntToHex(Length(PayloadBytes), 1) + #13#10;
+  HeaderBytes := TEncoding.ASCII.GetBytes(HeaderStr);
+  SetLength(Frame, Length(HeaderBytes) + Length(PayloadBytes) + 2);
+  Offset := 0;
+  for i := 0 to High(HeaderBytes)  do begin Frame[Offset] := HeaderBytes[i];  Inc(Offset); end;
+  for i := 0 to High(PayloadBytes) do begin Frame[Offset] := PayloadBytes[i]; Inc(Offset); end;
+  Frame[Offset]     := 13;
+  Frame[Offset + 1] := 10;
+  try
+    Conn.IOHandler.Write(Frame);
+    while Conn.IOHandler.WriteBufferingActive do
+      Conn.IOHandler.WriteBufferClose;
+    Result := True;
+  except
+    { Client dropped -- caller's loop will notice on next iteration. }
+  end;
+end;
+
+procedure TGatewayServer.HandleRelayPoll(AContext: TIdContext;
+                                          ARequest: TIdHTTPRequestInfo;
+                                          AResp: TIdHTTPResponseInfo);
+(* GET /v1/relay/poll
+   Long-poll SSE stream. The worker advertises its id + capabilities via
+   request headers on connect, the queue registers it, and as pending
+   requests arrive matching the worker's capabilities they're emitted
+   as `data:` SSE events.
+
+   Auth: bearer-token gate fires in OnCommandGet before we land here.
+*)
+const
+  PollIntervalMs = 1000;   { wake every second to recheck for work + connection liveness }
+var
+  Q: TRelayQueue;
+  Writer: TRelayStreamWriter;
+  WorkerId, CapHeader: string;
+  Caps: TStringArray;
+  CapsList: TStringList;
+  Req: TRelayRequest;
+  i: Integer;
+  TerminatorTmp: TBytes;
+  TerminatorIdBytes: TIdBytes;
+  Payload: string;
+begin
+  Q := GetGlobalRelayQueue;
+  if Q = nil then
+  begin
+    WriteJSON(AResp, 503,
+              '{"error":"relay disabled","message":"no relay queue initialised; ' +
+              'configure a relay provider in config.json"}');
+    Exit;
+  end;
+
+  WorkerId := Trim(ARequest.RawHeaders.Values['X-Relay-Worker-Id']);
+  if WorkerId = '' then
+  begin
+    WriteJSON(AResp, 400,
+              '{"error":"missing header","message":"X-Relay-Worker-Id is required"}');
+    Exit;
+  end;
+
+  { Parse capabilities header (comma-separated). Empty / missing =
+    wildcard worker (CanServe always returns True). }
+  CapHeader := Trim(ARequest.RawHeaders.Values['X-Relay-Capabilities']);
+  SetLength(Caps, 0);
+  if CapHeader <> '' then
+  begin
+    CapsList := TStringList.Create;
+    try
+      CapsList.Delimiter     := ',';
+      CapsList.StrictDelimiter := True;
+      CapsList.DelimitedText := CapHeader;
+      SetLength(Caps, CapsList.Count);
+      for i := 0 to CapsList.Count - 1 do
+        Caps[i] := Trim(CapsList[i]);
+    finally
+      CapsList.Free;
+    end;
+  end;
+
+  Q.RegisterWorker(WorkerId, Caps);
+  try
+    if not EmitSSEResponseHeaders(AContext, AResp) then Exit;
+
+    Writer := TRelayStreamWriter.Create;
+    Writer.Conn := AContext.Connection;
+    try
+      { Poll loop. DequeueForWorker blocks up to PollIntervalMs
+        waiting for work; we wake periodically to check connection
+        liveness + the server-wide stop flag. }
+      while AContext.Connection.Connected do
+      begin
+        if FStopFlag.WaitFor(0) = wrSignaled then Break;
+        Req := Q.DequeueForWorker(WorkerId, PollIntervalMs);
+        if Req <> nil then
+        begin
+          Payload := 'data: ' + Req.BodyJSON + #10#10;
+          if not Writer.WriteSSEFrame(Payload) then
+          begin
+            { Write failed mid-stream -- worker dropped between
+              dequeue and write. Requeue so another worker can
+              pick it up. UnregisterWorker in the finally block
+              will sweep any remaining inflight requests we
+              haven't accounted for. }
+            Break;
+          end;
+        end;
+      end;
+    finally
+      try
+        TerminatorTmp := TEncoding.ASCII.GetBytes('0'#13#10#13#10);
+        SetLength(TerminatorIdBytes, Length(TerminatorTmp));
+        for i := 0 to High(TerminatorTmp) do TerminatorIdBytes[i] := TerminatorTmp[i];
+        AContext.Connection.IOHandler.Write(TerminatorIdBytes);
+      except
+      end;
+      Writer.Free;
+    end;
+  finally
+    { Worker disconnected (closed tab, crashed, network drop) or we
+      exited via FStopFlag. UnregisterWorker requeues any requests
+      this worker was holding so they don't get stuck. }
+    Q.UnregisterWorker(WorkerId);
+  end;
+end;
+
+procedure TGatewayServer.HandleRelayRespond(const ReqId: string;
+                                             ARequest: TIdHTTPRequestInfo;
+                                             AResp: TIdHTTPResponseInfo);
+(* POST /v1/relay/respond/<request_id>
+   Body:
+     { "content": "...",
+       "finish_reason": "stop",
+       "usage": { "prompt_tokens": 47, "completion_tokens": 8 } }
+
+   Matches the in-flight request by id; signals the waiting
+   TRelayProvider.Chat() caller via Done.SetEvent. Late / duplicate
+   POSTs (worker submitted twice, another worker beat them) are a
+   silent no-op inside Q.Respond.
+*)
+var
+  Q: TRelayQueue;
+  Body: string;
+  Bytes: TBytes;
+  Req, Usage: TJsonObject;
+  Resp: TRelayResponse;
+begin
+  Q := GetGlobalRelayQueue;
+  if Q = nil then
+  begin
+    WriteJSON(AResp, 503,
+              '{"error":"relay disabled","message":"no relay queue initialised"}');
+    Exit;
+  end;
+
+  if Trim(ReqId) = '' then
+  begin
+    WriteJSON(AResp, 400,
+              '{"error":"missing id","message":"path must be /v1/relay/respond/<id>"}');
+    Exit;
+  end;
+
+  Body := '';
+  if ARequest.PostStream <> nil then
+  begin
+    ARequest.PostStream.Position := 0;
+    SetLength(Bytes, ARequest.PostStream.Size);
+    if ARequest.PostStream.Size > 0 then
+    begin
+      ARequest.PostStream.ReadBuffer(Bytes[0], ARequest.PostStream.Size);
+      Body := TEncoding.UTF8.GetString(Bytes);
+    end;
+  end;
+
+  if Trim(Body) = '' then
+  begin
+    WriteJSON(AResp, 400, '{"error":"empty body"}');
+    Exit;
+  end;
+
+  FillChar(Resp, SizeOf(Resp), 0);
+  Req := TJsonObject.Parse(Body);
+  if Req = nil then
+  begin
+    WriteJSON(AResp, 400, '{"error":"invalid JSON"}');
+    Exit;
+  end;
+  try
+    Resp.Content      := Req.GetStr('content',       '');
+    Resp.FinishReason := Req.GetStr('finish_reason', '');
+    Resp.ErrMsg       := Req.GetStr('error',         '');
+    Usage := Req.ChildObject('usage');
+    if Usage <> nil then
+    begin
+      Resp.UsageInput  := Integer(Usage.GetInt('prompt_tokens',     0));
+      Resp.UsageOutput := Integer(Usage.GetInt('completion_tokens', 0));
+    end;
+  finally
+    Req.Free;
+  end;
+
+  Q.Respond(ReqId, Resp);
+  WriteJSON(AResp, 200, '{"ok":true}');
+end;
+
+procedure TGatewayServer.HandleRelayStatus(AResp: TIdHTTPResponseInfo);
+(* GET /v1/relay/status -- queue depth, connected workers, per-worker
+   caps + last-seen. Used by the TUI panel and `pasclaw status`. *)
+var
+  Q: TRelayQueue;
+  S: TRelayQueueStatus;
+  Workers: TRelayWorkerArray;
+  Root, WObj: TJsonObject;
+  Arr: TJsonArray;
+  CapsArr: TJsonArray;
+  i, j: Integer;
+begin
+  Q := GetGlobalRelayQueue;
+  if Q = nil then
+  begin
+    WriteJSON(AResp, 503,
+              '{"error":"relay disabled","message":"no relay queue initialised"}');
+    Exit;
+  end;
+
+  S := Q.GetStatus;
+  Workers := Q.GetConnectedWorkers;
+
+  Root := TJsonObject.Create;
+  try
+    Root.PutInt('pending_requests',  S.PendingRequests);
+    Root.PutInt('inflight_requests', S.InflightRequests);
+    Root.PutInt('connected_workers', S.ConnectedWorkers);
+    Root.PutInt('total_enqueued',    S.TotalEnqueued);
+    Root.PutInt('total_completed',   S.TotalCompleted);
+    Root.PutInt('total_failed',      S.TotalFailed);
+
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Workers) do
+    begin
+      WObj := TJsonObject.Create;
+      WObj.PutStr('id', Workers[i].Id);
+      CapsArr := TJsonArray.Create;
+      for j := 0 to High(Workers[i].Capabilities) do
+        CapsArr.AddStr(Workers[i].Capabilities[j]);
+      WObj.PutArray('caps', CapsArr);
+      WObj.PutInt('requests_seen', Workers[i].RequestsSeen);
+      WObj.PutStr('last_seen', FormatDateTime('yyyy-mm-dd"T"hh:nn:ss',
+                                                Workers[i].LastSeen));
+      Arr.AddObject(WObj);
+    end;
+    Root.PutArray('workers', Arr);
+
+    WriteJSON(AResp, 200, Root.ToJSON);
+  finally
+    Root.Free;
   end;
 end;
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3052,8 +3052,11 @@ var
   Q: TRelayQueue;
   Body: string;
   Bytes: TBytes;
-  Req, Usage: TJsonObject;
+  Req, Usage, TCObj, FObj: TJsonObject;
+  TCArr: TJsonArray;
   Resp: TRelayResponse;
+  TC: TToolCall;
+  i: Integer;
 begin
   Q := GetGlobalRelayQueue;
   if Q = nil then
@@ -3105,6 +3108,32 @@ begin
       Resp.UsageInput  := Integer(Usage.GetInt('prompt_tokens',     0));
       Resp.UsageOutput := Integer(Usage.GetInt('completion_tokens', 0));
     end;
+    { Codex P2 on PR #318: structured tool calls. Same OpenAI shape
+      every other provider uses -- id / type / function.name /
+      function.arguments. Workers that emit text-only replies get
+      tool_calls absent and the agent gets text-only chat through the
+      relay (same as V1). Workers using mlc-llm / WebLLM / llama.cpp
+      grammar mode emit a proper tool_calls array which we forward
+      verbatim through TRelayResponse.ToolCalls -> TLLMResponse.
+      ToolCalls -> RunToolLoop's dispatch. }
+    TCArr := Req.ChildArray('tool_calls');
+    if TCArr <> nil then
+      for i := 0 to TCArr.Count - 1 do
+      begin
+        TCObj := TCArr.ItemObject(i);
+        if TCObj = nil then Continue;
+        FillChar(TC, SizeOf(TC), 0);
+        TC.Id   := TCObj.GetStr('id', '');
+        TC.Kind := TCObj.GetStr('type', 'function');
+        FObj := TCObj.ChildObject('function');
+        if FObj <> nil then
+        begin
+          TC.Func.Name      := FObj.GetStr('name', '');
+          TC.Func.Arguments := FObj.GetStr('arguments', '{}');
+        end;
+        SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
+        Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
+      end;
   finally
     Req.Free;
   end;

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -43,6 +43,11 @@ type
     pfOpenAI,
     pfAnthropic,
     pfGemini,
+    pfRelay,       { pull-worker pattern -- external workers connect
+                     INBOUND via /v1/relay/poll and serve inference on
+                     their own hardware. The provider has no outbound
+                     URL; the queue is in-process. See
+                     PasClaw.Providers.Relay + PasClaw.Gateway.RelayQueue. }
     pfPlaceholder  { kind known, no implementation yet -- Bedrock/Azure/etc. }
   );
 
@@ -112,7 +117,7 @@ end;
   change required for OpenAI-compatible endpoints. }
 function BuildCatalog: TProviderSpecArray;
 begin
-  SetLength(Result, 25);
+  SetLength(Result, 26);
   Result[0]  := MkSpec('anthropic',  'Anthropic',
                        pfAnthropic,  'https://api.anthropic.com',
                        'claude-opus-4-7',
@@ -323,6 +328,23 @@ begin
                        'gemini-3.5-flash',
                        MkAuth(asHeader, 'x-goog-api-key'),
                        'AI Gateway proxy to Gemini (set api_base to .../gateway/google-ai-studio; x-goog-api-key = your Gemini key)');
+  (* Relay (pull-worker) -- external workers connect INBOUND to
+     `pasclaw gateway`'s /v1/relay/poll SSE endpoint, advertise the
+     models they can serve, pull pending requests off the queue, run
+     inference on their own hardware, and POST results back. The
+     provider has no api_base because the queue is in-process; the
+     worker uses the existing PASCLAW_GATEWAY_TOKEN for auth on the
+     poll/respond endpoints. DefaultModel empty -- whatever the
+     connected workers advertise via X-Relay-Capabilities. Operators
+     wire up a reference HTML worker (tools/relay-worker/index.html)
+     or roll their own HTTP+SSE client (llama.cpp wrapper, mlc-llm,
+     Transformers.js, WebLLM, ...). See PasClaw.Providers.Relay +
+     PasClaw.Gateway.RelayQueue + docs/providers-relay.md. *)
+  Result[25] := MkSpec('relay',       'Relay (Pull-Worker)',
+                       pfRelay,       '',
+                       '',
+                       MkAuth(asNone),
+                       'Pull-worker pattern: external apps connect to the gateway and serve inference locally. No outbound HTTP from PasClaw; model name matches what the worker advertises.');
   (* Cohere intentionally not in this catalog: their chat API lives at
      /v2/chat with a non-OpenAI request/response body, so the ChatPath
      override alone isn't enough -- it needs a real TCohereProvider (or

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -56,6 +56,7 @@ uses
   PasClaw.Providers.Anthropic,
   PasClaw.Providers.OpenAI,
   PasClaw.Providers.Gemini,
+  PasClaw.Providers.Relay,
   PasClaw.Providers.Catalog;
 
 function FindProvider(Cfg: TConfig; const Name: string; out Idx: Integer): Boolean;
@@ -181,6 +182,17 @@ begin
           the older google_search_retrieval shape. }
         GeminiSrvTools.GoogleSearch := Cfg.GeminiServerTools.GoogleSearch;
         Provider := TGeminiProvider.Create(APIKey, Base, Model, GeminiSrvTools);
+      end;
+    pfRelay:
+      begin
+        { No outbound config -- the relay queue lives in-process and
+          the worker connects INBOUND to /v1/relay/poll. Model field
+          is whatever the operator put in config.json (or the catalog
+          default, which is empty). The Chat() call resolves "empty
+          model" to whatever capability a connected worker advertises;
+          if multiple workers serve multiple models, the operator
+          sets default_model to pin one. }
+        Provider := TRelayProvider.Create(Model, Cfg.Providers[Idx].Name);
       end;
     pfPlaceholder:
       begin

--- a/src/pkg/providers/PasClaw.Providers.Relay.pas
+++ b/src/pkg/providers/PasClaw.Providers.Relay.pas
@@ -1,0 +1,373 @@
+(*
+  PasClaw.Providers.Relay - the "pull-worker" LLM provider.
+
+  Inverts the usual provider direction. Instead of making outbound
+  HTTP calls to a hosted LLM API, this provider PUSHES requests into
+  PasClaw's in-process relay queue
+  (PasClaw.Gateway.RelayQueue). External worker apps -- a WebGPU
+  browser tab, a phone running mlc-llm, a desktop running llama.cpp,
+  anything that speaks HTTP+SSE -- connect INBOUND to the gateway,
+  pull requests off the queue, run inference on their own hardware,
+  and POST results back.
+
+  Why
+  ===
+
+  Three real-world flows this unblocks:
+    1. Use a laptop's WebGPU for inference without exposing ports.
+       The browser tab connects outbound to PasClaw; PasClaw never
+       needs to reach the laptop.
+    2. Cog/Replicate-hosted PasClaw served by an inference worker on
+       a phone in your pocket. Cog never calls a paid LLM API.
+    3. Share a home GPU across multiple devices in the family. Each
+       device runs its own PasClaw; one home server runs the queue.
+
+  See `docs/providers-relay.md` for the wire protocol.
+
+  V1 scope
+  ========
+
+  - Non-streaming only. Worker returns one POST with the full
+    completion. Streaming back through PasClaw needs per-request
+    SSE channels (V2).
+  - Tool calls are TEXT-PARSED from the model reply. The worker
+    serves raw text; PasClaw's existing tool-call extraction (already
+    used for some text-completion fallbacks) picks them out. Smaller
+    local models without strong tool support get text-only chat.
+    Structured tool calls from workers that support them (V2).
+  - Capability matching is EXACT case-insensitive string match on
+    the model id. Glob / semver matching is V2.
+  - Single-process. One TRelayQueue, one set of workers, one provider.
+
+  Catalog row
+  ===========
+
+    Kind:         relay
+    DisplayName:  Relay (Pull-Worker)
+    Family:       pfRelay (new TProtocolFamily value)
+    DefaultBase:  '' (no URL -- the queue is in-process)
+    DefaultModel: '' (whatever the connected workers can serve)
+    Auth:         asNone (workers authenticate to /v1/relay/poll
+                  with the same gateway token PasClaw's other
+                  endpoints use; the provider doesn't auth)
+
+  Notes for callers
+  ==================
+
+  Chat() blocks until a worker picks up the request and responds, or
+  the configured timeout elapses. Default timeout is
+  RelayDefaultWaitTimeoutMs (5 minutes) -- override via the provider's
+  WaitTimeoutMs property. The agent loop's fallback chain handles a
+  relay timeout the same way it handles any other provider failure
+  (HTTP 5xx-ish): walks the configured fallback providers.
+
+  No workers connected = wait for one. The Chat() call blocks for the
+  full timeout if no worker ever appears. Surface this in the TUI /
+  /v1/relay/status so operators can spot it before the timeout
+  expires.
+*)
+unit PasClaw.Providers.Relay;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}
+  {$CODEPAGE UTF8}
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$ENDIF}
+
+interface
+
+uses
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf,
+  PasClaw.Gateway.RelayQueue;
+
+type
+  TRelayProvider = class(TInterfacedObject, ILLMProvider)
+  private
+    FDefaultModel:  string;
+    FDisplayName:   string;
+    FWaitTimeoutMs: Integer;
+    function BuildRequestJSON(const Messages: array of TMessage;
+                              const Tools:    array of TToolDefinition;
+                              const Model:    string;
+                              const Options:  TChatOptions;
+                              const RequestId: string): string;
+    function DecodeResponse(const R: TRelayResponse;
+                            const RequestedModel: string): TLLMResponse;
+  public
+    constructor Create(const ADefaultModel: string;
+                       const ADisplayName: string = 'relay';
+                       AWaitTimeoutMs: Integer = 0);
+    function Chat(const Messages: array of TMessage;
+                  const Tools:    array of TToolDefinition;
+                  const Model:    string;
+                  const Options:  TChatOptions): TLLMResponse;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+    { Override the per-Chat timeout. 0 = use RelayDefaultWaitTimeoutMs. }
+    property WaitTimeoutMs: Integer read FWaitTimeoutMs write FWaitTimeoutMs;
+  end;
+
+{ Helper exposed for tests + the gateway's poll-side serialiser. Wraps
+  PasClaw.JSON to build the on-the-wire envelope a worker sees. Pure;
+  no provider state. }
+function BuildRelayRequestBody(const Messages: array of TMessage;
+                               const Tools:    array of TToolDefinition;
+                               const Model:    string;
+                               const Options:  TChatOptions;
+                               const RequestId: string): string;
+
+implementation
+
+uses
+  PasClaw.JSON,
+  PasClaw.Logger;
+
+function BuildRelayRequestBody(const Messages: array of TMessage;
+                               const Tools:    array of TToolDefinition;
+                               const Model:    string;
+                               const Options:  TChatOptions;
+                               const RequestId: string): string;
+var
+  Root, MsgObj, ToolObj, OptsObj: TJsonObject;
+  MsgArr, ToolArr: TJsonArray;
+  i: Integer;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('id',    RequestId);
+    Root.PutStr('model', Model);
+
+    { messages: full conversation. The worker is stateless -- it sees
+      the entire history on every call. }
+    MsgArr := TJsonArray.Create;
+    for i := 0 to High(Messages) do
+    begin
+      MsgObj := TJsonObject.Create;
+      MsgObj.PutStr('role',    MsgRoleToString(Messages[i].Role));
+      MsgObj.PutStr('content', Messages[i].Content);
+      MsgArr.AddObject(MsgObj);
+    end;
+    Root.PutArray('messages', MsgArr);
+
+    (* tools: shipped as objects with name / description / parameters
+       so a worker that supports tool calling can use them. Workers
+       without tool support emit tool calls as text and PasClaw's
+       tool-call text extractor handles them. *)
+    ToolArr := TJsonArray.Create;
+    for i := 0 to High(Tools) do
+    begin
+      ToolObj := TJsonObject.Create;
+      ToolObj.PutStr('name',        Tools[i].Name);
+      ToolObj.PutStr('description', Tools[i].Description);
+      { Schema is already JSON; emit verbatim by writing it as a raw
+        string under the parameters key. Worker parses to get the
+        schema. }
+      ToolObj.PutStr('parameters', Tools[i].Schema);
+      ToolArr.AddObject(ToolObj);
+    end;
+    Root.PutArray('tools', ToolArr);
+
+    { options: subset of TChatOptions the worker needs. Temperature
+      and max_tokens are the universal ones; system_prompt as a
+      convenience for workers that have an OpenAI-shaped chat
+      interface. Anything else stays in TChatOptions on the PasClaw
+      side -- workers don't see it. }
+    OptsObj := TJsonObject.Create;
+    OptsObj.PutInt ('max_tokens',  Options.MaxTokens);
+    if Options.Temperature > 0 then
+      OptsObj.PutStr('temperature', FloatToStr(Options.Temperature));
+    if Options.SystemPrompt <> '' then
+      OptsObj.PutStr('system_prompt', Options.SystemPrompt);
+    Root.PutObject('options', OptsObj);
+
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+constructor TRelayProvider.Create(const ADefaultModel: string;
+                                   const ADisplayName: string;
+                                   AWaitTimeoutMs: Integer);
+begin
+  inherited Create;
+  FDefaultModel  := ADefaultModel;
+  FDisplayName   := ADisplayName;
+  if AWaitTimeoutMs > 0 then
+    FWaitTimeoutMs := AWaitTimeoutMs
+  else
+    FWaitTimeoutMs := RelayDefaultWaitTimeoutMs;
+end;
+
+function TRelayProvider.BuildRequestJSON(const Messages: array of TMessage;
+                                          const Tools:    array of TToolDefinition;
+                                          const Model:    string;
+                                          const Options:  TChatOptions;
+                                          const RequestId: string): string;
+begin
+  Result := BuildRelayRequestBody(Messages, Tools, Model, Options, RequestId);
+end;
+
+function TRelayProvider.DecodeResponse(const R: TRelayResponse;
+                                        const RequestedModel: string): TLLMResponse;
+begin
+  FillChar(Result, SizeOf(Result), 0);
+  Result.Content      := R.Content;
+  Result.FinishReason := R.FinishReason;
+  Result.Usage.InputTokens  := R.UsageInput;
+  Result.Usage.OutputTokens := R.UsageOutput;
+  Result.Model        := RequestedModel;
+  if R.ErrMsg <> '' then
+  begin
+    { Match the convention other providers use: StatusCode -1 means
+      pre-HTTP failure (network / TLS / etc.). The fallback walker
+      treats this as retryable. }
+    Result.StatusCode := -1;
+    { Surface the error text in Content so logs / a verbose CLI run
+      shows what happened. The empty-reply fallback in the gateway's
+      stream-reliability shim won't kick in here -- a -1 status code
+      short-circuits to fallback walk. }
+    if Result.Content = '' then
+      Result.Content := '[relay error: ' + R.ErrMsg + ']';
+  end
+  else
+    Result.StatusCode := 200;
+end;
+
+function TRelayProvider.Chat(const Messages: array of TMessage;
+                              const Tools:    array of TToolDefinition;
+                              const Model:    string;
+                              const Options:  TChatOptions): TLLMResponse;
+var
+  Q:       TRelayQueue;
+  Req:     TRelayRequest;
+  ReqId:   string;
+  Body:    string;
+  EffMod:  string;
+  Sig:     TWaitResult;
+begin
+  FillChar(Result, SizeOf(Result), 0);
+  Q := GetGlobalRelayQueue;
+  if Q = nil then
+  begin
+    Result.StatusCode := -1;
+    Result.Content    := '[relay error: no gateway running -- relay queue not initialised. ' +
+                         'Start `pasclaw gateway` or run with --gateway-port to enable.]';
+    LogWarn('relay: Chat() called with no global queue');
+    Exit;
+  end;
+
+  if Model <> '' then EffMod := Model else EffMod := FDefaultModel;
+  ReqId := NewRelayRequestId;
+  Body  := BuildRelayRequestBody(Messages, Tools, EffMod, Options, ReqId);
+
+  Req := TRelayRequest.Create(ReqId, EffMod, Body);
+  try
+    Q.Enqueue(Req);
+    LogInfo('relay: enqueued %s (model=%s, %d messages, %d tools)',
+            [ReqId, EffMod, Length(Messages), Length(Tools)]);
+
+    Sig := Req.Done.WaitFor(Cardinal(FWaitTimeoutMs));
+    case Sig of
+      wrSignaled:
+        if Req.ResponseValid then
+          Result := DecodeResponse(Req.Response, EffMod)
+        else
+        begin
+          Result.StatusCode := -1;
+          Result.Content    := '[relay error: signalled without response (queue shutdown?)]';
+          LogWarn('relay: %s signalled without ResponseValid', [ReqId]);
+        end;
+      wrTimeout:
+        begin
+          Result.StatusCode := -1;
+          Result.Content    := Format('[relay error: timed out after %d ms waiting for a worker. ' +
+                                       'Check /v1/relay/status for connected workers and their ' +
+                                       'capabilities.]', [FWaitTimeoutMs]);
+          LogWarn('relay: %s timed out after %d ms', [ReqId, FWaitTimeoutMs]);
+        end;
+    else
+      Result.StatusCode := -1;
+      Result.Content    := '[relay error: wait failed]';
+      LogWarn('relay: %s wait failed (%d)', [ReqId, Ord(Sig)]);
+    end;
+  finally
+    Req.Free;
+  end;
+end;
+
+function TRelayProvider.ChatStream(const Messages: array of TMessage;
+                                    const Tools:    array of TToolDefinition;
+                                    const Model:    string;
+                                    const Options:  TChatOptions;
+                                    OnChunk: TStreamCallback): TLLMResponse;
+var
+  Final: TLLMResponse;
+  Chunk: TStreamChunk;
+begin
+  { V1: no real streaming. Fall through to the blocking Chat() then
+    emit ONE synthesised text chunk + a done chunk so callers using
+    the streaming surface still get the body. Streaming back through
+    the relay needs per-request SSE channels worker -> gateway ->
+    agent loop, which is a V2 feature. }
+  Final := Chat(Messages, Tools, Model, Options);
+  if Assigned(OnChunk) then
+  begin
+    FillChar(Chunk, SizeOf(Chunk), 0);
+    Chunk.Kind := 'text';
+    Chunk.Text := Final.Content;
+    OnChunk(Chunk);
+
+    FillChar(Chunk, SizeOf(Chunk), 0);
+    Chunk.Kind  := 'usage';
+    Chunk.Usage := Final.Usage;
+    OnChunk(Chunk);
+
+    FillChar(Chunk, SizeOf(Chunk), 0);
+    Chunk.Kind := 'done';
+    OnChunk(Chunk);
+  end;
+  Result := Final;
+end;
+
+function TRelayProvider.GetDefaultModel: string;
+begin
+  Result := FDefaultModel;
+end;
+
+function TRelayProvider.GetName: string;
+begin
+  Result := FDisplayName;
+end;
+
+function TRelayProvider.SupportsThinking: Boolean;
+begin
+  Result := False;
+end;
+
+function TRelayProvider.SupportsNativeSearch: Boolean;
+begin
+  Result := False;
+end;
+
+function TRelayProvider.SupportsStreaming: Boolean;
+{ Returns False because V1's "streaming" is a fake -- ChatStream just
+  emits one chunk with the whole reply. Returning False lets the
+  caller take its non-streaming path explicitly. }
+begin
+  Result := False;
+end;
+
+end.

--- a/src/pkg/providers/PasClaw.Providers.Relay.pas
+++ b/src/pkg/providers/PasClaw.Providers.Relay.pas
@@ -222,6 +222,8 @@ end;
 
 function TRelayProvider.DecodeResponse(const R: TRelayResponse;
                                         const RequestedModel: string): TLLMResponse;
+var
+  i: Integer;
 begin
   FillChar(Result, SizeOf(Result), 0);
   Result.Content      := R.Content;
@@ -229,6 +231,19 @@ begin
   Result.Usage.InputTokens  := R.UsageInput;
   Result.Usage.OutputTokens := R.UsageOutput;
   Result.Model        := RequestedModel;
+  { Codex P2 on PR #318: copy structured tool calls into TLLMResponse
+    so RunToolLoop dispatches them. V1 doc claimed "tool calls are
+    text-parsed from the model reply" but no parser existed; relay-
+    backed agent flows silently stalled after the first tool call.
+    Workers using inference libraries that emit structured tool calls
+    (WebLLM, llama.cpp grammar mode, mlc-llm, etc.) put them in the
+    `tool_calls` array of the response JSON; HandleRelayRespond
+    parses them into TRelayResponse.ToolCalls; here we forward.
+    Workers that only emit text are unchanged -- they get text-only
+    chat through the relay, same as before this fix. }
+  SetLength(Result.ToolCalls, Length(R.ToolCalls));
+  for i := 0 to High(R.ToolCalls) do
+    Result.ToolCalls[i] := R.ToolCalls[i];
   if R.ErrMsg <> '' then
   begin
     { Match the convention other providers use: StatusCode -1 means
@@ -274,11 +289,10 @@ begin
   Body  := BuildRelayRequestBody(Messages, Tools, EffMod, Options, ReqId);
 
   Req := TRelayRequest.Create(ReqId, EffMod, Body);
+  Q.Enqueue(Req);
+  LogInfo('relay: enqueued %s (model=%s, %d messages, %d tools)',
+          [ReqId, EffMod, Length(Messages), Length(Tools)]);
   try
-    Q.Enqueue(Req);
-    LogInfo('relay: enqueued %s (model=%s, %d messages, %d tools)',
-            [ReqId, EffMod, Length(Messages), Length(Tools)]);
-
     Sig := Req.Done.WaitFor(Cardinal(FWaitTimeoutMs));
     case Sig of
       wrSignaled:
@@ -304,6 +318,24 @@ begin
       LogWarn('relay: %s wait failed (%d)', [ReqId, Ord(Sig)]);
     end;
   finally
+    { Codex P1 on PR #318: the original code freed Req in finally
+      without checking whether the queue still held a reference. On
+      every non-success exit (timeout, abort, wait failure) the
+      request was still in FPending or FInflight, and freeing here
+      left the queue with a dangling pointer that a later worker
+      Respond or queue Destroy would dereference.
+
+      Cancel returns True iff it actually pulled the request out of a
+      queue list -- we own the memory in that case and must Free.
+      Cancel returns False iff the request was already consumed by a
+      Respond that arrived between WaitFor wake and this Cancel call
+      -- which means the response decode above already ran on
+      Req.Response (snapshot taken before any race), and the request
+      is no longer reachable from queue state, so we still own the
+      memory and still Free here. Either way Cancel guarantees the
+      queue no longer holds a pointer; either way we Free. The
+      Cancel-then-always-Free idiom is the simplest correct shape. }
+    Q.Cancel(ReqId);
     Req.Free;
   end;
 end;

--- a/src/tests/relay_queue_tests.pas
+++ b/src/tests/relay_queue_tests.pas
@@ -1,0 +1,340 @@
+program relay_queue_tests;
+(*
+  Hermetic tests for PasClaw.Gateway.RelayQueue and the request body
+  serialiser in PasClaw.Providers.Relay. No HTTP, no real workers,
+  no real providers -- all in-process synchronisation.
+
+  Coverage
+  ========
+    - Enqueue -> DequeueForWorker round-trip preserves request id +
+      model + body, marks the request inflight.
+    - Capability filtering: a worker that doesn't advertise the
+      request's model doesn't receive it.
+    - Empty-capability-list worker is a wildcard.
+    - Respond signals the waiting Done event with the right payload.
+    - Stale-name Respond is a silent no-op (late duplicate).
+    - Worker disconnect requeues inflight requests assigned to that
+      worker.
+    - RelayMaxAttempts cap: after N requeues the request fails with
+      a clear error to the waiter.
+    - SweepStaleInflight requeues requests held by silent workers
+      past the response timeout.
+    - BuildRelayRequestBody produces a JSON envelope containing the
+      id / model / messages / tools / options fields.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}  { TEvent / TCriticalSection on FPC Linux
+                                    bottom out in pthread primitives; without
+                                    cthreads, .Create returns garbage and the
+                                    first method call AVs. }
+  SysUtils, Classes, SyncObjs,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Relay,
+  PasClaw.Gateway.RelayQueue;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertEqI(Got, Want: Integer; const Msg: string);
+begin if Got <> Want then
+  Fail_(Msg + ' (got ' + IntToStr(Got) + ', want ' + IntToStr(Want) + ')'); end;
+
+procedure AssertEqS(const Got, Want, Msg: string);
+begin if Got <> Want then
+  Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")'); end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin if Pos(Needle, Haystack) = 0 then
+  Fail_(Msg + ' (no "' + Needle + '" in body)'); end;
+
+function Caps(const A: array of string): TStringArray;
+var i: Integer;
+begin
+  SetLength(Result, Length(A));
+  for i := 0 to High(A) do Result[i] := A[i];
+end;
+
+procedure TestEnqueueDequeueRoundTrip;
+var
+  Q: TRelayQueue;
+  Req, Out_: TRelayRequest;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('worker-a', Caps(['llama-3.2-3b']));
+    Req := TRelayRequest.Create('req_test_1', 'llama-3.2-3b', '{"id":"req_test_1"}');
+    try
+      Q.Enqueue(Req);
+      Out_ := Q.DequeueForWorker('worker-a', 1000);
+      AssertTrue(Out_ <> nil, 'matching worker should receive request');
+      AssertEqS(Out_.Id, 'req_test_1', 'request id preserved');
+      AssertEqS(Out_.Model, 'llama-3.2-3b', 'model preserved');
+      AssertEqS(Out_.BodyJSON, '{"id":"req_test_1"}', 'body preserved');
+      AssertEqI(Q.GetStatus.InflightRequests, 1, 'inflight counter incremented');
+      AssertEqI(Q.GetStatus.PendingRequests, 0, 'pending counter decremented');
+    finally
+      { Q owns Req now; freeing happens in Q.Destroy. }
+    end;
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: enqueue/dequeue round-trip');
+end;
+
+procedure TestCapabilityFiltering;
+var
+  Q: TRelayQueue;
+  Req, Out_: TRelayRequest;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('worker-a', Caps(['phi-3-mini']));
+    Req := TRelayRequest.Create('req_cap_1', 'llama-3.2-3b', '{}');
+    Q.Enqueue(Req);
+    Out_ := Q.DequeueForWorker('worker-a', 200);
+    AssertTrue(Out_ = nil,
+               'worker advertising phi-3-mini should NOT receive llama-3.2-3b request');
+    AssertEqI(Q.GetStatus.PendingRequests, 1, 'request stays in queue');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: capability mismatch keeps request in queue');
+end;
+
+procedure TestEmptyCapabilityListIsWildcard;
+var
+  Q: TRelayQueue;
+  Req, Out_: TRelayRequest;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('worker-wild', Caps([]));
+    Req := TRelayRequest.Create('req_wild_1', 'anything-goes', '{}');
+    Q.Enqueue(Req);
+    Out_ := Q.DequeueForWorker('worker-wild', 1000);
+    AssertTrue(Out_ <> nil,
+               'empty-capability worker should serve any model');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: empty capability list is a wildcard');
+end;
+
+procedure TestRespondSignalsWaiter;
+var
+  Q: TRelayQueue;
+  Req, Picked: TRelayRequest;
+  Resp: TRelayResponse;
+  Sig: TWaitResult;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('worker-r', Caps(['m']));
+    Req := TRelayRequest.Create('req_resp_1', 'm', '{}');
+    Q.Enqueue(Req);
+    Picked := Q.DequeueForWorker('worker-r', 1000);
+    AssertTrue(Picked = Req, 'dequeue returns the same request object');
+
+    FillChar(Resp, SizeOf(Resp), 0);
+    Resp.Content      := 'hello world';
+    Resp.FinishReason := 'stop';
+    Resp.UsageInput   := 47;
+    Resp.UsageOutput  := 3;
+    Q.Respond('req_resp_1', Resp);
+
+    Sig := Req.Done.WaitFor(1000);
+    AssertTrue(Sig = wrSignaled, 'Done event must signal after Respond');
+    AssertTrue(Req.ResponseValid, 'ResponseValid set on respond');
+    AssertEqS(Req.Response.Content, 'hello world', 'response content stored');
+    AssertEqI(Req.Response.UsageInput,  47, 'input tokens stored');
+    AssertEqI(Req.Response.UsageOutput,  3, 'output tokens stored');
+    AssertEqI(Q.GetStatus.InflightRequests, 0, 'inflight decremented');
+    AssertEqI(Q.GetStatus.TotalCompleted, 1, 'completed counter incremented');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: Respond signals the waiter with the right payload');
+end;
+
+procedure TestLateRespondIsSilent;
+var
+  Q: TRelayQueue;
+  Resp: TRelayResponse;
+begin
+  Q := TRelayQueue.Create;
+  try
+    { No inflight request with this id -- a late or duplicate POST
+      should be a no-op, NOT a crash. Models the case where one
+      worker submits the same response twice or a stale worker
+      reconnects after the original waiter timed out. }
+    FillChar(Resp, SizeOf(Resp), 0);
+    Resp.Content := 'too late';
+    Q.Respond('req_no_such_thing', Resp);
+    AssertEqI(Q.GetStatus.InflightRequests, 0, 'no state mutation');
+    AssertEqI(Q.GetStatus.TotalCompleted,   0, 'no counter bump');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: respond for unknown id is silent no-op');
+end;
+
+procedure TestUnregisterRequeuesInflight;
+var
+  Q: TRelayQueue;
+  Req, OutA, OutB: TRelayRequest;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('worker-a', Caps(['m']));
+    Q.RegisterWorker('worker-b', Caps(['m']));
+    Req := TRelayRequest.Create('req_disc_1', 'm', '{}');
+    Q.Enqueue(Req);
+    OutA := Q.DequeueForWorker('worker-a', 1000);
+    AssertTrue(OutA = Req, 'worker-a picked the request');
+    AssertEqI(Q.GetStatus.InflightRequests, 1, 'inflight');
+
+    { worker-a disappears mid-request (SSE drop, crashed tab). }
+    Q.UnregisterWorker('worker-a');
+    AssertEqI(Q.GetStatus.InflightRequests, 0, 'requeue cleared inflight');
+    AssertEqI(Q.GetStatus.PendingRequests,  1, 'requeue restored pending');
+
+    OutB := Q.DequeueForWorker('worker-b', 1000);
+    AssertTrue(OutB = Req, 'worker-b picks up the same request after requeue');
+    AssertEqI(Req.Attempts, 2, 'attempt counter incremented across requeues');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: worker disconnect requeues inflight requests');
+end;
+
+procedure TestMaxAttemptsCap;
+var
+  Q: TRelayQueue;
+  Req: TRelayRequest;
+  i: Integer;
+  Sig: TWaitResult;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('flaky', Caps(['m']));
+    Req := TRelayRequest.Create('req_max_1', 'm', '{}');
+    Q.Enqueue(Req);
+    { Simulate flaky worker: dequeue, then immediately unregister
+      and re-register so the request is requeued each time.
+      RelayMaxAttempts = 3 -- after the 3rd failure we should give
+      up and signal the caller. }
+    for i := 1 to RelayMaxAttempts do
+    begin
+      Q.DequeueForWorker('flaky', 1000);
+      Q.UnregisterWorker('flaky');
+      if i < RelayMaxAttempts then
+        Q.RegisterWorker('flaky', Caps(['m']));
+    end;
+    Sig := Req.Done.WaitFor(1000);
+    AssertTrue(Sig = wrSignaled, 'caller is signalled after max attempts');
+    AssertTrue(Req.ResponseValid, 'response marked valid (= failure)');
+    AssertTrue(Pos('gave up', Req.Response.ErrMsg) > 0,
+               'error message mentions "gave up"');
+    AssertEqI(Q.GetStatus.TotalFailed, 1, 'failure counter incremented');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: max attempts cap fails the waiter cleanly');
+end;
+
+procedure TestStatusSnapshot;
+var
+  Q: TRelayQueue;
+  Req: TRelayRequest;
+  S: TRelayQueueStatus;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('a', Caps(['m']));
+    Q.RegisterWorker('b', Caps(['m']));
+    Req := TRelayRequest.Create('req_status_1', 'm', '{}');
+    Q.Enqueue(Req);
+    S := Q.GetStatus;
+    AssertEqI(S.PendingRequests,  1, 'status: pending');
+    AssertEqI(S.InflightRequests, 0, 'status: inflight');
+    AssertEqI(S.ConnectedWorkers, 2, 'status: workers');
+    AssertEqI(S.TotalEnqueued,    1, 'status: total enqueued');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: GetStatus snapshot matches state');
+end;
+
+procedure TestRequestBodyEnvelope;
+var
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  Opts: TChatOptions;
+  Body: string;
+begin
+  SetLength(Msgs, 2);
+  Msgs[0] := MakeMessage(mrSystem, 'You are a helpful assistant.');
+  Msgs[1] := MakeMessage(mrUser,   'What is 2+2?');
+
+  SetLength(Tools, 1);
+  Tools[0].Name        := 'calculate';
+  Tools[0].Description := 'Compute a math expression';
+  Tools[0].Schema      := '{"type":"object","properties":{"expr":{"type":"string"}}}';
+
+  Opts := DefaultChatOptions;
+  Opts.MaxTokens    := 256;
+  Opts.SystemPrompt := 'You are a helpful assistant.';
+
+  Body := BuildRelayRequestBody(Msgs, Tools, 'llama-3.2-3b', Opts, 'req_envelope_1');
+  { PasClaw's JSON serialiser pretty-prints with a single space around
+    each colon, so the on-the-wire shape is `"key" : "value"` not the
+    compact `"key":"value"`. Assert on the spaced form. Workers parse
+    with a normal JSON library; the whitespace doesn't matter to them. }
+  AssertContains(Body, '"id" : "req_envelope_1"',  'envelope has id');
+  AssertContains(Body, '"model" : "llama-3.2-3b"', 'envelope has model');
+  AssertContains(Body, '"role" : "user"',          'envelope has user message');
+  AssertContains(Body, '"What is 2+2?"',           'envelope has user content');
+  AssertContains(Body, '"name" : "calculate"',     'envelope has tool name');
+  AssertContains(Body, '"max_tokens" : 256',       'envelope has max_tokens');
+  AssertContains(Body, 'system_prompt',            'envelope has system_prompt');
+  WriteLn('  ok: request body envelope shape');
+end;
+
+procedure TestGlobalQueueAccessor;
+var
+  Q: TRelayQueue;
+begin
+  AssertTrue(GetGlobalRelayQueue = nil, 'global queue starts nil');
+  Q := TRelayQueue.Create;
+  try
+    SetGlobalRelayQueue(Q);
+    AssertTrue(GetGlobalRelayQueue = Q, 'global queue accessor returns the set instance');
+    SetGlobalRelayQueue(nil);
+    AssertTrue(GetGlobalRelayQueue = nil, 'global queue cleared');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: SetGlobalRelayQueue / GetGlobalRelayQueue round-trip');
+end;
+
+begin
+  TestEnqueueDequeueRoundTrip;
+  TestCapabilityFiltering;
+  TestEmptyCapabilityListIsWildcard;
+  TestRespondSignalsWaiter;
+  TestLateRespondIsSilent;
+  TestUnregisterRequeuesInflight;
+  TestMaxAttemptsCap;
+  TestStatusSnapshot;
+  TestRequestBodyEnvelope;
+  TestGlobalQueueAccessor;
+  WriteLn('ok - relay queue tests passed');
+end.

--- a/src/tests/relay_queue_tests.pas
+++ b/src/tests/relay_queue_tests.pas
@@ -128,6 +128,32 @@ begin
   WriteLn('  ok: empty capability list is a wildcard');
 end;
 
+procedure TestEmptyRequestModelMatchesAnyWorker;
+var
+  Q: TRelayQueue;
+  Req, Out_: TRelayRequest;
+begin
+  (* The case the user surfaced during PR #318 review: when the
+     operator picks "relay" in onboarding without naming a model
+     (because they don't know which model the connected worker will
+     advertise), the agent loop calls Chat() with an empty Model
+     field. The empty model should match ANY worker -- caller said
+     "any worker will do" -- not zero workers as the original V1
+     code did. *)
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('worker-specific', Caps(['llama-3.2-3b']));
+    Req := TRelayRequest.Create('req_anymodel_1', '', '{}');
+    Q.Enqueue(Req);
+    Out_ := Q.DequeueForWorker('worker-specific', 1000);
+    AssertTrue(Out_ <> nil,
+               'empty-model request should match a worker with non-empty capabilities');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: empty request model matches any worker (onboarding case)');
+end;
+
 procedure TestRespondSignalsWaiter;
 var
   Q: TRelayQueue;
@@ -329,6 +355,7 @@ begin
   TestEnqueueDequeueRoundTrip;
   TestCapabilityFiltering;
   TestEmptyCapabilityListIsWildcard;
+  TestEmptyRequestModelMatchesAnyWorker;
   TestRespondSignalsWaiter;
   TestLateRespondIsSilent;
   TestUnregisterRequeuesInflight;

--- a/src/tests/relay_queue_tests.pas
+++ b/src/tests/relay_queue_tests.pas
@@ -276,6 +276,73 @@ begin
   WriteLn('  ok: max attempts cap fails the waiter cleanly');
 end;
 
+procedure TestCancelPullsFromPending;
+var
+  Q: TRelayQueue;
+  Req: TRelayRequest;
+  WasOurs: Boolean;
+begin
+  (* Codex P1 on PR #318: Chat() used to free a request from finally
+     without first removing it from the queue's lists. Cancel under-
+     the-lock is the safe shape; verify the public surface. *)
+  Q := TRelayQueue.Create;
+  try
+    Req := TRelayRequest.Create('req_cancel_p', 'm', '{}');
+    Q.Enqueue(Req);
+    AssertEqI(Q.GetStatus.PendingRequests, 1, 'pending before cancel');
+    WasOurs := Q.Cancel('req_cancel_p');
+    AssertTrue(WasOurs,
+               'Cancel returns True when the request was in pending');
+    AssertEqI(Q.GetStatus.PendingRequests, 0,
+              'pending counter decremented on cancel');
+    Req.Free;  { provider would Free here -- queue no longer holds the pointer }
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: Cancel pulls request from pending list');
+end;
+
+procedure TestCancelPullsFromInflight;
+var
+  Q: TRelayQueue;
+  Req: TRelayRequest;
+  WasOurs: Boolean;
+begin
+  Q := TRelayQueue.Create;
+  try
+    Q.RegisterWorker('w', Caps(['m']));
+    Req := TRelayRequest.Create('req_cancel_i', 'm', '{}');
+    Q.Enqueue(Req);
+    Q.DequeueForWorker('w', 1000);  { now inflight }
+    AssertEqI(Q.GetStatus.InflightRequests, 1, 'inflight before cancel');
+    WasOurs := Q.Cancel('req_cancel_i');
+    AssertTrue(WasOurs,
+               'Cancel returns True when the request was inflight');
+    AssertEqI(Q.GetStatus.InflightRequests, 0,
+              'inflight counter decremented on cancel');
+    Req.Free;
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: Cancel pulls request from inflight list');
+end;
+
+procedure TestCancelOfUnknownIsFalse;
+var
+  Q: TRelayQueue;
+  WasOurs: Boolean;
+begin
+  Q := TRelayQueue.Create;
+  try
+    WasOurs := Q.Cancel('req_never_existed');
+    AssertTrue(not WasOurs,
+               'Cancel returns False for unknown id (already consumed or never enqueued)');
+  finally
+    Q.Free;
+  end;
+  WriteLn('  ok: Cancel of unknown id is False');
+end;
+
 procedure TestStatusSnapshot;
 var
   Q: TRelayQueue;
@@ -360,6 +427,9 @@ begin
   TestLateRespondIsSilent;
   TestUnregisterRequeuesInflight;
   TestMaxAttemptsCap;
+  TestCancelPullsFromPending;
+  TestCancelPullsFromInflight;
+  TestCancelOfUnknownIsFalse;
   TestStatusSnapshot;
   TestRequestBodyEnvelope;
   TestGlobalQueueAccessor;


### PR DESCRIPTION
## Summary

A new provider that **inverts** the usual outbound-LLM relationship. Instead of PasClaw making HTTP calls TO a hosted LLM, an external worker app (a WebGPU browser tab, a phone running mlc-llm, a desktop running llama.cpp, anything that speaks HTTP+SSE) connects **inbound** to PasClaw's gateway, advertises which models it can serve, pulls pending inference requests off PasClaw's queue, runs them on its own hardware, and POSTs results back.

### Three flows this unblocks

1. **WebGPU on a laptop without exposing ports.** Browser tab connects outbound; PasClaw never reaches the laptop. Closes when the tab closes.
2. **Cog / Replicate-hosted PasClaw served by your phone.** PasClaw runs on Replicate (no GPU); inference happens on a phone in your pocket. The cog never talks to a paid LLM API.
3. **Share a home GPU.** Each device runs its own PasClaw; one home server runs the queue; the GPU machine connects as a worker.

## V1 scope

This PR lands the foundation — the HTTP endpoints are a focused follow-up since grafting onto the 5484-line gateway server deserves its own commit.

- ✅ Queue (`PasClaw.Gateway.RelayQueue`) — thread-safe FIFO with capability filtering, per-worker registration, requeue-on-disconnect, max-attempts cap, watchdog hook
- ✅ Provider (`PasClaw.Providers.Relay`) — implements `ILLMProvider`; enqueues and blocks on `TEvent.WaitFor`
- ✅ Catalog row + factory wiring (`relay` kind, new `pfRelay` family)
- ✅ Hermetic tests (10 cases, all passing)
- ✅ Wire-protocol doc (`docs/providers-relay.md`)
- ⏳ HTTP endpoints (`/v1/relay/poll` SSE, `/v1/relay/respond/:id`, `/v1/relay/status`) — follow-up PR
- ⏳ Reference HTML/WebLLM worker — follow-up PR
- 🔮 Streaming back to caller / structured tool calls from workers / sticky routing — V2

## Why multi-worker doesn't desync history

This was the load-bearing safety argument and worth being explicit about: **PasClaw's agent loop is strictly sequential per session**. The next `Provider.Chat()` call's prompt literally depends on the previous reply being in the history. There is only ever **one outstanding inference call per session**, so "out-of-order responses corrupting history" can't happen within one session even with 50 workers connected. Multiple workers parallelise *across* sessions / subagents, not *within* one.

Stale-on-timeout duplicate-response races are handled by request id matching: first arrival wins, late duplicates dropped silently. Worker disconnect → assigned requests requeued to head of queue, bounded by `RelayMaxAttempts` (default 3).

## How this differs from `/v1/responses`

| | `/v1/responses` (existing) | Relay (this PR) |
|---|---|---|
| Direction | App → PasClaw → upstream LLM | Worker → PasClaw ← (in-process queue) |
| Who runs inference | PasClaw's upstream LLM provider | The external worker |
| What does the external app supply? | A prompt; expects a response | Compute; expects work |
| What does PasClaw need configured? | An upstream LLM provider | An external worker (or its absence times out) |

They can coexist: a chat app calls `/v1/responses`, PasClaw orchestrates the agent loop, individual inference calls go out to relay workers. The chat-app caller never sees the relay layer. `docs/providers-relay.md` covers this in detail.

## Test plan

- [x] `make` passes
- [x] `make test-relay-queue` — 10 hermetic cases all pass (enqueue/dequeue, capability filtering, wildcard worker, respond signals waiter, late respond silent no-op, disconnect requeues, max-attempts cap, status snapshot, envelope JSON shape, global-queue accessor)
- [ ] Manual: SSE round-trip against a curl client once HTTP endpoints land (follow-up PR)
- [ ] Manual: end-to-end against a real WebLLM browser tab once HTTP endpoints land (follow-up PR)

## Files

| File | Status | LOC |
|---|---|---:|
| `src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas` | new | ~520 |
| `src/pkg/providers/PasClaw.Providers.Relay.pas` | new | ~280 |
| `src/pkg/providers/PasClaw.Providers.Catalog.pas` | modified | +24 |
| `src/pkg/providers/PasClaw.Providers.Factory.pas` | modified | +12 |
| `src/tests/relay_queue_tests.pas` | new | ~300 |
| `docs/providers-relay.md` | new | ~270 |
| `Makefile` | modified | +7 |

## cthreads gotcha worth flagging

The new test binary needs `{$IFDEF UNIX}cthreads,{$ENDIF}` in its uses clause — without it, `TEvent.Create` / `TCriticalSection.Create` succeed but the returned objects' methods AV on first call (the pthread primitives they wrap aren't initialised). The main `pasclaw` binary already pulls `cthreads` via the .dpr; the test harness has to pull it explicitly. Matches the pattern existing tests (checkpoints, condense_json, config_env_subst, fs_grep) already use. Took me 15 minutes to track down — flagging it here so the next maintainer doesn't.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_