### PR TITLE
zpaq/delphi: fix dcc64 errors in libzpaq (FillWord, local var init)

### DIFF
--- a/src/pkg/vendor/zpaq/libzpaq.pas
+++ b/src/pkg/vendor/zpaq/libzpaq.pas
@@ -5,6 +5,11 @@ unit libzpaq;
 {$IFDEF FPC}
   {$mode objfpc}{$H+}{$inline on}
   {$MODESWITCH AdvancedRecords}
+{$ELSE}
+  { Delphi: the port works in AnsiString for byte data; silence the noisy
+    UnicodeString<->AnsiString cast warnings (ASCII method/filename strings). }
+  {$WARN IMPLICIT_STRING_CAST OFF}
+  {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
 {$ENDIF}
 {$Q-}{$R-}{$POINTERMATH ON}
 
@@ -1606,7 +1611,7 @@ begin
     FinitTables := True;
     Move(sdt2k[0], Fdt2k[0], 256*4);
     Move(sdt_global[0], Fdt[0], 1024*4);
-    FillWord(Fsquasht[0], 1376, 0);
+    FillChar(Fsquasht[0], 1376 * SizeOf(Fsquasht[0]), 0);  { FillWord is FPC-only; value 0 -> FillChar is equivalent + cross-compiler }
     Move(ssquasht[0], Fsquasht[1376], 1344*2);
     for i := 2720 to 4095 do Fsquasht[i] := 32767;
     k := 16384;
@@ -3858,7 +3863,7 @@ procedure compressBlock(inbuf: TStringBuffer; out_: TZPAQLStream;
                         const comment: AnsiString;
                         dosha1: Boolean);
 var
-  methodStr: AnsiString = '';
+  methodStr: AnsiString;   { Delphi forbids local-var initializers; AnsiString auto-inits to '' }
   n: U32;
   arg0: Integer;
   mtype: AnsiChar;


### PR DESCRIPTION
## What

Next iteration of the zpaq-on-Delphi work — fixes the `dcc64` compile errors you hit in the vendored `libzpaq.pas`:

| dcc64 | Fix |
|---|---|
| **E2003** Undeclared identifier `FillWord` (1609) | `FillWord` is FPC-only. The call zeroes 1376 words, so `FillChar(Fsquasht[0], 1376*SizeOf(elem), 0)` is the cross-compiler equivalent (FillChar-with-0 == FillWord-with-0). |
| **E2195** Cannot initialize local variables (`compressBlock`) | Delphi forbids local-var initializers. Dropped `methodStr: AnsiString = ''` → plain decl; `AnsiString` auto-inits to `''` on both compilers. |
| **W1057 / W1058** implicit `AnsiString`↔`string` cast warnings | The port works in `AnsiString` for byte data; silenced on Delphi via `{$WARN IMPLICIT_STRING_CAST[_LOSS] OFF}` (guarded `{$IFNDEF FPC}`). |

I audited all three vendored units — these were the **only** `FillWord`/local-initializer sites (none in `ZpaqClasses`/`ZpaqSimple`).

## Verification

- **FPC: clean** — `make all` links; behaviour identical (`FillChar`-with-0 ≡ `FillWord`-with-0; `AnsiString` still starts `''`).
- **Delphi: still unverified here** (no toolchain). dcc stopped at the fatal after `libzpaq` failed, so there may be more errors *past* this point that it never reached. Please re-run `dcc64` — if more surface, paste them and I'll keep iterating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_