### PR TITLE
memory: Phase 2 — SQLite fact store + persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -531,6 +531,14 @@ test-memory-distill: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/memory_distill_tests.pas -o$(BUILDDIR)/memory_distill_tests
 	@$(BUILDDIR)/memory_distill_tests
 
+# Distilled-memory Phase 2: SQLite fact store. Real temp DB; pins the
+# add / active-excludes-expired / supersede / delete / durability contract
+# of PasClaw.Memory.Facts.
+test-memory-facts: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/memory_facts_tests.pas -o$(BUILDDIR)/memory_facts_tests
+	@$(BUILDDIR)/memory_facts_tests
+
 # JSON-aware condenser: pure string-in / string-out, no model. Pins
 # the collapse-arrays / ellipsize-strings contract that
 # PasClaw.Condense.JSON applies to tool output before it reaches the
@@ -756,4 +764,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -46,8 +46,10 @@ uses
   PasClaw.Utils,
   PasClaw.Config,
   PasClaw.Logger,
+  DateUtils,
   PasClaw.Memory,
   PasClaw.Memory.Distill,
+  PasClaw.Memory.Facts,
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
   PasClaw.Providers.Factory,
@@ -79,9 +81,13 @@ begin
   PrintLn('              embedding model into $PASCLAW_HOME/cache/localvector/');
   PrintLn('  status      Show which runtime artifacts are present and which');
   PrintLn('              backend memory_search would pick on the next call');
-  PrintLn('  distill [session]');
+  PrintLn('  distill [session] [--save]');
   PrintLn('              Extract durable facts from a session transcript via');
-  PrintLn('              the LLM and print them (latest session if omitted).');
+  PrintLn('              the LLM (latest session if omitted). --save persists');
+  PrintLn('              them to the fact store; otherwise it just previews.');
+  PrintLn('  facts [--all]');
+  PrintLn('              List stored facts (active only; --all includes');
+  PrintLn('              superseded/expired).');
 end;
 
 function ModelDir(const SubDir: string): string;
@@ -403,12 +409,21 @@ var
   Facts: TFactArray;
   i: Integer;
   Line: string;
+  Save: Boolean;
+  Store: IFactStore;
+  Saved: Integer;
+  NowU: Int64;
 begin
   Result := 1;
-  if Length(Argv) >= 2 then
-    SessionId := Argv[1]
-  else
-    SessionId := LatestSessionId;
+  { Args after 'distill': an optional session id and an optional --save. }
+  Save := False;
+  SessionId := '';
+  for i := 1 to High(Argv) do
+  begin
+    if (Argv[i] = '--save') or (Argv[i] = '-s') then Save := True
+    else if SessionId = '' then SessionId := Argv[i];
+  end;
+  if SessionId = '' then SessionId := LatestSessionId;
   if SessionId = '' then
   begin
     PrintErr('no session found under ' + MemoryDir + sLineBreak);
@@ -462,13 +477,81 @@ begin
 
   PrintLn(Ansi.Bold + 'Distilled ' + IntToStr(Length(Facts)) +
           ' fact(s) from session ' + SessionId + Ansi.Reset);
-  PrintLn(Ansi.Dim + '(preview only -- persistence lands in Phase 2)' + Ansi.Reset);
+  if not Save then
+    PrintLn(Ansi.Dim + '(preview only -- pass --save to persist)' + Ansi.Reset);
   for i := 0 to High(Facts) do
   begin
     Line := Format('  [%s/%s %.2f] %s',
       [Facts[i].Kind, Facts[i].Scope, Facts[i].Confidence, Facts[i].Text]);
     if Facts[i].Expires <> '' then
       Line := Line + Ansi.Dim + ' (expires ' + Facts[i].Expires + ')' + Ansi.Reset;
