### PR TITLE
gateway: hot-swap provider/model on /v1/config write (no restart)

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -218,9 +218,11 @@ type
       changes apply on the next restart. }
     procedure HandleConfigWrite(ARequest: TIdHTTPRequestInfo;
                                 AResp: TIdHTTPResponseInfo);
-    { Lock-guarded reads of the live provider state (rebuilt on config write). }
-    function CurrentPrimary: ILLMProvider;
-    function CurrentFallbacks: TLLMProviderArray;
+    { Lock-guarded snapshot of the live provider state (rebuilt on config write):
+      primary, fallback chain, and default model copied together so a swap can't
+      split them across a starting request. }
+    procedure SnapshotRuntime(out Prim: ILLMProvider; out FB: TLLMProviderArray;
+                              out DefModel: string);
     { Rebuild + swap the live provider/fallbacks from a saved config. Returns
       False (and keeps the current provider) if the new primary won't build. }
     function ApplyProviderConfig(NewCfg: TConfig): Boolean;
@@ -660,21 +662,24 @@ begin
   inherited Destroy;
 end;
 
-function TGatewayServer.CurrentPrimary: ILLMProvider;
-{ Copy the primary ref under the lock so a concurrent ApplyProviderConfig swap
-  can't free it between a request reading the field and retaining it. The
-  returned interface is refcounted, so an in-flight request that grabbed it
-  keeps running on that provider even after a swap -- the switch only affects
-  requests that start afterwards; nothing in flight is interrupted. }
+procedure TGatewayServer.SnapshotRuntime(out Prim: ILLMProvider;
+  out FB: TLLMProviderArray; out DefModel: string);
+{ Copy the primary provider, fallback chain, AND default model together under
+  the lock so a concurrent ApplyProviderConfig swap can't tear them apart -- a
+  request must not end up sending the new model to the old provider (or vice
+  versa) if a live /v1/config save lands mid-setup. The returned interfaces are
+  refcounted, so an in-flight request that grabbed them keeps running on that
+  provider even after a swap; the switch only affects requests that start
+  afterwards. Nothing in flight is interrupted. }
 begin
   FApplyLock.Acquire;
-  try Result := FProvider; finally FApplyLock.Release; end;
-end;
-
-function TGatewayServer.CurrentFallbacks: TLLMProviderArray;
-begin
-  FApplyLock.Acquire;
-  try Result := Copy(FFallbacks); finally FApplyLock.Release; end;
+  try
+    Prim     := FProvider;
+    FB       := Copy(FFallbacks);
+    DefModel := FCfg.DefaultModel;
+  finally
+    FApplyLock.Release;
+  end;
 end;
 
 function TGatewayServer.ApplyProviderConfig(NewCfg: TConfig): Boolean;
@@ -3593,6 +3598,9 @@ var
   Msgs: TMessageArray;
   Loop: TToolLoopResult;
   LoopCfg: TToolLoopConfig;
+  Prim: ILLMProvider;
+  FB: TLLMProviderArray;
+  DefModel: string;
 begin
   Body := '';
   if ARequest.PostStream <> nil then
@@ -3629,7 +3637,10 @@ begin
     Exit;
   end;
 
-  LoopCfg.Provider := CurrentPrimary;
+  { Snapshot provider + fallbacks + default model together (one lock) so a live
+    /v1/config swap can't pair the new model with the old provider. }
+  SnapshotRuntime(Prim, FB, DefModel);
+  LoopCfg.Provider := Prim;
   if LoopCfg.Provider = nil then
   begin
     WriteJSON(AResp, 503, '{"error":"no provider configured"}');
@@ -3640,14 +3651,14 @@ begin
   Msgs[0] := MakeMessage(mrUser, Prompt);
 
   LoopCfg.Registry      := FRegistry;
-  LoopCfg.Model         := FCfg.DefaultModel;
+  LoopCfg.Model         := DefModel;
   LoopCfg.MaxIterations := 8;
   LoopCfg.Parallel := True;
   { PR #290: per-request Plan/Build. Defaults to pmBuild when the body
     omits "mode", so OpenAI-compatible clients that don't know about
     plan keep working unchanged. }
   LoopCfg.Mode          := ParseModeFromBody(Body);
-  LoopCfg.Fallbacks     := CurrentFallbacks;
+  LoopCfg.Fallbacks     := FB;
   LoopCfg.Options       := DefaultChatOptions;
   ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
   LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '',
@@ -4194,6 +4205,9 @@ var
   Streamer: TSSEStreamer;
   StreamStarted, StreamClosed: Boolean;
   ActivityCollector: TToolActivityCollector;
+  Prim: ILLMProvider;
+  FB: TLLMProviderArray;
+  SnapModel: string;
   function SanitizeStreamError(const S: string): string;
   begin
     Result := StringReplace(S, #13, ' ', [rfReplaceAll]);
@@ -4280,7 +4294,10 @@ begin
       MsgArr.Free;
     end;
 
-    LoopCfg.Provider := CurrentPrimary;
+    { Provider + fallbacks snapshotted together (model is the request's
+      ReqModel, resolved at parse). }
+    SnapshotRuntime(Prim, FB, SnapModel);
+    LoopCfg.Provider := Prim;
     if LoopCfg.Provider = nil then
     begin
       if FDebugIO then LogDebug('chat/completions -> 503 (no provider configured)');
@@ -4294,7 +4311,7 @@ begin
     LoopCfg.MaxIterations := FMaxIter;
     LoopCfg.Parallel := True;
     LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
-    LoopCfg.Fallbacks     := CurrentFallbacks;
+    LoopCfg.Fallbacks     := FB;
     LoopCfg.Options       := DefaultChatOptions;
     ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
     if GetEffectiveGatewayToken(FCfg) <> '' then
@@ -5562,6 +5579,8 @@ var
   EmptyToolCalls: array of TToolCall;
   FcCallIdVal, FcSignatureVal: string;
   Prim: ILLMProvider;   { live-provider snapshot for this request (hot-swap safe) }
+  FB: TLLMProviderArray;
+  SnapModel: string;
 
   procedure AppendMessage(Role: TMsgRole; const Content: string);
   begin
@@ -5901,7 +5920,7 @@ begin
     finally
       ToolsArrIn.Free;
     end;
-    Prim := CurrentPrimary;
+    SnapshotRuntime(Prim, FB, SnapModel);
     if Prim = nil then
     begin
       WriteJSON(AResp, 503,
@@ -6052,7 +6071,7 @@ begin
       LoopCfg.MaxIterations := FMaxIter;
       LoopCfg.Parallel := True;
       LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
-      LoopCfg.Fallbacks     := CurrentFallbacks;
+      LoopCfg.Fallbacks     := FB;
       LoopCfg.Options       := DefaultChatOptions;
       ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
       if GetEffectiveGatewayToken(FCfg) <> '' then

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -79,6 +79,12 @@ type
        via SetGlobalRelayQueue so TRelayProvider can find it through
        the factory. Freed in Destroy after clearing the global. *)
     FRelayQueue: TRelayQueue;
+    (* Live provider hot-swap. FProvider and FFallbacks are rebuilt from config
+       on /v1/config write so a provider/model change applies without a
+       restart. FApplyLock guards the swap so a request thread reads a
+       consistent (primary, fallbacks) pair via SnapshotProviders. *)
+    FApplyLock: TCriticalSection;
+    FFallbacks: TLLMProviderArray;
     (* Per-process scoped credential. Random hex generated in Create
        once per `pasclaw serve` / `pasclaw gateway` startup. Gates the
        /v1/relay/* surface independently of Cfg.Gateway.Token so an
@@ -212,6 +218,12 @@ type
       changes apply on the next restart. }
     procedure HandleConfigWrite(ARequest: TIdHTTPRequestInfo;
                                 AResp: TIdHTTPResponseInfo);
+    { Lock-guarded reads of the live provider state (rebuilt on config write). }
+    function CurrentPrimary: ILLMProvider;
+    function CurrentFallbacks: TLLMProviderArray;
+    { Rebuild + swap the live provider/fallbacks from a saved config. Returns
+      False (and keeps the current provider) if the new primary won't build. }
+    function ApplyProviderConfig(NewCfg: TConfig): Boolean;
     procedure HandleStats(AResp: TIdHTTPResponseInfo);
     { Durable chat sessions, shared with the TUI / `pasclaw session`
       via PasClaw.Session.Store -- web chats land in the same
@@ -607,6 +619,11 @@ begin
   FRelayQueue := TRelayQueue.Create;
   SetGlobalRelayQueue(FRelayQueue);
 
+  { Live provider hot-swap state. Cache the fallback chain now (relay queue is
+    registered above, so a relay fallback resolves) -- rebuilt on config write. }
+  FApplyLock := TCriticalSection.Create;
+  FFallbacks := ResolveFallbacks(FCfg);
+
   { Generate a fresh per-process relay-scoped token. Format is
     phone-typable: two 4-char groups separated by a hyphen
     (e.g. A8M9-PXRT) drawn from Crockford base32
@@ -639,7 +656,59 @@ begin
     that's racing Destroy can't dereference a freed pointer. }
   SetGlobalRelayQueue(nil);
   FRelayQueue.Free;
+  FApplyLock.Free;
   inherited Destroy;
+end;
+
+function TGatewayServer.CurrentPrimary: ILLMProvider;
+{ Copy the primary ref under the lock so a concurrent ApplyProviderConfig swap
+  can't free it between a request reading the field and retaining it. The
+  returned interface is refcounted, so an in-flight request that grabbed it
+  keeps running on that provider even after a swap -- the switch only affects
+  requests that start afterwards; nothing in flight is interrupted. }
+begin
+  FApplyLock.Acquire;
+  try Result := FProvider; finally FApplyLock.Release; end;
+end;
+
+function TGatewayServer.CurrentFallbacks: TLLMProviderArray;
+begin
+  FApplyLock.Acquire;
+  try Result := Copy(FFallbacks); finally FApplyLock.Release; end;
+end;
+
+function TGatewayServer.ApplyProviderConfig(NewCfg: TConfig): Boolean;
+{ Rebuild the primary + fallback chain from a freshly-saved config and swap them
+  in, so a provider/model change over /v1/config takes effect without a restart.
+  The relay queue global is registered in Create, so a relay primary rebuilds
+  fine. Everything is built OUTSIDE the lock; only the pointer swap is guarded. }
+var
+  NewProv: ILLMProvider;
+  NewFB: TLLMProviderArray;
+  Err: string;
+begin
+  Result := False;
+  if not NewDefaultProvider(NewCfg, NewProv, Err) then
+  begin
+    LogWarn('gateway: live provider rebuild failed (%s) -- keeping current; restart to apply',
+            [Err]);
+    Exit;
+  end;
+  NewFB := ResolveFallbacks(NewCfg);
+  FApplyLock.Acquire;
+  try
+    FProvider  := NewProv;
+    FFallbacks := NewFB;
+    { Keep the in-memory display/model fields in step so /v1/status and the
+      legacy /v1/chat model reflect the switch immediately. }
+    FCfg.DefaultProvider := NewCfg.DefaultProvider;
+    FCfg.DefaultModel    := NewCfg.DefaultModel;
+  finally
+    FApplyLock.Release;
+  end;
+  LogInfo('gateway: provider switched live to %s / %s',
+          [NewCfg.DefaultProvider, NewCfg.DefaultModel]);
+  Result := True;
 end;
 
 procedure TGatewayServer.SetMCPAllowMutating(V: Boolean);
@@ -2207,7 +2276,9 @@ procedure TGatewayServer.HandleConfigWrite(ARequest: TIdHTTPRequestInfo;
 var
   Body, Merged, BaseJSON, Path: string;
   Tmp, Cur: TConfig;
+  Applied: Boolean;
 begin
+  Applied := False;
   Body := ReadRequestBody(ARequest);
   if Trim(Body) = '' then
   begin
@@ -2272,12 +2343,26 @@ begin
         Exit;
       end;
     end;
+    { Hot-swap the primary provider + fallback chain from the just-saved config
+      so a provider/model change takes effect without a restart. Built from Tmp
+      before it's freed. Other settings (sandbox, mcp, crons) still need a
+      restart. }
+    Applied := ApplyProviderConfig(Tmp);
   finally
     Tmp.Free;
   end;
-  LogInfo('gateway: config.json updated via /v1/config (restart to apply)');
-  WriteJSON(AResp, 200,
-    '{"saved":true,"note":"saved to config.json -- restart pasclaw for changes to take effect"}');
+  if Applied then
+  begin
+    LogInfo('gateway: config.json updated via /v1/config (provider applied live)');
+    WriteJSON(AResp, 200,
+      '{"saved":true,"applied":true,"note":"saved -- provider/model applied live; other settings take effect on restart"}');
+  end
+  else
+  begin
+    LogInfo('gateway: config.json updated via /v1/config (restart to apply)');
+    WriteJSON(AResp, 200,
+      '{"saved":true,"applied":false,"note":"saved to config.json -- restart pasclaw for changes to take effect"}');
+  end;
 end;
 
 procedure TGatewayServer.HandleStats(AResp: TIdHTTPResponseInfo);
@@ -3544,7 +3629,8 @@ begin
     Exit;
   end;
 
-  if FProvider = nil then
+  LoopCfg.Provider := CurrentPrimary;
+  if LoopCfg.Provider = nil then
   begin
     WriteJSON(AResp, 503, '{"error":"no provider configured"}');
     Exit;
@@ -3553,7 +3639,6 @@ begin
   SetLength(Msgs, 1);
   Msgs[0] := MakeMessage(mrUser, Prompt);
 
-  LoopCfg.Provider      := FProvider;
   LoopCfg.Registry      := FRegistry;
   LoopCfg.Model         := FCfg.DefaultModel;
   LoopCfg.MaxIterations := 8;
@@ -3562,7 +3647,7 @@ begin
     omits "mode", so OpenAI-compatible clients that don't know about
     plan keep working unchanged. }
   LoopCfg.Mode          := ParseModeFromBody(Body);
-  LoopCfg.Fallbacks     := ResolveFallbacks(FCfg);
+  LoopCfg.Fallbacks     := CurrentFallbacks;
   LoopCfg.Options       := DefaultChatOptions;
   ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
   LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '',
@@ -3593,7 +3678,7 @@ begin
   end;
   AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT,
                          '(gateway: /v1/chat)',
-                         FProvider.GetName, LoopCfg.Model, Loop);
+                         LoopCfg.Provider.GetName, LoopCfg.Model, Loop);
 
   RespJ := TJsonObject.Create;
   try
@@ -4195,7 +4280,8 @@ begin
       MsgArr.Free;
     end;
 
-    if FProvider = nil then
+    LoopCfg.Provider := CurrentPrimary;
+    if LoopCfg.Provider = nil then
     begin
       if FDebugIO then LogDebug('chat/completions -> 503 (no provider configured)');
       WriteJSON(AResp, 503,
@@ -4203,13 +4289,12 @@ begin
       Exit;
     end;
 
-    LoopCfg.Provider      := FProvider;
     LoopCfg.Registry      := FRegistry;
     LoopCfg.Model         := ReqModel;
     LoopCfg.MaxIterations := FMaxIter;
     LoopCfg.Parallel := True;
     LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
-    LoopCfg.Fallbacks     := ResolveFallbacks(FCfg);
+    LoopCfg.Fallbacks     := CurrentFallbacks;
     LoopCfg.Options       := DefaultChatOptions;
     ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
     if GetEffectiveGatewayToken(FCfg) <> '' then
@@ -4294,7 +4379,7 @@ begin
       end;
       AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
                              '(gateway: /v1/chat/completions)',
-                             FProvider.GetName, ReqModel, Loop);
+                             LoopCfg.Provider.GetName, ReqModel, Loop);
       if Loop.LastResp.FinishReason <> '' then
         FinishReason := Loop.LastResp.FinishReason
       else
@@ -4370,7 +4455,7 @@ begin
     end;
     AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
                            '(gateway: /v1/chat/completions)',
-                           FProvider.GetName, ReqModel, Loop);
+                           LoopCfg.Provider.GetName, ReqModel, Loop);
 
     if Loop.LastResp.FinishReason <> '' then
       FinishReason := Loop.LastResp.FinishReason
@@ -5476,6 +5561,7 @@ var
   ParamsRaw, ToolKind, ToolDisplayName: string;
   EmptyToolCalls: array of TToolCall;
   FcCallIdVal, FcSignatureVal: string;
+  Prim: ILLMProvider;   { live-provider snapshot for this request (hot-swap safe) }
 
   procedure AppendMessage(Role: TMsgRole; const Content: string);
   begin
@@ -5815,7 +5901,8 @@ begin
     finally
       ToolsArrIn.Free;
     end;
-    if FProvider = nil then
+    Prim := CurrentPrimary;
+    if Prim = nil then
     begin
       WriteJSON(AResp, 503,
         '{"error":{"message":"no provider configured","type":"server_error"}}');
@@ -5879,7 +5966,7 @@ begin
       if WantsStream then
       begin
         StreamResponsesViaProvider(AContext, AResp, AResponseStarted,
-                                    FProvider, RespId, ReqModel, Msgs, ToolDefs,
+                                    Prim, RespId, ReqModel, Msgs, ToolDefs,
                                     PassthroughOpts, ToolsRawJSON, FDebugIO,
                                     FCfg.StreamReliability,
                                     OutUsage, StreamToolCallCount);
@@ -5890,7 +5977,7 @@ begin
           Codex P2 on PR #204. }
         AccumulateGatewayStatsRaw(FCfg, GW_BUCKET_V1_RESPONSES,
                                   '(gateway: /v1/responses)',
-                                  FProvider.GetName, ReqModel,
+                                  Prim.GetName, ReqModel,
                                   OutUsage,
                                   StreamToolCallCount,
                                   0);
@@ -5904,7 +5991,7 @@ begin
           chain, so retries against the primary provider are the
           only recovery before the response goes back to the
           client. }
-        PassthroughResp := ChatWithEmptyRetry(FProvider, Msgs, ToolDefs,
+        PassthroughResp := ChatWithEmptyRetry(Prim, Msgs, ToolDefs,
                                                ReqModel, PassthroughOpts,
                                                FCfg.StreamReliability);
       except
@@ -5943,7 +6030,7 @@ begin
         server-side (the client did). }
       AccumulateGatewayStatsRaw(FCfg, GW_BUCKET_V1_RESPONSES,
                                 '(gateway: /v1/responses)',
-                                FProvider.GetName, ReqModel,
+                                Prim.GetName, ReqModel,
                                 OutUsage,
                                 Length(OutToolCalls),
                                 0);
@@ -5959,13 +6046,13 @@ begin
         internal tool loop and surface its text. This keeps the
         non-Codex flows (curl /v1/responses with just an input
         string) working as before. }
-      LoopCfg.Provider      := FProvider;
+      LoopCfg.Provider      := Prim;
       LoopCfg.Registry      := FRegistry;
       LoopCfg.Model         := ReqModel;
       LoopCfg.MaxIterations := FMaxIter;
       LoopCfg.Parallel := True;
       LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
-      LoopCfg.Fallbacks     := ResolveFallbacks(FCfg);
+      LoopCfg.Fallbacks     := CurrentFallbacks;
       LoopCfg.Options       := DefaultChatOptions;
       ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
       if GetEffectiveGatewayToken(FCfg) <> '' then
@@ -6008,7 +6095,7 @@ begin
       end;
       AccumulateGatewayStats(FCfg, GW_BUCKET_V1_RESPONSES,
                              '(gateway: /v1/responses)',
-                             FProvider.GetName, ReqModel, Loop);
+                             Prim.GetName, ReqModel, Loop);
 
       if Loop.LastResp.FinishReason <> '' then
         FinishReason := Loop.LastResp.FinishReason


### PR DESCRIPTION
## What

Makes a provider/model change over `PUT /v1/config` take effect **without a gateway restart**. Previously the gateway bound one `ILLMProvider` at startup (`FProvider`) and every request reused it; the config-write endpoint only persisted to disk.

## How

- **`FProvider` + a cached fallback chain (`FFallbacks`)** are now guarded by a `FApplyLock`. Request handlers read them through `CurrentPrimary` / `CurrentFallbacks`, which copy the interface refs under the lock.
- **`ApplyProviderConfig(NewCfg)`** (called from `HandleConfigWrite` after `SaveConfig`) builds the new primary (`NewDefaultProvider`) and fallback chain (`ResolveFallbacks`) **outside** the lock, then swaps `FProvider`/`FFallbacks` and updates `FCfg.DefaultProvider`/`DefaultModel` **under** the lock. Returns `False` (and keeps the current provider) if the new primary won't build. The relay-queue global is registered in `Create`, so a relay primary rebuilds fine.
- The three chat paths (`/v1/chat`, `/v1/chat/completions`, `/v1/responses`) were switched from reading `FProvider`/`ResolveFallbacks(FCfg)` directly to the lock-guarded getters.
- `/v1/config` response gains `"applied": true/false` and a clearer note.

## Does it interrupt in-flight chats? (No, and it doesn't block)

A request that already grabbed the provider keeps running on it — interfaces are refcounted, so the old provider instance stays alive until that request finishes. Only requests that **start after** the swap use the new provider. The config-write doesn't wait for in-flight chats and isn't blocked by them (important — a streaming chat can run for minutes). Nothing in flight is interrupted or corrupted.

## Scope / caveats

- **Provider + model** switch live. **Other settings** (sandbox, MCP servers, crons) still need a restart — the note says so.
- This pairs with the Settings-tab provider/model dropdowns in #351: saving there now applies immediately.

## Verification

- `make all` clean.
- **Smoke-tested against a running gateway**: with two providers configured, `PUT /v1/config` switching `default_provider` `alpha`→`beta` returned `{"saved":true,"applied":true}`, `/v1/status` reflected `beta`/`llama-3` **with no restart**, and the log showed `provider switched live to beta / llama-3`. Masked-secret (`•••`) round-tripping still works (keys not blanked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_