### PR TITLE
agent: clear "stopped at iteration limit" notice with how-to-continue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,12 @@ test-loop-shaping-defaults: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/loop_shaping_defaults_tests.pas -o$(BUILDDIR)/loop_shaping_defaults_tests
 	@$(BUILDDIR)/loop_shaping_defaults_tests
 
+# Max-iteration cutoff notice (FormatMaxIterNotice) surfaced in CLI/TUI/gateway.
+test-max-iter-notice: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/max_iter_notice_tests.pas -o$(BUILDDIR)/max_iter_notice_tests
+	@$(BUILDDIR)/max_iter_notice_tests
+
 # Plan / Build mode plumbing + dispatch gate (PR #290).
 test-plan-build-mode: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
@@ -772,4 +778,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -638,12 +638,14 @@ begin
         PrintLn(MaybeRender(Cfg, Loop.Content));
       { The tool loop stopped at the iteration cap mid-task -- tell the
         operator instead of letting the partial answer look complete. In
-        quiet mode route it to stderr so stdout stays machine-readable. }
+        quiet mode route it to stderr so stdout stays machine-readable.
+        One-shot history only carries over when --session is set, so the
+        "reply continue" hint is gated on that. }
       if Loop.HitMaxIterations then
         if A.Quiet then
-          PrintErr(FormatMaxIterNotice(Loop, A.MaxIterations, '--max-iterations N') + sLineBreak)
+          PrintErr(FormatMaxIterNotice(Loop, A.MaxIterations, '--max-iterations N', A.Session <> '') + sLineBreak)
         else
-          PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, A.MaxIterations, '--max-iterations N') + Ansi.Reset);
+          PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, A.MaxIterations, '--max-iterations N', A.Session <> '') + Ansi.Reset);
       { Self-improving skills: after the user-facing reply is printed,
         consider distilling this turn into a reusable skill. No-op
         unless the distiller is enabled and the turn was non-trivial. }
@@ -1663,7 +1665,7 @@ begin
           (the interactive history carries over to the next turn). }
         if Loop.HitMaxIterations then
           PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, A.MaxIterations,
-                  '--max-iterations N') + Ansi.Reset);
+                  '--max-iterations N', {Resumable=} True) + Ansi.Reset);
         if Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0 then
         begin
           { Surface aggregate usage across every provider call in the

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -636,6 +636,14 @@ begin
         PrintLn(Loop.Content)
       else
         PrintLn(MaybeRender(Cfg, Loop.Content));
+      { The tool loop stopped at the iteration cap mid-task -- tell the
+        operator instead of letting the partial answer look complete. In
+        quiet mode route it to stderr so stdout stays machine-readable. }
+      if Loop.HitMaxIterations then
+        if A.Quiet then
+          PrintErr(FormatMaxIterNotice(Loop, A.MaxIterations, '--max-iterations N') + sLineBreak)
+        else
+          PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, A.MaxIterations, '--max-iterations N') + Ansi.Reset);
       { Self-improving skills: after the user-facing reply is printed,
         consider distilling this turn into a reusable skill. No-op
         unless the distiller is enabled and the turn was non-trivial. }
@@ -1650,6 +1658,12 @@ begin
         else
           PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset + ' (' + Provider.GetName + '/' + Model + '):');
         PrintLn(MaybeRender(Cfg, Loop.Content));
