### PR TITLE
cog-build-deploy: Node 22 + verified --temporary deploy works end-to-end

### DIFF
--- a/cog-build-deploy/cog.yaml
+++ b/cog-build-deploy/cog.yaml
@@ -44,10 +44,12 @@ build:
     - "tzdata"
     - "zip"
     - "unzip"
-    # node -- required for the wrangler CLI. nodejs 20 ships in
-    # bookworm-backports / Nodesource; we install from Nodesource
-    # in the `run` block below to get a recent enough version
-    # (wrangler 3.x requires node >= 18).
+    # node -- required for the wrangler CLI. We install node 22 from
+    # Nodesource in the `run` block below: wrangler 4.x needs a recent
+    # Node (4.40+ dropped Node 18, and the 4.102+ line that ships the
+    # --temporary flag wants Node 20+; pin 22 LTS so we're comfortably
+    # above the floor and on a maintained line). gnupg is for the
+    # Nodesource apt key.
     - "gnupg"
   python_version: "3.10"
   python_requirements: "requirements.txt"
@@ -78,18 +80,22 @@ build:
     - curl -fsSL -o /usr/local/bin/pget https://github.com/replicate/pget/releases/latest/download/pget_linux_x86_64
     - chmod +x /usr/local/bin/pget
 
-    # 6. node 20 + wrangler (the deploy step). Cloudflare's
+    # 6. node 22 + wrangler (the deploy step). Cloudflare's
     #    `wrangler deploy --temporary` is what unlocks the no-API-key
     #    deploy path -- see https://blog.cloudflare.com/temporary-accounts/.
     #    REQUIRES wrangler >= 4.102.0 (the version that ships the
     #    --temporary flag); earlier majors -- including 3.x -- fail
     #    with "unknown flag --temporary" and the whole deploy step
-    #    dead-letters silently. Pin to the 4.x line via ^4.102 so a
-    #    patch bump can ship without re-editing the cog. Bump
-    #    deliberately when Cloudflare changes the flag shape.
-    - curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    #    dead-letters silently. wrangler 4.x also wants a recent Node,
+    #    so install Node 22 LTS (Node 20 is past its prime and some
+    #    wrangler 4.x deps emit engine warnings / break on it). Pin
+    #    wrangler to the 4.x line via ^4.102 so a patch bump can ship
+    #    without re-editing the cog; bump deliberately when Cloudflare
+    #    changes the flag shape.
+    - curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
     - apt-get install -y nodejs
     - npm install -g 'wrangler@^4.102'
+    - node --version
     - wrangler --version
 
     # 7. Cleanup

--- a/cog-build-deploy/predict.py
+++ b/cog-build-deploy/predict.py
@@ -50,8 +50,12 @@ just carry placeholder strings the caller can detect.
 
 Notes
 -----
-- wrangler is a Node CLI; the image installs node 20 + wrangler@3 in
-  cog.yaml's `run:` block.
+- wrangler is a Node CLI; the image installs node 22 + wrangler@^4.102
+  in cog.yaml's `run:` block. `wrangler deploy --temporary` (the
+  no-API-token temporary-account flow) requires wrangler >= 4.102 and
+  a recent Node; verified working headlessly against wrangler 4.103.0
+  on Node 22 (provisions a temp account + claim URL with no
+  credentials, terms auto-accepted in CI/non-interactive mode).
 - `wrangler deploy --temporary` prints both URLs to stdout. We
   capture the full output, regex out the worker URL (matches
   *.workers.dev) and the claim URL (dash.cloudflare.com path).


### PR DESCRIPTION
## Summary

You were right that Node 20 isn't enough — and rather than guess, I tested the actual deploy mechanism end-to-end. Changes:

- `cog.yaml`: Nodesource `setup_20.x` → `setup_22.x` (Node 22 LTS).
- `predict.py`: refreshed the stale "node 20 + wrangler@3" docstring (it predated the `wrangler@^4.102` pin).

## I tested it for real — here's a live deployed URL

In this environment (Node 22.22, no Cloudflare account/token) I installed `wrangler@^4.102` (got 4.103.0), wrote a minimal Worker, and ran the exact command `predict.py` uses:

```
$ wrangler deploy --temporary        # CLOUDFLARE_API_TOKEN unset, CI=1
Temporary account ready:
        Account: Gaudy Flute (created)
        Claim within: 60 minutes
        Claim URL: https://dash.cloudflare.com/claim-preview?claimToken=vhqrsgE1qtj_qL5UDeBawT5jRrQLlGdtuNy7VwPF-Vk
Deployed pasclaw-deploy-test triggers
  https://pasclaw-deploy-test.gaudy-flute.workers.dev

$ curl https://pasclaw-deploy-test.gaudy-flute.workers.dev
hello from pasclaw cog-build-deploy test          # LIVE
```

**Deployed URL:** `https://pasclaw-deploy-test.gaudy-flute.workers.dev` (a throwaway test Worker; the temp account auto-expires ~60 min after creation since I didn't claim it).

## Findings worth recording

- **`wrangler deploy --temporary` is the right command** — what `predict.py` already uses. The flag is `hidden: true` in `--help` (it's private beta), so `wrangler deploy --help` doesn't list it, but `deploy` carries `behaviour.supportTemporary: true` and accepts it. (`wrangler preview` does **not** accept `--temporary` — initial dead end.)
- **Headless works.** The terms-acceptance prompt auto-accepts under CI/non-interactive (`ensureTemporaryTermsAccepted` returns true when `isNonInteractiveOrCI`). `predict.py` already sets `CI=1` in `_deploy_to_cloudflare`'s env, so the cog's headless invocation is fine without a TTY.
- **Parser validated against real output.** `_extract_urls` correctly pulls `https://pasclaw-deploy-test.gaudy-flute.workers.dev` as the deployed URL and the `dash.cloudflare.com/claim-preview?claimToken=…` as the claim URL.
- **Why Node 22 specifically:** wrangler 4.x dependencies emit engine warnings on Node 20; 22 LTS is clean.

## Test plan

- [x] `python3 -m py_compile cog-build-deploy/predict.py` — OK.
- [x] Real `wrangler deploy --temporary` on Node 22 → live `*.workers.dev` URL + claim URL, no credentials.
- [x] `curl` of the deployed URL returns the worker's response.
- [x] `_extract_urls` parses the real captured output correctly.
- [ ] Full cog build (`cog build` + Replicate run) — needs the Cog runtime, not available in my environment; the deploy sub-step is the risky part and it's verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBcLtmpj7dqA5tyFbGnQon)_