### PR TITLE
browser: fix Dockerfile path in build.sh

### DIFF
--- a/browser/build.sh
+++ b/browser/build.sh
@@ -58,7 +58,10 @@ ensure_c2w
 echo "    using c2w: $C2W"
 
 echo "==> 1/7  build the image with browser networking compiled in (C2W=1)"
-docker build -f docker/Dockerfile --build-arg C2W=1 -t "$IMAGE" .
+# Dockerfile lives at the repo root (`./Dockerfile`), not under docker/ --
+# docker/ holds the README only. Omit `-f` so docker picks up the
+# default ./Dockerfile under our build context.
+docker build --build-arg C2W=1 -t "$IMAGE" .
 
 echo "==> 2/7  derive a browser image: onboard (BYO API key) then run the agent"
 # The normal image runs the gateway SERVER (no use in a single-user tab). For


### PR DESCRIPTION
## Summary

One-line fix in `browser/build.sh` step 1/7. It passed `-f docker/Dockerfile` to `docker build`, but the Dockerfile lives at the repo root (`./Dockerfile`); the `docker/` directory only holds the README. The build failed immediately with:

```
ERROR: failed to build: failed to solve: failed to read dockerfile:
       open Dockerfile: no such file or directory
```

Dropped the explicit `-f` so docker uses the default `./Dockerfile` under the build context. Added a comment explaining why the path looks the way it does, so the next person reading the script doesn't try to "fix" it back.

## Test plan

- [x] `bash -n browser/build.sh` — syntax OK.
- [x] `grep -n "docker/" browser/build.sh` — remaining matches are comments only.
- [ ] User reproduces the original failure mode with this build of `build.sh`: should now get past step 1/7 (the c2w → webpack pipeline downstream still needs docker + node + npm + no TLS-intercepting proxy per the script's preamble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_