### PR TITLE
memory: Phase 4b — make distilled facts searchable via memory_search

### DIFF
--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -82,18 +82,28 @@ function NewFactStore: IFactStore;
 function DefaultFactsDbPath(const HomeDir: string): string;
 
 { Render facts as a system-prompt block, newest first, until Budget bytes
-  are used; a trailing "(+N older fact(s) not shown)" breadcrumb notes any
-  omitted. The breadcrumb does NOT point at memory_search -- that tool only
-  indexes workspace/memory/*.md, not facts.db, so omitted facts aren't
-  reachable that way until facts are wired into retrieval (Phase 4b).
-  Wholesale (NOT relevance-sliced). '' when Facts is empty or Budget <= 0.
-  Pure -- exposed for testing. }
+  are used; a trailing "(+N more -- search with memory_search)" breadcrumb
+  notes any omitted. Wholesale (NOT relevance-sliced). '' when Facts is
+  empty or Budget <= 0. Pure -- exposed for testing. }
 function FormatFactsBlock(const Facts: TStoredFactArray; Budget: Integer): string;
 
 { Convenience for the prompt builder: open the default store, read the
   facts active as of Today, and format them within Budget. '' when the
   store is absent/empty or Budget <= 0. }
 function ActiveFactsBlock(const HomeDir, Today: string; Budget: Integer): string;
+
+{ Keyword-rank Facts against Query: score each by how many distinct query
+  terms appear (case-insensitive substring) in its text, drop zero-score,
+  sort by score then confidence then recency, return the top K. Pure (the
+  keyword half of hybrid retrieval) -- exposed for testing. }
+function RankFactsByQuery(const Facts: TStoredFactArray;
+                          const Query: string; K: Integer): TStoredFactArray;
+
+{ Open the default store and return the top-K active (as of Today) facts
+  matching Query. [] when the store is absent/empty. Used by memory_search
+  so distilled facts are reachable alongside the .md notes. }
+function SearchActiveFacts(const HomeDir, Today, Query: string;
+                          K: Integer): TStoredFactArray;
 
 implementation
 
@@ -144,11 +154,10 @@ begin
   if Body = '' then Exit;
   Result := Header + sLineBreak + Body;
   if Omitted > 0 then
-    { No memory_search hint: it indexes only workspace/memory/*.md, not
-      facts.db, so it can't recover these. Just flag the omission;
-      raising memory_facts_budget surfaces more. }
+    { memory_search now also searches facts.db (Phase 4b), so this hint is
+      actionable -- the model can recover omitted facts by querying. }
     Result := Result + sLineBreak +
-      Format('(+%d older fact(s) not shown)', [Omitted]);
+      Format('(+%d more -- search with memory_search)', [Omitted]);
 end;
 
 function ActiveFactsBlock(const HomeDir, Today: string; Budget: Integer): string;
@@ -161,6 +170,95 @@ begin
   if not Store.Open(DefaultFactsDbPath(HomeDir)) then Exit;
   try
     Result := FormatFactsBlock(Store.ActiveFacts(Today), Budget);
+  finally
+    Store.Close;
+  end;
+end;
+
+function RankFactsByQuery(const Facts: TStoredFactArray;
+  const Query: string; K: Integer): TStoredFactArray;
+var
+  Terms: array of string;
+  Cur, LowText: string;
+  i, j, NTerms, Score: Integer;
+  { Parallel scored set: a fact + its match score, before top-K sort. }
+  Scored: array of TStoredFact;
+  ScoreOf: array of Integer;
+  n, a, b: Integer;
+  TmpF: TStoredFact;
+  TmpI: Integer;
+
+  procedure AddTerm(const T: string);
+  var t2: string; x: Integer; dup: Boolean;
+  begin
+    t2 := LowerCase(Trim(T));
+    if t2 = '' then Exit;
+    dup := False;
+    for x := 0 to High(Terms) do if Terms[x] = t2 then begin dup := True; Break; end;
+    if not dup then begin SetLength(Terms, Length(Terms) + 1); Terms[High(Terms)] := t2; end;
+  end;
+
+begin
+  Result := nil;
+  if (Length(Facts) = 0) or (Trim(Query) = '') then Exit;
+  if K <= 0 then K := 5;
+
+  { Tokenise the query on non-alphanumeric (>= $80 kept so UTF-8 survives). }
+  SetLength(Terms, 0);
+  Cur := '';
+  for i := 1 to Length(Query) do
+    if (Query[i] in ['a'..'z','A'..'Z','0'..'9']) or (Ord(Query[i]) >= $80) then
+      Cur := Cur + Query[i]
+    else begin AddTerm(Cur); Cur := ''; end;
+  AddTerm(Cur);
+  NTerms := Length(Terms);
+  if NTerms = 0 then Exit;
+
+  { Score: distinct query terms present (substring) in the fact text. }
+  n := 0;
+  for i := 0 to High(Facts) do
+  begin
+    LowText := LowerCase(Facts[i].Text);
+    Score := 0;
+    for j := 0 to NTerms - 1 do
+      if Pos(Terms[j], LowText) > 0 then Inc(Score);
+    if Score = 0 then Continue;
+    SetLength(Scored, n + 1);
+    SetLength(ScoreOf, n + 1);
+    Scored[n] := Facts[i];
+    ScoreOf[n] := Score;
+    Inc(n);
+  end;
+  if n = 0 then Exit;
+
+  { Selection sort (small n): score desc, then confidence desc, then
+    created_at desc. }
+  for a := 0 to n - 2 do
+    for b := a + 1 to n - 1 do
+      if (ScoreOf[b] > ScoreOf[a]) or
+         ((ScoreOf[b] = ScoreOf[a]) and (Scored[b].Confidence > Scored[a].Confidence)) or
+         ((ScoreOf[b] = ScoreOf[a]) and (Scored[b].Confidence = Scored[a].Confidence)
+            and (Scored[b].CreatedAt > Scored[a].CreatedAt)) then
+      begin
+        TmpF := Scored[a]; Scored[a] := Scored[b]; Scored[b] := TmpF;
+        TmpI := ScoreOf[a]; ScoreOf[a] := ScoreOf[b]; ScoreOf[b] := TmpI;
+      end;
+
+  if n > K then n := K;
+  SetLength(Result, n);
+  for i := 0 to n - 1 do Result[i] := Scored[i];
+end;
+
+function SearchActiveFacts(const HomeDir, Today, Query: string;
+  K: Integer): TStoredFactArray;
+var
+  Store: IFactStore;
+begin
+  Result := nil;
+  Store := NewFactStore;
+  if not Store.Open(DefaultFactsDbPath(HomeDir)) then Exit;
+  try
+    Result := RankFactsByQuery(Store.ActiveFacts(Today), Query, K);
   finally
     Store.Close;
   end;

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -46,6 +46,7 @@ uses
   PasClaw.Logger,
   PasClaw.Memory.Index,
   PasClaw.Memory.Vector,
+  PasClaw.Memory.Facts,   { distilled-fact search (Phase 4b) }
   PasClaw.Promptware;     { injection scan on recalled snippets -- chokepoint 2 }
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
@@ -110,6 +111,9 @@ var
   Lines: TStringList;
   Dir:   string;
   Cfg:   TConfig;
+  UseVector, DistillOn: Boolean;
+  MdText, FactText: string;
+  FactHits: TStoredFactArray;
 begin
   ErrMsg := '';
   Result := '';
@@ -145,14 +149,17 @@ begin
     exist and isn't touched. }
   Cfg := LoadConfig;
   try
-    if Cfg.VectorSearchEnabled then
-    begin
-      Idx := NewVectorMemoryIndex;
-      if not Idx.Open(IndexDbPath + '.vec') then
-        Idx := nil;  { releases the interface; falls through to FTS }
-    end;
+    UseVector := Cfg.VectorSearchEnabled;
+    DistillOn := Cfg.MemoryDistillEnabled;
   finally
     Cfg.Free;
+  end;
+
+  if UseVector then
+  begin
+    Idx := NewVectorMemoryIndex;
+    if not Idx.Open(IndexDbPath + '.vec') then
+      Idx := nil;  { releases the interface; falls through to FTS }
   end;
 
   if Idx = nil then
@@ -161,11 +168,17 @@ begin
     if not Idx.Open(IndexDbPath) then
     begin
       Idx := nil;
-      ErrMsg := 'memory index unavailable (libsqlite3 missing or unreadable)';
-      Exit;
+      { Index unavailable. If distilled facts are on, fall through and let
+        the facts search still answer; otherwise this is a hard error. }
+      if not DistillOn then
+      begin
+        ErrMsg := 'memory index unavailable (libsqlite3 missing or unreadable)';
+        Exit;
+      end;
     end;
   end;
 
+  if Idx <> nil then
   try
     Idx.SyncDir(Dir);
     Hits := Idx.Search(Query, K);
@@ -173,22 +186,59 @@ begin
     Idx := nil;  { IInterface release closes the DB }
   end;
 
-  if Length(Hits) = 0 then
+  { ----- .md note hits ----- }
+  MdText := '';
+  if Length(Hits) > 0 then
+  begin
+    Lines := TStringList.Create;
+    try
+      Lines.Add(Format('%d match(es) for %s:', [Length(Hits), Query]));
+      Lines.Add('');
+      for i := 0 to High(Hits) do
+      begin
+        Lines.Add(Format('%s  (bm25=%.3f)', [Hits[i].Path, Hits[i].Score]));
+        Lines.Add('  ' + Hits[i].Snippet);
+        if i < High(Hits) then Lines.Add('');
+      end;
+      MdText := Lines.Text;
+    finally
+      Lines.Free;
+    end;
+  end;
+
+  { ----- distilled-fact hits (Phase 4b) ----- }
+  FactText := '';
+  if DistillOn then
+  begin
+    FactHits := SearchActiveFacts(GetHome,
+                  FormatDateTime('yyyy"-"mm"-"dd', Now), Query, K);
+    if Length(FactHits) > 0 then
+    begin
+      Lines := TStringList.Create;
+      try
+        Lines.Add(Format('%d distilled fact(s) for %s:', [Length(FactHits), Query]));
+        for i := 0 to High(FactHits) do
+        begin
+          if FactHits[i].Expires <> '' then
+            Lines.Add(Format('- %s (until %s)', [FactHits[i].Text, FactHits[i].Expires]))
+          else
+            Lines.Add('- ' + FactHits[i].Text);
+        end;
+        FactText := Lines.Text;
+      finally
+        Lines.Free;
+      end;
+    end;
+  end;
+
+  if (MdText = '') and (FactText = '') then
     Exit(Format('(no matches for %s in %s)', [Query, Dir]));
 
-  Lines := TStringList.Create;
-  try
-    Lines.Add(Format('%d match(es) for %s:', [Length(Hits), Query]));
-    Lines.Add('');
-    for i := 0 to High(Hits) do
-    begin
-      Lines.Add(Format('%s  (bm25=%.3f)', [Hits[i].Path, Hits[i].Score]));
-      Lines.Add('  ' + Hits[i].Snippet);
-      if i < High(Hits) then Lines.Add('');
-    end;
-    Result := Lines.Text;
-  finally
-    Lines.Free;
+  Result := MdText;
+  if FactText <> '' then
+  begin
+    if Result <> '' then Result := Result + sLineBreak;
+    Result := Result + FactText;
   end;
 
   { Promptware chokepoint 2 of 3: recalled memory. Snippets were
@@ -211,11 +261,12 @@ begin
   if R = nil then Exit;
   T.Name        := 'memory_search';
   T.Description :=
-    'Search the workspace memory directory (MEMORY.md + workspace/memory/*.md) ' +
-    'with SQLite FTS5 BM25 ranking. Use this before answering questions about ' +
-    'prior conversations, the user''s preferences, or project facts you might ' +
-    'have written down on an earlier turn. Returns up to k matches as path + ' +
-    'snippet + score (smaller score = stronger match).';
+    'Search workspace memory: the markdown notes (MEMORY.md + ' +
+    'workspace/memory/*.md, SQLite FTS5 BM25) AND, when distilled memory ' +
+    'is enabled, the auto-distilled fact store. Use this before answering ' +
+    'questions about prior conversations, the user''s preferences, or ' +
+    'project facts from an earlier turn. Returns up to k note matches ' +
+    '(path + snippet + score) plus matching distilled facts.';
   T.Schema      :=
     '{"type":"object",' +
     '"properties":{' +

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -111,7 +111,7 @@ var
   Lines: TStringList;
   Dir:   string;
   Cfg:   TConfig;
-  UseVector, DistillOn: Boolean;
+  UseVector, DistillOn, IndexFailed: Boolean;
   MdText, FactText: string;
   FactHits: TStoredFactArray;
 begin
@@ -162,19 +162,24 @@ begin
       Idx := nil;  { releases the interface; falls through to FTS }
   end;
 
+  IndexFailed := False;
   if Idx = nil then
   begin
     Idx := NewMemoryIndex;
     if not Idx.Open(IndexDbPath) then
     begin
       Idx := nil;
-      { Index unavailable. If distilled facts are on, fall through and let
-        the facts search still answer; otherwise this is a hard error. }
+      { Index unavailable. If distilled facts are on, remember the failure
+        and fall through so the fact store can still answer; otherwise this
+        is a hard error (unchanged behaviour). The failure is NOT silently
+        dropped -- it's reported below if facts don't produce results, and
+        flagged as a partial search if they do. }
       if not DistillOn then
       begin
         ErrMsg := 'memory index unavailable (libsqlite3 missing or unreadable)';
         Exit;
       end;
+      IndexFailed := True;
     end;
   end;
 
@@ -232,7 +237,17 @@ begin
   end;
 
   if (MdText = '') and (FactText = '') then
-    Exit(Format('(no matches for %s in %s)', [Query, Dir]));
+  begin
+    { Nothing to return. If the markdown index never opened, that's the
+      real reason -- report it as unavailable rather than a misleading
+      "no matches" (the notes were never searched). }
+    if IndexFailed then
+      ErrMsg := 'memory index unavailable (libsqlite3 missing or unreadable); ' +
+                'no matching distilled facts either'
+    else
+      Result := Format('(no matches for %s in %s)', [Query, Dir]);
+    Exit;
+  end;
 
   Result := MdText;
   if FactText <> '' then
@@ -240,6 +255,11 @@ begin
     if Result <> '' then Result := Result + sLineBreak;
     Result := Result + FactText;
   end;
+  { Facts answered but the markdown index was down -- tell the model this
+    was a partial search so it doesn't assume the notes were checked. }
+  if IndexFailed then
+    Result := '(note: markdown memory index unavailable -- searched ' +
+              'distilled facts only)' + sLineBreak + Result;
 
   { Promptware chokepoint 2 of 3: recalled memory. Snippets were
     written on earlier turns -- possibly copied from attacker-supplied

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -171,15 +171,45 @@ begin
   AssertTrue(Pos('Durable facts', S) > 0, 'has header');
   AssertTrue(Pos('- Prefers Delphi', S) > 0, 'has a bullet');
   AssertTrue(Pos('(until 2026-12-31)', S) > 0, 'expiry annotated');
-  AssertTrue(Pos('not shown', S) = 0, 'no breadcrumb when all fit');
-  { Must NOT promise memory_search -- it can't reach facts.db (Phase 4b). }
-  AssertTrue(Pos('memory_search', S) = 0, 'no false memory_search hint');
+  AssertTrue(Pos('more --', S) = 0, 'no breadcrumb when all fit');
 
-  { Tiny budget: at least one fact kept, rest summarised as a breadcrumb. }
+  { Tiny budget: at least one fact kept, rest summarised as a breadcrumb
+    that now (Phase 4b) points at the searchable store. }
   S := FormatFactsBlock(Facts, 45);
   AssertTrue(Pos('- Prefers Delphi', S) > 0, 'keeps newest fact under tiny budget');
-  AssertTrue(Pos('not shown', S) > 0, 'breadcrumb notes the omitted facts');
-  AssertTrue(Pos('memory_search', S) = 0, 'breadcrumb does not point at memory_search');
+  AssertTrue(Pos('more --', S) > 0, 'breadcrumb notes the omitted facts');
+  AssertTrue(Pos('memory_search', S) > 0, 'breadcrumb points at memory_search (now searchable)');
+end;
+
+procedure RunRankTests;
+{ Pure keyword ranking: term matching, score/confidence ordering, K cap,
+  no-match -> empty. }
+var
+  Facts, R: TStoredFactArray;
+begin
+  SetLength(Facts, 3);
+  Facts[0] := SF('User prefers Delphi over Lazarus', ''); Facts[0].Confidence := 0.5; Facts[0].CreatedAt := 10;
+  Facts[1] := SF('Deploys on FreeBSD', '');                Facts[1].Confidence := 0.9; Facts[1].CreatedAt := 20;
+  Facts[2] := SF('Delphi build uses dcc64', '');           Facts[2].Confidence := 0.5; Facts[2].CreatedAt := 30;
+
+  { No match -> empty. }
+  R := RankFactsByQuery(Facts, 'kubernetes', 5);
+  AssertEqInt(Length(R), 0, 'no-match query -> empty');
+
+  { "delphi build" hits #2 (both terms) over #0 (one term). }
+  R := RankFactsByQuery(Facts, 'delphi build', 5);
+  AssertTrue(Length(R) >= 2, 'matches the two delphi facts');
+  AssertEqStr(R[0].Text, 'Delphi build uses dcc64', 'higher term-overlap ranks first');
+
+  { Single shared term -> tie broken by confidence (FreeBSD 0.9 not relevant;
+    use a term in two equal-score facts). "delphi" hits #0 and #2 (score 1
+    each); #2 is newer so wins the recency tiebreak (equal confidence). }
+  R := RankFactsByQuery(Facts, 'delphi', 5);
+  AssertEqStr(R[0].Text, 'Delphi build uses dcc64', 'equal score -> newer wins');
+
+  { K cap. }
+  R := RankFactsByQuery(Facts, 'delphi', 1);
+  AssertEqInt(Length(R), 1, 'K caps results');
 end;
 
 begin
@@ -194,6 +224,8 @@ begin
     WriteLn('  ok: exact-text dedup (expired copy does not block refresh)');
     RunFormatTests;
     WriteLn('  ok: format facts block (budget / breadcrumb / expiry)');
+    RunRankTests;
+    WriteLn('  ok: keyword rank facts (match / order / K cap)');
     WriteLn('PASS');
   finally
     {$IFDEF UNIX}


### PR DESCRIPTION
**Stacked on #370** (the Phase 4a re-land). Merge #370 first.

## What

Closes the gap the #369 review (and the LoCoMo PDF) flagged: the overflow breadcrumb said "use `memory_search`," but that tool only indexed `workspace/memory/*.md` — facts in `facts.db` were unreachable. Now `memory_search` searches **both**.

This is the **keyword half** of the hybrid retrieval those systems use (vectors + keyword/scope filters). **Dependency-free — no ONNX.** The `sqlite-vec` semantic tier + mem0-style LLM reconcile are a later step.

- **`RankFactsByQuery`** (pure): tokenise the query, score each active fact by distinct-term substring overlap, sort by score → confidence → recency, top-K. + `SearchActiveFacts` convenience.
- **`memory_search`** now appends a `distilled fact(s)` section after the `.md` hits when `memory_distill_enabled`. If the `.md` index can't open but distill is on, facts still answer (no hard error). Tool description updated.
- **Overflow breadcrumb restored** to point at `memory_search` — now actionable/honest.

## Gating
Behind `memory_distill_enabled` (default false): off ⇒ `memory_search` behaves exactly as before, zero fact I/O.

## Tests
`RankFactsByQuery` (match / score+confidence+recency ordering / K cap / no-match) + restored breadcrumb assertion. All memory suites green; full build links.

## Next
- Phase 4c: `sqlite-vec` semantic dedup + retrieval (ONNX-gated, graceful fallback to this keyword tier) + scope filtering.
- Phase 5: `/remember`, `/forget`, web Memory tab, markdown export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_