### PR TITLE
memory: Phase 1 distiller — transcript → structured facts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -523,6 +523,14 @@ test-checkpoints: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/checkpoints_tests.pas -o$(BUILDDIR)/checkpoints_tests
 	@$(BUILDDIR)/checkpoints_tests
 
+# Distilled-memory Phase 1: transcript -> normalised TFact[] via a
+# scripted provider (no model, no DB). Pins the parse/normalise/dedup
+# contract of PasClaw.Memory.Distill.
+test-memory-distill: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/memory_distill_tests.pas -o$(BUILDDIR)/memory_distill_tests
+	@$(BUILDDIR)/memory_distill_tests
+
 # JSON-aware condenser: pure string-in / string-out, no model. Pins
 # the collapse-arrays / ellipsize-strings contract that
 # PasClaw.Condense.JSON applies to tool output before it reaches the
@@ -748,4 +756,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -46,6 +46,11 @@ uses
   PasClaw.Utils,
   PasClaw.Config,
   PasClaw.Logger,
+  PasClaw.Memory,
+  PasClaw.Memory.Distill,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Factory,
   LocalVector.Models,
   LocalVector.OrtProvision,
   LocalVector.VecProvision,
@@ -74,6 +79,9 @@ begin
   PrintLn('              embedding model into $PASCLAW_HOME/cache/localvector/');
   PrintLn('  status      Show which runtime artifacts are present and which');
   PrintLn('              backend memory_search would pick on the next call');
+  PrintLn('  distill [session]');
+  PrintLn('              Extract durable facts from a session transcript via');
+  PrintLn('              the LLM and print them (latest session if omitted).');
 end;
 
 function ModelDir(const SubDir: string): string;
@@ -345,6 +353,117 @@ begin
   Result := 0;
 end;
 
+function MemoryDir: string;
+begin
+  Result := JoinPath(JoinPath(GetHome, 'workspace'), 'memory');
+end;
+
+function LatestSessionId: string;
+{ Newest *.ndjson under workspace/memory (by mtime), or '' if none. }
+var
+  SR: TSearchRec;
+  Best: string;
+  BestTime: LongInt;
+begin
+  Result := '';
+  Best := '';
+  BestTime := -1;
+  if FindFirst(JoinPath(MemoryDir, '*.ndjson'), faAnyFile, SR) = 0 then
+  try
+    repeat
+      if (SR.Attr and faDirectory) <> 0 then Continue;
+      { SR.Time is a packed file timestamp -- fine for "newest" ordering
+        and available under both FPC and Delphi (unlike .TimeStamp). }
+      if (Best = '') or (SR.Time > BestTime) then
+      begin
+        Best := SR.Name;
+        BestTime := SR.Time;
+      end;
+    until FindNext(SR) <> 0;
+  finally
+    FindClose(SR);
+  end;
+  if Best <> '' then
+    Result := ChangeFileExt(Best, '');   { strip .ndjson -> session id }
+end;
+
+function RunDistill(const Argv: array of string): Integer;
+{ pasclaw memory distill [sessionId]
+
+  Phase 1: read a session's transcript, run the LLM distiller, and PRINT
+  the extracted facts. Persistence (SQLite fact store) lands in Phase 2,
+  so this is a read-only preview of what the distiller would remember. }
+var
+  Cfg: TConfig;
+  Provider: ILLMProvider;
+  Err, SessionId, Today: string;
+  Log: TMemoryLog;
+  Hist: TMessageArray;
+  Distiller: TMemoryDistiller;
+  Facts: TFactArray;
+  i: Integer;
+  Line: string;
+begin
+  Result := 1;
+  if Length(Argv) >= 2 then
+    SessionId := Argv[1]
+  else
+    SessionId := LatestSessionId;
+  if SessionId = '' then
+  begin
+    PrintErr('no session found under ' + MemoryDir + sLineBreak);
+    Exit;
+  end;
+
+  Cfg := LoadConfig;
+  try
+    if not NewDefaultProvider(Cfg, Provider, Err) then
+    begin
+      PrintErr('distill: ' + Err + sLineBreak);
+      Exit;
+    end;
+
+    Log := NewMemoryLog(GetHome, SessionId);
+    try
+      Hist := Log.LoadHistory;
+    finally
+      Log.Free;
+    end;
+    if Length(Hist) = 0 then
+    begin
+      PrintErr('session "' + SessionId + '" has no transcript' + sLineBreak);
+      Exit;
+    end;
+
+    Today := FormatDateTime('yyyy"-"mm"-"dd', Now);
+    Distiller := TMemoryDistiller.Create(Provider, Cfg.DefaultModel);
+    try
+      if not Distiller.Distill(Hist, SessionId, Today, Facts, Err) then
+      begin
+        PrintErr('distill: ' + Err + sLineBreak);
+        Exit;
+      end;
+    finally
+      Distiller.Free;
+    end;
+  finally
+    Cfg.Free;
+  end;
+
+  PrintLn(Ansi.Bold + 'Distilled ' + IntToStr(Length(Facts)) +
+          ' fact(s) from session ' + SessionId + Ansi.Reset);
+  PrintLn(Ansi.Dim + '(preview only -- persistence lands in Phase 2)' + Ansi.Reset);
+  for i := 0 to High(Facts) do
+  begin
+    Line := Format('  [%s/%s %.2f] %s',
+      [Facts[i].Kind, Facts[i].Scope, Facts[i].Confidence, Facts[i].Text]);
+    if Facts[i].Expires <> '' then
+      Line := Line + Ansi.Dim + ' (expires ' + Facts[i].Expires + ')' + Ansi.Reset;
+    PrintLn(Line);
+  end;
+  Result := 0;
+end;
+
 function Cmd_Memory_Run(const Argv: array of string): Integer;
 var
   Sub: string;
