### PR TITLE
zpaq/delphi: drop inline from nested routines (E2449)

### DIFF
--- a/src/pkg/vendor/zpaq/libzpaq.pas
+++ b/src/pkg/vendor/zpaq/libzpaq.pas
@@ -3234,12 +3234,15 @@ var
   n1, t: Integer;
 
   { ---- read next char from meth at mpos ---- }
-  function MC(): AnsiChar; inline;
+  { Not inlined: Delphi (E2449) refuses to inline a nested routine that touches
+    the enclosing scope (meth / mpos); FPC's {$inline on} made these inline but
+    the perf cost of dropping it on a method-string parser is nil. }
+  function MC(): AnsiChar;
   begin if mpos <= Length(meth) then Result := meth[mpos] else Result := #0; end;
-  function MCadv(): AnsiChar; inline;
+  function MCadv(): AnsiChar;
   begin Result := MC(); if mpos <= Length(meth) then Inc(mpos); end;
 
-  function isDigit(c: AnsiChar): Boolean; inline;
+  function isDigit(c: AnsiChar): Boolean;
   begin Result := (c >= '0') and (c <= '9'); end;
 
 begin


### PR DESCRIPTION
## What

Next `dcc64` error after #359 merged:

```
[dcc64 Error] libzpaq.pas(3238): E2449 Inlined nested routine 'MC' cannot access outer scope variable 'meth'
```

Delphi won't inline a **nested** routine that reads the enclosing routine's locals. The method-string parser has three nested helpers marked `inline` (FPC's `{$inline on}` made them inline); `MC`/`MCadv` read `meth`/`mpos` from the outer scope, so dcc rejects them.

## Fix

Drop `inline` from the three nested helpers (`MC`, `MCadv`, `isDigit`). They're the only **nested** inline routines in the unit — every other `inline;` is a class method or unit-level function, which Delphi inlines fine. Perf cost is nil (it's a one-shot method-string parser).

## Verification

- FPC `make all` links clean — removing `inline` is a no-op for correctness on FPC.
- Delphi still unverified here; this clears E2449 at line 3238. Re-run `dcc64` and send the next one if any.

(Note: this is a follow-on to #359, which is merged — same iteration loop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_