### PR TITLE
gateway: overload TRelayRequest.Create for dcc64

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
@@ -165,8 +165,15 @@ type
     FResponse:       TRelayResponse;
     FResponseValid:  Boolean;
   public
+    { Overloaded rather than a single ctor with `const ASessionId: string =
+      ''` -- dcc64 rejects calls that supply the optional 4th arg with
+      E2034 "Too many actual parameters" when the default sits behind a
+      `const string` parameter. FPC accepts both forms; we just pick the
+      overload shape that compiles on both. The 3-arg overload delegates
+      to the 4-arg form with an empty session id. }
+    constructor Create(const AId, AModel, ABodyJSON: string); overload;
     constructor Create(const AId, AModel, ABodyJSON: string;
-                       const ASessionId: string = '');
+                       const ASessionId: string); overload;
     destructor  Destroy; override;
     property Id:             TRelayRequestId  read FId;
     property Model:          string           read FModel;
@@ -348,6 +355,11 @@ begin
 end;
 
 { ----- TRelayRequest ----- }
+
+constructor TRelayRequest.Create(const AId, AModel, ABodyJSON: string);
+begin
+  Create(AId, AModel, ABodyJSON, '');
+end;
 
 constructor TRelayRequest.Create(const AId, AModel, ABodyJSON: string;
                                   const ASessionId: string);


### PR DESCRIPTION
## Summary

- dcc64 rejects the 4-arg call at `PasClaw.Providers.Relay.pas:307` with `E2034 Too many actual parameters` when the optional `ASessionId` sits behind a `const string = ''` default. FPC accepts both forms, Delphi does not.
- Split `TRelayRequest.Create` into two overloaded constructors -- a 3-arg overload that delegates to the 4-arg form with an empty session id -- so the call shape compiles on both compilers.
- PR #321 follow-up; no behaviour change.

## Test plan

- [x] `make all` (FPC build clean)
- [x] `make test-relay-queue` -- all 18 tests pass, including the 4 sticky-routing tests that exercise the 4-arg call shape
- [ ] dcc64 build to verify E2034 is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_