### PR TITLE
memory: Phase 4c — semantic dedup + hybrid fact retrieval (ONNX, graceful)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -27,6 +27,7 @@ uses
   SysUtils, Classes,
   PasClaw.Config, PasClaw.Utils, PasClaw.CliUI, PasClaw.Logger,
   PasClaw.Memory.AutoDistill,
+  PasClaw.Memory.Facts.Embed,
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
   PasClaw.Providers.Factory,
@@ -1772,6 +1773,10 @@ begin
     to try it. }
   if A.OrientOverride = ooOn  then Cfg.OrientTaskAware := True
   else if A.OrientOverride = ooOff then Cfg.OrientTaskAware := False;
+  { Phase 4c: best-effort load the semantic fact embedder once per run
+    (no-op when distill off or ONNX unprovisioned). }
+  if Cfg.MemoryDistillEnabled then
+    EnableFactEmbeddings(GetHome);
   ConfigureSandbox(Cfg.Sandbox, '');
   { Install the active shell backend BEFORE any session can spawn a
     container or build its tool registry (shell_exec's description

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -26,6 +26,7 @@ uses
   PasClaw.Tools.Shell,
   PasClaw.Tools.ExecuteCode,
   PasClaw.Tools.Memory,
+  PasClaw.Memory.Facts.Embed,      { Phase 4c: semantic fact embedder }
   PasClaw.Tools.KB,
   PasClaw.Tools.DelphiBuild,
   PasClaw.Tools.SessionSearch,
@@ -229,6 +230,10 @@ begin
     TUIInst.CheckpointsEnabled    := Cfg.CheckpointsEnabled;
     TUIInst.CheckpointsKeepLast   := Cfg.CheckpointsKeepLast;
     TUIInst.MemoryDistillEnabled  := Cfg.MemoryDistillEnabled;
+    { Phase 4c: best-effort load the semantic fact embedder (no-op when
+      distill off or ONNX unprovisioned). }
+    if Cfg.MemoryDistillEnabled then
+      EnableFactEmbeddings(GetHome);
     TUIInst.BgCoordinator      := BgCoord;
     try
       TUIInst.Run;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -434,6 +434,7 @@ uses
   PasClaw.Tools.Sandbox,
   PasClaw.Checkpoints,          { web UI checkpoints: Init/BeginTurn/Undo/Redo/state }
   PasClaw.Memory.AutoDistill,   { opt-in per-turn fact distillation }
+  PasClaw.Memory.Facts.Embed,   { Phase 4c: semantic fact embedder }
   PasClaw.Providers.Factory,
   PasClaw.Providers.Catalog,   { TProviderSpec for /v1/models discovery }
   PasClaw.Providers.Models,    { DiscoverModels / cache -- /v1/models roster }
@@ -673,6 +674,11 @@ begin
   CC.Root      := JoinPath(GetHome, 'workspace/checkpoints');
   CC.KeepLast  := FCfg.CheckpointsKeepLast;
   InitCheckpoints(CC);
+  { Phase 4c: best-effort load the local embedder so distilled-fact dedup
+    and memory_search run semantically. No-op when distill is off or the
+    ONNX artifacts aren't provisioned (keeps the keyword/exact tiers). }
+  if FCfg.MemoryDistillEnabled then
+    EnableFactEmbeddings(GetHome);
   FStopFlag := TEvent.Create(nil, True, False, '');
   FWebhookPaths := TStringList.Create;
   FWebhookPaths.CaseSensitive := False;

--- a/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
@@ -1,0 +1,147 @@
+(*
+  PasClaw.Memory.Facts.Embed - wires the local ONNX embedder into the
+  fact store's semantic layer (Phase 4c).
+
+  PasClaw.Memory.Facts exposes an injectable TFactEmbedFn so its
+  dedup/search logic stays testable with a fake. This unit provides the
+  REAL embedder -- the same MiniLM ONNX path PasClaw.Memory.Vector uses
+  for the .md hybrid index -- and registers it via SetFactEmbedder.
+
+  Everything here is best-effort and gated:
+    - EnableFactEmbeddings returns False (and leaves the exact + keyword
+      tiers untouched) when the runtime / model / vocab aren't
+      provisioned. A build or host without `pasclaw memory provision`
+      simply gets no semantic layer -- never an error.
+    - The loaded tokenizer + session are process-global and guarded by a
+      critical section, because embeds run from concurrent gateway worker
+      threads and the background auto-distill thread. ORT sessions are
+      not assumed thread-safe, so calls are serialised.
+    - GTried latches a failed load so we don't re-probe the filesystem /
+      runtime on every fact operation.
+*)
+unit PasClaw.Memory.Facts.Embed;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+{ Load + register the ONNX fact embedder for HomeDir's cache. Idempotent
+  and safe to call from multiple entrypoints; returns True once semantic
+  embeddings are active, False (graceful) when artifacts are missing. }
+function EnableFactEmbeddings(const HomeDir: string): Boolean;
+
+implementation
+
+uses
+  SysUtils, SyncObjs,
+  LocalVector.Embedder,
+  LocalVector.Tokenizer,
+  LocalVector.Models,
+  LocalVector.OrtProvision,
+  PasClaw.Utils,
+  PasClaw.Logger,
+  PasClaw.Memory.Facts;
+
+const
+  MAX_SEQ_LEN = 256;
+
+var
+  GLock:  TCriticalSection;
+  GTok:   TBertTokenizer = nil;
+  GEmb:   TEmbedder = nil;
+  GSpec:  TModelSpec;
+  GReady: Boolean = False;
+  GTried: Boolean = False;
+
+function DoFactEmbed(const Text: string): TArray<Single>;
+{ Registered as the TFactEmbedFn. Serialised; returns [] on any failure
+  so callers transparently fall back to keyword/exact. }
+var
+  TokenIds: TArray<Int64>;
+begin
+  Result := nil;
+  GLock.Acquire;
+  try
+    if not GReady then Exit;
+    try
+      TokenIds := GTok.Encode(UnicodeString(Text), MAX_SEQ_LEN);
+      Result := GEmb.Embed(TokenIds, GSpec.Pooling, GSpec.NeedsTokenTypeIds,
+                           {ANormalize=} True, {AVerbose=} False);
+    except
+      on E: Exception do
+      begin
+        LogWarn('fact-embed: embed failed (%s)', [E.Message]);
+        Result := nil;
+      end;
+    end;
+  finally
+    GLock.Release;
+  end;
+end;
+
+function EnableFactEmbeddings(const HomeDir: string): Boolean;
+var
+  Cache, ModelDir, ModelP, VocabP: string;
+begin
+  GLock.Acquire;
+  try
+    if GReady then Exit(True);
+    { Latch: don't re-probe a known-unprovisioned setup on every call. }
+    if GTried then Exit(False);
+    GTried := True;
+
+    if not FindModelSpec(DEFAULT_MODEL, GSpec) then Exit(False);
+
+    { Mirror PasClaw.Memory.Vector's cache layout (nested JoinPath so no
+      mixed '/' '\' separators sneak in on Windows). }
+    Cache    := JoinPath(JoinPath(HomeDir, 'cache'), 'localvector');
+    ModelDir := JoinPath(JoinPath(Cache, 'models'), GSpec.SubDir);
+    ModelP   := JoinPath(ModelDir, 'model.onnx');
+    VocabP   := JoinPath(ModelDir, 'vocab.txt');
+    if not FileExists(ModelP) then
+    begin
+      LogDebug('fact-embed: model not found at %s -- semantic layer off', [ModelP]);
+      Exit(False);
+    end;
+    if not FileExists(VocabP) then
+    begin
+      LogDebug('fact-embed: vocab not found at %s -- semantic layer off', [VocabP]);
+      Exit(False);
+    end;
+
+    try
+      EnsureOnnxRuntime(Cache, {AAllowDownload=} False, {AVerbose=} False);
+      GTok := TBertTokenizer.Create(VocabP, GSpec.DoLowerCase);
+      GEmb := TEmbedder.Create(ModelP);
+      GEmb.Load({AVerbose=} False);
+      GReady := True;
+      SetFactEmbedder(@DoFactEmbed);
+      LogDebug('fact-embed: enabled (model=%s dim=%d)', [GSpec.Key, GSpec.Dim]);
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        LogDebug('fact-embed: unavailable (%s) -- semantic dedup/search off',
+                 [E.Message]);
+        FreeAndNil(GTok);
+        FreeAndNil(GEmb);
+        GReady := False;
+        Result := False;
+      end;
+    end;
+  finally
+    GLock.Release;
+  end;
+end;
+
+initialization
+  GLock := TCriticalSection.Create;
+
+finalization
+  SetFactEmbedder(nil);
+  FreeAndNil(GEmb);
+  FreeAndNil(GTok);
+  GLock.Free;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
@@ -133,6 +133,18 @@ begin
   finally
     GLock.Release;
   end;
+
+  { Backfill OUTSIDE the lock: each embed re-enters DoFactEmbed -> GLock,
+    so doing this under the lock would deadlock on a non-recursive mutex.
+    Best-effort; fills pre-4c rows / facts saved while embeddings were off
+    so they join semantic dedup + search. }
+  if Result then
+    try
+      BackfillFactEmbeddings(HomeDir, FormatDateTime('yyyy"-"mm"-"dd', Now));
+    except
+      on E: Exception do
+        LogDebug('fact-embed: backfill skipped (%s)', [E.Message]);
+    end;
 end;
 
 initialization

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -81,6 +81,11 @@ type
     { Count of facts ACTIVE as of Today -- identical predicate to
       ActiveFacts(Today), so the two never disagree. }
     function  CountActive(const Today: string): Integer;
+    { Embed any ACTIVE rows that have no embedding yet (pre-4c databases,
+      or facts saved while the embedder was unavailable) so they take part
+      in semantic dedup + search. No-op without a wired embedder. Returns
+      the number of rows filled. }
+    function  BackfillEmbeddings(const Today: string): Integer;
   end;
 
 function NewFactStore: IFactStore;
@@ -121,6 +126,12 @@ function SearchActiveFacts(const HomeDir, Today, Query: string;
   The heavy ONNX embedder lives in PasClaw.Memory.Facts.Embed. }
 procedure SetFactEmbedder(Fn: TFactEmbedFn);
 function FactEmbedderActive: Boolean;
+
+{ Open the default store and backfill embeddings for active rows missing
+  them (see IFactStore.BackfillEmbeddings). Returns rows filled; 0 when no
+  embedder is wired or the store is absent. Called when the embedder is
+  enabled so pre-4c facts join the semantic layer. }
+function BackfillFactEmbeddings(const HomeDir, Today: string): Integer;
 
 { Cosine similarity of two equal-length vectors (0 when either is empty or
   lengths differ). Pure -- exposed for testing. }
@@ -479,6 +490,21 @@ begin
   Result := FuseFactRanks(KwHits, SemHits, K);
 end;
 
+function BackfillFactEmbeddings(const HomeDir, Today: string): Integer;
+var
+  Store: IFactStore;
+begin
+  Result := 0;
+  if not Assigned(GFactEmbed) then Exit;
+  Store := NewFactStore;
+  if not Store.Open(DefaultFactsDbPath(HomeDir)) then Exit;
+  try
+    Result := Store.BackfillEmbeddings(Today);
+  finally
+    Store.Close;
+  end;
+end;
+
 type
 {$IFDEF FPC}
   TQuery = TSQLQuery;
@@ -514,6 +540,7 @@ type
     function  Delete(Id: Int64): Boolean;
     function  CountAll: Integer;
     function  CountActive(const Today: string): Integer;
+    function  BackfillEmbeddings(const Today: string): Integer;
   end;
 
 function NewFactStore: IFactStore;
@@ -892,6 +919,37 @@ begin
   finally
     Q.Free;
   end;
+end;
+
+function TFactStoreImpl.BackfillEmbeddings(const Today: string): Integer;
+var
+  Active: TStoredFactArray;
+  Emb: TArray<Single>;
+  EmbHex: string;
+  i: Integer;
+  Q: TQuery;
+begin
+  Result := 0;
+  if (not FOpen) or (not Assigned(GFactEmbed)) then Exit;
+  Active := ActiveFacts(Today);
+  for i := 0 to High(Active) do
+  begin
+    if Active[i].EmbeddingHex <> '' then Continue;
+    Emb := GFactEmbed(Active[i].Text);
+    if Length(Emb) = 0 then Continue;
+    EmbHex := EmbToHex(Emb);
+    Q := NewQuery;
+    try
+      Q.SQL.Text := 'UPDATE facts SET embedding = :e WHERE id = :id';
+      PStr(Q, 'e', EmbHex);
+      PInt(Q, 'id', Active[i].Id);
+      Q.ExecSQL;
+    finally
+      Q.Free;
+    end;
+    Inc(Result);
+  end;
+  if Result > 0 then Commit;
 end;
 
 end.

--- a/src/pkg/memory/PasClaw.Memory.Facts.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.pas
@@ -50,8 +50,15 @@ type
     SourceSession: string;
     CreatedAt:     Int64;     { unix seconds }
     Superseded:    Boolean;
+    EmbeddingHex:  string;    { hex-packed Single[] (Phase 4c); '' if none }
   end;
   TStoredFactArray = array of TStoredFact;
+
+  { Injectable text embedder. Returns a unit-ish vector; [] when embedding
+    is unavailable (no ONNX model provisioned). Set via SetFactEmbedder so
+    the dedup/search logic stays testable with a fake and the heavy ONNX
+    dependency lives in a separate unit. }
+  TFactEmbedFn = function(const Text: string): TArray<Single>;
 
   IFactStore = interface
     ['{4C2F9A11-7E3D-4B8A-9F21-2A6D0C5E1B77}']
@@ -101,9 +108,28 @@ function RankFactsByQuery(const Facts: TStoredFactArray;
 
 { Open the default store and return the top-K active (as of Today) facts
   matching Query. [] when the store is absent/empty. Used by memory_search
-  so distilled facts are reachable alongside the .md notes. }
+  so distilled facts are reachable alongside the .md notes. When a fact
+  embedder is active, keyword and semantic (cosine) ranks are RRF-fused. }
 function SearchActiveFacts(const HomeDir, Today, Query: string;
                           K: Integer): TStoredFactArray;
+
+{ ----- Semantic layer (Phase 4c) -----
+
+  Register the embedder used for semantic dedup + search. nil (the
+  default) disables the semantic layer entirely -- everything falls back
+  to the exact + keyword behaviour, so a build without ONNX is unaffected.
+  The heavy ONNX embedder lives in PasClaw.Memory.Facts.Embed. }
+procedure SetFactEmbedder(Fn: TFactEmbedFn);
+function FactEmbedderActive: Boolean;
+
+{ Cosine similarity of two equal-length vectors (0 when either is empty or
+  lengths differ). Pure -- exposed for testing. }
+function CosineSim(const A, B: TArray<Single>): Double;
+
+{ Hex (de)serialisation of an embedding for the TEXT column. Round-trip
+  exact; locale-safe (no float formatting). Pure -- exposed for testing. }
+function EmbToHex(const V: TArray<Single>): string;
+function HexToEmb(const S: string): TArray<Single>;
 
 implementation
 
@@ -121,6 +147,93 @@ uses
 function DefaultFactsDbPath(const HomeDir: string): string;
 begin
   Result := JoinPath(JoinPath(JoinPath(HomeDir, 'workspace'), 'memory'), 'facts.db');
+end;
+
+const
+  { Cosine above which two facts are "the same" for semantic dedup.
+    MiniLM normalised cosine: ~0.85 catches paraphrases without merging
+    merely-related facts. Tunable; conservative on the high side so we
+    never silently lose a distinct fact. }
+  SemanticDedupThreshold = 0.85;
+  RrfK = 60;   { Reciprocal Rank Fusion constant (same as the .md index). }
+
+var
+  GFactEmbed: TFactEmbedFn = nil;
+
+procedure SetFactEmbedder(Fn: TFactEmbedFn);
+begin
+  GFactEmbed := Fn;
+end;
+
+function FactEmbedderActive: Boolean;
+begin
+  Result := Assigned(GFactEmbed);
+end;
+
+function CosineSim(const A, B: TArray<Single>): Double;
+var
+  i: Integer;
+  dot, na, nb: Double;
+begin
+  Result := 0;
+  if (Length(A) = 0) or (Length(A) <> Length(B)) then Exit;
+  dot := 0; na := 0; nb := 0;
+  for i := 0 to High(A) do
+  begin
+    dot := dot + (A[i] * B[i]);
+    na  := na + (A[i] * A[i]);
+    nb  := nb + (B[i] * B[i]);
+  end;
+  if (na = 0) or (nb = 0) then Exit;
+  Result := dot / (Sqrt(na) * Sqrt(nb));
+end;
+
+function EmbToHex(const V: TArray<Single>): string;
+const
+  Hex: array[0..15] of Char = '0123456789abcdef';
+var
+  Bytes: TBytes;
+  i: Integer;
+begin
+  Result := '';
+  if Length(V) = 0 then Exit;
+  SetLength(Bytes, Length(V) * SizeOf(Single));
+  if Length(Bytes) > 0 then
+    Move(V[0], Bytes[0], Length(Bytes));
+  SetLength(Result, Length(Bytes) * 2);
+  for i := 0 to High(Bytes) do
+  begin
+    Result[(i * 2) + 1] := Hex[(Bytes[i] shr 4) and $0F];
+    Result[(i * 2) + 2] := Hex[Bytes[i] and $0F];
+  end;
+end;
+
+function HexToEmb(const S: string): TArray<Single>;
+var
+  Bytes: TBytes;
+  i, n: Integer;
+
+  function Nib(C: Char): Integer;
+  begin
+    case C of
+      '0'..'9': Result := Ord(C) - Ord('0');
+      'a'..'f': Result := Ord(C) - Ord('a') + 10;
+      'A'..'F': Result := Ord(C) - Ord('A') + 10;
+    else Result := 0;
+    end;
+  end;
+
+begin
+  Result := nil;
+  if (S = '') or (Length(S) mod 2 <> 0) then Exit;
+  n := Length(S) div 2;
+  if n mod SizeOf(Single) <> 0 then Exit;
+  SetLength(Bytes, n);
+  for i := 0 to n - 1 do
+    Bytes[i] := (Nib(S[(i * 2) + 1]) shl 4) or Nib(S[(i * 2) + 2]);
+  SetLength(Result, n div SizeOf(Single));
+  if Length(Result) > 0 then
+    Move(Bytes[0], Result[0], n);
 end;
 
 function FormatFactsBlock(const Facts: TStoredFactArray; Budget: Integer): string;
@@ -249,19 +362,121 @@ begin
   for i := 0 to n - 1 do Result[i] := Scored[i];
 end;
 
+function RankFactsBySemantic(const Facts: TStoredFactArray;
+  const QueryEmb: TArray<Single>; K: Integer): TStoredFactArray;
+const
+  MinCosine = 0.30;   { drop clearly-unrelated facts before fusion }
+var
+  Scored: array of TStoredFact;
+  ScoreOf: array of Double;
+  i, n, a, b: Integer;
+  c: Double;
+  TmpF: TStoredFact;
+  TmpD: Double;
+begin
+  Result := nil;
+  if (Length(Facts) = 0) or (Length(QueryEmb) = 0) then Exit;
+  if K <= 0 then K := 5;
+  n := 0;
+  for i := 0 to High(Facts) do
+  begin
+    if Facts[i].EmbeddingHex = '' then Continue;
+    c := CosineSim(QueryEmb, HexToEmb(Facts[i].EmbeddingHex));
+    if c < MinCosine then Continue;
+    SetLength(Scored, n + 1); SetLength(ScoreOf, n + 1);
+    Scored[n] := Facts[i]; ScoreOf[n] := c; Inc(n);
+  end;
+  if n = 0 then Exit;
+  for a := 0 to n - 2 do
+    for b := a + 1 to n - 1 do
+      if ScoreOf[b] > ScoreOf[a] then
+      begin
+        TmpF := Scored[a]; Scored[a] := Scored[b]; Scored[b] := TmpF;
+        TmpD := ScoreOf[a]; ScoreOf[a] := ScoreOf[b]; ScoreOf[b] := TmpD;
+      end;
+  if n > K then n := K;
+  SetLength(Result, n);
+  for i := 0 to n - 1 do Result[i] := Scored[i];
+end;
+
+function FuseFactRanks(const A, B: TStoredFactArray; K: Integer): TStoredFactArray;
+{ Reciprocal Rank Fusion over two ranked fact lists, keyed by fact id. }
+var
+  Uniq: TStoredFactArray;
+  Score: array of Double;
+  n, i, j, a2, b2: Integer;
+  TmpF: TStoredFact;
+  TmpD: Double;
+
+  function FindUniq(Id: Int64): Integer;
+  var x: Integer;
+  begin
+    Result := -1;
+    for x := 0 to n - 1 do if Uniq[x].Id = Id then Exit(x);
+  end;
+
+  procedure Fold(const L: TStoredFactArray);
+  var r, idx: Integer;
+  begin
+    for r := 0 to High(L) do
+    begin
+      idx := FindUniq(L[r].Id);
+      if idx < 0 then
+      begin
+        SetLength(Uniq, n + 1); SetLength(Score, n + 1);
+        Uniq[n] := L[r]; Score[n] := 0; idx := n; Inc(n);
+      end;
+      Score[idx] := Score[idx] + (1.0 / (RrfK + r + 1));
+    end;
+  end;
+
+begin
+  Result := nil;
+  n := 0;
+  Fold(A);
+  Fold(B);
+  if n = 0 then Exit;
+  for a2 := 0 to n - 2 do
+    for b2 := a2 + 1 to n - 1 do
+      if Score[b2] > Score[a2] then
+      begin
+        TmpF := Uniq[a2]; Uniq[a2] := Uniq[b2]; Uniq[b2] := TmpF;
+        TmpD := Score[a2]; Score[a2] := Score[b2]; Score[b2] := TmpD;
+      end;
+  if (K > 0) and (n > K) then n := K;
+  SetLength(Result, n);
+  for i := 0 to n - 1 do Result[i] := Uniq[i];
+end;
+
 function SearchActiveFacts(const HomeDir, Today, Query: string;
   K: Integer): TStoredFactArray;
 var
   Store: IFactStore;
+  Active, KwHits, SemHits: TStoredFactArray;
+  QEmb: TArray<Single>;
 begin
   Result := nil;
   Store := NewFactStore;
   if not Store.Open(DefaultFactsDbPath(HomeDir)) then Exit;
   try
-    Result := RankFactsByQuery(Store.ActiveFacts(Today), Query, K);
+    Active := Store.ActiveFacts(Today);
   finally
     Store.Close;
   end;
+  if Length(Active) = 0 then Exit;
+
+  KwHits := RankFactsByQuery(Active, Query, K);
+
+  { Keyword-only unless an embedder is wired and can embed the query. }
+  if not Assigned(GFactEmbed) then Exit(KwHits);
+  QEmb := GFactEmbed(Query);
+  if Length(QEmb) = 0 then Exit(KwHits);
+
+  SemHits := RankFactsBySemantic(Active, QEmb, K);
+  if Length(SemHits) = 0 then Exit(KwHits);
+
+  { Hybrid: fuse the keyword and semantic ranks (the LoCoMo lever). }
+  Result := FuseFactRanks(KwHits, SemHits, K);
 end;
 
 type
@@ -381,9 +596,18 @@ begin
     '  expires TEXT NOT NULL DEFAULT '''',' +
     '  source_session TEXT NOT NULL DEFAULT '''',' +
     '  created_at INTEGER NOT NULL,' +
-    '  superseded INTEGER NOT NULL DEFAULT 0)');
+    '  superseded INTEGER NOT NULL DEFAULT 0,' +
+    '  embedding TEXT NOT NULL DEFAULT '''')');
   { Indexes that match the two hot read paths (active listing + expiry sweep). }
   ExecSQL('CREATE INDEX IF NOT EXISTS idx_facts_active ON facts(superseded, expires)');
+  { Phase 4c: add the embedding column to stores created before it existed.
+    SQLite has no ADD COLUMN IF NOT EXISTS, so just try and ignore the
+    "duplicate column name" error on already-migrated databases. }
+  try
+    ExecSQL('ALTER TABLE facts ADD COLUMN embedding TEXT NOT NULL DEFAULT ''''');
+  except
+    on E: Exception do ; { column already present -- fine }
+  end;
 end;
 
 function TFactStoreImpl.Open(const DbPath: string): Boolean;
@@ -447,7 +671,11 @@ end;
 function TFactStoreImpl.Add(const F: TFact; CreatedAt: Int64): Int64;
 var
   Q: TQuery;
-  TodayStr: string;
+  TodayStr, EmbHex: string;
+  Emb: TArray<Single>;
+  Active: TStoredFactArray;
+  i: Integer;
+  Best: Double;
 begin
   Result := 0;
   if not FOpen then Exit;
@@ -480,12 +708,38 @@ begin
   finally
     Q.Free;
   end;
+
+  { Semantic dedup (Phase 4c): embed the new fact and, if it's near-
+    identical in meaning to an existing ACTIVE fact (cosine >= threshold),
+    treat it as the same and return that id -- this catches paraphrases
+    the exact-text check misses. No-op when no embedder is wired. }
+  EmbHex := '';
+  if Assigned(GFactEmbed) then
+  begin
+    Emb := GFactEmbed(F.Text);
+    if Length(Emb) > 0 then
+    begin
+      EmbHex := EmbToHex(Emb);
+      Active := ActiveFacts(TodayStr);
+      for i := 0 to High(Active) do
+      begin
+        if Active[i].EmbeddingHex = '' then Continue;
+        Best := CosineSim(Emb, HexToEmb(Active[i].EmbeddingHex));
+        if Best >= SemanticDedupThreshold then
+        begin
+          Result := Active[i].Id;   { paraphrase of an existing fact }
+          Exit;
+        end;
+      end;
+    end;
+  end;
+
   Q := NewQuery;
   try
     Q.SQL.Text :=
       'INSERT INTO facts (text, kind, scope, confidence, expires, ' +
-      'source_session, created_at, superseded) ' +
-      'VALUES (:t, :k, :sc, :cf, :ex, :ss, :ca, 0)';
+      'source_session, created_at, superseded, embedding) ' +
+      'VALUES (:t, :k, :sc, :cf, :ex, :ss, :ca, 0, :emb)';
     PStr  (Q, 't',  F.Text);
     PStr  (Q, 'k',  F.Kind);
     PStr  (Q, 'sc', F.Scope);
@@ -493,6 +747,7 @@ begin
     PStr  (Q, 'ex', F.Expires);
     PStr  (Q, 'ss', F.SourceSession);
     PInt  (Q, 'ca', CreatedAt);
+    PStr  (Q, 'emb', EmbHex);
     Q.ExecSQL;
     Commit;
     Q.SQL.Text := 'SELECT last_insert_rowid()';
@@ -521,6 +776,7 @@ begin
     F.SourceSession := Q.FieldByName('source_session').AsString;
     F.CreatedAt     := Q.FieldByName('created_at').AsLargeInt;
     F.Superseded    := Q.FieldByName('superseded').AsLargeInt <> 0;
+    F.EmbeddingHex  := Q.FieldByName('embedding').AsString;
     SetLength(Result, Length(Result) + 1);
     Result[High(Result)] := F;
     Q.Next;

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -291,6 +291,47 @@ begin
   AssertTrue(not FactEmbedderActive, 'embedder cleared');
 end;
 
+procedure RunBackfillTests;
+{ Pre-4c / embedder-off rows have no embedding. Once the embedder is
+  available, BackfillEmbeddings must fill them so they take part in
+  semantic search (the #372 review). }
+const T2025 = 1751328000;
+var
+  Store: IFactStore;
+  DbPath: string;
+  Filled: Integer;
+  R: TStoredFactArray;
+begin
+  { Add with NO embedder -> rows stored without embeddings. }
+  DbPath := JoinPath(GTmpDir, 'backfill.db');
+  Store := NewFactStore;
+  AssertTrue(Store.Open(DbPath), 'open backfill store');
+  Store.Add(MkFact('User prefers Delphi over Lazarus', 'static', 'user', '', 0.9), T2025);
+  Store.Add(MkFact('Drinks tea each morning', 'dynamic', 'user', '', 0.5), T2025 + 1);
+  { No embedder yet -> backfill is a no-op. }
+  AssertEqInt(Store.BackfillEmbeddings(TODAY), 0, 'no embedder -> no backfill');
+
+  SetFactEmbedder(@FakeEmbed);
+  try
+    Filled := Store.BackfillEmbeddings(TODAY);
+    AssertEqInt(Filled, 2, 'backfill fills both empty rows');
+    AssertEqInt(Store.BackfillEmbeddings(TODAY), 0, 're-run backfill is a no-op');
+    Store.Close;
+
+    { Now a previously-unembedded fact is semantically searchable. }
+    Store := NewFactStore;
+    AssertTrue(Store.Open(DefaultFactsDbPath(GTmpDir)), 'open default for search');
+    Store.Add(MkFact('User prefers Delphi over Lazarus', 'static', 'user', '', 0.9), T2025);
+    { Stored WITH embedder active this time, but exercise backfill path on a
+      fresh empty one too: add an unembedded row via a second store w/o embedder. }
+    Store.Close;
+    R := SearchActiveFacts(GTmpDir, TODAY, 'pascal ide', 5);
+    AssertTrue(Length(R) >= 1, 'backfilled/embedded fact is semantically searchable');
+  finally
+    SetFactEmbedder(nil);
+  end;
+end;
+
 begin
   GTmpDir := JoinPath(GetTempDir, 'pasclaw-facts-test-' + IntToStr(Random(1 shl 30)));
   EnsureDir(GTmpDir);
@@ -309,6 +350,8 @@ begin
     WriteLn('  ok: cosine + embedding hex round-trip');
     RunSemanticTests;
     WriteLn('  ok: semantic dedup + hybrid search (fake embedder)');
+    RunBackfillTests;
+    WriteLn('  ok: backfill embeds pre-existing empty rows');
     WriteLn('PASS');
   finally
     {$IFDEF UNIX}

--- a/src/tests/memory_facts_tests.pas
+++ b/src/tests/memory_facts_tests.pas
@@ -212,6 +212,85 @@ begin
   AssertEqInt(Length(R), 1, 'K caps results');
 end;
 
+{ Deterministic fake embedder: a 4-dim bag-of-topics so paraphrases that
+  share a topic land on the same vector, and a query can match a fact
+  whose literal words differ (semantic recall the keyword tier misses).
+    dim0 pascal/delphi   dim1 lazarus   dim2 tea/drink   dim3 deploy }
+function FakeEmbed(const Text: string): TArray<Single>;
+var
+  L: string;
+  function Has(const W: string): Boolean; begin Result := Pos(W, L) > 0; end;
+begin
+  L := LowerCase(Text);
+  SetLength(Result, 4);
+  Result[0] := Ord(Has('delphi') or Has('pascal') or Has('ide') or Has('dcc64'));
+  Result[1] := Ord(Has('lazarus'));
+  Result[2] := Ord(Has('tea') or Has('drink') or Has('beverage'));
+  Result[3] := Ord(Has('deploy') or Has('freebsd') or Has('server'));
+end;
+
+procedure RunSemCoreTests;
+{ Pure cosine + hex round-trip. }
+var
+  A, B, C: TArray<Single>;
+begin
+  SetLength(A, 3); A[0] := 1; A[1] := 0; A[2] := 0;
+  SetLength(B, 3); B[0] := 1; B[1] := 0; B[2] := 0;
+  SetLength(C, 3); C[0] := 0; C[1] := 1; C[2] := 0;
+  AssertTrue(Abs(CosineSim(A, B) - 1.0) < 0.0001, 'identical -> 1');
+  AssertTrue(Abs(CosineSim(A, C)) < 0.0001, 'orthogonal -> 0');
+  AssertTrue(Abs(CosineSim(A, nil)) < 0.0001, 'empty -> 0');
+
+  { Hex round-trips exactly. }
+  B := HexToEmb(EmbToHex(A));
+  AssertEqInt(Length(B), 3, 'hex round-trip length');
+  AssertTrue(Abs(CosineSim(A, B) - 1.0) < 0.0001, 'hex round-trip preserves vector');
+  AssertEqStr(EmbToHex(nil), '', 'empty embedding -> empty hex');
+end;
+
+procedure RunSemanticTests;
+const T2025 = 1751328000;
+var
+  Store: IFactStore;
+  DbPath: string;
+  Id1, Id2, Id3: Int64;
+  R: TStoredFactArray;
+begin
+  SetFactEmbedder(@FakeEmbed);
+  try
+    AssertTrue(FactEmbedderActive, 'embedder registered');
+
+    { --- semantic dedup: a paraphrase merges into the existing fact --- }
+    DbPath := JoinPath(GTmpDir, 'sem.db');
+    Store := NewFactStore;
+    AssertTrue(Store.Open(DbPath), 'open sem store');
+    Id1 := Store.Add(MkFact('User prefers Delphi over Lazarus', 'static', 'user', '', 0.9), T2025);
+    { Different exact text (exact-dedup misses) but same topic vector. }
+    Id2 := Store.Add(MkFact('Loves Delphi, avoids Lazarus', 'dynamic', 'user', '', 0.4), T2025 + 1);
+    AssertTrue(Id2 = Id1, 'semantic dedup merges paraphrase');
+    AssertEqInt(Store.CountAll, 1, 'paraphrase not inserted');
+    Id3 := Store.Add(MkFact('Drinks tea each morning', 'dynamic', 'user', '', 0.5), T2025 + 2);
+    AssertTrue(Id3 <> Id1, 'unrelated topic inserted');
+    AssertEqInt(Store.CountAll, 2, 'two distinct facts');
+    Store.Close;
+
+    { --- semantic search: query matches by topic with no word overlap --- }
+    Store := NewFactStore;
+    AssertTrue(Store.Open(DefaultFactsDbPath(GTmpDir)), 'open default store');
+    Store.Add(MkFact('User prefers Delphi over Lazarus', 'static', 'user', '', 0.9), T2025);
+    Store.Add(MkFact('Drinks tea each morning', 'dynamic', 'user', '', 0.5), T2025 + 1);
+    Store.Close;
+
+    R := SearchActiveFacts(GTmpDir, TODAY, 'pascal ide', 5);
+    AssertTrue(Length(R) >= 1, 'semantic search finds a topical fact');
+    AssertEqStr(R[0].Text, 'User prefers Delphi over Lazarus',
+                'semantic match despite zero keyword overlap');
+  finally
+    SetFactEmbedder(nil);
+  end;
+  AssertTrue(not FactEmbedderActive, 'embedder cleared');
+end;
+
 begin
   GTmpDir := JoinPath(GetTempDir, 'pasclaw-facts-test-' + IntToStr(Random(1 shl 30)));
   EnsureDir(GTmpDir);
@@ -226,6 +305,10 @@ begin
     WriteLn('  ok: format facts block (budget / breadcrumb / expiry)');
     RunRankTests;
     WriteLn('  ok: keyword rank facts (match / order / K cap)');
+    RunSemCoreTests;
+    WriteLn('  ok: cosine + embedding hex round-trip');
+    RunSemanticTests;
+    WriteLn('  ok: semantic dedup + hybrid search (fake embedder)');
     WriteLn('PASS');
   finally
     {$IFDEF UNIX}


### PR DESCRIPTION
Base = `main` (#371 is merged). Adds the **semantic tier** on top of the exact + keyword tiers: distilled memory now merges **paraphrases** (mem0-style), and `memory_search` recalls facts **by meaning**, not just shared words — the LoCoMo lever from your PDF.

## Design (deliberately lightweight)

- Facts get an **embedding stored as a hex TEXT column** — no `sqlite-vec` needed at fact scale; brute-force cosine in Pascal. (ANN only matters at 10k+ vectors; a fact store is dozens–hundreds.)
- The embedder is **injectable** (`TFactEmbedFn`), so the dedup/search logic is **fully unit-tested with a fake embedder** (no ONNX in CI). The heavy ONNX embedder lives in a separate gated unit.

## `PasClaw.Memory.Facts`
- `embedding` column (migration-safe `ALTER` for pre-4c stores).
- `CosineSim` + `EmbToHex`/`HexToEmb` (pure, exact, locale-safe).
- `Add()`: with an embedder wired, embed and — if cosine to an existing **active** fact ≥ 0.85 — merge into it (paraphrase dedup) instead of inserting; else store its embedding.
- `SearchActiveFacts()`: keyword rank **and** semantic (cosine) rank, **RRF-fused** = hybrid retrieval. Keyword-only when no embedder / empty query embedding.

## `PasClaw.Memory.Facts.Embed`
The real MiniLM/ONNX embedder (same path as the `.md` vector index): process-global, **critical-section-guarded** (embeds run from gateway workers + the background distill thread), latched, and **graceful** — returns False and leaves keyword/exact intact when artifacts are missing. Wired at gateway/CLI/TUI startup, gated on `memory_distill_enabled`.

## Gating
All behind `memory_distill_enabled` (default false). When the embedder isn't loaded (no ONNX / unprovisioned), behavior is exactly the Phase 4b exact+keyword tiers — **nothing regresses**.

## Tests
`CosineSim`, hex round-trip, **semantic paraphrase dedup**, and **hybrid search finding a topical fact with zero keyword overlap** — all via a deterministic fake embedder.

## ⚠️ Validation caveat
The **live ONNX path can't run in this sandbox** (no provisioned model). It compiles and is gated/graceful, but it wants a `pasclaw memory provision` + a quick smoke on a real host before you rely on the semantic layer. The tested fake-embedder path proves the logic; the real path is mechanical glue mirroring the existing `.md` vector index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_