@@ -362,6 +481,7 @@ begin
   end;
   if Sub = 'provision' then Exit(RunProvision);
   if Sub = 'status'    then Exit(RunStatus);
+  if Sub = 'distill'   then Exit(RunDistill(Argv));
   PrintErr('unknown memory subcommand: ' + Sub + sLineBreak);
   Help;
   Result := 1;

--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -415,6 +415,16 @@ begin
     Exit;
   end;
 
+  { Guard before touching NewMemoryLog: it opens the .ndjson with fmCreate,
+    so a typo'd session id would CREATE an empty log -- which then becomes
+    the newest session and hijacks the default-latest selection on every
+    later run. Require the transcript to already exist. }
+  if not FileExists(JoinPath(MemoryDir, SessionId + '.ndjson')) then
+  begin
+    PrintErr('session "' + SessionId + '" not found under ' + MemoryDir + sLineBreak);
+    Exit;
+  end;
+
   Cfg := LoadConfig;
   try
     if not NewDefaultProvider(Cfg, Provider, Err) then

--- a/src/pkg/memory/PasClaw.Memory.Distill.pas
+++ b/src/pkg/memory/PasClaw.Memory.Distill.pas
@@ -1,0 +1,288 @@
+(*
+  PasClaw.Memory.Distill -- Phase 1 of the distilled-memory system.
+
+  Turns a raw conversation transcript into a small set of durable,
+  structured FACTS using one LLM pass -- the "write side" PasClaw was
+  missing (today's NDJSON session logs are never distilled; notes must
+  be hand-written). This is the extraction step ONLY:
+
+      transcript (TMessageArray)  --LLM-->  TFact[]
+
+  It is deliberately storage-agnostic. Persistence (a SQLite fact table
+  + sqlite-vec sidecar), dedup/contradiction/expiry reconciliation, and
+  retrieval/injection land in later phases. Keeping extraction pure
+  makes it trivially testable with a scripted provider -- no model, no
+  database, no I/O.
+
+  A fact:
+
+    { "text": "User prefers Delphi over Lazarus",
+      "kind": "static" | "dynamic",          // stable trait vs current focus
+      "scope": "user" | "project" | "session",
+      "confidence": 0.0 .. 1.0,
+      "expires": "YYYY-MM-DD" | "" }          // temporary facts self-expire
+
+  The model is asked to return ONLY a JSON object {"facts":[...]}; we
+  parse leniently (strip code fences, slice the outer object) and
+  normalise every field so a sloppy model can't produce a malformed
+  fact. Facts that are empty after trimming are dropped; duplicates
+  within the batch (case-insensitive text) collapse to the first.
+*)
+unit PasClaw.Memory.Distill;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf;
+
+type
+  TFact = record
+    Text:          string;
+    Kind:          string;   { 'static' | 'dynamic' }
+    Scope:         string;   { 'user' | 'project' | 'session' }
+    Confidence:    Double;   { 0..1 }
+    Expires:       string;   { 'YYYY-MM-DD' or '' }
+    SourceSession: string;
+  end;
+  TFactArray = array of TFact;
+
+  TMemoryDistiller = class
+  private
+    FProvider: ILLMProvider;
+    FModel:    string;
+    FMaxChars: Integer;   { transcript byte budget handed to the model }
+    function BuildSystemPrompt(const Today: string): string;
+    function RenderTranscript(const Transcript: array of TMessage): string;
+    function ParseFacts(const Raw, SessionId: string): TFactArray;
+  public
+    constructor Create(AProvider: ILLMProvider; const AModel: string);
+    { Extract facts from Transcript. Today ('YYYY-MM-DD') is injected so
+      the model can resolve relative dates ("tomorrow") into Expires; pass
+      it explicitly so the extraction is deterministic/testable. Returns
+      False with ErrMsg on a provider/parse failure (Facts is then empty). }
+    function Distill(const Transcript: array of TMessage;
+                     const SessionId, Today: string;
+                     out Facts: TFactArray; out ErrMsg: string): Boolean;
+    property MaxTranscriptChars: Integer read FMaxChars write FMaxChars;
+  end;
+
+{ Lenient extractor: returns the outermost brace-delimited JSON object
+  found in S (after stripping ``` fences), or '' if none. For testing. }
+function SliceJsonObject(const S: string): string;
+
+{ Normalise a single raw fact's fields in place (kind/scope/confidence/
+  expires). Exposed for testing. }
+procedure NormaliseFact(var F: TFact);
+
+implementation
+
+uses
+  PasClaw.JSON;
+
+const
+  KindStatic  = 'static';
+  KindDynamic = 'dynamic';
+  DefaultMaxTranscriptChars = 16000;
+
+constructor TMemoryDistiller.Create(AProvider: ILLMProvider; const AModel: string);
+begin
+  inherited Create;
+  FProvider := AProvider;
+  FModel    := AModel;
+  FMaxChars := DefaultMaxTranscriptChars;
+end;
+
+function TMemoryDistiller.BuildSystemPrompt(const Today: string): string;
+begin
+  Result :=
+    'You distil durable MEMORY from a conversation. Read the transcript and '   + sLineBreak +
+    'extract a SMALL set of facts worth remembering across future sessions: '   + sLineBreak +
+    'stable user/project traits, decisions, preferences, and current focus. '   + sLineBreak +
+    'Ignore one-off chatter, tool noise, and anything already obvious.'         + sLineBreak +
+    sLineBreak +
+    'Today is ' + Today + '. Resolve relative dates against it.'                + sLineBreak +
+    sLineBreak +
+    'For each fact set:'                                                        + sLineBreak +
+    '  text       a single concise sentence, self-contained.'                  + sLineBreak +
+    '  kind       "static" for stable traits, "dynamic" for current focus.'    + sLineBreak +
+    '  scope      "user", "project", or "session".'                            + sLineBreak +
+    '  confidence 0.0-1.0, how sure you are.'                                   + sLineBreak +
+    '  expires    "YYYY-MM-DD" for temporary facts ("exam tomorrow"), else "".'+ sLineBreak +
+    sLineBreak +
+    'Return ONLY a JSON object, no prose, no code fence:'                       + sLineBreak +
+    '{"facts":[{"text":"...","kind":"static","scope":"user",'                   +
+    '"confidence":0.9,"expires":""}]}'                                          + sLineBreak +
+    'If nothing is worth remembering, return {"facts":[]}.';
+end;
+
+function TMemoryDistiller.RenderTranscript(const Transcript: array of TMessage): string;
+var
+  i: Integer;
+  Line, Acc: string;
+  Budget: Integer;
+begin
+  { Build from the TAIL backwards so that when we hit the byte budget we
+    keep the most recent exchanges (most relevant for "current focus"). }
+  Acc    := '';
+  Budget := FMaxChars;
+  for i := High(Transcript) downto 0 do
+  begin
+    if Trim(Transcript[i].Content) = '' then Continue;
+    Line := MsgRoleToString(Transcript[i].Role) + ': ' +
+            Transcript[i].Content + sLineBreak;
+    if (Budget - Length(Line)) < 0 then Break;
+    Acc    := Line + Acc;
+    Budget := Budget - Length(Line);
+  end;
+  Result := Acc;
+end;
+
+function SliceJsonObject(const S: string): string;
+var
+  T: string;
+  i, j: Integer;
+begin
+  Result := '';
+  T := Trim(S);
+  { Strip a leading ```json / ``` fence and a trailing ``` if present. }
+  if Copy(T, 1, 3) = '```' then
+  begin
+    i := Pos(#10, T);
+    if i > 0 then T := Copy(T, i + 1, MaxInt);
+    j := Pos('```', T);
+    if j > 0 then T := Copy(T, 1, j - 1);
+    T := Trim(T);
+  end;
+  i := Pos('{', T);
+  if i <= 0 then Exit;
+  for j := Length(T) downto i do
+    if T[j] = '}' then
+    begin
+      Result := Copy(T, i, j - i + 1);
+      Exit;
+    end;
+end;
+
+procedure NormaliseFact(var F: TFact);
+var
+  K, Sc: string;
+begin
+  F.Text := Trim(F.Text);
+
+  K := LowerCase(Trim(F.Kind));
+  if (K <> KindStatic) and (K <> KindDynamic) then K := KindDynamic;
+  F.Kind := K;
+
+  Sc := LowerCase(Trim(F.Scope));
+  if (Sc <> 'user') and (Sc <> 'project') and (Sc <> 'session') then Sc := 'user';
+  F.Scope := Sc;
+
+  if F.Confidence < 0 then F.Confidence := 0
+  else if F.Confidence > 1 then F.Confidence := 1;
+
+  F.Expires := Trim(F.Expires);
+  { Accept only a plausible YYYY-MM-DD; anything else means "no expiry". }
+  if (Length(F.Expires) <> 10) or (F.Expires[5] <> '-') or (F.Expires[8] <> '-') then
+    F.Expires := '';
+end;
+
+function TMemoryDistiller.ParseFacts(const Raw, SessionId: string): TFactArray;
+var
+  Json, Body: string;
+  Root: TJsonObject;
+  Arr: TJsonArray;
+  Obj: TJsonObject;
+  i: Integer;
+  F: TFact;
+  Seen: TStringList;
+begin
+  Result := nil;
+  Json := SliceJsonObject(Raw);
+  if Json = '' then Exit;
+  Root := TJsonObject.Parse(Json);
+  if Root = nil then Exit;
+  Seen := TStringList.Create;
+  try
+    Seen.CaseSensitive := False;
+    Arr := Root.ChildArray('facts');
+    if Arr = nil then Exit;
+    for i := 0 to Arr.Count - 1 do
+    begin
+      Obj := Arr.ItemObject(i);
+      if Obj = nil then Continue;
+      F.Text          := Obj.GetStr('text', '');
+      F.Kind          := Obj.GetStr('kind', '');
+      F.Scope         := Obj.GetStr('scope', '');
+      F.Confidence    := Obj.GetFloat('confidence', 0.5);
+      F.Expires       := Obj.GetStr('expires', '');
+      F.SourceSession := SessionId;
+      NormaliseFact(F);
+      if F.Text = '' then Continue;
+      Body := LowerCase(F.Text);
+      if Seen.IndexOf(Body) >= 0 then Continue;   { dedup within the batch }
+      Seen.Add(Body);
+      SetLength(Result, Length(Result) + 1);
+      Result[High(Result)] := F;
+    end;
+  finally
+    Seen.Free;
+    Root.Free;
+  end;
+end;
+
+function TMemoryDistiller.Distill(const Transcript: array of TMessage;
+  const SessionId, Today: string;
+  out Facts: TFactArray; out ErrMsg: string): Boolean;
+var
+  Msgs: array of TMessage;
+  NoTools: array of TToolDefinition;
+  Opts: TChatOptions;
+  Resp: TLLMResponse;
+  Rendered: string;
+begin
+  SetLength(Facts, 0);
+  ErrMsg := '';
+  if FProvider = nil then
+  begin
+    ErrMsg := 'distill: no provider';
+    Exit(False);
+  end;
+
+  Rendered := RenderTranscript(Transcript);
+  if Trim(Rendered) = '' then
+  begin
+    { Empty transcript -> no facts, not an error. }
+    Exit(True);
+  end;
+
+  Opts := DefaultChatOptions;
+  Opts.Temperature  := 0;          { deterministic extraction }
+  Opts.SystemPrompt := BuildSystemPrompt(Today);
+  Opts.Stream       := False;
+
+  SetLength(NoTools, 0);
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser,
+    'Transcript to distil:' + sLineBreak + sLineBreak + Rendered);
+
+  Resp := Default(TLLMResponse);
+  try
+    Resp := FProvider.Chat(Msgs, NoTools, FModel, Opts);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'distill: provider error: ' + E.Message;
+      Exit(False);
+    end;
+  end;
+
+  Facts := ParseFacts(Resp.Content, SessionId);
+  Result := True;
+end;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.Distill.pas
+++ b/src/pkg/memory/PasClaw.Memory.Distill.pas
@@ -135,7 +135,17 @@ begin
     if Trim(Transcript[i].Content) = '' then Continue;
     Line := MsgRoleToString(Transcript[i].Role) + ': ' +
             Transcript[i].Content + sLineBreak;
-    if (Budget - Length(Line)) < 0 then Break;
+    if Length(Line) > Budget then
+    begin
+      { This entry overflows the remaining budget. If we've added nothing
+        yet -- the newest message alone is bigger than the whole budget,
+        common for a large tool result saved last -- keep a truncated head
+        so the model still gets recent context instead of an empty string
+        (which would make Distill silently return zero facts). }
+      if (Acc = '') and (Budget > 0) then
+        Acc := Copy(Line, 1, Budget);
+      Break;
+    end;
     Acc    := Line + Acc;
     Budget := Budget - Length(Line);
   end;
@@ -204,7 +214,17 @@ begin
   Result := nil;
   Json := SliceJsonObject(Raw);
   if Json = '' then Exit;
-  Root := TJsonObject.Parse(Json);
+  { Lenient parse: the model can emit brace characters that don't form
+    valid JSON (stray braces in prose). TJsonObject.Parse RAISES on
+    those, so swallow it and treat the reply as "no facts" rather than
+    letting the exception escape Distill (which only wraps the provider
+    call) and abort the caller. }
+  Root := nil;
+  try
+    Root := TJsonObject.Parse(Json);
+  except
+    Root := nil;
+  end;
   if Root = nil then Exit;
   Seen := TStringList.Create;
   try

--- a/src/tests/memory_distill_tests.pas
+++ b/src/tests/memory_distill_tests.pas
@@ -1,0 +1,231 @@
+program memory_distill_tests;
+(*
+  Covers PasClaw.Memory.Distill -- Phase 1 of the distilled-memory
+  system: turning a transcript into normalised TFact records via one
+  LLM pass. No real model: a scripted ILLMProvider returns canned
+  Content so we exercise the prompt/parse/normalise/dedup path
+  deterministically.
+
+  Pinned contracts:
+    - facts parse out of {"facts":[...]} (and survive a ```json fence)
+    - kind/scope normalise to the allowed enums; bad values default
+    - confidence clamps to 0..1
+    - expires keeps a YYYY-MM-DD shape, blanks anything else
+    - empty-text facts are dropped; duplicate text collapses
+    - empty transcript -> ok, zero facts, provider NOT called
+    - provider exception -> False + ErrMsg
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf,
+  PasClaw.Memory.Distill;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertEqInt(Got, Want: Integer; const Msg: string);
+begin if Got <> Want then Fail_(Format('%s (got %d, want %d)', [Msg, Got, Want])); end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")'); end;
+
+type
+  { Returns FReply verbatim as Content; counts calls; optionally raises. }
+  TScriptedProvider = class(TInterfacedObject, ILLMProvider)
+  public
+    Reply:     string;
+    Calls:     Integer;
+    RaiseIt:   Boolean;
+    LastSystem: string;
+    function Chat(const Messages: array of TMessage;
+                  const Tools: array of TToolDefinition;
+                  const Model: string;
+                  const Options: TChatOptions): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools: array of TToolDefinition;
+                        const Model: string;
+                        const Options: TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+  end;
+
+function TScriptedProvider.GetDefaultModel: string; begin Result := 'fake'; end;
+function TScriptedProvider.GetName: string;         begin Result := 'fake'; end;
+function TScriptedProvider.SupportsThinking: Boolean;     begin Result := False; end;
+function TScriptedProvider.SupportsNativeSearch: Boolean; begin Result := False; end;
+function TScriptedProvider.SupportsStreaming: Boolean;    begin Result := False; end;
+
+function TScriptedProvider.Chat(const Messages: array of TMessage;
+  const Tools: array of TToolDefinition; const Model: string;
+  const Options: TChatOptions): TLLMResponse;
+begin
+  Inc(Calls);
+  LastSystem := Options.SystemPrompt;
+  if RaiseIt then raise Exception.Create('boom');
+  Result := Default(TLLMResponse);
+  Result.StatusCode := 200;
+  Result.Content := Reply;
+end;
+
+function TScriptedProvider.ChatStream(const Messages: array of TMessage;
+  const Tools: array of TToolDefinition; const Model: string;
+  const Options: TChatOptions; OnChunk: TStreamCallback): TLLMResponse;
+begin
+  Result := Chat(Messages, Tools, Model, Options);
+end;
+
+function Convo: TMessageArray;
+begin
+  SetLength(Result, 2);
+  Result[0] := MakeMessage(mrUser, 'I always use Delphi, never Lazarus. Exam tomorrow.');
+  Result[1] := MakeMessage(mrAssistant, 'Noted.');
+end;
+
+procedure TestSliceJsonObject;
+begin
+  AssertEqStr(SliceJsonObject('{"a":1}'), '{"a":1}', 'plain object');
+  AssertEqStr(SliceJsonObject('```json'#10'{"a":1}'#10'```'), '{"a":1}', 'fenced object');
+  AssertEqStr(SliceJsonObject('here you go: {"a":{"b":2}} ok'), '{"a":{"b":2}}', 'embedded object');
+  AssertEqStr(SliceJsonObject('no json here'), '', 'no object -> empty');
+end;
+
+procedure TestNormaliseFact;
+var F: TFact;
+begin
+  F.Text := '  hi  '; F.Kind := 'STATIC'; F.Scope := 'Project';
+  F.Confidence := 2.5; F.Expires := '2026-07-01';
+  NormaliseFact(F);
+  AssertEqStr(F.Text, 'hi', 'text trimmed');
+  AssertEqStr(F.Kind, 'static', 'kind lowercased/kept');
+  AssertEqStr(F.Scope, 'project', 'scope lowercased/kept');
+  AssertTrue(F.Confidence = 1, 'confidence clamped to 1');
+  AssertEqStr(F.Expires, '2026-07-01', 'valid expiry kept');
+
+  F.Kind := 'weird'; F.Scope := 'galaxy'; F.Confidence := -3; F.Expires := 'soon';
+  NormaliseFact(F);
+  AssertEqStr(F.Kind, 'dynamic', 'bad kind -> dynamic');
+  AssertEqStr(F.Scope, 'user', 'bad scope -> user');
+  AssertTrue(F.Confidence = 0, 'confidence clamped to 0');
+  AssertEqStr(F.Expires, '', 'malformed expiry -> blank');
+end;
+
+procedure TestDistillParsesAndNormalises;
+var
+  P: TScriptedProvider;
+  D: TMemoryDistiller;
+  Facts: TFactArray;
+  Err: string;
+begin
+  P := TScriptedProvider.Create;
+  P.Reply :=
+    '```json'#10 +
+    '{"facts":[' +
+    '{"text":"User prefers Delphi over Lazarus","kind":"static","scope":"user","confidence":0.9,"expires":""},' +
+    '{"text":"Has an exam","kind":"bogus","scope":"nowhere","confidence":5,"expires":"2026-06-27"},' +
+    '{"text":"  ","kind":"static","scope":"user","confidence":0.5,"expires":""},' +
+    '{"text":"User prefers Delphi over Lazarus","kind":"dynamic","scope":"user","confidence":0.4,"expires":""}' +
+    ']}'#10'```';
+  D := TMemoryDistiller.Create(P, 'fake');
+  try
+    AssertTrue(D.Distill(Convo, 'sess-1', '2026-06-26', Facts, Err), 'distill ok: ' + Err);
+    AssertEqInt(Length(Facts), 2, 'empty dropped + duplicate collapsed -> 2 facts');
+
+    AssertEqStr(Facts[0].Text, 'User prefers Delphi over Lazarus', 'fact 0 text');
+    AssertEqStr(Facts[0].Kind, 'static', 'fact 0 kind');
+    AssertEqStr(Facts[0].Scope, 'user', 'fact 0 scope');
+    AssertEqStr(Facts[0].SourceSession, 'sess-1', 'fact 0 carries session');
+
+    AssertEqStr(Facts[1].Kind, 'dynamic', 'fact 1 bad kind normalised');
+    AssertEqStr(Facts[1].Scope, 'user', 'fact 1 bad scope normalised');
+    AssertTrue(Facts[1].Confidence = 1, 'fact 1 confidence clamped');
+    AssertEqStr(Facts[1].Expires, '2026-06-27', 'fact 1 keeps valid expiry');
+
+    AssertTrue(Pos('2026-06-26', P.LastSystem) > 0, 'today injected into system prompt');
+  finally
+    D.Free;
+  end;
+end;
+
+procedure TestEmptyTranscriptSkipsProvider;
+var
+  P: TScriptedProvider;
+  D: TMemoryDistiller;
+  Facts: TFactArray;
+  Err: string;
+  Empty: TMessageArray;
+begin
+  P := TScriptedProvider.Create;
+  P.Reply := '{"facts":[{"text":"should not happen","kind":"static","scope":"user","confidence":1,"expires":""}]}';
+  D := TMemoryDistiller.Create(P, 'fake');
+  try
+    SetLength(Empty, 0);
+    AssertTrue(D.Distill(Empty, 'sess-2', '2026-06-26', Facts, Err), 'empty transcript ok');
+    AssertEqInt(Length(Facts), 0, 'no facts from empty transcript');
+    AssertEqInt(P.Calls, 0, 'provider not called for empty transcript');
+  finally
+    D.Free;
+  end;
+end;
+
+procedure TestProviderErrorSurfaces;
+var
+  P: TScriptedProvider;
+  D: TMemoryDistiller;
+  Facts: TFactArray;
+  Err: string;
+begin
+  P := TScriptedProvider.Create;
+  P.RaiseIt := True;
+  D := TMemoryDistiller.Create(P, 'fake');
+  try
+    AssertTrue(not D.Distill(Convo, 'sess-3', '2026-06-26', Facts, Err), 'provider error -> False');
+    AssertTrue(Pos('provider error', Err) > 0, 'ErrMsg names the cause');
+    AssertEqInt(Length(Facts), 0, 'no facts on error');
+  finally
+    D.Free;
+  end;
+end;
+
+procedure TestGarbageReplyYieldsNoFacts;
+var
+  P: TScriptedProvider;
+  D: TMemoryDistiller;
+  Facts: TFactArray;
+  Err: string;
+begin
+  P := TScriptedProvider.Create;
+  P.Reply := 'I could not find anything to remember, sorry!';
+  D := TMemoryDistiller.Create(P, 'fake');
+  try
+    AssertTrue(D.Distill(Convo, 'sess-4', '2026-06-26', Facts, Err), 'non-JSON reply still ok');
+    AssertEqInt(Length(Facts), 0, 'no facts from prose reply');
+  finally
+    D.Free;
+  end;
+end;
+
+begin
+  TestSliceJsonObject;                  WriteLn('  ok: slice json object (fences/embedded)');
+  TestNormaliseFact;                    WriteLn('  ok: normalise fact fields');
+  TestDistillParsesAndNormalises;       WriteLn('  ok: distill parses + normalises + dedups');
+  TestEmptyTranscriptSkipsProvider;     WriteLn('  ok: empty transcript skips provider');
+  TestProviderErrorSurfaces;            WriteLn('  ok: provider error surfaces');
+  TestGarbageReplyYieldsNoFacts;        WriteLn('  ok: non-JSON reply -> no facts');
+  WriteLn('PASS');
+end.

--- a/src/tests/memory_distill_tests.pas
+++ b/src/tests/memory_distill_tests.pas
@@ -220,6 +220,52 @@ begin
   end;
 end;
 
+procedure TestMalformedBracesDoNotRaise;
+{ Braces that are NOT valid JSON must be swallowed -> 0 facts, no crash
+  (TJsonObject.Parse raises on these). }
+var
+  P: TScriptedProvider;
+  D: TMemoryDistiller;
+  Facts: TFactArray;
+  Err: string;
+begin
+  P := TScriptedProvider.Create;
+  P.Reply := 'sure: {not json, just braces ::}';
+  D := TMemoryDistiller.Create(P, 'fake');
+  try
+    AssertTrue(D.Distill(Convo, 'sess-5', '2026-06-26', Facts, Err), 'malformed braces -> still ok');
+    AssertEqInt(Length(Facts), 0, 'malformed braces -> no facts (no exception)');
+  finally
+    D.Free;
+  end;
+end;
+
+procedure TestOversizedNewestMessageStillRenders;
+{ When the newest message alone exceeds the byte budget, RenderTranscript
+  must keep a truncated head rather than producing an empty transcript
+  (which would skip the provider and silently return zero facts). }
+var
+  P: TScriptedProvider;
+  D: TMemoryDistiller;
+  Facts: TFactArray;
+  Err: string;
+  Big: TMessageArray;
+begin
+  P := TScriptedProvider.Create;
+  P.Reply := '{"facts":[{"text":"something","kind":"static","scope":"user","confidence":0.8,"expires":""}]}';
+  D := TMemoryDistiller.Create(P, 'fake');
+  try
+    D.MaxTranscriptChars := 50;
+    SetLength(Big, 1);
+    Big[0] := MakeMessage(mrUser, StringOfChar('x', 500));   { newest > budget }
+    AssertTrue(D.Distill(Big, 'sess-6', '2026-06-26', Facts, Err), 'oversized ok');
+    AssertEqInt(P.Calls, 1, 'provider WAS called (transcript not empty)');
+    AssertEqInt(Length(Facts), 1, 'facts still extracted from truncated context');
+  finally
+    D.Free;
+  end;
+end;
+
 begin
   TestSliceJsonObject;                  WriteLn('  ok: slice json object (fences/embedded)');
   TestNormaliseFact;                    WriteLn('  ok: normalise fact fields');
@@ -227,5 +273,7 @@ begin
   TestEmptyTranscriptSkipsProvider;     WriteLn('  ok: empty transcript skips provider');
   TestProviderErrorSurfaces;            WriteLn('  ok: provider error surfaces');
   TestGarbageReplyYieldsNoFacts;        WriteLn('  ok: non-JSON reply -> no facts');
+  TestMalformedBracesDoNotRaise;        WriteLn('  ok: malformed braces -> no crash, no facts');
+  TestOversizedNewestMessageStillRenders; WriteLn('  ok: oversized newest message still renders');
   WriteLn('PASS');
 end.


### PR DESCRIPTION
## Context

PasClaw already has the **retrieval** half of a supermemory-style memory system — hybrid FTS5 + `sqlite-vec`, local ONNX embeddings, the `memory_search` tool, and `pasclaw memory provision`. What's missing is the **write side**: nothing distils conversations into durable memory; notes have to be hand-written. This PR adds the extraction step (Phase 1 of the roadmap discussed in chat).

## What it does

`PasClaw.Memory.Distill` turns a transcript into a small set of normalised `TFact` records via **one LLM pass**:

```
{ text, kind(static|dynamic), scope(user|project|session),
  confidence(0..1), expires("YYYY-MM-DD"|""), source_session }
```

Design choices:

- **Storage-agnostic — extraction only.** Persistence (a SQLite fact table + `sqlite-vec` sidecar) and dedup/contradiction/expiry reconciliation are deliberately **Phase 2/3**. Keeping extraction pure makes it testable with no model, no DB, no I/O. *(Per the chat discussion: facts will live in SQLite, not flat files, because the lifecycle queries — similarity dedup, `WHERE expires < today`, supersede — are exactly what SQLite is good at and files are bad at. Auditability comes via a future Memory web tab + markdown export.)*
- **Lenient parsing, strict normalisation.** Strips ``` fences and slices the outer JSON object; every field is normalised (kind/scope default to the allowed enums, confidence clamps to 0..1, malformed `expires` blanks out). Empty-text facts drop; duplicates within a batch collapse. The model is handed today's date so it can resolve "tomorrow" into an expiry.
- **Deterministic.** `Today` is a parameter (not `Now`), temperature 0.

## CLI

`pasclaw memory distill [session]` runs the distiller over a session's NDJSON transcript and **prints** the facts (preview only — persistence is Phase 2). Defaults to the latest session.

## Tests

`make test-memory-distill` — scripted-provider coverage of: JSON parse + fence-strip, field normalise/clamp/expiry-shape, within-batch dedup, empty-text drop, empty-transcript-skips-provider, provider-error surfacing, and non-JSON-reply → no facts. All green. Shipping unit compiles warning-free; cross-compiler safe (no FPC-only constructs).

## Not in this PR (next phases)

- Phase 2: SQLite fact store + `sqlite-vec` sidecar implementing persistence.
- Phase 3: dedup / contradiction-supersede / temporal expiry sweep.
- Phase 4: auto-trigger after turns + inject top-K facts; `memory_profile`.
- Phase 5: `/remember`, `/forget`, web Memory tab, markdown export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_