### PR TITLE
browser: forward c2w --build-arg SOURCE_REPO to dodge stale ktock/container2wasm pin

### DIFF
--- a/browser/build.sh
+++ b/browser/build.sh
@@ -80,7 +80,19 @@ DOCKERFILE
 
 echo "==> 3/7  c2w --to-js : emscripten wasm + js into $OUT/"
 rm -rf "$OUT"; mkdir -p "$OUT"
-"$C2W" --to-js "$BROWSER_IMAGE" "$OUT/"
+# c2w v0.8.4's internal Dockerfile clones ${SOURCE_REPO} (default
+# https://github.com/ktock/container2wasm) at the pinned
+# ${SOURCE_REPO_VERSION} for build assets. ktock's repo no longer
+# carries tags (the project moved to its own org), so the default
+# clone now dies with `Remote branch v0.8.4 not found in upstream
+# origin`. Forward a docker --build-arg through c2w's --build-arg
+# passthrough so the assets stage clones the still-tagged
+# container2wasm/container2wasm fork instead. Override via the
+# C2W_SOURCE_REPO env if a future upstream move breaks this again.
+C2W_SOURCE_REPO="${C2W_SOURCE_REPO:-https://github.com/container2wasm/container2wasm}"
+"$C2W" --to-js \
+  --build-arg "SOURCE_REPO=$C2W_SOURCE_REPO" \
+  "$BROWSER_IMAGE" "$OUT/"
 
 echo "==> 4/7  fetch the container2wasm example harness ($C2W_VERSION)"
 git clone --depth 1 -b "$C2W_VERSION" \


### PR DESCRIPTION
## Summary

Follow-up to merged PR #336. The Dockerfile-path fix unblocked step 1/7, but step 3/7 (`c2w --to-js`) then died deeper in:

```
> [assets-base 3/3] RUN git clone -b v0.8.4
>   https://github.com/ktock/container2wasm /assets
fatal: Remote branch v0.8.4 not found in upstream origin
```

That clone is from **c2w v0.8.4's own internal Dockerfile**, not ours. It hard-codes `SOURCE_REPO=https://github.com/ktock/container2wasm` as the default `ARG`. The project moved to its own org `container2wasm/container2wasm`, and the original `ktock/container2wasm` fork's tags page now reads *"There aren't any releases here."* The same `v0.8.4` tag still exists at `container2wasm/container2wasm` — which is the URL the rest of `build.sh` (step 4/7) was already cloning from.

Fix: forward `SOURCE_REPO=https://github.com/container2wasm/container2wasm` via c2w's `--build-arg` passthrough so the assets stage clones from the canonical fork. Exposed as `C2W_SOURCE_REPO` env override so the next URL drift can be patched without editing the script.

## Test plan

- [x] `bash -n browser/build.sh` — syntax OK.
- [x] Confirmed via the upstream c2w v0.8.4 Dockerfile that `SOURCE_REPO` is an overridable `ARG`.
- [x] Confirmed via `cmd/c2w/main.go` (v0.8.4) that the c2w CLI exposes `--build-arg` as a `StringSliceFlag`.
- [ ] User reproduces with this build of `build.sh`: should get past step 3/7's stale-clone failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_