### PR TITLE
onnx: fix dccosx64 'dllname' undeclared (Delphi macOS)

### DIFF
--- a/src/pkg/memory/localvector/onnxruntime_pas_api.pas
+++ b/src/pkg/memory/localvector/onnxruntime_pas_api.pas
@@ -67,9 +67,11 @@ type
   const dllname='onnxruntime.dll';
   {$endif}
 
-  {$ifdef darwin}
+  { macOS: FPC defines `darwin`; Delphi (dccosx64) defines MACOS/OSX instead,
+    so cover both or the dccosx64 build leaves dllname undeclared (E2003). }
+  {$if defined(darwin) or defined(MACOS) or defined(OSX)}
   const dllname='onnxruntime.dylib';
-  {$endif}
+  {$ifend}
   {$ifdef linux}
   const dllname='onnxruntime.so';
   {$endif}


### PR DESCRIPTION
## Problem

The Delphi macOS 64-bit compiler (`dccosx64`) fails:

```
[dccosx64 Error] onnxruntime_pas_api.pas(1112): E2003 Undeclared identifier: 'dllname'
[dccosx64 Fatal Error] LocalVector.Embedder.pas(34): F2063 Could not compile used unit 'onnxruntime_pas_api.pas'
```

## Cause

The dylib name was declared under `{$ifdef darwin}`. `darwin` is an **FPC-only** conditional symbol — Delphi's macOS compiler defines `MACOS` / `OSX` instead. So on `dccosx64` none of the `MSWINDOWS` / `darwin` / `linux` branches matched, `dllname` was never declared, and the later `ortDoLoad(dllname)` reference (line 1112) failed.

## Fix

Widen the macOS branch to cover both compilers:

```pascal
{$if defined(darwin) or defined(MACOS) or defined(OSX)}
const dllname='onnxruntime.dylib';
{$ifend}
```

- **FPC macOS** (`darwin`) and **Delphi macOS** (`MACOS`/`OSX`) both now resolve `onnxruntime.dylib`.
- Windows (`MSWINDOWS`) and Linux (`linux`, which Delphi matches case-insensitively as `LINUX`) branches are unchanged.
- No platform matches two branches, so `dllname` is declared exactly once everywhere.

## Verification

- The unit compiles cleanly under **FPC** (`fpc -Mdelphi`, 1151 lines, only a pre-existing benign enum note) — confirming the `{$if}`/`{$ifend}` form is valid for FPC and the Linux path still resolves `onnxruntime.so`.
- Full `make all` (FPC) still links.
- I don't have a Delphi/macOS toolchain in this environment, so the `dccosx64` compile itself wasn't run here — but the fix adds exactly the symbols `dccosx64` defines for macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_