### PR TITLE
memory: Phase 4a (re-land to main) — inject distilled facts into the system prompt

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -165,6 +165,7 @@ uses
   PasClaw.Logger,         { LogWarn for BuildActivePlanSection's PLAN.md read failures }
   PasClaw.Skills.Loader,
   PasClaw.Agent.Orient,   { task-aware MEMORY slicing (Cfg.OrientTaskAware) }
+  PasClaw.Memory.Facts,   { distilled-fact injection (Cfg.MemoryDistillEnabled) }
   PasClaw.MCP.Disclosure; { deferred-tools section (Cfg.MCPProgressiveDisclosure) }
 
 const
@@ -236,6 +237,22 @@ begin
     '- Memory: ' + JoinPath(Home, 'workspace/memory/MEMORY.md') + sLineBreak +
     '- Skills: ' + JoinPath(Home, 'workspace/skills') + '/{skill-name}/SKILL.md' + sLineBreak +
     '- Logs:   ' + JoinPath(Home, 'logs');
+end;
+
+function BuildFactsSection(Cfg: TConfig): string;
+{ Always-on block of distilled facts, injected WHOLESALE (newest first,
+  bounded by MemoryFactsBudget) when MemoryDistillEnabled. Deliberately
+  NOT relevance-sliced like the OrientTaskAware path -- standing memory
+  shouldn't narrow to the current query and give the model a one-track
+  mind. Empty (no I/O) when the feature is off or the budget is 0, so a
+  default install pays nothing. }
+begin
+  Result := '';
+  if (Cfg = nil) or (not Cfg.MemoryDistillEnabled) or (Cfg.MemoryFactsBudget <= 0) then
+    Exit;
+  Result := ActiveFactsBlock(GetHome,
+                             FormatDateTime('yyyy"-"mm"-"dd', Now),
+                             Cfg.MemoryFactsBudget);
 end;
 
 function BuildMemorySection(TaskAware: Boolean; const TaskHint: string): string;
@@ -772,6 +789,9 @@ begin
   Result := AppendSection(Result, BuildWorkspaceSection);
   Result := AppendSection(Result,
               BuildMemorySection((Cfg <> nil) and Cfg.OrientTaskAware, TaskHint));
+  { Distilled facts (Cfg.MemoryDistillEnabled). Wholesale, after the .md
+    memory so curated MEMORY.md leads and auto-facts follow. }
+  Result := AppendSection(Result, BuildFactsSection(Cfg));
   { Project-level rules from AGENTS.md (opencode/Codex/Cursor
     convention). Read from the cwd, walking up to the git root. Emitted
     after memory so it can override or extend MEMORY.md guidance for

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -639,6 +639,15 @@ type
        Independent of vector_search_enabled. Costs ~one extra LLM call
        per turn, which is why it's off unless the operator asks. *)
     MemoryDistillEnabled:  Boolean;
+    (* Byte budget for the always-on "durable facts" block injected into
+       the system prompt when MemoryDistillEnabled. Facts are tiny, so the
+       whole active set usually fits; past the budget the newest/highest-
+       confidence win and the rest stay reachable via memory_search. This
+       is a WHOLESALE block, deliberately NOT relevance-sliced like
+       OrientTaskAware -- standing memory shouldn't narrow to the current
+       query. 0 disables auto-injection (facts become search-only).
+       Default 2000 (~30 facts). *)
+    MemoryFactsBudget:     Integer;
     (* On-by-default: scan tool output / recalled memory / stored
        skill descriptions for prompt-injection patterns and annotate
        hits with a warning banner (PasClaw.Promptware). A lowercase
@@ -940,6 +949,7 @@ begin
   StatsCollectionEnabled := True;  { on by default -- zero prompt cost, useful for diagnosing turn-count regressions. Onboarding can flip off for privacy-conscious operators. }
   CheckpointsEnabled     := True;  { on by default -- zero prompt cost, prevents lost work on multi-edit sessions. }
   MemoryDistillEnabled   := False; { opt-in: ~one extra LLM call per turn. }
+  MemoryFactsBudget      := 2000;  { ~30 facts injected wholesale when distill on. }
   CheckpointsKeepLast    := 32;    { keep last 32 atomic edit checkpoints. }
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
   OrientTaskAware        := False; { off by default -- whole-file MEMORY injection is the contract; opt in per-run with `pasclaw agent --orient` or "orient_task_aware":true. }
@@ -1230,6 +1240,10 @@ begin
       (onboarding or hand-edit) sticks across save/load. }
     if MemoryDistillEnabled then
       Root.PutBool('memory_distill_enabled', True);
+    { Emit only when changed from the 2000 default (0 = injection off both
+      round-trip). }
+    if MemoryFactsBudget <> 2000 then
+      Root.PutInt('memory_facts_budget', MemoryFactsBudget);
     { CheckpointsKeepLast default flipped from 0 (=> use library
       default 32) to an explicit 32 in PR #314. Emit when it differs --
       0 and other values both round-trip. }
@@ -1641,6 +1655,7 @@ begin
                                            StatsCollectionEnabled);
     CheckpointsEnabled  := Root.GetBool('checkpoints_enabled', CheckpointsEnabled);
     MemoryDistillEnabled := Root.GetBool('memory_distill_enabled', MemoryDistillEnabled);
+    MemoryFactsBudget    := Root.GetInt('memory_facts_budget', MemoryFactsBudget);
     CheckpointsKeepLast := Integer(Root.GetInt('checkpoints_keep_last',
                                                 CheckpointsKeepLast));
     PromptwareEnabled   := Root.GetBool('promptware_enabled', PromptwareEnabled);

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -81,6 +81,17 @@ function NewFactStore: IFactStore;
 { Default on-disk location: <home>/workspace/memory/facts.db }
 function DefaultFactsDbPath(const HomeDir: string): string;
 
+{ Render facts as a system-prompt block, newest first, until Budget bytes
+  are used; a trailing "(N more -- use memory_search)" breadcrumb notes
+  any omitted. Wholesale (NOT relevance-sliced). '' when Facts is empty or
+  Budget <= 0. Pure -- exposed for testing. }
+function FormatFactsBlock(const Facts: TStoredFactArray; Budget: Integer): string;
+
+{ Convenience for the prompt builder: open the default store, read the
+  facts active as of Today, and format them within Budget. '' when the
+  store is absent/empty or Budget <= 0. }
+function ActiveFactsBlock(const HomeDir, Today: string; Budget: Integer): string;
+
 implementation
 
 uses
@@ -97,6 +108,56 @@ uses
 function DefaultFactsDbPath(const HomeDir: string): string;
 begin
   Result := JoinPath(JoinPath(JoinPath(HomeDir, 'workspace'), 'memory'), 'facts.db');
+end;
+
+function FormatFactsBlock(const Facts: TStoredFactArray; Budget: Integer): string;
+const
+  Header = 'Durable facts (auto-distilled memory):';
+var
+  i, Used, Omitted: Integer;
+  Line, Body: string;
+begin
+  Result := '';
+  if (Length(Facts) = 0) or (Budget <= 0) then Exit;
+  Body := '';
+  Used := Length(Header);
+  Omitted := 0;
+  for i := 0 to High(Facts) do
+  begin
+    if Trim(Facts[i].Text) = '' then Continue;
+    Line := '- ' + Facts[i].Text;
+    if Facts[i].Expires <> '' then
+      Line := Line + ' (until ' + Facts[i].Expires + ')';
+    { +1 for the newline this line will cost. Always keep at least one. }
+    if (Body <> '') and (Used + Length(Line) + 1 > Budget) then
+    begin
+      Omitted := Length(Facts) - i;
+      Break;
+    end;
+    if Body <> '' then Body := Body + sLineBreak;
+    Body := Body + Line;
+    Used := Used + Length(Line) + 1;
+  end;
+  if Body = '' then Exit;
+  Result := Header + sLineBreak + Body;
+  if Omitted > 0 then
+    Result := Result + sLineBreak +
+      Format('(%d more -- ask via memory_search)', [Omitted]);
+end;
+
+function ActiveFactsBlock(const HomeDir, Today: string; Budget: Integer): string;
+var
+  Store: IFactStore;
+begin
+  Result := '';
+  if Budget <= 0 then Exit;
+  Store := NewFactStore;
+  if not Store.Open(DefaultFactsDbPath(HomeDir)) then Exit;
+  try
+    Result := FormatFactsBlock(Store.ActiveFacts(Today), Budget);
+  finally
+    Store.Close;
+  end;
 end;
 
 type

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -82,9 +82,12 @@ function NewFactStore: IFactStore;
 function DefaultFactsDbPath(const HomeDir: string): string;
 
 { Render facts as a system-prompt block, newest first, until Budget bytes
-  are used; a trailing "(N more -- use memory_search)" breadcrumb notes
-  any omitted. Wholesale (NOT relevance-sliced). '' when Facts is empty or
-  Budget <= 0. Pure -- exposed for testing. }
+  are used; a trailing "(+N older fact(s) not shown)" breadcrumb notes any
+  omitted. The breadcrumb does NOT point at memory_search -- that tool only
+  indexes workspace/memory/*.md, not facts.db, so omitted facts aren't
+  reachable that way until facts are wired into retrieval (Phase 4b).
+  Wholesale (NOT relevance-sliced). '' when Facts is empty or Budget <= 0.
+  Pure -- exposed for testing. }
 function FormatFactsBlock(const Facts: TStoredFactArray; Budget: Integer): string;
 
 { Convenience for the prompt builder: open the default store, read the
@@ -141,8 +144,11 @@ begin
   if Body = '' then Exit;
   Result := Header + sLineBreak + Body;
   if Omitted > 0 then
+    { No memory_search hint: it indexes only workspace/memory/*.md, not
+      facts.db, so it can't recover these. Just flag the omission;
+      raising memory_facts_budget surfaces more. }
     Result := Result + sLineBreak +
-      Format('(%d more -- ask via memory_search)', [Omitted]);
+      Format('(+%d older fact(s) not shown)', [Omitted]);
 end;
 
 function ActiveFactsBlock(const HomeDir, Today: string; Budget: Integer): string;

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -143,6 +143,42 @@ begin
   Store.Close;
 end;
 
+function SF(const Txt, Expires: string): TStoredFact;
+begin
+  Result := Default(TStoredFact);
+  Result.Text := Txt;
+  Result.Kind := 'static'; Result.Scope := 'user';
+  Result.Expires := Expires;
+end;
+
+procedure RunFormatTests;
+{ Pure FormatFactsBlock: budget gating, breadcrumb, expiry annotation. }
+var
+  Facts: TStoredFactArray;
+  S: string;
+begin
+  SetLength(Facts, 0);
+  AssertEqStr(FormatFactsBlock(Facts, 2000), '', 'empty -> empty block');
+
+  SetLength(Facts, 3);
+  Facts[0] := SF('Prefers Delphi', '');
+  Facts[1] := SF('Sprint ends', '2026-12-31');
+  Facts[2] := SF('Likes terse commits', '');
+
+  AssertEqStr(FormatFactsBlock(Facts, 0), '', 'budget 0 -> no injection');
+
+  S := FormatFactsBlock(Facts, 2000);
+  AssertTrue(Pos('Durable facts', S) > 0, 'has header');
+  AssertTrue(Pos('- Prefers Delphi', S) > 0, 'has a bullet');
+  AssertTrue(Pos('(until 2026-12-31)', S) > 0, 'expiry annotated');
+  AssertTrue(Pos('more --', S) = 0, 'no breadcrumb when all fit');
+
+  { Tiny budget: at least one fact kept, rest summarised as a breadcrumb. }
+  S := FormatFactsBlock(Facts, 45);
+  AssertTrue(Pos('- Prefers Delphi', S) > 0, 'keeps newest fact under tiny budget');
+  AssertTrue(Pos('more --', S) > 0, 'breadcrumb notes the omitted facts');
+end;
+
 begin
   GTmpDir := JoinPath(GetTempDir, 'pasclaw-facts-test-' + IntToStr(Random(1 shl 30)));
   EnsureDir(GTmpDir);
@@ -153,6 +189,8 @@ begin
     WriteLn('  ok: durability across reopen');
     RunDedupTests;
     WriteLn('  ok: exact-text dedup (expired copy does not block refresh)');
+    RunFormatTests;
+    WriteLn('  ok: format facts block (budget / breadcrumb / expiry)');
     WriteLn('PASS');
   finally
     {$IFDEF UNIX}

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -171,12 +171,15 @@ begin
   AssertTrue(Pos('Durable facts', S) > 0, 'has header');
   AssertTrue(Pos('- Prefers Delphi', S) > 0, 'has a bullet');
   AssertTrue(Pos('(until 2026-12-31)', S) > 0, 'expiry annotated');
-  AssertTrue(Pos('more --', S) = 0, 'no breadcrumb when all fit');
+  AssertTrue(Pos('not shown', S) = 0, 'no breadcrumb when all fit');
+  { Must NOT promise memory_search -- it can't reach facts.db (Phase 4b). }
+  AssertTrue(Pos('memory_search', S) = 0, 'no false memory_search hint');
 
   { Tiny budget: at least one fact kept, rest summarised as a breadcrumb. }
   S := FormatFactsBlock(Facts, 45);
   AssertTrue(Pos('- Prefers Delphi', S) > 0, 'keeps newest fact under tiny budget');
-  AssertTrue(Pos('more --', S) > 0, 'breadcrumb notes the omitted facts');
+  AssertTrue(Pos('not shown', S) > 0, 'breadcrumb notes the omitted facts');
+  AssertTrue(Pos('memory_search', S) = 0, 'breadcrumb does not point at memory_search');
 end;
 
 begin


### PR DESCRIPTION
## Why this exists

PR #369 was merged, but into the wrong base: its base was the stacked branch `claude/memory-autodistill-phase3` (#368), and #368 had **already merged to main first**, so #369's commits landed on an already-merged branch and **never reached `main`** (the symbols `FormatFactsBlock` / `MemoryFactsBudget` / `BuildFactsSection` are absent from main). My fault — I retargeted #367 to main after its parent merged but forgot to do the same for #369.

This re-lands the identical work, **rebased cleanly onto current `main`** (its 2 commits replay; the already-merged phase-3 commits drop out). No new changes vs #369.

## What it is (unchanged from #369)

When `memory_distill_enabled` is on, active distilled facts are injected **wholesale** (newest-first, bounded by `memory_facts_budget`, default 2000) into the system prompt — deliberately **not** relevance-sliced (no `OrientTaskAware` one-track-mind). Includes the review fix that the overflow breadcrumb no longer falsely points at `memory_search`.

Gated entirely on `memory_distill_enabled` (default false): off ⇒ zero I/O in the prompt path.

Verified: `make all` links; `test-memory-facts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_