### PR TITLE
zpaq/delphi: fix array-type mismatch + comment-directive break (E2008/E2029)

### DIFF
--- a/src/pkg/vendor/zpaq/ZpaqClasses.pas
+++ b/src/pkg/vendor/zpaq/ZpaqClasses.pas
@@ -20,7 +20,14 @@ unit ZpaqClasses;
 
 
 { PasClaw: mode directive guarded so the unit also compiles under Delphi. }
-{$IFDEF FPC}{$mode objfpc}{$H+}{$ENDIF}
+{$IFDEF FPC}
+  {$mode objfpc}{$H+}
+{$ELSE}
+  { Delphi: the archive scanner deliberately mixes Cardinal fragment counts with
+    Integer offsets (values stay well within Integer range); silence the noisy
+    signed/unsigned widening warning. }
+  {$WARN COMBINING_SIGNED_UNSIGNED OFF}
+{$ENDIF}
 
 interface
 
@@ -101,7 +108,8 @@ type
         Size : Int64;                { -1 for streaming archives }
         Date : TDateTime;            {  0 for streaming archives }
         { journaling: fragment indices into Fht[] }
-        Ptrs : array of Cardinal;
+        Ptrs : TU32Array;   { shared named type (= array of Cardinal) so Delphi
+                              accepts assignment to/from the locals below }
         { streaming: entire decompressed file data cached here }
         Data : TMemoryStream;
       end;
@@ -434,7 +442,7 @@ var
   p, pEnd  : PAnsiChar;
   date     : Int64;
   na, ni   : Cardinal;
-  ptrArr   : array of Cardinal;
+  ptrArr   : TU32Array;
   fsize    : Int64;
   fi       : Integer;
   { streaming }
@@ -683,7 +691,7 @@ end;
 
 procedure TZpaqUnpacker.DecompressJournalEntry(idx: Integer; Dest: TStream);
 var
-  ptrs       : array of Cardinal;
+  ptrs       : TU32Array;
   lastBlk    : Integer;
   fs         : TFileStream;
   reader     : TReadBridge;

--- a/src/pkg/vendor/zpaq/libzpaq.pas
+++ b/src/pkg/vendor/zpaq/libzpaq.pas
@@ -3235,7 +3235,7 @@ var
 
   { ---- read next char from meth at mpos ---- }
   { Not inlined: Delphi (E2449) refuses to inline a nested routine that touches
-    the enclosing scope (meth / mpos); FPC's {$inline on} made these inline but
+    the enclosing scope (meth / mpos). FPC inline-mode had made them inline, but
     the perf cost of dropping it on a method-string parser is nil. }
   function MC(): AnsiChar;
   begin if mpos <= Length(meth) then Result := meth[mpos] else Result := #0; end;


### PR DESCRIPTION
## What

Next `dcc64` round for the zpaq Delphi port.

| dcc64 | Cause | Fix |
|---|---|---|
| **E2029** `libzpaq.pas(3238)` `',' or ':' expected ... 'these'` | My comment from #360 contained `{$inline on}` — the `}` in it **closes the `{ }` comment early**, so the trailing words parsed as code. | Reworded the comment without the literal directive. |
| **E2008** `ZpaqClasses.pas(594, 700)` Incompatible types | `Ptrs` (record field), `ptrArr`, `ptrs` (locals) were three **separate anonymous** `array of Cardinal` types; Delphi treats each as distinct and refuses cross-assignment (FPC doesn't). | Point all three at the shared named `TU32Array` (= `array of U32` = Cardinal) already in libzpaq. |
| **W1024** `ZpaqClasses.pas(731, 760)` signed/unsigned widening | Cardinal counts mixed with Integer offsets (values within Integer range). | `{$WARN COMBINING_SIGNED_UNSIGNED OFF}` on Delphi. |

## On the comment bug (and why FPC missed it)

That `{$inline on}`-in-a-comment was mine, and I'd claimed "FPC clean" — but FPC had a **cached `.ppu`** and never recompiled the file, so it didn't see the break. This time I deleted the zpaq `.ppu`s first and forced a real recompile:

```
Compiling ./src/pkg/vendor/zpaq/ZpaqClasses.pas
Compiling ./src/pkg/vendor/zpaq/libzpaq.pas
Linking build/pasclaw
```

So FPC genuinely re-parsed both units and linked, and `test-checkpoints-zpaq` / `-redo` still pass. (Lesson logged: force-recompile vendored units when verifying, not just relink.)

## Status

Delphi still unverified here, but this clears E2029 + both E2008s. Re-run `dcc64` and paste the next error if any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_