+        { Stopped at the iteration cap mid-task -- surface it so the
+          operator knows the answer is partial and can just type "continue"
+          (the interactive history carries over to the next turn). }
+        if Loop.HitMaxIterations then
+          PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, A.MaxIterations,
+                  '--max-iterations N') + Ansi.Reset);
         if Loop.TotalUsage.InputTokens + Loop.TotalUsage.OutputTokens > 0 then
         begin
           { Surface aggregate usage across every provider call in the

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -5040,11 +5040,8 @@ begin
       begin
         Loop.Content := Trim(Loop.Content);
         if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
-        Loop.Content := Loop.Content + Format(
-          '(reached MaxIterations=%d while the model was still calling tools; '+
-          'last finish_reason=%s, %d pending tool call(s) -- raise the --max-iter '+
-          'cap on `pasclaw serve` or reduce the task scope.)',
-          [FMaxIter, FinishReason, Length(Loop.LastResp.ToolCalls)]);
+        Loop.Content := Loop.Content + FormatMaxIterNotice(Loop, FMaxIter,
+          '`--max-iter` on `pasclaw serve` or `max_iterations` in config');
         FinishReason := 'length';
         LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
                 [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
@@ -5130,11 +5127,8 @@ begin
     begin
       Loop.Content := Trim(Loop.Content);
       if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
-      Loop.Content := Loop.Content + Format(
-        '(reached MaxIterations=%d while the model was still calling tools; '+
-        'last finish_reason=%s, %d pending tool call(s) -- raise the --max-iter '+
-        'cap on `pasclaw serve` or reduce the task scope.)',
-        [FMaxIter, FinishReason, Length(Loop.LastResp.ToolCalls)]);
+      Loop.Content := Loop.Content + FormatMaxIterNotice(Loop, FMaxIter,
+        '`--max-iter` on `pasclaw serve` or `max_iterations` in config');
       FinishReason := 'length';
       LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
               [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
@@ -6759,11 +6753,8 @@ begin
       begin
         Loop.Content := Trim(Loop.Content);
         if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
-        Loop.Content := Loop.Content + Format(
-          '(reached MaxIterations=%d while the model was still calling tools; '+
-          'last finish_reason=%s, %d pending tool call(s) -- raise the --max-iter '+
-          'cap on `pasclaw serve` or reduce the task scope.)',
-          [FMaxIter, FinishReason, Length(Loop.LastResp.ToolCalls)]);
+        Loop.Content := Loop.Content + FormatMaxIterNotice(Loop, FMaxIter,
+          '`--max-iter` on `pasclaw serve` or `max_iterations` in config');
         FinishReason := 'length';
         LogWarn('responses: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
                 [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -5041,7 +5041,7 @@ begin
         Loop.Content := Trim(Loop.Content);
         if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
         Loop.Content := Loop.Content + FormatMaxIterNotice(Loop, FMaxIter,
-          '`--max-iter` on `pasclaw serve` or `max_iterations` in config');
+          '`--max-iter` on `pasclaw serve` or `max_iterations` in config', True);
         FinishReason := 'length';
         LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
                 [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
@@ -5128,7 +5128,7 @@ begin
       Loop.Content := Trim(Loop.Content);
       if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
       Loop.Content := Loop.Content + FormatMaxIterNotice(Loop, FMaxIter,
-        '`--max-iter` on `pasclaw serve` or `max_iterations` in config');
+        '`--max-iter` on `pasclaw serve` or `max_iterations` in config', True);
       FinishReason := 'length';
       LogWarn('chat/completions: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
               [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);
@@ -6754,7 +6754,7 @@ begin
         Loop.Content := Trim(Loop.Content);
         if Loop.Content <> '' then Loop.Content := Loop.Content + #10#10;
         Loop.Content := Loop.Content + FormatMaxIterNotice(Loop, FMaxIter,
-          '`--max-iter` on `pasclaw serve` or `max_iterations` in config');
+          '`--max-iter` on `pasclaw serve` or `max_iterations` in config', True);
         FinishReason := 'length';
         LogWarn('responses: tool loop hit MaxIterations=%d (%d pending tool call(s), %d content chars)',
                 [FMaxIter, Length(Loop.LastResp.ToolCalls), Length(Loop.Content)]);

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -176,11 +176,32 @@ type
        into Options.SystemPrompt are NOT in this list. *)
     FinalMessages:    TMessageArray;
     FinalSystemPrompt: string;
+    (* Set True when the loop stopped because it reached Cfg.MaxIterations
+       while the model still wanted to call tools -- i.e. the task is most
+       likely UNFINISHED, not a clean stop. Callers surface a "stopped at
+       the limit -- reply to continue" notice (FormatMaxIterNotice) instead
+       of presenting the partial output as a completed answer. *)
+    HitMaxIterations: Boolean;
+    (* Distinct tool names from the final (never-fed-back) model response
+       when HitMaxIterations -- the "what it was doing when it stopped"
+       detail for the notice. Empty otherwise. *)
+    PendingToolNames: TArray<string>;
   end;
 
 function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
+
+{ Build the operator-facing "stopped at the tool-iteration limit" notice
+  from a finished loop result, or '' when the loop did NOT hit the cap (so
+  callers can append it unconditionally). MaxIter is the configured cap;
+  HowToRaise is a surface-specific hint for lifting it (e.g.
+  '--max-iter on `pasclaw serve`', or '' to omit that clause). The notice
+  explains why it stopped, what it was mid-doing, and that replying
+  "continue" resumes -- the history carries over, so a follow-up turn picks
+  up where this one left off. }
+function FormatMaxIterNotice(const Loop: TToolLoopResult; MaxIter: Integer;
+                            const HowToRaise: string): string;
 
 type
   (* Late-bound hook so PasClaw.Tools.ToolLoop doesn't have to
@@ -583,6 +604,55 @@ begin
     end;
   end;
   FlushCur;
+end;
+
+function CollectToolNames(const Calls: array of TToolCall): TArray<string>;
+{ Distinct tool names in first-seen order. Small N (a single model turn's
+  tool calls), so a linear dedupe is fine. }
+var
+  i, j: Integer;
+  Nm: string;
+  Seen: Boolean;
+begin
+  SetLength(Result, 0);
+  for i := 0 to High(Calls) do
+  begin
+    Nm := Calls[i].Func.Name;
+    if Nm = '' then Continue;
+    Seen := False;
+    for j := 0 to High(Result) do
+      if Result[j] = Nm then begin Seen := True; Break; end;
+    if Seen then Continue;
+    SetLength(Result, Length(Result) + 1);
+    Result[High(Result)] := Nm;
+  end;
+end;
+
+function FormatMaxIterNotice(const Loop: TToolLoopResult; MaxIter: Integer;
+  const HowToRaise: string): string;
+var
+  Names: string;
+  i: Integer;
+begin
+  Result := '';
+  if not Loop.HitMaxIterations then Exit;
+  Names := '';
+  for i := 0 to High(Loop.PendingToolNames) do
+  begin
+    if Names <> '' then Names := Names + ', ';
+    Names := Names + Loop.PendingToolNames[i];
+  end;
+  Result := Format(
+    '[stopped: hit the tool-call limit of %d iteration(s) while still ' +
+    'working -- this task is probably unfinished]', [MaxIter]);
+  if Names <> '' then
+    Result := Result + sLineBreak +
+      'It was mid-way through: ' + Names + '.';
+  Result := Result + sLineBreak +
+    'Reply "continue" to resume from here (the conversation carries over)';
+  if HowToRaise <> '' then
+    Result := Result + ', or raise the limit (' + HowToRaise + ')';
+  Result := Result + '.';
 end;
 
 function RunToolLoop(const Cfg: TToolLoopConfig;
@@ -1248,11 +1318,17 @@ begin
     end;
   end;
 
-  { Max iterations exhausted; return whatever we last got. }
+  { Max iterations exhausted; return whatever we last got. The loop only
+    reaches here with Resp still carrying tool calls (a tool-less response
+    Exit(True)s above), so this is the "ran out of room mid-task" stop --
+    flag it and capture what it was doing so callers can offer a continue. }
   Loop.Content    := Resp.Content;
   Loop.Iterations := Iter;
   Loop.FinalMessages    := Hist;
   Loop.FinalSystemPrompt := LiveOptions.SystemPrompt;
+  Loop.HitMaxIterations := Length(Resp.ToolCalls) > 0;
+  if Loop.HitMaxIterations then
+    Loop.PendingToolNames := CollectToolNames(Resp.ToolCalls);
   Result := True;
   finally
     { Roll the final per-turn telemetry into the span before

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -196,12 +196,17 @@ function RunToolLoop(const Cfg: TToolLoopConfig;
   from a finished loop result, or '' when the loop did NOT hit the cap (so
   callers can append it unconditionally). MaxIter is the configured cap;
   HowToRaise is a surface-specific hint for lifting it (e.g.
-  '--max-iter on `pasclaw serve`', or '' to omit that clause). The notice
-  explains why it stopped, what it was mid-doing, and that replying
-  "continue" resumes -- the history carries over, so a follow-up turn picks
-  up where this one left off. }
+  '--max-iter on `pasclaw serve`', or '' to omit that clause).
+
+  Resumable says whether THIS caller carries conversation history forward:
+    True  (interactive CLI, session-backed TUI, gateway clients that resend
+          the message array) -> "reply continue to resume from here".
+    False (one-shot CLI without --session, the line-based TUI that rebuilds
+          the history from the current input each turn) -> there is nothing
+          to resume into, so the notice tells the user to raise the cap and
+          re-run instead of promising a continue that would start fresh. }
 function FormatMaxIterNotice(const Loop: TToolLoopResult; MaxIter: Integer;
-                            const HowToRaise: string): string;
+                            const HowToRaise: string; Resumable: Boolean): string;
 
 type
   (* Late-bound hook so PasClaw.Tools.ToolLoop doesn't have to
@@ -629,7 +634,7 @@ begin
 end;
 
 function FormatMaxIterNotice(const Loop: TToolLoopResult; MaxIter: Integer;
-  const HowToRaise: string): string;
+  const HowToRaise: string; Resumable: Boolean): string;
 var
   Names: string;
   i: Integer;
@@ -648,11 +653,26 @@ begin
   if Names <> '' then
     Result := Result + sLineBreak +
       'It was mid-way through: ' + Names + '.';
-  Result := Result + sLineBreak +
-    'Reply "continue" to resume from here (the conversation carries over)';
-  if HowToRaise <> '' then
-    Result := Result + ', or raise the limit (' + HowToRaise + ')';
-  Result := Result + '.';
+  if Resumable then
+  begin
+    { History carries over -- a follow-up turn resumes from here. }
+    Result := Result + sLineBreak +
+      'Reply "continue" to resume from here (the conversation carries over)';
+    if HowToRaise <> '' then
+      Result := Result + ', or raise the limit (' + HowToRaise + ')';
+    Result := Result + '.';
+  end
+  else
+  begin
+    { Stateless caller: there is nothing to "continue" into -- a fresh
+      request would start over without the tool history -- so point the
+      user at raising the cap and re-running. }
+    Result := Result + sLineBreak + 'This turn does not carry over -- ';
+    if HowToRaise <> '' then
+      Result := Result + 'raise the limit (' + HowToRaise + ') and re-run to finish.'
+    else
+      Result := Result + 'raise the iteration limit and re-run to finish.';
+  end;
 end;
 
 function RunToolLoop(const Cfg: TToolLoopConfig;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1374,7 +1374,8 @@ begin
     if Trim(DisplayContent) <> '' then
       DisplayContent := DisplayContent + sLineBreak + sLineBreak;
     DisplayContent := DisplayContent +
-      FormatMaxIterNotice(Loop, Loop.Iterations, 'max_iterations in config');
+      FormatMaxIterNotice(Loop, Loop.Iterations, 'max_iterations in config',
+                          {Resumable=} True);   { session-backed -- history persists }
   end;
   if (CurrentSession <> nil) and (CurrentSession.Meta.Id = SessionId) then
   begin
@@ -2854,8 +2855,10 @@ begin
   else
     PrintLn(Loop.Content);
   if Loop.HitMaxIterations then
+    { This line-based path rebuilds the history from the current input each
+      turn -- nothing to "continue" into, so Resumable=False. }
     PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, Loop.Iterations,
-            'max_iterations in config') + Ansi.Reset);
+            'max_iterations in config', {Resumable=} False) + Ansi.Reset);
   if Loop.LastResp.Usage.InputTokens + Loop.LastResp.Usage.OutputTokens > 0 then
     PrintLn(Ansi.Dim + '         ' +
       Format('[tokens in=%d out=%d, iters=%d]',

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1362,7 +1362,20 @@ var
   i: Integer;
   OwnsTarget: Boolean;
   Cfg: TConfig;
+  DisplayContent: string;
 begin
+  { Fold the max-iteration notice into the assistant turn so the operator
+    sees the turn stopped mid-task (and can type "continue"). Kept in the
+    content -- as the gateway does -- so the carried-over history records
+    that this turn was cut off. }
+  DisplayContent := Loop.Content;
+  if Loop.HitMaxIterations then
+  begin
+    if Trim(DisplayContent) <> '' then
+      DisplayContent := DisplayContent + sLineBreak + sLineBreak;
+    DisplayContent := DisplayContent +
+      FormatMaxIterNotice(Loop, Loop.Iterations, 'max_iterations in config');
+  end;
   if (CurrentSession <> nil) and (CurrentSession.Meta.Id = SessionId) then
   begin
     Target := CurrentSession;
@@ -1380,13 +1393,13 @@ begin
       for i := 0 to High(Loop.FinalMessages) do
         Target.Messages[i] := Loop.FinalMessages[i];
       Target.Messages[High(Target.Messages)] :=
-        MakeMessage(mrAssistant, Loop.Content);
+        MakeMessage(mrAssistant, DisplayContent);
     end
     else
     begin
       SetLength(Target.Messages, Length(Target.Messages) + 1);
       Target.Messages[High(Target.Messages)] :=
-        MakeMessage(mrAssistant, Loop.Content);
+        MakeMessage(mrAssistant, DisplayContent);
     end;
     { Working-state snapshot: refresh from this loop's final message
       history (edits / shell commands / errors) so the next turn can
@@ -2840,6 +2853,9 @@ begin
     PrintLn(RenderMarkdown(Loop.Content))
   else
     PrintLn(Loop.Content);
+  if Loop.HitMaxIterations then
+    PrintLn(Ansi.Yellow + FormatMaxIterNotice(Loop, Loop.Iterations,
+            'max_iterations in config') + Ansi.Reset);
   if Loop.LastResp.Usage.InputTokens + Loop.LastResp.Usage.OutputTokens > 0 then
     PrintLn(Ansi.Dim + '         ' +
       Format('[tokens in=%d out=%d, iters=%d]',

--- a/src/tests/max_iter_notice_tests.pas
+++ b/src/tests/max_iter_notice_tests.pas
@@ -30,7 +30,7 @@ begin
     it unconditionally. }
   Loop := Default(TToolLoopResult);
   Loop.HitMaxIterations := False;
-  AssertTrue(FormatMaxIterNotice(Loop, 25, '--max-iter') = '',
+  AssertTrue(FormatMaxIterNotice(Loop, 25, '--max-iter', True) = '',
     'no notice on a clean stop');
 
   { Hit the cap mid-task with two distinct pending tools. }
@@ -41,21 +41,32 @@ begin
   Loop.PendingToolNames[0] := 'fs_write';
   Loop.PendingToolNames[1] := 'shell_exec';
 
-  S := FormatMaxIterNotice(Loop, 25, '`--max-iter` on `pasclaw serve`');
+  { Resumable caller -> "reply continue". }
+  S := FormatMaxIterNotice(Loop, 25, '`--max-iter` on `pasclaw serve`', True);
   AssertTrue(S <> '', 'notice emitted when the cap was hit');
   AssertTrue(Has(S, '25'), 'notice states the iteration count');
   AssertTrue(Has(S, 'unfinished'), 'notice says the task is probably unfinished');
   AssertTrue(Has(S, 'fs_write') and Has(S, 'shell_exec'),
     'notice lists what it was mid-doing');
-  AssertTrue(Has(S, 'continue'), 'notice tells the user to reply continue');
+  AssertTrue(Has(S, 'continue'), 'resumable notice tells the user to reply continue');
   AssertTrue(Has(S, '--max-iter'), 'notice includes the how-to-raise hint');
 
   { Empty how-to-raise hint -> the "or raise the limit" clause is omitted. }
-  S := FormatMaxIterNotice(Loop, 25, '');
+  S := FormatMaxIterNotice(Loop, 25, '', True);
   AssertTrue(Has(S, 'continue'), 'continue hint still present without raise clause');
   AssertTrue(not Has(S, 'raise the limit'),
     'raise-the-limit clause omitted when hint is empty');
 
-  WriteLn('  ok: format max-iter notice (empty / fields / optional raise clause)');
+  { Stateless caller -> NO false "continue" promise; tells the user to
+    raise the cap and re-run instead (the P2 review fix). }
+  S := FormatMaxIterNotice(Loop, 25, '--max-iterations N', False);
+  AssertTrue(Has(S, 'does not carry over'),
+    'stateless notice says the turn does not carry over');
+  AssertTrue(Has(S, 're-run'), 'stateless notice tells the user to re-run');
+  AssertTrue(not Has(S, 'reply "continue"') and not Has(S, 'resume from here'),
+    'stateless notice does NOT promise a continue that would start fresh');
+  AssertTrue(Has(S, '--max-iterations N'), 'stateless notice keeps the how-to-raise hint');
+
+  WriteLn('  ok: format max-iter notice (clean / fields / resumable vs stateless)');
   WriteLn('PASS');
 end.

--- a/src/tests/max_iter_notice_tests.pas
+++ b/src/tests/max_iter_notice_tests.pas
@@ -1,0 +1,61 @@
+program max_iter_notice_tests;
+(*
+  Covers FormatMaxIterNotice -- the operator-facing "stopped at the
+  tool-iteration limit" message surfaced by the gateway, CLI and TUI when
+  RunToolLoop runs out of iterations mid-task.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Tools.ToolLoop;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+function Has(const Hay, Needle: string): Boolean;
+begin Result := Pos(Needle, Hay) > 0; end;
+
+var
+  Loop: TToolLoopResult;
+  S: string;
+begin
+  { Clean stop (did not hit the cap) -> empty notice, so callers can append
+    it unconditionally. }
+  Loop := Default(TToolLoopResult);
+  Loop.HitMaxIterations := False;
+  AssertTrue(FormatMaxIterNotice(Loop, 25, '--max-iter') = '',
+    'no notice on a clean stop');
+
+  { Hit the cap mid-task with two distinct pending tools. }
+  Loop := Default(TToolLoopResult);
+  Loop.HitMaxIterations := True;
+  Loop.Iterations := 25;
+  SetLength(Loop.PendingToolNames, 2);
+  Loop.PendingToolNames[0] := 'fs_write';
+  Loop.PendingToolNames[1] := 'shell_exec';
+
+  S := FormatMaxIterNotice(Loop, 25, '`--max-iter` on `pasclaw serve`');
+  AssertTrue(S <> '', 'notice emitted when the cap was hit');
+  AssertTrue(Has(S, '25'), 'notice states the iteration count');
+  AssertTrue(Has(S, 'unfinished'), 'notice says the task is probably unfinished');
+  AssertTrue(Has(S, 'fs_write') and Has(S, 'shell_exec'),
+    'notice lists what it was mid-doing');
+  AssertTrue(Has(S, 'continue'), 'notice tells the user to reply continue');
+  AssertTrue(Has(S, '--max-iter'), 'notice includes the how-to-raise hint');
+
+  { Empty how-to-raise hint -> the "or raise the limit" clause is omitted. }
+  S := FormatMaxIterNotice(Loop, 25, '');
+  AssertTrue(Has(S, 'continue'), 'continue hint still present without raise clause');
+  AssertTrue(not Has(S, 'raise the limit'),
+    'raise-the-limit clause omitted when hint is empty');
+
+  WriteLn('  ok: format max-iter notice (empty / fields / optional raise clause)');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## What

When the tool loop hits `MaxIterations` mid-task, it used to stop **silently** in the CLI/TUI (the partial answer looked complete), and the gateway emitted a terse `(reached MaxIterations=… raise the --max-iter cap)` line. This replaces that with a single shared, operator-friendly notice that says **what it was doing, why it stopped, and how to continue**:

```
[stopped: hit the tool-call limit of 25 iteration(s) while still working -- this task is probably unfinished]
It was mid-way through: fs_write, shell_exec.
Reply "continue" to resume from here (the conversation carries over), or raise the limit (`--max-iter` on `pasclaw serve` or `max_iterations` in config).
```

## How

- **ToolLoop** — `TToolLoopResult` gains `HitMaxIterations` + `PendingToolNames` (the final, never-fed-back tool calls = "what it was mid-doing"), set at the max-iter exit. New `FormatMaxIterNotice` builds the message and returns `''` on a clean stop, so callers can append it unconditionally.
- **Gateway** — all three endpoints (chat streaming, chat non-streaming, responses) use the shared notice; still sets `finish_reason=length`.
- **CLI** — one-shot prints it after the reply (to **stderr** under `--quiet` so stdout stays machine-readable); interactive prints it too.
- **TUI** — folds the notice into the assistant turn (interactive + one-shot), matching the gateway so the carried-over history records the cutoff and the user can just type "continue".

"Continue" works because the history carries over: the next turn resumes from where this one stopped.

## Test

- New `make test-max-iter-notice`: empty/clean-stop returns `''`, the notice includes the iteration count + tool names + continue hint, and the how-to-raise clause is omitted when no hint is given.
- FPC `make all` clean; `test-loop-shaping-defaults` / `test-plan-build-mode` green.

## Note

The web chat already shows the gateway's notice text (it's in the message content), so the "reply continue" guidance reaches web users too. A dedicated **Continue button** in the web UI would be a nice follow-up — happy to add it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_