+    PrintLn(Line);
+  end;
+
+  if Save and (Length(Facts) > 0) then
+  begin
+    Store := NewFactStore;
+    if not Store.Open(DefaultFactsDbPath(GetHome)) then
+    begin
+      PrintErr('distill: could not open fact store' + sLineBreak);
+      Exit;
+    end;
+    try
+      NowU := DateTimeToUnix(Now, False);
+      Saved := 0;
+      for i := 0 to High(Facts) do
+        if Store.Add(Facts[i], NowU + i) > 0 then Inc(Saved);
+    finally
+      Store.Close;
+    end;
+    PrintLn(Ansi.Green + 'Saved ' + IntToStr(Saved) + ' fact(s) to ' +
+            DefaultFactsDbPath(GetHome) + Ansi.Reset);
+  end;
+  Result := 0;
+end;
+
+function RunFacts(const Argv: array of string): Integer;
+{ pasclaw memory facts [--all]
+
+  List stored facts. Default shows only ACTIVE facts (not superseded,
+  not expired as of today); --all includes superseded/expired. }
+var
+  Store: IFactStore;
+  Facts: TStoredFactArray;
+  All: Boolean;
+  i: Integer;
+  Line, Today: string;
+begin
+  All := False;
+  for i := 1 to High(Argv) do
+    if (Argv[i] = '--all') or (Argv[i] = '-a') then All := True;
+
+  Store := NewFactStore;
+  if not Store.Open(DefaultFactsDbPath(GetHome)) then
+  begin
+    PrintErr('facts: no fact store at ' + DefaultFactsDbPath(GetHome) + sLineBreak);
+    Exit(1);
+  end;
+  try
+    Today := FormatDateTime('yyyy"-"mm"-"dd', Now);
+    if All then Facts := Store.AllFacts
+    else Facts := Store.ActiveFacts(Today);
+  finally
+    Store.Close;
+  end;
+
+  if All then
+    PrintLn(Ansi.Bold + IntToStr(Length(Facts)) + ' fact(s) (all)' + Ansi.Reset)
+  else
+    PrintLn(Ansi.Bold + IntToStr(Length(Facts)) + ' active fact(s)' + Ansi.Reset);
+  for i := 0 to High(Facts) do
+  begin
+    Line := Format('  #%d [%s/%s %.2f] %s',
+      [Facts[i].Id, Facts[i].Kind, Facts[i].Scope, Facts[i].Confidence, Facts[i].Text]);
+    if Facts[i].Expires <> '' then
+      Line := Line + Ansi.Dim + ' (expires ' + Facts[i].Expires + ')' + Ansi.Reset;
+    if Facts[i].Superseded then
+      Line := Line + Ansi.Dim + ' (superseded)' + Ansi.Reset;
     PrintLn(Line);
   end;
   Result := 0;
@@ -492,6 +575,7 @@ begin
   if Sub = 'provision' then Exit(RunProvision);
   if Sub = 'status'    then Exit(RunStatus);
   if Sub = 'distill'   then Exit(RunDistill(Argv));
+  if Sub = 'facts'     then Exit(RunFacts(Argv));
   PrintErr('unknown memory subcommand: ' + Sub + sLineBreak);
   Help;
   Result := 1;

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -69,8 +69,11 @@ type
     function  Supersede(Id: Int64): Boolean;
     { Hard-delete a fact. True if a row was removed. }
     function  Delete(Id: Int64): Boolean;
-    { Row count; IncludeInactive=False counts only non-superseded. }
-    function  Count(IncludeInactive: Boolean): Integer;
+    { Total rows, including superseded/expired. }
+    function  CountAll: Integer;
+    { Count of facts ACTIVE as of Today -- identical predicate to
+      ActiveFacts(Today), so the two never disagree. }
+    function  CountActive(const Today: string): Integer;
   end;
 
 function NewFactStore: IFactStore;
@@ -128,7 +131,8 @@ type
     function  AllFacts: TStoredFactArray;
     function  Supersede(Id: Int64): Boolean;
     function  Delete(Id: Int64): Boolean;
-    function  Count(IncludeInactive: Boolean): Integer;
+    function  CountAll: Integer;
+    function  CountActive(const Today: string): Integer;
   end;
 
 function NewFactStore: IFactStore;
@@ -398,7 +402,7 @@ begin
   end;
 end;
 
