### PR TITLE
dproj: fix illegal '--' in XML comment (Delphi parse error)

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -353,7 +353,7 @@
         <None Include="..\pkg\vendor\dmvcframework\dmvcframework.inc"/>
         <None Include="..\pkg\vendor\dmvcframework\NOTICE"/>
 
-        <!-- pkg/vendor/zpaq (MIT) -- libzpaq port; backs the zpaq checkpoint store -->
+        <!-- pkg/vendor/zpaq (MIT): libzpaq port; backs the zpaq checkpoint store -->
         <DCCReference Include="..\pkg\vendor\zpaq\libzpaq.pas"/>
         <DCCReference Include="..\pkg\vendor\zpaq\ZpaqClasses.pas"/>
         <DCCReference Include="..\pkg\vendor\zpaq\ZpaqSimple.pas"/>


### PR DESCRIPTION
## Bug

The zpaq vendor comment I added to `PasClaw.dproj` in #356 reads:

```xml
<!-- pkg/vendor/zpaq (MIT) -- libzpaq port; backs the zpaq checkpoint store -->
```

A double hyphen (`--`) is **illegal inside an XML comment**, so Delphi's project parser errors on the `.dproj` (line 358).

## Fix

Replace the `--` with a colon:

```xml
<!-- pkg/vendor/zpaq (MIT): libzpaq port; backs the zpaq checkpoint store -->
```

Validated the whole file is now well-formed XML (`xml.dom.minidom.parse` succeeds; no other `--`-in-comment anywhere).

Delphi-only fix; no effect on the FPC build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_