### PR TITLE
gateway: Files browser lands on the PasClaw workspace, not the launch dir

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3150,9 +3150,20 @@ begin
        The sandbox "workspace" defaults to the process launch directory
        (GetCurrentDir) when none is configured, so an operator browsing
        Files in the web UI was landing on wherever the binary booted
-       instead of the agent's workspace. Only adopt it when it exists
-       and the policy actually permits reading it, else fall back to the
-       historical CurrentWorkspace / $PASCLAW_HOME behaviour. *)
+       instead of the agent's workspace.
+
+       Adopt it only when it exists AND the policy permits reading it:
+         - Default config (restrict_to_workspace=false): CanReadPath
+           short-circuits to True, so the browser lands on the workspace
+           -- the common Docker/web-only boot the user reported.
+         - restrict_to_workspace=true with no configured workspace
+           (GWorkspace defaulted to cwd): the agent workspace is OUTSIDE
+           the sandbox, so the probe fails and we fall back to
+           CurrentWorkspace. That is correct, not a regression -- a
+           listing of $PASCLAW_HOME/workspace would be refused by the
+           CanReadPath gate below anyway, so the allowed cwd is the only
+           directory that won't 403. Operators who want the workspace
+           browsable under restriction set sandbox.workspace explicitly. *)
     Path := JoinPath(GetHome, 'workspace');
     if not (DirectoryExists(Path) and CanReadPathHTTP(Path, Reason)) then
       Path := CurrentWorkspace;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3143,8 +3143,19 @@ begin
        (that's tools/fs_read), and an empty-path "give me
        something" request really does want the directory the
        sandbox WILL allow rather than one it's guaranteed to
-       refuse. *)
-    Path := CurrentWorkspace;
+       refuse.
+
+       Prefer the PasClaw workspace ($PASCLAW_HOME/workspace -- where
+       memory, skills and generated files live) over CurrentWorkspace.
+       The sandbox "workspace" defaults to the process launch directory
+       (GetCurrentDir) when none is configured, so an operator browsing
+       Files in the web UI was landing on wherever the binary booted
+       instead of the agent's workspace. Only adopt it when it exists
+       and the policy actually permits reading it, else fall back to the
+       historical CurrentWorkspace / $PASCLAW_HOME behaviour. *)
+    Path := JoinPath(GetHome, 'workspace');
+    if not (DirectoryExists(Path) and CanReadPathHTTP(Path, Reason)) then
+      Path := CurrentWorkspace;
     if Path = '' then Path := GetHome;
   end;
   { Route through the same sandbox CanReadPath check that fs_read


### PR DESCRIPTION
## What

The web UI **Files** tab (`GET /v1/fs` with no `path`) defaulted its landing directory to `CurrentWorkspace` — the *sandbox* workspace, which `ConfigureSandbox` sets to `GetCurrentDir` (the process launch directory) when no workspace is configured. So an operator browsing Files saw whatever directory the binary booted from instead of the agent's workspace (`memory/`, `skills/`, generated files). Especially confusing in a Docker / web-only deployment.

## Fix

Default to `$PASCLAW_HOME/workspace` when it exists **and** the sandbox policy permits reading it; otherwise fall back to the previous `CurrentWorkspace` / `$PASCLAW_HOME` behaviour so restricted setups are unaffected.

## Test

Launched the gateway from `/tmp` (so cwd ≠ workspace) with `PASCLAW_HOME` pointing elsewhere:

```
$ curl -s localhost:8089/v1/fs
{ "path": ".../pcfs/workspace", "entries": [ {skills}, {checkpoints}, {memory} ] }
```

Lands on the workspace, not `/tmp`. Build clean (FPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_