### PR TITLE
fix Delphi (dcc64) deprecation warnings: FileAge / TSearchRec.Time

### DIFF
--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -503,21 +503,23 @@ function LatestSessionId: string;
 var
   SR: TSearchRec;
   Best: string;
-  BestTime: LongInt;
+  BestTime, FT: TDateTime;
 begin
   Result := '';
   Best := '';
-  BestTime := -1;
+  BestTime := 0;
   if FindFirst(JoinPath(MemoryDir, '*.ndjson'), faAnyFile, SR) = 0 then
   try
     repeat
       if (SR.Attr and faDirectory) <> 0 then Continue;
-      { SR.Time is a packed file timestamp -- fine for "newest" ordering
-        and available under both FPC and Delphi (unlike .TimeStamp). }
-      if (Best = '') or (SR.Time > BestTime) then
+      { Use FileAge's TDateTime overload for "newest" ordering rather than
+        SR.Time -- the packed TSearchRec.Time field is deprecated under
+        Delphi, and the two-arg FileAge exists on both FPC and Delphi. }
+      if not FileAge(JoinPath(MemoryDir, SR.Name), FT) then Continue;
+      if (Best = '') or (FT > BestTime) then
       begin
         Best := SR.Name;
-        BestTime := SR.Time;
+        BestTime := FT;
       end;
     until FindNext(SR) <> 0;
   finally

--- a/src/cmd/PasClaw.Cmd.Plan.pas
+++ b/src/cmd/PasClaw.Cmd.Plan.pas
@@ -436,7 +436,7 @@ var
   Rc: Integer;
   HomeIsTemp, PlanExisted: Boolean;
   Bytes, FinalSize: Int64;
-  PreviousAge, FinalAge: Integer;
+  PreviousAge, FinalAge: TDateTime;
 begin
   Result := 1;
   InitArgs(A);
@@ -511,9 +511,12 @@ begin
       ExistingPlan := ReadExistingPlanBody;
       PlanPath := ResolvePlanPath;
       PlanExisted := FileExists(PlanPath);
+      { Two-arg FileAge (out TDateTime) -- the single-arg Integer overload
+        is deprecated under Delphi; this form is on both FPC and Delphi.
+        On failure PreviousAge stays 0. }
       PreviousAge := 0;
       if PlanExisted then
-        PreviousAge := FileAge(PlanPath);
+        FileAge(PlanPath, PreviousAge);
 
       Directive := BuildPlannerDirective(ExistingPlan);
 
@@ -550,7 +553,8 @@ begin
         Exit(1);
       end;
       FinalSize := FileSizeOf(PlanPath);
-      FinalAge  := FileAge(PlanPath);
+      FinalAge  := 0;
+      FileAge(PlanPath, FinalAge);
       if PlanExisted and (FinalAge = PreviousAge) then
       begin
         { FileAge unchanged -- the model didn't update PLAN.md.

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -704,7 +704,7 @@ const
   StaleHours = 24.0;
 var
   Path, Body, StaleNote: string;
-  AgeRaw: Integer;
+  FileTS: TDateTime;
   Hours: Double;
 begin
   Result := '';
@@ -729,20 +729,15 @@ begin
   if Body = '' then Exit;
 
   StaleNote := '';
-  AgeRaw := FileAge(Path);
-  if AgeRaw <> -1 then
+  { Two-arg FileAge (out TDateTime) -- the single-arg Integer overload is
+    deprecated under Delphi; this form exists on both FPC and Delphi and
+    skips the FileDateToDateTime conversion entirely. }
+  if FileAge(Path, FileTS) then
   begin
-    try
-      Hours := (Now - FileDateToDateTime(AgeRaw)) * 24.0;
-      if Hours > StaleHours then
-        StaleNote := Format(' (stale: %.0f hours old -- ' +
-                            'pass --no-plan to ignore PLAN.md)', [Hours]);
-    except
-      { FileDateToDateTime can raise on a corrupt time stamp on some
-        filesystems. Fall through with no stale note rather than
-        failing the whole section. }
-      StaleNote := '';
-    end;
+    Hours := (Now - FileTS) * 24.0;
+    if Hours > StaleHours then
+      StaleNote := Format(' (stale: %.0f hours old -- ' +
+                          'pass --no-plan to ignore PLAN.md)', [Hours]);
   end;
 
   Result :=


### PR DESCRIPTION
## What

Delphi's `dcc64` flags two deprecated symbols still in use:

- `FileAge(string): Integer` → **W1000** (deprecated)
- `TSearchRec.Time` (packed DOS timestamp field) → **W1000** + **W1002** (platform-specific)

This switches the remaining call sites to the non-deprecated **two-arg `FileAge(name; out TDateTime): Boolean`** overload, which exists on both FPC and Delphi.

## Sites fixed (from the reported warnings)

- `PasClaw.Cmd.Memory.pas:517,520` — `LatestSessionId` ordered `*.ndjson` by `SR.Time`; now uses `FileAge`.
- `PasClaw.Agent.Prompt.pas:732` — `BuildActivePlanSection` read PLAN.md mtime via single-arg `FileAge` + `FileDateToDateTime`; now reads a `TDateTime` directly (the conversion and its `try/except` are no longer needed).
- `PasClaw.Cmd.Plan.pas:516,553` — snapshots/compares PLAN.md mtime as `TDateTime`.

No behavior change. This matches the pattern already used in `PasClaw.Memory.Index` and `PasClaw.Agent.Steering` (which use `FileAge`/`TimeStamp` and document the same deprecations).

## Test

- FPC `make all` clean.
- `make test-memory-facts` / `test-memory-distill` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_