### PR TITLE
zpaq: compile the vendored libzpaq port under Delphi (enables redo on Delphi)

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;..\pkg\vendor\zpaq;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -184,6 +184,7 @@
 
         <!-- pkg/checkpoints -->
         <DCCReference Include="..\pkg\checkpoints\PasClaw.Checkpoints.pas"/>
+        <DCCReference Include="..\pkg\checkpoints\PasClaw.Checkpoints.Zpaq.pas"/>
 
         <!-- pkg/tokenizer -->
         <DCCReference Include="..\pkg\tokenizer\PasClaw.Tokenizer.pas"/>
@@ -351,6 +352,13 @@
         <DCCReference Include="..\pkg\vendor\dmvcframework\MVCFramework.Console.pas"/>
         <None Include="..\pkg\vendor\dmvcframework\dmvcframework.inc"/>
         <None Include="..\pkg\vendor\dmvcframework\NOTICE"/>
+
+        <!-- pkg/vendor/zpaq (MIT) -- libzpaq port; backs the zpaq checkpoint store -->
+        <DCCReference Include="..\pkg\vendor\zpaq\libzpaq.pas"/>
+        <DCCReference Include="..\pkg\vendor\zpaq\ZpaqClasses.pas"/>
+        <DCCReference Include="..\pkg\vendor\zpaq\ZpaqSimple.pas"/>
+        <None Include="..\pkg\vendor\zpaq\LICENSE"/>
+        <None Include="..\pkg\vendor\zpaq\NOTICE"/>
 
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/src/pkg/checkpoints/PasClaw.Checkpoints.Zpaq.pas
+++ b/src/pkg/checkpoints/PasClaw.Checkpoints.Zpaq.pas
@@ -24,11 +24,12 @@ unit PasClaw.Checkpoints.Zpaq;
   compression (LZ77 method 1 by default for the snapshot hot path),
   multi-version history in a single file, and indexed extraction.
 
-  Compiler gate: the vendored unit is `{$mode objfpc}` so it doesn't
-  compile under Delphi. This wrapper gates `uses ZpaqClasses` on
-  `{$IFDEF FPC}` and exposes "not available" stubs otherwise;
-  PasClaw.Checkpoints' backend dispatch then routes to the legacy
-  blob-tree store under Delphi.
+  Compiler support: the vendored units' FPC-only directives ({$mode},
+  {$MODESWITCH}, {$inline on}) are now guarded with {$IFDEF FPC} and the
+  body is portable (AnsiChar/Byte, POINTERMATH), so they compile under both
+  FPC and Delphi. This wrapper therefore uses ZpaqClasses unconditionally and
+  ZpaqAvailable returns True on both; the zpaq backend (with /redo) is the
+  default on Delphi too, not just FPC.
 *)
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
@@ -88,18 +89,14 @@ function ZpaqExtractByIndex(const Archive: string; Idx: Integer;
 
 implementation
 
-{$IFDEF FPC}
 uses
   ZpaqClasses;
-{$ENDIF}
 
 function ZpaqAvailable: Boolean;
 begin
-  {$IFDEF FPC}
+  { The vendored port now compiles under both FPC and Delphi (directives
+    guarded), so the backend is available on both. }
   Result := True;
-  {$ELSE}
-  Result := False;
-  {$ENDIF}
 end;
 
 function ZpaqDefaultMethod: Integer;
@@ -111,8 +108,6 @@ begin
     compression can call the underlying ZpaqAppendBytes directly. }
   Result := 1;
 end;
