### PR TITLE
memory: Phase 3 — opt-in onboarding + automatic per-turn distillation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -539,6 +539,14 @@ test-memory-facts: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/memory_facts_tests.pas -o$(BUILDDIR)/memory_facts_tests
 	@$(BUILDDIR)/memory_facts_tests
 
+# Distilled-memory Phase 3: per-turn auto-distill windowing
+# (BuildRecentTranscript). Pure logic; the thread/store glue is covered
+# by the distill + facts suites.
+test-memory-autodistill: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/memory_autodistill_tests.pas -o$(BUILDDIR)/memory_autodistill_tests
+	@$(BUILDDIR)/memory_autodistill_tests
+
 # JSON-aware condenser: pure string-in / string-out, no model. Pins
 # the collapse-arrays / ellipsize-strings contract that
 # PasClaw.Condense.JSON applies to tool output before it reaches the
@@ -764,4 +772,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -26,6 +26,7 @@ implementation
 uses
   SysUtils, Classes,
   PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger,
+  PasClaw.Memory.AutoDistill,
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
   PasClaw.Providers.Factory,
@@ -1666,6 +1667,13 @@ begin
                               Loop.TotalUsage.CacheCreatedTokens,
                               Loop.ToolCallsDispatched,
                               Loop.TruncatedBytesSaved);
