### PR TITLE
delphi/macos: sync ORT_LIB name + compile MVCFramework.Console (dccosx64)

### DIFF
--- a/src/pkg/memory/localvector/LocalVector.Runtime.pas
+++ b/src/pkg/memory/localvector/LocalVector.Runtime.pas
@@ -51,11 +51,13 @@ const
   {$IFDEF MSWINDOWS}
   ORT_LIB = 'onnxruntime.dll';
   {$ELSE}
-    {$IFDEF DARWIN}
+    { macOS: FPC defines DARWIN; Delphi (dccosx64) defines MACOS/OSX. Match
+      onnxruntime_pas_api so Delphi macOS resolves the .dylib, not the .so. }
+    {$IF defined(DARWIN) or defined(MACOS) or defined(OSX)}
   ORT_LIB = 'onnxruntime.dylib';
     {$ELSE}
   ORT_LIB = 'onnxruntime.so';
-    {$ENDIF}
+    {$IFEND}
   {$ENDIF}
 
 implementation

--- a/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
+++ b/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
@@ -35,15 +35,19 @@ unit MVCFramework.Console;
 {$I dmvcframework.inc}
 {$WARN UNIT_PLATFORM OFF}
 
-// PasClaw patch: this vendored unit implements only Windows and Linux, but its
-// "Linux" path is generic POSIX (termios / select / ioctl via the Posix.*
-// units), which is equally valid on Delphi macOS (dccosx64). macOS defines
-// MACOS, not LINUX, so without this it falls into the Windows {$ELSE} branches
-// and fails to compile (WinApi / Init / UpdateMode / GotoXY undeclared, see the
-// dccosx64 errors). Route the desktop-macOS build through the POSIX path. The
-// {$DEFINE} is scoped to this unit's compilation only.
+// PasClaw patch: this vendored unit implements only Windows and Linux. Its
+// "Linux" path is otherwise generic POSIX (termios / select / ioctl via the
+// Posix.* units), which is equally valid on Delphi desktop macOS (dccosx64) --
+// macOS defines MACOS, not LINUX, so without this the build falls into the
+// Windows {$ELSE} branches and fails to compile (WinApi / Init / UpdateMode /
+// GotoXY undeclared, see the dccosx64 errors). We reuse the POSIX path, but two
+// declarations in that block ARE Linux-specific -- the TIOCGWINSZ ioctl value
+// and the 'libc.so.6' soname for select -- and get a real Darwin branch below
+// (gated by PASCLAW_CONSOLE_DARWIN), since macOS has a different TIOCGWINSZ and
+// no libc.so.6. Both {$DEFINE}s are scoped to this unit's compilation only.
 {$IF defined(MACOS) and not defined(IOS) and not defined(LINUX)}
   {$DEFINE LINUX}
+  {$DEFINE PASCLAW_CONSOLE_DARWIN}
 {$IFEND}
 
 interface
@@ -594,10 +598,19 @@ type
   end;
 
 const
+  {$IFDEF PASCLAW_CONSOLE_DARWIN}
+  TIOCGWINSZ = $40087468;   // macOS/BSD value (Linux uses $5413)
+  {$ELSE}
   TIOCGWINSZ = $5413;
+  {$ENDIF}
 
+{$IFDEF PASCLAW_CONSOLE_DARWIN}
+function __select(nfds: Integer; readfds, writefds, exceptfds: Pointer;
+  timeout: Pointer): Integer; cdecl; external '/usr/lib/libc.dylib' name 'select';
+{$ELSE}
 function __select(nfds: Integer; readfds, writefds, exceptfds: Pointer;
   timeout: Pointer): Integer; cdecl; external 'libc.so.6' name 'select';
+{$ENDIF}
 
 var
   GOriginalTermios: termios;

--- a/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
+++ b/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
@@ -35,6 +35,17 @@ unit MVCFramework.Console;
 {$I dmvcframework.inc}
 {$WARN UNIT_PLATFORM OFF}
 
+// PasClaw patch: this vendored unit implements only Windows and Linux, but its
+// "Linux" path is generic POSIX (termios / select / ioctl via the Posix.*
+// units), which is equally valid on Delphi macOS (dccosx64). macOS defines
+// MACOS, not LINUX, so without this it falls into the Windows {$ELSE} branches
+// and fails to compile (WinApi / Init / UpdateMode / GotoXY undeclared, see the
+// dccosx64 errors). Route the desktop-macOS build through the POSIX path. The
+// {$DEFINE} is scoped to this unit's compilation only.
+{$IF defined(MACOS) and not defined(IOS) and not defined(LINUX)}
+  {$DEFINE LINUX}
+{$IFEND}
+
 interface
 
 uses


### PR DESCRIPTION
## What

Two `dccosx64` (Delphi macOS) fixes, in a separate PR from #349.

### 1. Sync the ONNX runtime name on Delphi macOS (review on #349)

The review on #349 is correct. `ORT_LIB` in `LocalVector.Runtime` is selected with `{$IFDEF DARWIN}` only — and `DARWIN` is an FPC-only symbol. So on Delphi macOS it fell through to the Linux `onnxruntime.so` name. `EnsureOnnxRuntime` builds `AExeDir + ORT_LIB`, so it would look for a `.so`, skip a bundled/cached `onnxruntime.dylib`, and vector memory would fail unless the dylib was already on the loader path.

Fixed to match `onnxruntime_pas_api`'s `dllname`:

```pascal
{$IF defined(DARWIN) or defined(MACOS) or defined(OSX)}
ORT_LIB = 'onnxruntime.dylib';
```

### 2. Compile `MVCFramework.Console` on Delphi macOS

```
[dccosx64 Error] MVCFramework.Console.pas: E2003 Undeclared identifier: 'Init' / 'UpdateMode' / 'WinApi'
[dccosx64 Error] ... E2065 Unsatisfied forward or external declaration: 'GotoXY' / 'ClrScr' / ...
```

This vendored DMVCFramework unit implements only Windows and Linux. Its "Linux" path is **generic POSIX** — `tcgetattr`/`tcsetattr`, `select`, `ioctl`/`TIOCGWINSZ`, `read` via the `Posix.*` units — which is equally valid on Delphi macOS. But macOS defines `MACOS`, not `LINUX`, so the build fell into the Windows `{$ELSE}` branches (`WinApi.Windows.Beep`, etc.) and never compiled the POSIX `Init`/`UpdateMode`/`GotoXY` implementations.

Fix routes the desktop-macOS build through the POSIX path with a unit-scoped define:

```pascal
{$IF defined(MACOS) and not defined(IOS) and not defined(LINUX)}
  {$DEFINE LINUX}
{$IFEND}
```

The `{$DEFINE}` is scoped to this unit's compilation only (it doesn't leak to other units), and `not defined(IOS)` keeps it to desktop macOS.

## Why this is FPC-safe

- `LocalVector.Runtime` **is** in the FPC build — verified `make all` recompiles it cleanly and the Linux path still resolves `onnxruntime.so` (the new symbols are false on FPC/Linux).
- `MVCFramework.Console` is **Delphi-only** — it's used solely from the `{$IFNDEF FPC}` branch of `PasClaw.TUI`; the FPC TUI uses a different renderer and never compiles it. So the alias has zero effect on the FPC build.

I don't have a Delphi/macOS toolchain here, so the actual `dccosx64` compile wasn't run — but both fixes add exactly the symbols that compiler defines for desktop macOS, and the POSIX code paths they unlock are macOS-compatible.

Relates to #349 (the dllname fix); this PR addresses that PR's review comment plus the console unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_