### PR TITLE
cmd: implement pasclaw relay SSE worker on TNetHTTPClient

### DIFF
--- a/src/cmd/PasClaw.Cmd.Relay.pas
+++ b/src/cmd/PasClaw.Cmd.Relay.pas
@@ -498,6 +498,7 @@ var
   Stream: TSSEStream;
   URL:    string;
   Hdrs:   TNetHeaders;
+  Resp:   IHTTPResponse;
 begin
   Result := False;
   ErrMsg := '';
@@ -531,10 +532,29 @@ begin
     Stream := TSSEStream.Create(@Ctx);
     try
       try
-        Client.Get(URL, Stream, Hdrs);
-        { Get returned without an exception -> server closed the
-          stream cleanly. Outer loop reconnects. }
-        Result := True;
+        (* Capture the response so we can inspect StatusCode.
+           THTTPClient.Get does NOT raise on non-2xx (unlike Indy's
+           TIdHTTP.Get, which raises EIdHTTPProtocolException by
+           default). The gateway's /v1/relay/poll handler returns
+           plain JSON for 401 (bad / missing token), 400 (missing
+           worker id) and 503 (relay queue not initialised); without
+           checking StatusCode here, every one of those reads as
+           "server closed cleanly" -> outer loop resets backoff to
+           1s -> worker spins forever hammering the gateway with the
+           same bad request. Codex P2 review on PR #330. *)
+        Resp := Client.Get(URL, Stream, Hdrs);
+        if (Resp = nil) or (Resp.StatusCode < 200) or (Resp.StatusCode >= 300) then
+        begin
+          if Resp <> nil then
+            ErrMsg := Format('HTTP %d %s', [Resp.StatusCode, Resp.StatusText])
+          else
+            ErrMsg := 'no response from gateway';
+          Result := False;
+        end
+        else
+          { 2xx + stream closed = clean disconnect, outer loop
+            reconnects with backoff reset. }
+          Result := True;
       except
         on E: Exception do
         begin

--- a/src/cmd/PasClaw.Cmd.Relay.pas
+++ b/src/cmd/PasClaw.Cmd.Relay.pas
@@ -477,14 +477,77 @@ end;
 
 function OpenSSEAndPump(const Ctx: TWorkerCtx; out ErrMsg: string): Boolean;
 {$IF Defined(PASCLAW_NETHTTP) and not Defined(FPC)}
-{ TNetHTTPClient path: not supported for V1. SSE through TNetHTTPClient
-  requires its OnReceiveData callback, which has a different lifecycle.
-  Surface a clear error so operators on the Delphi -DPASCLAW_NETHTTP
-  build know to switch backends. }
+(* TNetHTTPClient path -- Delphi-only, opt-in via -DPASCLAW_NETHTTP for
+   builds that need to skip OpenSSL DLL shipping (Windows SChannel /
+   macOS Secure Transport / Linux libcurl handle TLS instead).
+
+   Shape mirrors the Indy branch below: build a custom destination
+   stream, kick off a GET that writes body bytes into it as they
+   arrive, and let the inline TSSEStream.Write parse + dispatch each
+   `data:` event synchronously. THTTPClient.Get(URL, Stream, Headers)
+   blocks until the server closes the connection or raises on
+   disconnect / read error -- same lifecycle the Indy version
+   relies on. Outer Run loop handles reconnect on either path.
+
+   The original V1 left this branch as an error stub so anyone
+   running `pasclaw relay` on a -DPASCLAW_NETHTTP build hit an
+   immediate "rebuild without the define" message; that defeated the
+   point of the OpenSSL-free path. *)
+var
+  Client: THTTPClient;
+  Stream: TSSEStream;
+  URL:    string;
+  Hdrs:   TNetHeaders;
 begin
-  ErrMsg := 'pasclaw relay worker requires the Indy HTTP backend; ' +
-           'rebuild without -DPASCLAW_NETHTTP';
   Result := False;
+  ErrMsg := '';
+  URL := StripTrailingSlash(Ctx.GatewayURL) + '/v1/relay/poll';
+
+  Client := THTTPClient.Create;
+  try
+    { Connection timeout is bounded (15 s) so a dead gateway surfaces
+      promptly via the reconnect loop. ResponseTimeout = 0 means "no
+      timeout" -- required for SSE long-polling where idle periods
+      between events can be arbitrarily long. }
+    Client.ConnectionTimeout := 15 * 1000;
+    Client.ResponseTimeout   := 0;
+    Client.HandleRedirects   := True;
+    Client.UserAgent         := 'PasClaw-relay-worker/0.1';
+    Client.Accept            := 'text/event-stream';
+
+    { Build headers array. TNetHeaders is `array of TNetHeader`;
+      THTTPClient.Get's third argument expects this shape. Capabilities
+      header omitted when empty so the gateway sees the same "wildcard
+      worker" signal it gets from the Indy path. }
+    if Ctx.Caps <> '' then
+      SetLength(Hdrs, 3)
+    else
+      SetLength(Hdrs, 2);
+    Hdrs[0] := TNetHeader.Create('Authorization',     'Bearer ' + Ctx.Token);
+    Hdrs[1] := TNetHeader.Create('X-Relay-Worker-Id', Ctx.WorkerId);
+    if Ctx.Caps <> '' then
+      Hdrs[2] := TNetHeader.Create('X-Relay-Capabilities', Ctx.Caps);
+
+    Stream := TSSEStream.Create(@Ctx);
+    try
+      try
+        Client.Get(URL, Stream, Hdrs);
+        { Get returned without an exception -> server closed the
+          stream cleanly. Outer loop reconnects. }
+        Result := True;
+      except
+        on E: Exception do
+        begin
+          ErrMsg := E.Message;
+          Result := False;
+        end;
+      end;
+    finally
+      Stream.Free;
+    end;
+  finally
+    Client.Free;
+  end;
 end;
 {$ELSE}
 var


### PR DESCRIPTION
## Summary

Replaces the `OpenSSEAndPump` stub on the `PASCLAW_NETHTTP` branch with a real `TNetHTTPClient` implementation, so `pasclaw relay` works under the OpenSSL-free Delphi build (Windows SChannel / macOS Secure Transport / Linux libcurl). Previously that branch errored with `pasclaw relay worker requires the Indy HTTP backend; rebuild without -DPASCLAW_NETHTTP` — defeating the whole point of the define (shipping a runtime-clean Windows binary without OpenSSL DLLs alongside `pasclaw.exe`).

## Implementation

Mirrors the Indy branch shape so the rest of `PasClaw.Cmd.Relay` (`TSSEStream`, `DispatchEvent`, `PostResponse`, reconnect loop) is reused verbatim:

- `THTTPClient` with `ConnectionTimeout = 15s`, `ResponseTimeout = 0` (no timeout) for SSE long-polling. The outer `Run` loop handles reconnect on drops, matching the Indy `ReadTimeout := 0` convention.
- `TNetHeaders` array built with `TNetHeader.Create` — Authorization + X-Relay-Worker-Id + X-Relay-Capabilities. Capabilities header omitted when empty so the gateway sees the same "wildcard worker" signal it gets from the Indy code path.
- `THTTPClient.Get(URL, Stream, Headers)` writes body bytes to the destination stream as they arrive (same shape as Indy's `TIdHTTP.Get(URL, Stream)`), so `TSSEStream`'s existing `Write` override parses + dispatches each `data:` event without modification.
- No explicit TLS setup — `THTTPClient` picks the platform's TLS stack automatically from the URL scheme.

~70 LOC added; net behaviour change is "this branch now works" instead of "this branch errors out."

## Test plan

- [x] FPC build clean (`make all`) — the `PASCLAW_NETHTTP` branch is gated out under FPC.
- [x] `make test-relay-queue` — 20/20 green.
- [x] **Indy smoke**: gateway + worker round-trip verified end-to-end (worker registers via `/v1/relay/poll`, gateway enqueues via `POST /v1/chat`, worker dispatches and posts back, response surfaces). No regression on the historical path.
- [ ] dcc64 + `-DPASCLAW_NETHTTP` build — untested locally (no dcc64 in this environment). The TNetHTTPClient APIs used (`THTTPClient`, `TNetHeader.Create`, `THTTPClient.Get(URL, Stream, Headers)`, `ConnectionTimeout`, `ResponseTimeout`) all match the patterns already in `PasClaw.Providers.HTTP`'s NetHTTP backend, so this should be a clean compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_