-function TFactStoreImpl.Count(IncludeInactive: Boolean): Integer;
+function TFactStoreImpl.CountAll: Integer;
 var
   Q: TQuery;
 begin
@@ -406,10 +410,30 @@ begin
   if not FOpen then Exit;
   Q := NewQuery;
   try
-    if IncludeInactive then
-      Q.SQL.Text := 'SELECT COUNT(*) FROM facts'
-    else
-      Q.SQL.Text := 'SELECT COUNT(*) FROM facts WHERE superseded = 0';
+    Q.SQL.Text := 'SELECT COUNT(*) FROM facts';
+    Q.Open;
+    if not Q.EOF then Result := Q.Fields[0].AsInteger;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFactStoreImpl.CountActive(const Today: string): Integer;
+{ Same predicate as ActiveFacts(Today): not superseded AND not expired.
+  Kept in lockstep so Count and the listing can't disagree (the earlier
+  Count(False) only filtered superseded and over-counted expired rows). }
+var
+  Q: TQuery;
+begin
+  Result := 0;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    Q.SQL.Text :=
+      'SELECT COUNT(*) FROM facts WHERE superseded = 0 ' +
+      'AND (expires = '''' OR expires >= :today)';
+    PStr(Q, 'today', Today);
     Q.Open;
     if not Q.EOF then Result := Q.Fields[0].AsInteger;
     Q.Close;

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -1,0 +1,421 @@
+(*
+  PasClaw.Memory.Facts - Phase 2 persistence for distilled memory.
+
+  Stores the TFact records produced by PasClaw.Memory.Distill in a
+  SQLite table (workspace/memory/facts.db). This is the relational
+  store + lifecycle bookkeeping; the similarity/dedup side (sqlite-vec
+  embeddings, contradiction resolution) is Phase 3 and slots in on top
+  of this schema.
+
+  Why SQLite rather than flat .md files: the fact store's core ops are
+  metadata queries and in-place updates -- "active facts as of today"
+  (WHERE not superseded AND not expired), supersede a contradicted
+  fact, expire-sweep -- which SQL does cleanly and a markdown blob does
+  not. Auditability (the thing pure-vector stores lose) comes back via
+  a future Memory web tab + a markdown export, not by making files the
+  source of truth.
+
+  Cross-target split mirrors PasClaw.Memory.Index:
+    - {$IFDEF FPC}: TSQLite3Connection + TSQLQuery (sqldb).
+    - {$ELSE}:      FireDAC TFDConnection + TFDQuery.
+
+  Schema:
+    facts(id INTEGER PK, text, kind, scope, confidence REAL,
+          expires TEXT, source_session TEXT, created_at INTEGER,
+          superseded INTEGER)
+
+    expires is '' (never) or 'YYYY-MM-DD'. A fact is ACTIVE when
+    superseded = 0 and (expires = '' or expires >= today). "today" is
+    passed in by the caller so reads stay deterministic/testable.
+*)
+unit PasClaw.Memory.Facts;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Memory.Distill;   { TFact }
+
+type
+  TStoredFact = record
+    Id:            Int64;
+    Text:          string;
+    Kind:          string;
+    Scope:         string;
+    Confidence:    Double;
+    Expires:       string;
+    SourceSession: string;
+    CreatedAt:     Int64;     { unix seconds }
+    Superseded:    Boolean;
+  end;
+  TStoredFactArray = array of TStoredFact;
+
+  IFactStore = interface
+    ['{4C2F9A11-7E3D-4B8A-9F21-2A6D0C5E1B77}']
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    { Insert F; returns the new row id (0 on failure). CreatedAt is set
+      to now; Superseded starts false. }
+    function  Add(const F: TFact; CreatedAt: Int64): Int64;
+    { Facts that are live as of Today ('YYYY-MM-DD'): not superseded and
+      not past their expiry. Newest first. }
+    function  ActiveFacts(const Today: string): TStoredFactArray;
+    { Every fact, including superseded/expired (newest first). }
+    function  AllFacts: TStoredFactArray;
+    { Mark a fact superseded (kept for history). True if a row changed. }
+    function  Supersede(Id: Int64): Boolean;
+    { Hard-delete a fact. True if a row was removed. }
+    function  Delete(Id: Int64): Boolean;
+    { Row count; IncludeInactive=False counts only non-superseded. }
+    function  Count(IncludeInactive: Boolean): Integer;
+  end;
+
+function NewFactStore: IFactStore;
+
+{ Default on-disk location: <home>/workspace/memory/facts.db }
+function DefaultFactsDbPath(const HomeDir: string): string;
+
+implementation
+
+uses
+  {$IFDEF FPC}
+  sqldb, sqlite3conn,
+  {$ELSE}
+  FireDAC.Comp.Client, FireDAC.Phys.SQLite, FireDAC.Stan.Def,
+  FireDAC.Stan.Async, FireDAC.Stan.Param, FireDAC.DApt,
+  {$ENDIF}
+  PasClaw.Utils,
+  PasClaw.Logger;
+
+function DefaultFactsDbPath(const HomeDir: string): string;
+begin
+  Result := JoinPath(JoinPath(JoinPath(HomeDir, 'workspace'), 'memory'), 'facts.db');
+end;
+
+type
+{$IFDEF FPC}
+  TQuery = TSQLQuery;
+{$ELSE}
+  TQuery = TFDQuery;
+{$ENDIF}
+
+  TFactStoreImpl = class(TInterfacedObject, IFactStore)
+  private
+    {$IFDEF FPC}
+    FConn: TSQLite3Connection;
+    FTx:   TSQLTransaction;
+    {$ELSE}
+    FConn: TFDConnection;
+    {$ENDIF}
+    FOpen: Boolean;
+    function  NewQuery: TQuery;
+    procedure PStr(Q: TQuery; const N, V: string);
+    procedure PInt(Q: TQuery; const N: string; V: Int64);
+    procedure PFloat(Q: TQuery; const N: string; V: Double);
+    procedure Commit;
+    procedure ExecSQL(const SQL: string);
+    procedure EnsureSchema;
+    function  ReadRows(Q: TQuery): TStoredFactArray;
+  public
+    destructor Destroy; override;
+    function  Open(const DbPath: string): Boolean;
+    procedure Close;
+    function  Add(const F: TFact; CreatedAt: Int64): Int64;
+    function  ActiveFacts(const Today: string): TStoredFactArray;
+    function  AllFacts: TStoredFactArray;
+    function  Supersede(Id: Int64): Boolean;
+    function  Delete(Id: Int64): Boolean;
+    function  Count(IncludeInactive: Boolean): Integer;
+  end;
+
+function NewFactStore: IFactStore;
+begin
+  Result := TFactStoreImpl.Create;
+end;
+
+destructor TFactStoreImpl.Destroy;
+begin
+  Close;
+  inherited Destroy;
+end;
+
+function TFactStoreImpl.NewQuery: TQuery;
+begin
+  Result := TQuery.Create(nil);
+  {$IFDEF FPC}
+  Result.Database := FConn;
+  {$ELSE}
+  Result.Connection := FConn;
+  {$ENDIF}
+end;
+
+procedure TFactStoreImpl.PStr(Q: TQuery; const N, V: string);
+begin
+  {$IFDEF FPC}
+  Q.Params.ParamByName(N).AsString := V;
+  {$ELSE}
+  Q.ParamByName(N).AsString := V;
+  {$ENDIF}
+end;
+
+procedure TFactStoreImpl.PInt(Q: TQuery; const N: string; V: Int64);
+begin
+  {$IFDEF FPC}
+  Q.Params.ParamByName(N).AsLargeInt := V;
+  {$ELSE}
+  Q.ParamByName(N).AsLargeInt := V;
+  {$ENDIF}
+end;
+
+procedure TFactStoreImpl.PFloat(Q: TQuery; const N: string; V: Double);
+begin
+  {$IFDEF FPC}
+  Q.Params.ParamByName(N).AsFloat := V;
+  {$ELSE}
+  Q.ParamByName(N).AsFloat := V;
+  {$ENDIF}
+end;
+
+procedure TFactStoreImpl.Commit;
+begin
+  {$IFDEF FPC}
+  if (FTx <> nil) and FTx.Active then FTx.CommitRetaining;
+  {$ENDIF}
+  { FireDAC autocommits each statement by default -- no-op on Delphi. }
+end;
+
+procedure TFactStoreImpl.ExecSQL(const SQL: string);
+{$IFDEF FPC}
+begin
+  FConn.ExecuteDirect(SQL);
+  FTx.CommitRetaining;
+end;
+{$ELSE}
+begin
+  FConn.ExecSQL(SQL);
+end;
+{$ENDIF}
+
+procedure TFactStoreImpl.EnsureSchema;
+begin
+  ExecSQL(
+    'CREATE TABLE IF NOT EXISTS facts (' +
+    '  id INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  text TEXT NOT NULL,' +
+    '  kind TEXT NOT NULL,' +
+    '  scope TEXT NOT NULL,' +
+    '  confidence REAL NOT NULL,' +
+    '  expires TEXT NOT NULL DEFAULT '''',' +
+    '  source_session TEXT NOT NULL DEFAULT '''',' +
+    '  created_at INTEGER NOT NULL,' +
+    '  superseded INTEGER NOT NULL DEFAULT 0)');
+  { Indexes that match the two hot read paths (active listing + expiry sweep). }
+  ExecSQL('CREATE INDEX IF NOT EXISTS idx_facts_active ON facts(superseded, expires)');
+end;
+
+function TFactStoreImpl.Open(const DbPath: string): Boolean;
+begin
+  Result := False;
+  if FOpen then Exit(True);
+  try
+    EnsureDir(ExtractFilePath(DbPath));
+    {$IFDEF FPC}
+    FConn := TSQLite3Connection.Create(nil);
+    FTx   := TSQLTransaction.Create(nil);
+    FConn.DatabaseName := DbPath;
+    FConn.Transaction  := FTx;
+    FTx.Database       := FConn;
+    FConn.Open;
+    FTx.StartTransaction;
+    {$ELSE}
+    FConn := TFDConnection.Create(nil);
+    FConn.DriverName := 'SQLite';
+    FConn.Params.Values['Database'] := DbPath;
+    FConn.LoginPrompt := False;
+    FConn.Connected := True;
+    {$ENDIF}
+    EnsureSchema;
+    FOpen := True;
+    Result := True;
+    LogDebug('memory.facts: opened %s', [DbPath]);
+  except
+    on E: Exception do
+    begin
+      LogWarn('memory.facts: failed to open %s (%s) -- fact store disabled',
+              [DbPath, E.Message]);
+      {$IFDEF FPC}
+      FreeAndNil(FTx);
+      {$ENDIF}
+      FreeAndNil(FConn);
+      FOpen := False;
+    end;
+  end;
+end;
+
+procedure TFactStoreImpl.Close;
+begin
+  if not FOpen then Exit;
+  try
+    {$IFDEF FPC}
+    if (FTx <> nil) and FTx.Active then FTx.Commit;
+    if (FConn <> nil) and FConn.Connected then FConn.Close;
+    FreeAndNil(FTx);
+    {$ELSE}
+    if (FConn <> nil) and FConn.Connected then FConn.Connected := False;
+    {$ENDIF}
+    FreeAndNil(FConn);
+  except
+    on E: Exception do
+      LogWarn('memory.facts: close error: %s', [E.Message]);
+  end;
+  FOpen := False;
+end;
+
+function TFactStoreImpl.Add(const F: TFact; CreatedAt: Int64): Int64;
+var
+  Q: TQuery;
+begin
+  Result := 0;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    Q.SQL.Text :=
+      'INSERT INTO facts (text, kind, scope, confidence, expires, ' +
+      'source_session, created_at, superseded) ' +
+      'VALUES (:t, :k, :sc, :cf, :ex, :ss, :ca, 0)';
+    PStr  (Q, 't',  F.Text);
+    PStr  (Q, 'k',  F.Kind);
+    PStr  (Q, 'sc', F.Scope);
+    PFloat(Q, 'cf', F.Confidence);
+    PStr  (Q, 'ex', F.Expires);
+    PStr  (Q, 'ss', F.SourceSession);
+    PInt  (Q, 'ca', CreatedAt);
+    Q.ExecSQL;
+    Commit;
+    Q.SQL.Text := 'SELECT last_insert_rowid()';
+    Q.Open;
+    if not Q.EOF then Result := Q.Fields[0].AsLargeInt;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFactStoreImpl.ReadRows(Q: TQuery): TStoredFactArray;
+var
+  F: TStoredFact;
+begin
+  Result := nil;
+  Q.Open;
+  while not Q.EOF do
+  begin
+    F.Id            := Q.FieldByName('id').AsLargeInt;
+    F.Text          := Q.FieldByName('text').AsString;
+    F.Kind          := Q.FieldByName('kind').AsString;
+    F.Scope         := Q.FieldByName('scope').AsString;
+    F.Confidence    := Q.FieldByName('confidence').AsFloat;
+    F.Expires       := Q.FieldByName('expires').AsString;
+    F.SourceSession := Q.FieldByName('source_session').AsString;
+    F.CreatedAt     := Q.FieldByName('created_at').AsLargeInt;
+    F.Superseded    := Q.FieldByName('superseded').AsLargeInt <> 0;
+    SetLength(Result, Length(Result) + 1);
+    Result[High(Result)] := F;
+    Q.Next;
+  end;
+  Q.Close;
+end;
+
+function TFactStoreImpl.ActiveFacts(const Today: string): TStoredFactArray;
+var
+  Q: TQuery;
+begin
+  Result := nil;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    Q.SQL.Text :=
+      'SELECT * FROM facts WHERE superseded = 0 ' +
+      'AND (expires = '''' OR expires >= :today) ' +
+      'ORDER BY created_at DESC, id DESC';
+    PStr(Q, 'today', Today);
+    Result := ReadRows(Q);
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFactStoreImpl.AllFacts: TStoredFactArray;
+var
+  Q: TQuery;
+begin
+  Result := nil;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    Q.SQL.Text := 'SELECT * FROM facts ORDER BY created_at DESC, id DESC';
+    Result := ReadRows(Q);
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFactStoreImpl.Supersede(Id: Int64): Boolean;
+var
+  Q: TQuery;
+begin
+  Result := False;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    Q.SQL.Text := 'UPDATE facts SET superseded = 1 WHERE id = :id AND superseded = 0';
+    PInt(Q, 'id', Id);
+    Q.ExecSQL;
+    Result := Q.RowsAffected > 0;
+    Commit;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFactStoreImpl.Delete(Id: Int64): Boolean;
+var
+  Q: TQuery;
+begin
+  Result := False;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    Q.SQL.Text := 'DELETE FROM facts WHERE id = :id';
+    PInt(Q, 'id', Id);
+    Q.ExecSQL;
+    Result := Q.RowsAffected > 0;
+    Commit;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TFactStoreImpl.Count(IncludeInactive: Boolean): Integer;
+var
+  Q: TQuery;
+begin
+  Result := 0;
+  if not FOpen then Exit;
+  Q := NewQuery;
+  try
+    if IncludeInactive then
+      Q.SQL.Text := 'SELECT COUNT(*) FROM facts'
+    else
+      Q.SQL.Text := 'SELECT COUNT(*) FROM facts WHERE superseded = 0';
+    Q.Open;
+    if not Q.EOF then Result := Q.Fields[0].AsInteger;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
+end;
+
+end.

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -92,19 +92,24 @@ begin
   All := Store.AllFacts;
   AssertEqInt(Length(All), 4, 'AllFacts keeps superseded + expired');
 
