### PR TITLE
gateway: declare TStringArray locally in RelayQueue for dcc64 (PR #318 follow-up)

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
@@ -107,6 +107,15 @@ const
   RelayWorkerResponseTimeoutMs = 3 * 60 * 1000;
 
 type
+  {$IFNDEF FPC}
+  { Delphi's RTL doesn't declare TStringArray (FPC's SysUtils does);
+    declare it locally so the cross-compiler signatures below resolve.
+    Same pattern PasClaw.Tools.Registry + PasClaw.Tools.Shell.Filters
+    use for the same gap. dcc64 E2003 / E2005 errors at every signature
+    that references TStringArray cascade until this is in scope. }
+  TStringArray = array of string;
+  {$ENDIF}
+
   TRelayRequestId = string;
   TRelayWorkerId  = string;
 


### PR DESCRIPTION
## Summary

Delphi build broke on PR #318's `PasClaw.Gateway.RelayQueue.pas` with 11 dcc64 errors all rooted in `TStringArray` not being a known type. Fix matches the established pattern used elsewhere in the codebase.

## Root cause

FPC's `SysUtils` declares `TStringArray = array of string`. Delphi's RTL does not. The 11 errors broke down as:

| Errors | Cause |
|---|---|
| Lines 172 / 178 / 183 / 220 / 345 / 536 (E2003 / E2005) | Field, parameter, and property signatures reference unknown `TStringArray` |
| Lines 351 (×2) / 397 / 563 (E2008 "Incompatible types") | Cascade — assignments / `SetLength` against unknown type fail downstream |
| Line 353 (E2250 "no overloaded Trim") | Cascade — `Trim(Caps[i])` where `Caps` is unresolved type |

## Fix

Local `{$IFNDEF FPC} TStringArray = array of string; {$ENDIF}` block inside the `type` section, right at the top before `TRelayRequestId`. Guarded so FPC builds are unaffected.

## "Do we have one we use for all?"

The user's question — and the honest answer is **no, we don't have a central shared compat unit**. The convention so far is local guarded declarations in each consuming unit. Three other places do it:

- `src/pkg/tools/PasClaw.Tools.Registry.pas` (the canonical place with the long-form explanation comment)
- `src/pkg/tools/PasClaw.Tools.Shell.Filters.pas`
- `src/cmd/PasClaw.Cmd.Profile.pas`

PR #318 missed this established pattern.

## Should we centralize?

A `PasClaw.RTL.Compat` unit re-exporting `TStringArray` (and any other FPC/Delphi RTL gaps we hit) would let units just `uses PasClaw.RTL.Compat` instead of repeating the IFNDEF block. Worth considering once we hit this for the 5th time. With 4 instances the duplicate-IFNDEF pattern is still defensible — and the local guard documents the cross-compiler issue right where it's needed. Flagging as a follow-up candidate, **not** landing here.

## Test plan

- [x] `make clean && make` passes (FPC build — the Delphi-only declaration is guarded by `IFNDEF FPC` so FPC is unaffected)
- [x] `make test-relay-queue` passes all 14 cases
- [ ] dcc64 verification — needs a Delphi build host; the fix is the same pattern that already compiles cleanly in the three sibling locations

## Files

`src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas` — 9 lines added (the IFNDEF block + comment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_