### PR TITLE
relay: round-trip provider_signature through the wire envelope (Gemini 3 thoughtSignature)

### DIFF
--- a/docs/providers-relay.md
+++ b/docs/providers-relay.md
@@ -182,6 +182,17 @@ Workers that don't support tool calling just ignore the `tools` array
 and emit any tool calls as text in the response; PasClaw extracts them
 on receipt.
 
+Assistant messages in `messages[]` that carry tool calls use the same
+OpenAI shape — `role:"assistant"` + `tool_calls: [{id, type,
+function: {name, arguments}, provider_signature? }, ...]` — with
+`tool_call_id` on the matching tool result. The optional
+`provider_signature` round-trips Gemini 3+'s `thoughtSignature` (or
+any future opaque per-call provider blob); workers forwarding to a
+Gemini 3 model must echo it back into the upstream request or
+Gemini returns 400 *"Function call is missing a thought_signature."*
+Workers forwarding to other providers see the field absent and
+ignore it.
+
 ## Response envelope
 
 ```jsonc
@@ -206,7 +217,20 @@ on receipt.
       "function": {
         "name":      "fs_read",
         "arguments": "{\"path\":\"foo.pas\"}"
-      }
+      },
+      "provider_signature": "..."   // optional; opaque blob the
+                                    // assistant must echo back on the
+                                    // follow-up turn. Currently only
+                                    // Gemini 3+ uses this (its
+                                    // `thoughtSignature` on
+                                    // functionCall parts); other
+                                    // providers and Gemini 2.x leave
+                                    // it empty / absent. PasClaw round-
+                                    // trips it through the request
+                                    // envelope's `tool_calls` so the
+                                    // next turn doesn't 400 with
+                                    // "Function call is missing a
+                                    // thought_signature."
     }
   ]
 }

--- a/src/cmd/PasClaw.Cmd.Relay.pas
+++ b/src/cmd/PasClaw.Cmd.Relay.pas
@@ -198,6 +198,12 @@ begin
       if TCObj = nil then Continue;
       Result[i].ToolCalls[j].Id   := TCObj.GetStr('id', '');
       Result[i].ToolCalls[j].Kind := TCObj.GetStr('type', 'function');
+      { Round-trip the Gemini-3 thoughtSignature -- BuildRelayRequestBody
+        emits it as `provider_signature` next to each tool_call when
+        non-empty. Empty for non-Gemini callers, in which case the
+        getter returns ''. }
+      Result[i].ToolCalls[j].ProviderSignature :=
+        TCObj.GetStr('provider_signature', '');
       FObj := TCObj.ChildObject('function');
       if FObj <> nil then
       begin
@@ -270,6 +276,15 @@ begin
     FObj.PutStr('name',      Calls[i].Func.Name);
     FObj.PutStr('arguments', Calls[i].Func.Arguments);
     Obj.PutObject('function', FObj);
+    { Emit provider_signature from the worker's local provider so the
+      gateway side can stash it on TLLMResponse.ToolCalls[i] and feed
+      it back in next turn's request envelope (BuildRelayRequestBody).
+      Gemini 3+ returns this on the assistant's functionCall part and
+      400s the follow-up if it's dropped. Only emitted when
+      non-empty -- other providers (including Gemini 2.x) leave it
+      blank and the field is omitted from the wire. }
+    if Calls[i].ProviderSignature <> '' then
+      Obj.PutStr('provider_signature', Calls[i].ProviderSignature);
     Result.AddObject(Obj);
   end;
 end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3265,6 +3265,16 @@ begin
           TC.Func.Name      := FObj.GetStr('name', '');
           TC.Func.Arguments := FObj.GetStr('arguments', '{}');
         end;
+        { Round-trip the Gemini-3 thoughtSignature (or any future
+          opaque per-tool-call provider blob). EncodeToolCalls on the
+          worker side emits it as `provider_signature`; here we read
+          it back into TC.ProviderSignature so TRelayProvider.
+          DecodeResponse can copy it forward into TLLMResponse and the
+          gateway-side agent loop threads it back into the next
+          turn's BuildRelayRequestBody envelope. Without this, the
+          worker's local Gemini 3 provider 400s on turn 2 with
+          "Function call is missing a thought_signature." }
+        TC.ProviderSignature := TCObj.GetStr('provider_signature', '');
         SetLength(Resp.ToolCalls, Length(Resp.ToolCalls) + 1);
         Resp.ToolCalls[High(Resp.ToolCalls)] := TC;
       end;

--- a/src/pkg/providers/PasClaw.Providers.Relay.pas
+++ b/src/pkg/providers/PasClaw.Providers.Relay.pas
@@ -201,6 +201,19 @@ begin
           FnObj.PutStr('name',      Messages[i].ToolCalls[j].Func.Name);
           FnObj.PutStr('arguments', Messages[i].ToolCalls[j].Func.Arguments);
           TCObj.PutObject('function', FnObj);
+          (* provider_signature: opaque blob the assistant must echo
+             back on the follow-up turn. Currently used only by Gemini
+             3+ (the thoughtSignature on functionCall parts) -- Gemini
+             3 rejects the next request with 400 "Function call is
+             missing a thought_signature" if it's dropped. Empty for
+             other providers and for Gemini 2.x; only emitted when
+             non-empty to keep the wire compact. The worker's
+             DecodeMessages reads it back into TToolCall.
+             ProviderSignature, which the worker's local Gemini
+             provider then threads back into the request. *)
+          if Messages[i].ToolCalls[j].ProviderSignature <> '' then
+            TCObj.PutStr('provider_signature',
+                          Messages[i].ToolCalls[j].ProviderSignature);
           TCArr.AddObject(TCObj);
         end;
         MsgObj.PutArray('tool_calls', TCArr);

--- a/src/tests/relay_queue_tests.pas
+++ b/src/tests/relay_queue_tests.pas
@@ -628,6 +628,48 @@ begin
   WriteLn('  ok: tool-call metadata round-trips through the envelope');
 end;
 
+procedure TestRequestBodyEmitsProviderSignature;
+(* Gemini 3+ thoughtSignature must round-trip through the request
+   envelope. The assistant's prior turn carries a thoughtSignature
+   per functionCall part; if BuildRelayRequestBody drops it on the
+   wire, the worker's local Gemini 3 provider 400s the next request
+   with "Function call is missing a thought_signature." User report
+   on PR #330. *)
+var
+  Msgs:  array of TMessage;
+  Tools: array of TToolDefinition;
+  Opts:  TChatOptions;
+  Body:  string;
+begin
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrAssistant, '');
+  SetLength(Msgs[0].ToolCalls, 1);
+  Msgs[0].ToolCalls[0].Id                := 'call_sig_1';
+  Msgs[0].ToolCalls[0].Kind              := 'function';
+  Msgs[0].ToolCalls[0].Func.Name         := 'fs_list';
+  Msgs[0].ToolCalls[0].Func.Arguments    := '{}';
+  Msgs[0].ToolCalls[0].ProviderSignature := 'OPAQUE_GEMINI_3_SIG_BLOB';
+
+  SetLength(Tools, 0);
+  Opts := DefaultChatOptions;
+
+  Body := BuildRelayRequestBody(Msgs, Tools, 'gemini-3-pro', Opts, 'req_sig_1');
+
+  AssertContains(Body, '"provider_signature"',
+                 'envelope carries provider_signature key');
+  AssertContains(Body, 'OPAQUE_GEMINI_3_SIG_BLOB',
+                 'envelope carries the actual signature value');
+
+  { Empty signature must NOT emit the key -- keeps the wire clean
+    for non-Gemini callers and Gemini 2.x. }
+  Msgs[0].ToolCalls[0].ProviderSignature := '';
+  Body := BuildRelayRequestBody(Msgs, Tools, 'gpt-4o', Opts, 'req_sig_2');
+  AssertTrue(Pos('provider_signature', Body) = 0,
+             'empty signature omitted from wire');
+
+  WriteLn('  ok: provider_signature round-trips through the request envelope');
+end;
+
 procedure TestWorkerResponseSurfacesNon2xxAsError;
 (* Codex P2 review on PR #323: a worker forwarding to a provider that
    returns 401/429/5xx must encode the result as an "error" envelope
@@ -685,6 +727,41 @@ begin
   WriteLn('  ok: worker encodes non-2xx upstream status as a relay error');
 end;
 
+procedure TestWorkerResponseEmitsProviderSignature;
+(* Worker-side response envelope must carry provider_signature so
+   HandleRelayRespond can stash it on TLLMResponse.ToolCalls[i] for
+   BuildRelayRequestBody to emit on the next turn. Without this, the
+   round-trip is broken at the worker -> gateway hop and Gemini 3
+   still 400s on turn 2. *)
+var
+  R: TLLMResponse;
+  Body: string;
+begin
+  FillChar(R, SizeOf(R), 0);
+  R.StatusCode    := 200;
+  R.Content       := '';
+  R.FinishReason  := 'tool_calls';
+  SetLength(R.ToolCalls, 1);
+  R.ToolCalls[0].Id                := 'call_resp_sig_1';
+  R.ToolCalls[0].Kind              := 'function';
+  R.ToolCalls[0].Func.Name         := 'fs_list';
+  R.ToolCalls[0].Func.Arguments    := '{}';
+  R.ToolCalls[0].ProviderSignature := 'GEMINI_3_RESPONSE_SIG_BLOB';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertContains(Body, '"provider_signature"',
+                 'response carries provider_signature key');
+  AssertContains(Body, 'GEMINI_3_RESPONSE_SIG_BLOB',
+                 'response carries the actual signature value');
+
+  { Empty signature must NOT emit the field. }
+  R.ToolCalls[0].ProviderSignature := '';
+  Body := BuildRelayWorkerResponseJSON(R);
+  AssertTrue(Pos('provider_signature', Body) = 0,
+             'empty signature omitted from response wire');
+
+  WriteLn('  ok: provider_signature round-trips through the response envelope');
+end;
+
 procedure TestGlobalQueueAccessor;
 var
   Q: TRelayQueue;
@@ -721,7 +798,9 @@ begin
   TestStatusSnapshot;
   TestRequestBodyEnvelope;
   TestRequestBodyToolMetadataRoundTrip;
+  TestRequestBodyEmitsProviderSignature;
   TestWorkerResponseSurfacesNon2xxAsError;
+  TestWorkerResponseEmitsProviderSignature;
   TestGlobalQueueAccessor;
   WriteLn('ok - relay queue tests passed');
 end.


### PR DESCRIPTION
## Summary

User report: `pasclaw serve` (default_provider=relay) + `pasclaw relay --provider gemini`. Chat fired `fs_list`, got the result, and Gemini 3 returned 400 on the follow-up turn:

> Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly...

PasClaw already has `TToolCall.ProviderSignature` on the record type, and the Gemini provider both reads it from incoming responses (`PasClaw.Providers.Gemini.pas:749`) and emits it on outgoing requests (line 538) — the round-trip works fine when the agent talks to Gemini directly. The relay envelope sat in the middle and silently dropped the field at all four crossings:

| Direction | Site | Field added |
|---|---|---|
| worker Gemini response → wire | `EncodeToolCalls` (Cmd.Relay) | emit `provider_signature` when non-empty |
| `POST /v1/relay/respond` → `TLLMResponse` | `HandleRelayRespond` (Gateway.Server) | read `provider_signature` into `TC.ProviderSignature` |
| agent loop next turn → wire | `BuildRelayRequestBody` (Providers.Relay) | emit `provider_signature` when non-empty |
| SSE event read → worker `TMessage` | `DecodeMessages` (Cmd.Relay) | read `provider_signature` into `Result[i].ToolCalls[j].ProviderSignature` |

Field name on the wire is `provider_signature` — intentionally neutral so any future provider needing a similar opaque per-call blob can reuse the slot without renaming. Only emitted when non-empty so non-Gemini providers (and Gemini 2.x) see no wire change.

## Test plan

- [x] `make all` clean.
- [x] `make test-relay-queue` — 22/22 green. Added two new cases:
  - `provider_signature round-trips through the request envelope` — covers non-empty emit + empty omit on `BuildRelayRequestBody`.
  - `provider_signature round-trips through the response envelope` — covers non-empty emit + empty omit on `BuildRelayWorkerResponseJSON`.
- [x] `docs/providers-relay.md` updated: added `provider_signature` to the response envelope example and a paragraph under the request envelope explaining the Gemini-3 use case and the omit-when-empty rule.
- [ ] Live retest of the reported flow (`serve` + relay-to-Gemini, chat with a tool call, observe next turn) — should be unblocked end-to-end once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_