+
+        { Opt-in distilled memory: background-distil the latest exchange
+          into the fact store. Best-effort, non-blocking; needs a session
+          for provenance. Uses the chat provider, no ONNX. }
+        if Cfg.MemoryDistillEnabled and (Session <> nil) then
+          ScheduleDistill(Provider, Model, GetHome, Session.Meta.Id,
+            BuildRecentTranscript(Loop.FinalMessages, Loop.Content, DefaultRecentMsgs));
 
         { Pick up the compacted history from RunToolLoop so the next
           interactive turn starts from the summarised state, not the

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -479,6 +479,49 @@ begin
   end;
 end;
 
+procedure PromptMemoryDistill(Cfg: TConfig);
+{ Opt-in (default N): auto-distil durable facts from each turn into
+  workspace/memory/facts.db. Uses the chat model -- NOT the embedding
+  model -- so it needs no `memory provision` / ONNX download, and is
+  independent of vector search. Off by default because it spends ~one
+  extra LLM call per turn. }
+var
+  Choice: string;
+begin
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Distilled memory (auto-facts)' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'After each turn, run one LLM pass that extracts durable facts ' +
+    '(preferences, decisions, current focus) and stores them in ' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'workspace/memory/facts.db -- recalled later via memory_search.' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Uses your chat model (no extra download, independent of vector ' +
+    'search); costs ~one extra LLM call per turn.' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '(Off by default. Manage with `pasclaw memory facts` / ' +
+    '`pasclaw memory distill`.)' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable distilled memory [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Cfg.MemoryDistillEnabled := True;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+            ' distilled memory enabled (facts captured each turn)');
+  end
+  else
+  begin
+    Cfg.MemoryDistillEnabled := False;
+    PrintLn('  ' + Ansi.Dim +
+            '(skipped -- flip memory_distill_enabled in config.json to enable later)' +
+            Ansi.Reset);
+  end;
+end;
+
 procedure PromptShellBackend(Cfg: TConfig);
 { Pick where shell_exec / execute_code run. Local (default) =
   /bin/sh in the host process, same as PasClaw has shipped to date.
@@ -1591,6 +1634,10 @@ begin
     PromptVaultTools(Cfg);
     PromptVectorSearch(Cfg);
     PromptKnowledgebase(Cfg);
+    { Distilled memory: conceptually "memory", so it reads naturally after
+      the vector/KB prompts -- but it's independent (chat model, no ONNX),
+      so it's NOT gated on vector search. }
+    PromptMemoryDistill(Cfg);
     if not PickedAProfile then
     begin
       { Loop-shaping prompts (PR #289). Order is intentional: each

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -228,6 +228,7 @@ begin
     TUIInst.RenderMarkdownEnabled := Cfg.RenderMarkdown;
     TUIInst.CheckpointsEnabled    := Cfg.CheckpointsEnabled;
     TUIInst.CheckpointsKeepLast   := Cfg.CheckpointsKeepLast;
+    TUIInst.MemoryDistillEnabled  := Cfg.MemoryDistillEnabled;
     TUIInst.BgCoordinator      := BgCoord;
     try
       TUIInst.Run;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -631,6 +631,14 @@ type
        by flipping checkpoints_enabled in config.json. *)
     CheckpointsEnabled:    Boolean;
     CheckpointsKeepLast:   Integer;
+    (* Opt-in (default OFF): after each turn, run one LLM pass that
+       distils durable facts from the latest exchange and stores them in
+       workspace/memory/facts.db (PasClaw.Memory.Distill + .Facts). Uses
+       the chat provider -- NOT the embedding model -- so it needs no
+       `memory provision` / ONNX download; just a configured provider.
+       Independent of vector_search_enabled. Costs ~one extra LLM call
+       per turn, which is why it's off unless the operator asks. *)
+    MemoryDistillEnabled:  Boolean;
     (* On-by-default: scan tool output / recalled memory / stored
        skill descriptions for prompt-injection patterns and annotate
        hits with a warning banner (PasClaw.Promptware). A lowercase
@@ -931,6 +939,7 @@ begin
   ToolOutputCap        := 0;     { off by default; operators opt in. See TConfig.ToolOutputCap. }
   StatsCollectionEnabled := True;  { on by default -- zero prompt cost, useful for diagnosing turn-count regressions. Onboarding can flip off for privacy-conscious operators. }
   CheckpointsEnabled     := True;  { on by default -- zero prompt cost, prevents lost work on multi-edit sessions. }
+  MemoryDistillEnabled   := False; { opt-in: ~one extra LLM call per turn. }
   CheckpointsKeepLast    := 32;    { keep last 32 atomic edit checkpoints. }
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
   OrientTaskAware        := False; { off by default -- whole-file MEMORY injection is the contract; opt in per-run with `pasclaw agent --orient` or "orient_task_aware":true. }
@@ -1217,6 +1226,10 @@ begin
       Root.PutBool('stats_collection_enabled', False);
     if not CheckpointsEnabled then
       Root.PutBool('checkpoints_enabled', False);
+    { Default OFF -- emit only the explicit-on so an operator opt-in
+      (onboarding or hand-edit) sticks across save/load. }
+    if MemoryDistillEnabled then
+      Root.PutBool('memory_distill_enabled', True);
     { CheckpointsKeepLast default flipped from 0 (=> use library
       default 32) to an explicit 32 in PR #314. Emit when it differs --
       0 and other values both round-trip. }
@@ -1627,6 +1640,7 @@ begin
     StatsCollectionEnabled := Root.GetBool('stats_collection_enabled',
                                            StatsCollectionEnabled);
     CheckpointsEnabled  := Root.GetBool('checkpoints_enabled', CheckpointsEnabled);
+    MemoryDistillEnabled := Root.GetBool('memory_distill_enabled', MemoryDistillEnabled);
     CheckpointsKeepLast := Integer(Root.GetInt('checkpoints_keep_last',
                                                 CheckpointsKeepLast));
     PromptwareEnabled   := Root.GetBool('promptware_enabled', PromptwareEnabled);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3327,9 +3327,12 @@ begin
 
   { Opt-in distilled memory: on a successful turn, fire a background pass
     that extracts durable facts from the latest exchange and stores them.
-    Best-effort and non-blocking -- never affects the response. }
+    Best-effort and non-blocking -- never affects the response.
+    Use Cfg.Provider/Cfg.Model -- the SNAPSHOT this turn actually ran on --
+    not FProvider, which a concurrent /v1/config hot-swap may have already
+    repointed at a different backend. }
   if Result and FCfg.MemoryDistillEnabled then
-    ScheduleDistill(FProvider, Cfg.Model, GetHome, ReqSession,
+    ScheduleDistill(Cfg.Provider, Cfg.Model, GetHome, ReqSession,
       BuildRecentTranscript(Loop.FinalMessages, Loop.Content, DefaultRecentMsgs));
 end;
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -433,6 +433,7 @@ uses
     type. Don't re-import here. }
   PasClaw.Tools.Sandbox,
   PasClaw.Checkpoints,          { web UI checkpoints: Init/BeginTurn/Undo/Redo/state }
+  PasClaw.Memory.AutoDistill,   { opt-in per-turn fact distillation }
   PasClaw.Providers.Factory,
   PasClaw.Providers.Catalog,   { TProviderSpec for /v1/models discovery }
   PasClaw.Providers.Models,    { DiscoverModels / cache -- /v1/models roster }
@@ -3323,6 +3324,13 @@ begin
   end
   else
     Result := RunToolLoop(Cfg, Messages, Loop);
+
+  { Opt-in distilled memory: on a successful turn, fire a background pass
+    that extracts durable facts from the latest exchange and stores them.
+    Best-effort and non-blocking -- never affects the response. }
+  if Result and FCfg.MemoryDistillEnabled then
+    ScheduleDistill(FProvider, Cfg.Model, GetHome, ReqSession,
+      BuildRecentTranscript(Loop.FinalMessages, Loop.Content, DefaultRecentMsgs));
 end;
 
 procedure TGatewayServer.HandleCheckpointsList(ARequest: TIdHTTPRequestInfo;

--- a/src/pkg/memory/PasClaw.Memory.AutoDistill.pas
+++ b/src/pkg/memory/PasClaw.Memory.AutoDistill.pas
@@ -1,0 +1,206 @@
+(*
+  PasClaw.Memory.AutoDistill - fire-and-forget per-turn fact distillation.
+
+  When memory_distill_enabled is on, each completed turn schedules a
+  BACKGROUND distill of the latest exchange: extract facts with the chat
+  provider (PasClaw.Memory.Distill) and persist them to the SQLite fact
+  store (PasClaw.Memory.Facts). Background so the ~one extra LLM call
+  never adds latency to the user's turn.
+
+  Scope of each pass is the RECENT TAIL, not the whole session: the new
+  user/assistant exchange plus a few prior messages for grounding. That
+  keeps the prompt bounded (cost doesn't grow with session length) and
+  avoids re-extracting facts already stored every turn. Exact-text dedup
+  in the fact store collapses the residual repeats; semantic dedup is a
+  later phase.
+
+  Lifecycle: each schedule spins one TThread with FreeOnTerminate. A
+  small global cap (MaxConcurrentDistill) drops new jobs when the
+  backlog is saturated -- distilled memory is best-effort, never worth
+  unbounded threads or blocking a turn.
+*)
+unit PasClaw.Memory.AutoDistill;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  SysUtils, Classes,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf;
+
+const
+  { Default number of trailing messages handed to the distiller -- the
+    new exchange plus a little grounding context. The distiller also
+    caps by bytes, so this is just a message-count ceiling. }
+  DefaultRecentMsgs = 8;
+  { At most this many distill jobs in flight at once; extra turns skip
+    (best-effort). }
+  MaxConcurrentDistill = 2;
+
+{ Build the recent-tail transcript for a turn: the last MaxMsgs of Full,
+  with FinalContent appended as a trailing assistant message when it's
+  non-empty (RunToolLoop returns FinalMessages BEFORE the final answer,
+  so callers pass Loop.Content here to include it). }
+function BuildRecentTranscript(const Full: array of TMessage;
+                               const FinalContent: string;
+                               MaxMsgs: Integer): TMessageArray;
+
+{ Schedule a background distill of Transcript for SessionId, persisting
+  to <HomeDir>/workspace/memory/facts.db. No-op when Provider is nil,
+  the transcript is empty, or the concurrency cap is hit. Never raises. }
+procedure ScheduleDistill(Provider: ILLMProvider; const Model, HomeDir,
+                          SessionId: string; const Transcript: array of TMessage);
+
+implementation
+
+uses
+  DateUtils,
+  SyncObjs,
+  PasClaw.Logger,
+  PasClaw.Memory.Distill,
+  PasClaw.Memory.Facts;
+
+var
+  GLock:   TCriticalSection;
+  GActive: Integer;
+
+type
+  TDistillThread = class(TThread)
+  private
+    FProvider:  ILLMProvider;
+    FModel:     string;
+    FHome:      string;
+    FSession:   string;
+    FTranscript: TMessageArray;
+  protected
+    procedure Execute; override;
+  end;
+
+procedure TDistillThread.Execute;
+var
+  Distiller: TMemoryDistiller;
+  Store: IFactStore;
+  Facts: TFactArray;
+  Err, Today: string;
+  i: Integer;
+  NowU: Int64;
+begin
+  try
+    Today := FormatDateTime('yyyy"-"mm"-"dd', Now);
+    Distiller := TMemoryDistiller.Create(FProvider, FModel);
+    try
+      if not Distiller.Distill(FTranscript, FSession, Today, Facts, Err) then
+      begin
+        LogDebug('auto-distill: %s', [Err]);
+        Exit;
+      end;
+    finally
+      Distiller.Free;
+    end;
+
+    if Length(Facts) = 0 then Exit;
+
+    Store := NewFactStore;
+    if not Store.Open(DefaultFactsDbPath(FHome)) then Exit;
+    try
+      NowU := DateTimeToUnix(Now, False);
+      for i := 0 to High(Facts) do
+        Store.Add(Facts[i], NowU + i);
+    finally
+      Store.Close;
+    end;
+    LogDebug('auto-distill: stored %d fact(s) from session %s',
+             [Length(Facts), FSession]);
+  except
+    on E: Exception do
+      LogWarn('auto-distill: %s', [E.Message]);
+  end;
+  GLock.Acquire;
+  try
+    Dec(GActive);
+  finally
+    GLock.Release;
+  end;
+end;
+
+function BuildRecentTranscript(const Full: array of TMessage;
+  const FinalContent: string; MaxMsgs: Integer): TMessageArray;
+var
+  StartIdx, i, n: Integer;
+begin
+  SetLength(Result, 0);
+  if MaxMsgs <= 0 then MaxMsgs := DefaultRecentMsgs;
+  StartIdx := Length(Full) - MaxMsgs;
+  if StartIdx < 0 then StartIdx := 0;
+  n := 0;
+  for i := StartIdx to High(Full) do
+  begin
+    SetLength(Result, n + 1);
+    Result[n] := Full[i];
+    Inc(n);
+  end;
+  if Trim(FinalContent) <> '' then
+  begin
+    SetLength(Result, n + 1);
+    Result[n] := MakeMessage(mrAssistant, FinalContent);
+  end;
+end;
+
+procedure ScheduleDistill(Provider: ILLMProvider; const Model, HomeDir,
+  SessionId: string; const Transcript: array of TMessage);
+var
+  T: TDistillThread;
+  i: Integer;
+begin
+  if (Provider = nil) or (Length(Transcript) = 0) then Exit;
+
+  GLock.Acquire;
+  try
+    if GActive >= MaxConcurrentDistill then
+    begin
+      LogDebug('auto-distill: %d in flight (cap %d) -- skipping this turn',
+               [GActive, MaxConcurrentDistill]);
+      Exit;
+    end;
+    Inc(GActive);
+  finally
+    GLock.Release;
+  end;
+
+  try
+    T := TDistillThread.Create(True);   { suspended }
+    T.FreeOnTerminate := True;
+    T.FProvider := Provider;
+    T.FModel    := Model;
+    T.FHome     := HomeDir;
+    T.FSession  := SessionId;
+    SetLength(T.FTranscript, Length(Transcript));
+    for i := 0 to High(Transcript) do
+      T.FTranscript[i] := Transcript[i];
+    T.Start;
+  except
+    on E: Exception do
+    begin
+      { Failed to even launch -- release the slot we reserved. }
+      GLock.Acquire;
+      try
+        Dec(GActive);
+      finally
+        GLock.Release;
+      end;
+      LogWarn('auto-distill: schedule failed: %s', [E.Message]);
+    end;
+  end;
+end;
+
+initialization
+  GLock := TCriticalSection.Create;
+  GActive := 0;
+
+finalization
+  GLock.Free;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.AutoDistill.pas
+++ b/src/pkg/memory/PasClaw.Memory.AutoDistill.pas
@@ -88,41 +88,48 @@ var
   i: Integer;
   NowU: Int64;
 begin
+  { Outer try/finally guarantees the concurrency slot is released on EVERY
+    path -- the early Exits below (no facts, store open failed, distill
+    error) used to skip the decrement, so after a couple of no-fact turns
+    GActive stuck at the cap and auto-distill silently stopped forever. }
   try
-    Today := FormatDateTime('yyyy"-"mm"-"dd', Now);
-    Distiller := TMemoryDistiller.Create(FProvider, FModel);
     try
-      if not Distiller.Distill(FTranscript, FSession, Today, Facts, Err) then
-      begin
-        LogDebug('auto-distill: %s', [Err]);
-        Exit;
+      Today := FormatDateTime('yyyy"-"mm"-"dd', Now);
+      Distiller := TMemoryDistiller.Create(FProvider, FModel);
+      try
+        if not Distiller.Distill(FTranscript, FSession, Today, Facts, Err) then
+        begin
+          LogDebug('auto-distill: %s', [Err]);
+          Exit;
+        end;
+      finally
+        Distiller.Free;
       end;
-    finally
-      Distiller.Free;
-    end;
 
-    if Length(Facts) = 0 then Exit;
+      if Length(Facts) = 0 then Exit;
 
-    Store := NewFactStore;
-    if not Store.Open(DefaultFactsDbPath(FHome)) then Exit;
-    try
-      NowU := DateTimeToUnix(Now, False);
-      for i := 0 to High(Facts) do
-        Store.Add(Facts[i], NowU + i);
-    finally
-      Store.Close;
+      Store := NewFactStore;
+      if not Store.Open(DefaultFactsDbPath(FHome)) then Exit;
+      try
+        NowU := DateTimeToUnix(Now, False);
+        for i := 0 to High(Facts) do
+          Store.Add(Facts[i], NowU + i);
+      finally
+        Store.Close;
+      end;
+      LogDebug('auto-distill: stored %d fact(s) from session %s',
+               [Length(Facts), FSession]);
+    except
+      on E: Exception do
+        LogWarn('auto-distill: %s', [E.Message]);
     end;
-    LogDebug('auto-distill: stored %d fact(s) from session %s',
-             [Length(Facts), FSession]);
-  except
-    on E: Exception do
-      LogWarn('auto-distill: %s', [E.Message]);
-  end;
-  GLock.Acquire;
-  try
-    Dec(GActive);
   finally
-    GLock.Release;
+    GLock.Acquire;
+    try
+      Dec(GActive);
+    finally
+      GLock.Release;
+    end;
   end;
 end;
 

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -284,6 +284,27 @@ var
 begin
   Result := 0;
   if not FOpen then Exit;
+  { Exact-text dedup: per-turn auto-distill keeps re-surfacing the same
+    wording, so if an ACTIVE fact already has this exact text (case-
+    insensitive) return its id instead of inserting a duplicate. Cheap;
+    paraphrase/semantic dedup is a later phase. }
+  Q := NewQuery;
+  try
+    Q.SQL.Text :=
+      'SELECT id FROM facts WHERE superseded = 0 ' +
+      'AND lower(text) = lower(:t) LIMIT 1';
+    PStr(Q, 't', F.Text);
+    Q.Open;
+    if not Q.EOF then
+    begin
+      Result := Q.Fields[0].AsLargeInt;
+      Q.Close;
+      Exit;
+    end;
+    Q.Close;
+  finally
+    Q.Free;
+  end;
   Q := NewQuery;
   try
     Q.SQL.Text :=

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -90,6 +90,7 @@ uses
   FireDAC.Comp.Client, FireDAC.Phys.SQLite, FireDAC.Stan.Def,
   FireDAC.Stan.Async, FireDAC.Stan.Param, FireDAC.DApt,
   {$ENDIF}
+  DateUtils,
   PasClaw.Utils,
   PasClaw.Logger;
 
@@ -281,18 +282,27 @@ end;
 function TFactStoreImpl.Add(const F: TFact; CreatedAt: Int64): Int64;
 var
   Q: TQuery;
+  TodayStr: string;
 begin
   Result := 0;
   if not FOpen then Exit;
   { Exact-text dedup: per-turn auto-distill keeps re-surfacing the same
     wording, so if an ACTIVE fact already has this exact text (case-
     insensitive) return its id instead of inserting a duplicate. Cheap;
-    paraphrase/semantic dedup is a later phase. }
+    paraphrase/semantic dedup is a later phase.
+
+    Must use the SAME active predicate as ActiveFacts -- skip EXPIRED
+    rows too. Otherwise a re-observed fact whose old copy has expired
+    would match the stale row and never re-enter active memory. "today"
+    is the date this fact is being created (CreatedAt). }
+  TodayStr := FormatDateTime('yyyy"-"mm"-"dd', UnixToDateTime(CreatedAt, False));
   Q := NewQuery;
   try
     Q.SQL.Text :=
       'SELECT id FROM facts WHERE superseded = 0 ' +
+      'AND (expires = '''' OR expires >= :today) ' +
       'AND lower(text) = lower(:t) LIMIT 1';
+    PStr(Q, 'today', TodayStr);
     PStr(Q, 't', F.Text);
     Q.Open;
     if not Q.EOF then

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -218,6 +218,10 @@ type
       so /undo stays bound to whatever's on screen. }
     CheckpointsEnabled:    Boolean;
     CheckpointsKeepLast:   Integer;
+    { Per-turn distilled memory. Cmd_TUI_Run forwards Cfg.MemoryDistillEnabled
+      here; when on, each finished turn background-distils the latest
+      exchange into the fact store (PasClaw.Memory.AutoDistill). }
+    MemoryDistillEnabled:  Boolean;
     (* When True, the assistant's reply is run through
        PasClaw.Markdown.Render before being printed -- headings and
        fenced code blocks get ANSI styling, raw stars and hashes
@@ -280,6 +284,7 @@ uses
   PasClaw.Checkpoints,             { InitCheckpoints / BeginTurn / UndoTurns
                                      -- /undo slash command + per-turn
                                      snapshot bookkeeping. }
+  PasClaw.Memory.AutoDistill,      { opt-in per-turn fact distillation }
   PasClaw.Cmd.Init,                { Cmd_Init_Run -- /init slash command
                                      delegates to the same code path as
                                      `pasclaw init` on the CLI. }
@@ -1491,6 +1496,12 @@ begin
     Loop := Worker.LoopResult;
     ApplyLoopResultTo(FLoopSessionId, Loop, FSession);
     AccumulateLoopStats(Loop);
+    { Opt-in distilled memory: background-distil the latest exchange into
+      the fact store. Best-effort, non-blocking; scoped to the session the
+      turn ran under. }
+    if MemoryDistillEnabled then
+      ScheduleDistill(FProvider, FModel, GetHome, FLoopSessionId,
+        BuildRecentTranscript(Loop.FinalMessages, Loop.Content, DefaultRecentMsgs));
     if FLoopSessionId <> FSession.Meta.Id then
       Flash('result -> ' + FLoopSessionId);
     RefreshSessions;

--- a/src/tests/memory_autodistill_tests.pas
+++ b/src/tests/memory_autodistill_tests.pas
@@ -1,0 +1,84 @@
+program memory_autodistill_tests;
+(*
+  Covers the pure logic in PasClaw.Memory.AutoDistill -- BuildRecentTranscript,
+  which selects the recent tail handed to the per-turn distiller. The
+  background thread / store glue is exercised via the distill + facts
+  suites; here we just pin the windowing contract:
+
+    - keeps at most MaxMsgs trailing messages
+    - appends FinalContent as a trailing assistant message when non-empty
+    - omits the assistant message when FinalContent is blank
+    - returns everything (plus final) when the history is shorter than the window
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Providers.Types,
+  PasClaw.Memory.AutoDistill;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertEqInt(Got, Want: Integer; const Msg: string);
+begin if Got <> Want then Fail_(Format('%s (got %d, want %d)', [Msg, Got, Want])); end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")'); end;
+
+function Hist(N: Integer): TMessageArray;
+var i: Integer;
+begin
+  SetLength(Result, N);
+  for i := 0 to N - 1 do
+    Result[i] := MakeMessage(mrUser, 'm' + IntToStr(i));
+end;
+
+procedure TestWindowCapsTail;
+var
+  R: TMessageArray;
+begin
+  { 10 messages, window 4, no final -> last 4 (m6..m9). }
+  R := BuildRecentTranscript(Hist(10), '', 4);
+  AssertEqInt(Length(R), 4, 'capped to window');
+  AssertEqStr(R[0].Content, 'm6', 'tail starts at m6');
+  AssertEqStr(R[3].Content, 'm9', 'tail ends at m9');
+end;
+
+procedure TestFinalContentAppended;
+var
+  R: TMessageArray;
+begin
+  R := BuildRecentTranscript(Hist(3), 'the answer', 8);
+  AssertEqInt(Length(R), 4, '3 history + 1 final');
+  AssertEqStr(R[3].Content, 'the answer', 'final appended last');
+  if R[3].Role <> mrAssistant then Fail_('final is an assistant message');
+end;
+
+procedure TestBlankFinalOmitted;
+var
+  R: TMessageArray;
+begin
+  R := BuildRecentTranscript(Hist(2), '   ', 8);
+  AssertEqInt(Length(R), 2, 'blank final not appended');
+end;
+
+procedure TestShortHistoryKeptWhole;
+var
+  R: TMessageArray;
+begin
+  R := BuildRecentTranscript(Hist(2), 'x', 8);
+  AssertEqInt(Length(R), 3, 'short history kept whole + final');
+  AssertEqStr(R[0].Content, 'm0', 'first kept');
+end;
+
+begin
+  TestWindowCapsTail;        WriteLn('  ok: window caps the tail');
+  TestFinalContentAppended;  WriteLn('  ok: final content appended as assistant');
+  TestBlankFinalOmitted;     WriteLn('  ok: blank final omitted');
+  TestShortHistoryKeptWhole; WriteLn('  ok: short history kept whole');
+  WriteLn('PASS');
+end.

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -115,6 +115,34 @@ begin
   Store.Close;
 end;
 
+procedure RunDedupTests;
+{ Exact-text dedup: a re-observed active fact returns the existing id
+  (no duplicate row). But an EXPIRED prior copy must NOT block a fresh
+  insert -- otherwise the refreshed fact never re-enters active memory. }
+const
+  T2025 = 1751328000;   { ~2025-07-01; "today" for these Adds derives from it }
+var
+  DbPath: string;
+  Store: IFactStore;
+  Id1, Id2, Id3, Id4: Int64;
+begin
+  DbPath := JoinPath(GTmpDir, 'dedup.db');
+  Store := NewFactStore;
+  AssertTrue(Store.Open(DbPath), 'open dedup store');
+
+  Id1 := Store.Add(MkFact('Likes tea', 'static', 'user', '', 0.9), T2025);
+  Id2 := Store.Add(MkFact('LIKES TEA', 'dynamic', 'user', '', 0.4), T2025 + 1);
+  AssertTrue(Id2 = Id1, 'case-insensitive exact dup returns existing id');
+  AssertEqInt(Store.CountAll, 1, 'exact dup not inserted');
+
+  { Expired prior copy must not suppress the refreshed one. }
+  Id3 := Store.Add(MkFact('Sprint topic', 'dynamic', 'project', '2020-01-01', 0.5), T2025);
+  Id4 := Store.Add(MkFact('Sprint topic', 'dynamic', 'project', '', 0.6), T2025 + 1);
+  AssertTrue(Id4 <> Id3, 'expired dup does NOT block a fresh insert');
+  AssertEqInt(Store.CountAll, 3, 'tea + expired sprint + fresh sprint');
+  Store.Close;
+end;
+
 begin
   GTmpDir := JoinPath(GetTempDir, 'pasclaw-facts-test-' + IntToStr(Random(1 shl 30)));
   EnsureDir(GTmpDir);
@@ -123,6 +151,8 @@ begin
     WriteLn('  ok: add / read-back / active-excludes-expired');
     WriteLn('  ok: supersede / delete / counts');
     WriteLn('  ok: durability across reopen');
+    RunDedupTests;
+    WriteLn('  ok: exact-text dedup (expired copy does not block refresh)');
     WriteLn('PASS');
   finally
     {$IFDEF UNIX}


### PR DESCRIPTION
**Stacked on #367.** Makes facts-memory a real opt-in feature that captures **automatically**, instead of only via the manual CLI command.

Addresses your feedback directly:
- *"its own question in onboarding, default N"* → done.
- *"if facts memory is on, wouldn't it do it auto each turn?"* → yes, now it does.
- *"reliant on the ONNX download?"* → **no** — uses the chat model, not embeddings; independent of vector search / `memory provision`.

## What

- **Config `memory_distill_enabled` (default OFF).** Emits only the explicit-on so the opt-in round-trips. Independent of `vector_search_enabled`.
- **Onboarding prompt** — "Distilled memory (auto-facts)", default **N**, placed *after* the vector/KB prompts (reads as "memory") but not gated on them. Calls out the ~one-extra-LLM-call-per-turn cost.
- **`PasClaw.Memory.AutoDistill`** — fire-and-forget per-turn distillation on a background thread, so it never adds latency. It distils the **recent tail** (the new exchange + a few prior messages for grounding), **not the whole session** — cost stays bounded and old facts aren't re-extracted each turn. Capped at 2 concurrent jobs; over cap it skips (best-effort).
- **Exact-text dedup in `Add`** — per-turn distill keeps re-surfacing the same wording, so an identical active fact returns the existing id instead of inserting a dup. (Semantic/paraphrase dedup is Phase 4.)
- **Wired into the gateway's `RunCheckpointedLoop`** — the single per-turn chokepoint for every web chat endpoint.

## On "each turn" cost
One extra LLM call per turn, only when enabled (default off). It's the recent tail, not the whole session, so the call is small and constant regardless of conversation length.

## Tests
`test-memory-autodistill` pins `BuildRecentTranscript` (tail cap, final-as-assistant, blank-final omitted, short-history whole). Distill + facts suites unchanged and green. Full build links.

## Follow-ups
- CLI/TUI auto-wiring (same one-call pattern; manual `memory distill --save` covers them today).
- Phase 4: semantic dedup + contradiction detection + expiry sweep (the `sqlite-vec` sidecar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_