-  AssertEqInt(Store.Count(False), 3, 'Count(active-only) excludes superseded');
-  AssertEqInt(Store.Count(True), 4, 'Count(all) includes superseded');
+  { CountActive must match ActiveFacts exactly: NoExp + Future = 2 (the
+    past-expiry fact is NOT counted, and the superseded one is gone). The
+    old Count(False) wrongly reported 3 by ignoring expiry. }
+  AssertEqInt(Store.CountActive(TODAY), 2, 'active count excludes superseded AND expired');
+  AssertEqInt(Store.CountActive(TODAY), Length(Store.ActiveFacts(TODAY)),
+              'CountActive agrees with ActiveFacts');
+  AssertEqInt(Store.CountAll, 4, 'CountAll includes superseded + expired');
 
   { Delete the expired one entirely. }
   AssertTrue(Store.Delete(IdPast), 'delete returns true');
-  AssertEqInt(Store.Count(True), 3, 'count drops after delete');
+  AssertEqInt(Store.CountAll, 3, 'count drops after delete');
 
   Store.Close;
 
   { Reopen: durability. }
   Store := NewFactStore;
   AssertTrue(Store.Open(DbPath), 'reopen store');
-  AssertEqInt(Store.Count(True), 3, 'facts persisted across reopen');
+  AssertEqInt(Store.CountAll, 3, 'facts persisted across reopen');
   Active := Store.ActiveFacts(TODAY);
   AssertEqInt(Length(Active), 2, 'active count stable after reopen');
   Store.Close;

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -1,0 +1,127 @@
+program memory_facts_tests;
+(*
+  Covers PasClaw.Memory.Facts -- Phase 2 SQLite persistence for distilled
+  facts. Uses a real temp SQLite db (libsqlite3 at runtime) and exercises
+  the lifecycle contract:
+
+    - Add returns a row id; facts read back with all fields intact
+    - ActiveFacts(today) excludes EXPIRED facts (expires < today)
+    - Supersede hides a fact from ActiveFacts but keeps it in AllFacts
+    - Delete removes it entirely
+    - Count(false) ignores superseded; Count(true) includes them
+    - Facts persist across Close/Open (durable)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Utils,
+  PasClaw.Memory.Distill,
+  PasClaw.Memory.Facts;
+
+var
+  GTmpDir: string;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertEqInt(Got, Want: Integer; const Msg: string);
+begin if Got <> Want then Fail_(Format('%s (got %d, want %d)', [Msg, Got, Want])); end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")'); end;
+
+function MkFact(const Txt, Kind, Scope, Expires: string; Conf: Double): TFact;
+begin
+  Result.Text          := Txt;
+  Result.Kind          := Kind;
+  Result.Scope         := Scope;
+  Result.Confidence    := Conf;
+  Result.Expires       := Expires;
+  Result.SourceSession := 'sess-x';
+end;
+
+const
+  TODAY = '2026-06-26';
+
+procedure RunTests;
+var
+  DbPath: string;
+  Store: IFactStore;
+  IdNoExp, IdFuture, IdPast, IdSup: Int64;
+  Active, All: TStoredFactArray;
+begin
+  DbPath := JoinPath(GTmpDir, 'facts.db');
+
+  Store := NewFactStore;
+  AssertTrue(Store.Open(DbPath), 'open store');
+
+  IdNoExp  := Store.Add(MkFact('Prefers Delphi', 'static', 'user', '', 0.9), 1000);
+  IdFuture := Store.Add(MkFact('Sprint ends soon', 'dynamic', 'project', '2026-12-31', 0.7), 1001);
+  IdPast   := Store.Add(MkFact('Exam yesterday', 'dynamic', 'session', '2026-06-01', 0.6), 1002);
+  IdSup    := Store.Add(MkFact('Old preference', 'static', 'user', '', 0.5), 1003);
+
+  AssertTrue(IdNoExp > 0, 'add returns id');
+  AssertTrue((IdFuture <> IdNoExp) and (IdPast <> IdFuture), 'ids distinct');
+
+  { Active as of today: no-expiry + future-expiry + the soon-to-be-superseded
+    one = 3; the past-expiry one is filtered out. }
+  Active := Store.ActiveFacts(TODAY);
+  AssertEqInt(Length(Active), 3, 'active excludes expired');
+  { Newest first -> IdSup (created_at 1003) is row 0. }
+  AssertEqStr(Active[0].Text, 'Old preference', 'newest first ordering');
+  AssertEqStr(Active[0].Kind, 'static', 'kind round-trips');
+  AssertEqStr(Active[0].Scope, 'user', 'scope round-trips');
+  AssertTrue(Abs(Active[0].Confidence - 0.5) < 0.001, 'confidence round-trips');
+
+  { Supersede hides from Active but keeps in All. }
+  AssertTrue(Store.Supersede(IdSup), 'supersede returns true');
+  AssertTrue(not Store.Supersede(IdSup), 'second supersede is a no-op');
+  Active := Store.ActiveFacts(TODAY);
+  AssertEqInt(Length(Active), 2, 'superseded fact drops out of active');
+
+  All := Store.AllFacts;
+  AssertEqInt(Length(All), 4, 'AllFacts keeps superseded + expired');
+
+  AssertEqInt(Store.Count(False), 3, 'Count(active-only) excludes superseded');
+  AssertEqInt(Store.Count(True), 4, 'Count(all) includes superseded');
+
+  { Delete the expired one entirely. }
+  AssertTrue(Store.Delete(IdPast), 'delete returns true');
+  AssertEqInt(Store.Count(True), 3, 'count drops after delete');
+
+  Store.Close;
+
+  { Reopen: durability. }
+  Store := NewFactStore;
+  AssertTrue(Store.Open(DbPath), 'reopen store');
+  AssertEqInt(Store.Count(True), 3, 'facts persisted across reopen');
+  Active := Store.ActiveFacts(TODAY);
+  AssertEqInt(Length(Active), 2, 'active count stable after reopen');
+  Store.Close;
+end;
+
+begin
+  GTmpDir := JoinPath(GetTempDir, 'pasclaw-facts-test-' + IntToStr(Random(1 shl 30)));
+  EnsureDir(GTmpDir);
+  try
+    RunTests;
+    WriteLn('  ok: add / read-back / active-excludes-expired');
+    WriteLn('  ok: supersede / delete / counts');
+    WriteLn('  ok: durability across reopen');
+    WriteLn('PASS');
+  finally
+    {$IFDEF UNIX}
+    ExecuteProcess('/bin/sh', ['-c', 'rm -rf "' + GTmpDir + '"']);
+    {$ENDIF}
+  end;
+end.


### PR DESCRIPTION
**Stacked on #366 (Phase 1).** Base is the Phase 1 branch so the diff here is Phase 2 only; I'll retarget to `main` once #366 merges.

## What

Phase 1 produced `TFact` records but only printed them. This adds the store they persist into — and the lifecycle bookkeeping the later phases build on.

`PasClaw.Memory.Facts` → SQLite table at `workspace/memory/facts.db`:

```
facts(id, text, kind, scope, confidence, expires, source_session,
      created_at, superseded)
```

`IFactStore`: `Add`, `ActiveFacts(today)`, `AllFacts`, `Supersede`, `Delete`, `Count`.

A fact is **active** when `superseded = 0 AND (expires = '' OR expires >= today)` — so expiry and contradiction-supersede are plain SQL. That's exactly why this is SQLite and not flat `.md` files (per the earlier discussion): metadata filters + in-place updates markdown can't do. `today` is passed in, so reads stay deterministic/testable.

Cross-target backend split mirrors `PasClaw.Memory.Index` (sqldb under FPC, FireDAC under Delphi); a small `PStr/PInt/PFloat` param-helper + a `TQuery` alias keep the per-method `IFDEF` noise down.

## CLI

```
pasclaw memory distill [session] [--save]   # --save now persists the facts
pasclaw memory facts [--all]                # list active (or all) facts
```

## Tests

`make test-memory-facts` — real temp SQLite DB, pins: add + full field round-trip, **active-excludes-expired**, supersede-hides-but-keeps-in-AllFacts, delete, active-vs-all counts, and **durability across Close/Open**. Green. Clean compile; cross-compiler safe.

## Not here (Phase 3)

Vector-similarity dedup, contradiction detection, and the periodic expiry sweep — they sit on top of this schema (a `sqlite-vec` sidecar keyed by `facts.id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_