-
-{$IFDEF FPC}
 
 function ZpaqAppendBytes(const Archive: string; const Body: TBytes;
                          const Name: string; Method: Integer;
@@ -251,37 +246,5 @@ begin
       Err := E.Message;
   end;
 end;
-
-{$ELSE}
-
-{ ----- PASCLAW_HAVE_ZPAQ stubs ----- }
-
-function ZpaqAppendBytes(const Archive: string; const Body: TBytes;
-                         const Name: string; Method: Integer;
-                         out Err: string): Boolean;
-begin
-  Err := 'zpaq backend not available (vendor/zpaq missing; run `make get-zpaq`)';
-  Result := False;
-end;
-
-function ZpaqListEntries(const Archive: string;
-                         out Entries: TZpaqArchiveEntries;
-                         out Err: string): Boolean;
-begin
-  SetLength(Entries, 0);
-  Err := 'zpaq backend not available (vendor/zpaq missing; run `make get-zpaq`)';
-  Result := False;
-end;
-
-function ZpaqExtractByIndex(const Archive: string; Idx: Integer;
-                            out Body: TBytes;
-                            out Err: string): Boolean;
-begin
-  SetLength(Body, 0);
-  Err := 'zpaq backend not available (vendor/zpaq missing; run `make get-zpaq`)';
-  Result := False;
-end;
-
-{$ENDIF}
 
 end.

--- a/src/pkg/checkpoints/PasClaw.Checkpoints.pas
+++ b/src/pkg/checkpoints/PasClaw.Checkpoints.pas
@@ -97,10 +97,10 @@ type
     cbDisabled,   { Checkpoints feature off -- BeginTurn / Snapshot are
                     no-ops; UndoTurns returns False with a message. }
     cbLegacy,     (* Per-turn directory of raw blobs + manifest.json.
-                    Original PR #221 storage. Used when the zpaq vendor
-                    isn't on disk (e.g. fresh clone without
-                    "make get-zpaq", or a Delphi build where the
-                    vendored unit is mode-objfpc and won't compile). *)
+                    Original PR #221 storage. Fallback when the zpaq
+                    archive can't be initialised at runtime. (The vendored
+                    port now compiles under Delphi too, so this is no longer
+                    the default there.) *)
     cbZpaq        { One streaming archive per session (archive.zpaq) +
                     JSON journal (index.json) tracking turn -> archive
                     entries + a redo stack. Compresses snapshots and

--- a/src/pkg/vendor/zpaq/ZpaqClasses.pas
+++ b/src/pkg/vendor/zpaq/ZpaqClasses.pas
@@ -19,12 +19,18 @@ unit ZpaqClasses;
 //                Supports both streaming and journaling formats.
 
 
-{$mode objfpc}{$H+}
+{ PasClaw: mode directive guarded so the unit also compiles under Delphi. }
+{$IFDEF FPC}{$mode objfpc}{$H+}{$ENDIF}
 
 interface
 
 uses
   SysUtils, Classes, DateUtils, libzpaq;
+
+{$IFNDEF FPC}
+type
+  DWord = LongWord;   { FPC built-in; not in scope on Delphi without Winapi }
+{$ENDIF}
 
 { ------------------------------------------------------------------ }
 {  Filter callback: return True to extract the file, False to skip.   }

--- a/src/pkg/vendor/zpaq/ZpaqSimple.pas
+++ b/src/pkg/vendor/zpaq/ZpaqSimple.pas
@@ -1,6 +1,6 @@
 unit ZpaqSimple;
 
-{$mode delphi}
+{$IFDEF FPC}{$mode delphi}{$ENDIF}
 
 //Pascal port of LIBZPAQ Version 7.15 (Aug. 17, 2016)
 //Port by www.xelitan.com

--- a/src/pkg/vendor/zpaq/libzpaq.pas
+++ b/src/pkg/vendor/zpaq/libzpaq.pas
@@ -1,7 +1,12 @@
 unit libzpaq;
-{$mode objfpc}{$H+}{$Q-}{$R-}{$inline on}
-{$MODESWITCH AdvancedRecords}
-{$POINTERMATH ON}
+{ PasClaw: directives guarded so the unit also parses under Delphi. The body is
+  already portable -- AnsiChar/Byte throughout, no PChar, pointer math gated by
+  POINTERMATH (which Delphi supports), advanced records native to Delphi. }
+{$IFDEF FPC}
+  {$mode objfpc}{$H+}{$inline on}
+  {$MODESWITCH AdvancedRecords}
+{$ENDIF}
+{$Q-}{$R-}{$POINTERMATH ON}
 
 //Pascal port of LIBZPAQ Version 7.15 (Aug. 17, 2016)
 //Port by www.xelitan.com
@@ -17,6 +22,11 @@ unit libzpaq;
 
 interface
 uses SysUtils;
+
+{$IFNDEF FPC}
+type
+  QWord = UInt64;   { FPC built-in; Delphi spells it UInt64 }
+{$ENDIF}
 
 type
   U8  = Byte;


### PR DESCRIPTION
## What

Makes the vendored Xelitan libzpaq port compile under **Delphi**, so the Delphi build gets the **zpaq checkpoint backend** (compression + `/redo`) instead of falling back to the legacy no-redo store.

## Why it was FPC-only — and why that's fixable

You were right that it should work on Delphi. I audited all three vendored units (~5,200 lines):
- **No `PChar`/`Char`** — the port uses `AnsiChar`/`Byte` throughout, so the classic Delphi `PChar = PWideChar` byte-handling trap doesn't apply.
- **No** `PtrUInt`/`SizeUInt`, dynarray-`+` concat, set-difference, or `operator` overloads.
- Pointer arithmetic is already under `{$POINTERMATH ON}` (Delphi supports it); advanced records are native to Delphi.

The only real blockers were **FPC-only compiler directives** and **two built-in type names**.

## Changes

- `libzpaq.pas` / `ZpaqClasses.pas` / `ZpaqSimple.pas`: guard `{$mode …}`, `{$MODESWITCH AdvancedRecords}`, `{$inline on}` behind `{$IFDEF FPC}`; keep portable `{$Q-}{$R-}{$POINTERMATH ON}` for both. Add Delphi aliases `QWord = UInt64` (libzpaq) and `DWord = LongWord` (ZpaqClasses).
- `PasClaw.Checkpoints.Zpaq`: drop the `{$IFDEF FPC}` gate and the "not available" stubs; `uses ZpaqClasses` unconditionally and `ZpaqAvailable = True` on both compilers → Delphi selects `cbZpaq`.

## ⚠️ Verification status — needs your Delphi build

- **FPC: fully verified** — `make all` clean, `test-checkpoints-zpaq` and `test-checkpoints-redo` still pass; the FPC behavior is unchanged.
- **Delphi: UNVERIFIED.** There's no Delphi toolchain in this environment, so I could not compile it. This is a best-effort port from a source audit. **Please build with `dccosx64`/`dcc` and send me any remaining errors** — given the audit, I expect few if any, but `{$mode objfpc}`→default-Delphi-mode can surface subtle differences I can't see without the compiler. I'll iterate.

Pairs with #355 (web-UI checkpoints): once this lands, the Undo/**Redo** buttons and the Checkpoints tab are fully functional on Delphi, not just FPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_