### PR TITLE
relay: round-trip tool metadata + surface upstream non-2xx as error (PR #323 review fix)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Relay.pas
+++ b/src/cmd/PasClaw.Cmd.Relay.pas
@@ -52,7 +52,19 @@ unit PasClaw.Cmd.Relay;
 
 interface
 
+uses
+  PasClaw.Providers.Types;
+
 function Cmd_Relay_Run(const Argv: array of string): Integer;
+
+(* Exposed for test coverage of the worker-side response envelope.
+   Returns the JSON the worker POSTs to /v1/relay/respond/<id>. Any
+   non-2xx upstream status (and the StatusCode=-1 socket-failure
+   sentinel) becomes an "error" field so the gateway's DecodeResponse
+   flips the relay response into the retryable-failure path -- without
+   this, a 429/5xx upstream surfaced as the assistant's reply text
+   and bypassed Cfg.Fallbacks. Codex P2 review on PR #323. *)
+function BuildRelayWorkerResponseJSON(const R: TLLMResponse): string;
 
 implementation
 
@@ -68,7 +80,7 @@ uses
 {$IFEND}
   PasClaw.CliUI, PasClaw.Logger, PasClaw.Utils,
   PasClaw.JSON, PasClaw.Config,
-  PasClaw.Providers.Types, PasClaw.Providers.Intf, PasClaw.Providers.Factory,
+  PasClaw.Providers.Intf, PasClaw.Providers.Factory,
   PasClaw.Providers.HTTP;
 
 type
@@ -120,7 +132,37 @@ begin
     SetLength(Result, Length(Result) - 1);
 end;
 
+function DecodeToolCalls(TCArr: TJsonArray): TToolCallArray;
+var
+  i: Integer;
+  Obj, FObj: TJsonObject;
+begin
+  SetLength(Result, 0);
+  if TCArr = nil then Exit;
+  SetLength(Result, TCArr.Count);
+  for i := 0 to TCArr.Count - 1 do
+  begin
+    Obj := TCArr.ItemObject(i);
+    if Obj = nil then Continue;
+    Result[i].Id   := Obj.GetStr('id', '');
+    Result[i].Kind := Obj.GetStr('type', 'function');
+    FObj := Obj.ChildObject('function');
+    if FObj <> nil then
+    begin
+      Result[i].Func.Name      := FObj.GetStr('name', '');
+      Result[i].Func.Arguments := FObj.GetStr('arguments', '{}');
+    end;
+  end;
+end;
+
 function DecodeMessages(MArr: TJsonArray): TMessageArray;
+{ Round-trip the OpenAI-shape message fields BuildRelayRequestBody now
+  emits: role + content + optional name + tool_call_id + tool_calls.
+  Without these, a multi-turn relayed session that fires a tool call
+  loses the tool-call/result correlation on its second turn and the
+  forwarded Provider.Chat() fails with "missing tool_call_id" (OpenAI)
+  / "tool_use_id not found" (Anthropic) / similar elsewhere. Codex P1
+  review on PR #323. }
 var
   i: Integer;
   Obj: TJsonObject;
@@ -132,8 +174,11 @@ begin
   begin
     Obj := MArr.ItemObject(i);
     if Obj = nil then Continue;
-    Result[i].Role    := MsgRoleFromString(Obj.GetStr('role', 'user'));
-    Result[i].Content := Obj.GetStr('content', '');
+    Result[i].Role       := MsgRoleFromString(Obj.GetStr('role', 'user'));
+    Result[i].Content    := Obj.GetStr('content', '');
+    Result[i].Name       := Obj.GetStr('name', '');
+    Result[i].ToolCallId := Obj.GetStr('tool_call_id', '');
+    Result[i].ToolCalls  := DecodeToolCalls(Obj.ChildArray('tool_calls'));
   end;
 end;
 
@@ -196,15 +241,41 @@ begin
   end;
 end;
 
-function BuildResponseJSON(const R: TLLMResponse): string;
+function ResponseIsError(const R: TLLMResponse): Boolean; inline;
+{ Any non-success outcome the worker should surface as a relay error
+  rather than a "valid LLM reply." StatusCode = -1 is the pre-HTTP /
+  socket / TLS failure path other providers use (network unreachable,
+  DNS, etc.). StatusCode in [200..299] is a successful HTTP exchange.
+  Anything else -- 4xx / 5xx returned by the upstream provider --
+  must NOT be encoded as a normal completion: the gateway-side
+  TRelayProvider.DecodeResponse reads `error` to flip StatusCode to
+  -1, which is what triggers the agent loop's fallback-walk over
+  Cfg.Fallbacks. Without this, a worker forwarding to a 429-rate-
+  limited OpenAI key would surface the upstream error JSON to the
+  agent as if it were the assistant's reply, killing fallback. Codex
+  P2 review on PR #323. }
+begin
+  if R.StatusCode = -1 then Exit(True);
+  if R.StatusCode = 0  then Exit(False);  { older providers that don't populate -- treat as success }
+  Result := (R.StatusCode < 200) or (R.StatusCode >= 300);
+end;
+
+function BuildRelayWorkerResponseJSON(const R: TLLMResponse): string;
 var
   Root, Usage: TJsonObject;
   TCArr: TJsonArray;
+  ErrText: string;
 begin
   Root := TJsonObject.Create;
   try
-    if R.StatusCode = -1 then
-      Root.PutStr('error', R.Content)
+    if ResponseIsError(R) then
+    begin
+      if R.StatusCode = -1 then
+        ErrText := R.Content
+      else
+        ErrText := Format('upstream HTTP %d: %s', [R.StatusCode, R.Content]);
+      Root.PutStr('error', ErrText);
+    end
     else
     begin
       Root.PutStr('content',       R.Content);
@@ -291,7 +362,7 @@ begin
           [ReqId, GetTickCount64 - StartTick, Resp.StatusCode,
            Resp.Usage.InputTokens, Resp.Usage.OutputTokens]);
 
-  RespJSON := BuildResponseJSON(Resp);
+  RespJSON := BuildRelayWorkerResponseJSON(Resp);
   PostResponse(Ctx, ReqId, RespJSON);
 end;
 

--- a/src/pkg/providers/PasClaw.Providers.Relay.pas
+++ b/src/pkg/providers/PasClaw.Providers.Relay.pas
@@ -140,9 +140,9 @@ function BuildRelayRequestBody(const Messages: array of TMessage;
                                const Options:  TChatOptions;
                                const RequestId: string): string;
 var
-  Root, MsgObj, ToolObj, OptsObj: TJsonObject;
-  MsgArr, ToolArr: TJsonArray;
-  i: Integer;
+  Root, MsgObj, ToolObj, OptsObj, TCObj, FnObj: TJsonObject;
+  MsgArr, ToolArr, TCArr: TJsonArray;
+  i, j: Integer;
 begin
   Root := TJsonObject.Create;
   try
@@ -156,14 +156,55 @@ begin
     if Options.CacheKey <> '' then
       Root.PutStr('session_id', Options.CacheKey);
 
-    { messages: full conversation. The worker is stateless -- it sees
-      the entire history on every call. }
+    (* messages: full conversation. The worker is stateless -- it
+       sees the entire history on every call.
+
+       Tool-call metadata MUST round-trip. A multi-turn relayed
+       session that fires a tool call has assistant messages carrying
+       ToolCalls and tool-result messages carrying ToolCallId / Name
+       -- provider request builders (OpenAI, Anthropic, Gemini)
+       require these to thread the call/result pair. Dropping them on
+       the worker wire (as the original V1 did) made the second turn
+       after any tool call fail with "missing tool_call_id" or stall
+       silently. Emit the OpenAI-shape envelope so workers that
+       forward through any OpenAI-compatible (and Anthropic/Gemini
+       via their adapters) provider get a valid request shape:
+
+         - assistant with tool calls: role="assistant", content, and
+           a tool_calls array of objects each with id, type, and a
+           function sub-object holding name and arguments.
+         - tool result: role="tool", tool_call_id, name (the tool
+           name), and content (the tool's output as a string).
+         - named system/user message (rare): adds a top-level name
+           field alongside role / content.
+
+       Codex P1 review on PR #323. *)
     MsgArr := TJsonArray.Create;
     for i := 0 to High(Messages) do
     begin
       MsgObj := TJsonObject.Create;
       MsgObj.PutStr('role',    MsgRoleToString(Messages[i].Role));
       MsgObj.PutStr('content', Messages[i].Content);
+      if Messages[i].Name <> '' then
+        MsgObj.PutStr('name', Messages[i].Name);
+      if Messages[i].ToolCallId <> '' then
+        MsgObj.PutStr('tool_call_id', Messages[i].ToolCallId);
+      if Length(Messages[i].ToolCalls) > 0 then
+      begin
+        TCArr := TJsonArray.Create;
+        for j := 0 to High(Messages[i].ToolCalls) do
+        begin
+          TCObj := TJsonObject.Create;
+          TCObj.PutStr('id',   Messages[i].ToolCalls[j].Id);
+          TCObj.PutStr('type', Messages[i].ToolCalls[j].Kind);
+          FnObj := TJsonObject.Create;
+          FnObj.PutStr('name',      Messages[i].ToolCalls[j].Func.Name);
+          FnObj.PutStr('arguments', Messages[i].ToolCalls[j].Func.Arguments);
+          TCObj.PutObject('function', FnObj);
+          TCArr.AddObject(TCObj);
+        end;
+        MsgObj.PutArray('tool_calls', TCArr);
+      end;
       MsgArr.AddObject(MsgObj);
     end;
     Root.PutArray('messages', MsgArr);

--- a/src/tests/relay_queue_tests.pas
+++ b/src/tests/relay_queue_tests.pas
@@ -35,7 +35,10 @@ uses
   SysUtils, Classes, SyncObjs,
   PasClaw.Providers.Types,
   PasClaw.Providers.Relay,
-  PasClaw.Gateway.RelayQueue;
+  PasClaw.Gateway.RelayQueue,
+  PasClaw.Cmd.Relay;          { BuildRelayWorkerResponseJSON -- worker-side
+                                response envelope. Exposed for the Codex P2
+                                non-2xx-as-error coverage. }
 
 procedure Fail_(const Msg: string);
 begin WriteLn('FAIL: ' + Msg); Halt(1); end;
@@ -582,6 +585,106 @@ begin
   WriteLn('  ok: request body envelope shape');
 end;
 
+procedure TestRequestBodyToolMetadataRoundTrip;
+(* Codex P1 review on PR #323: round-trip the tool-call metadata
+   BuildRelayRequestBody now emits so workers can rebuild a faithful
+   TMessage[] for their forwarded Provider.Chat() call. Pre-fix, an
+   assistant message with ToolCalls + a tool result with ToolCallId
+   came out the worker side as bare role/content, and the next turn's
+   request to OpenAI/Anthropic failed with "missing tool_call_id". *)
+var
+  Msgs:  array of TMessage;
+  Tools: array of TToolDefinition;
+  Opts:  TChatOptions;
+  Body:  string;
+begin
+  SetLength(Msgs, 3);
+  Msgs[0] := MakeMessage(mrUser, 'Read foo.pas');
+
+  Msgs[1] := MakeMessage(mrAssistant, '');
+  SetLength(Msgs[1].ToolCalls, 1);
+  Msgs[1].ToolCalls[0].Id            := 'call_42';
+  Msgs[1].ToolCalls[0].Kind          := 'function';
+  Msgs[1].ToolCalls[0].Func.Name     := 'fs_read';
+  Msgs[1].ToolCalls[0].Func.Arguments := '{"path":"foo.pas"}';
+
+  Msgs[2] := MakeMessage(mrTool, 'unit Foo; ...');
+  Msgs[2].ToolCallId := 'call_42';
+  Msgs[2].Name       := 'fs_read';
+
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+
+  Body := BuildRelayRequestBody(Msgs, Tools, 'm', Opts, 'req_tool_rt_1');
+
+  AssertContains(Body, '"tool_calls"',            'assistant tool_calls array emitted');
+  AssertContains(Body, '"id" : "call_42"',        'tool call id emitted');
+  AssertContains(Body, '"name" : "fs_read"',      'tool call function name emitted');
+  AssertContains(Body, '"arguments" : "{\"path\":\"foo.pas\"}"',
+                                                  'tool call arguments emitted (json-string)');
+  AssertContains(Body, '"tool_call_id" : "call_42"', 'tool result tool_call_id emitted');
+  AssertContains(Body, '"role" : "tool"',         'tool result role emitted');
+
+  WriteLn('  ok: tool-call metadata round-trips through the envelope');
+end;
+
+procedure TestWorkerResponseSurfacesNon2xxAsError;
+(* Codex P2 review on PR #323: a worker forwarding to a provider that
+   returns 401/429/5xx must encode the result as an "error" envelope
+   so the gateway-side TRelayProvider.DecodeResponse maps it to
+   StatusCode := -1 -- the retryable sentinel that triggers
+   Cfg.Fallbacks. Pre-fix, only StatusCode = -1 (pre-HTTP socket
+   failure) got encoded as error; positive non-2xx fell into the
+   success path and the upstream error text surfaced to the agent as
+   the assistant's reply, bypassing fallback. *)
+var
+  R: TLLMResponse;
+  Body: string;
+begin
+  { 429 from upstream rate limiting. }
+  FillChar(R, SizeOf(R), 0);
+  R.StatusCode := 429;
+  R.Content    := '{"error":"rate_limited"}';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertContains(Body, '"error"',                 '429 surfaces error key');
+  AssertContains(Body, 'upstream HTTP 429',       '429 message names the status');
+  AssertContains(Body, 'rate_limited',            '429 carries upstream body');
+
+  { 500 from a flaky vLLM. }
+  FillChar(R, SizeOf(R), 0);
+  R.StatusCode := 500;
+  R.Content    := 'internal server error';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertContains(Body, '"error"',                 '500 surfaces error key');
+  AssertContains(Body, 'upstream HTTP 500',       '500 message names the status');
+
+  { -1 socket failure -- pre-fix path; must still encode as error. }
+  FillChar(R, SizeOf(R), 0);
+  R.StatusCode := -1;
+  R.Content    := 'ECONNREFUSED';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertContains(Body, '"error"',                 '-1 still surfaces error key');
+  AssertContains(Body, 'ECONNREFUSED',            '-1 keeps the socket-error text');
+
+  { 200 success -- must NOT have an error key. }
+  FillChar(R, SizeOf(R), 0);
+  R.StatusCode := 200;
+  R.Content    := 'Hello!';
+  R.FinishReason := 'stop';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertTrue(Pos('"error"', Body) = 0,            '200 has no error key');
+  AssertContains(Body, '"content" : "Hello!"',    '200 carries content');
+
+  { 0 (older provider that doesn't populate the code) -- treat as success. }
+  FillChar(R, SizeOf(R), 0);
+  R.StatusCode := 0;
+  R.Content    := 'legacy provider reply';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertTrue(Pos('"error"', Body) = 0,            '0 has no error key (legacy success path)');
+
+  WriteLn('  ok: worker encodes non-2xx upstream status as a relay error');
+end;
+
 procedure TestGlobalQueueAccessor;
 var
   Q: TRelayQueue;
@@ -617,6 +720,8 @@ begin
   TestEmptySessionIdIsNeverSticky;
   TestStatusSnapshot;
   TestRequestBodyEnvelope;
+  TestRequestBodyToolMetadataRoundTrip;
+  TestWorkerResponseSurfacesNon2xxAsError;
   TestGlobalQueueAccessor;
   WriteLn('ok - relay queue tests passed');
 end.


### PR DESCRIPTION
## Summary

Two review fixes against PR #323. Stacked on `claude/cmd-relay-worker` so the diff shows only the delta; auto-rebases to main once #323 merges.

### P1 — tool-call metadata must round-trip

A multi-turn relayed session that fires a tool call had its assistant `ToolCalls` and tool-result `ToolCallId` / `Name` silently dropped — both ends of the wire were stripping them. The next turn forwarded a request with no `tool_call_id`, and OpenAI 400'd with "missing tool_call_id" (Anthropic / Gemini equivalent on their side). Fixed at both ends:

- `BuildRelayRequestBody` (gateway side, `PasClaw.Providers.Relay.pas`): emits `tool_calls` array (id / type / function.name / function.arguments), top-level `tool_call_id`, and top-level `name` when non-empty.
- `DecodeMessages` (worker side, `PasClaw.Cmd.Relay.pas`): reads them back into the corresponding `TMessage` fields, with a new `DecodeToolCalls` helper that mirrors the existing response-side decoder in `HandleRelayRespond`.

### P2 — surface upstream non-2xx as a relay error

`BuildResponseJSON` only encoded `error` when `StatusCode = -1` (pre-HTTP socket failure). A 429 / 5xx from upstream OpenAI/Anthropic/etc. fell into the success branch, the gateway saw no error field, mapped to `StatusCode := 200`, and the agent saw the provider's error JSON as the assistant's reply — bypassing `Cfg.Fallbacks` entirely. New `ResponseIsError` helper treats `-1` and any code outside [200..299] as an error; `StatusCode = 0` (older providers that don't populate the code) still treats as success for back-compat. Renamed `BuildResponseJSON` → `BuildRelayWorkerResponseJSON` and exposed it in the interface so the new test can drive it.

## Test plan

Both fixes covered by new cases in `src/tests/relay_queue_tests.pas`:

- [x] `tool-call metadata round-trips through the envelope` — assistant with `ToolCalls`, tool result with `ToolCallId` + `Name`; asserts `tool_calls` array, `id`, function `name` + `arguments`, `tool_call_id`, `role:"tool"` all present.
- [x] `worker encodes non-2xx upstream status as a relay error` — covers `StatusCode = 429`, `500`, `-1` (all → `error` key with descriptive prefix), and `200` / `0` (both → no `error` key, success path).
- [x] `make test-relay-queue` — 20/20 cases green.
- [x] `make all` clean.
- [ ] dcc64 build (un-blocked once PR #322 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_