### PR TITLE
agent: orient announces a plan before diving in (opt-in transparency)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -577,6 +577,12 @@ test-orient: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/orient_tests.pas -o$(BUILDDIR)/orient_tests
 	@$(BUILDDIR)/orient_tests
 
+# Orient launch-preamble section (opt-in "announce a plan before tools").
+test-orient-preamble: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/orient_preamble_tests.pas -o$(BUILDDIR)/orient_preamble_tests
+	@$(BUILDDIR)/orient_preamble_tests
+
 # Reversible condensation (CCR): when JSON/shell condensers shrink output,
 # stash the original under a tool_output_get handle. PasClaw.Tools.OutputCache.
 test-condense-reversible: | $(BUILDDIR)
@@ -778,4 +784,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -150,6 +150,17 @@ function FindProjectAgentsMd(const StartDir: string): string;
   guidance. }
 function BuildProjectRulesSection: string;
 
+{ Orient launch-preamble section. When Cfg.OrientTaskAware is on, returns an
+  instruction telling the model to open a task with a brief plan BEFORE it
+  starts calling tools, so the operator sees what it's about to do instead
+  of it silently diving in -- the transparency half of the orient feature
+  (the other half being task-aware MEMORY slicing in BuildMemorySection).
+  Returns '' when orient is off (the default), in plan mode (the planner
+  already produces a plan), or without tools (nothing to preface). Exposed
+  for tests. }
+function BuildOrientPreambleSection(Cfg: TConfig; ToolsEnabled: Boolean;
+                                    Mode: TPasClawMode): string;
+
 { True iff at least one message in the array is mrSystem. The gateway's
   /v1/chat/completions handler uses this to decide whether to inject the
   composed system prompt -- third-party clients that supply their own
@@ -797,6 +808,23 @@ begin
     'UI) when ready to apply the plan.';
 end;
 
+function BuildOrientPreambleSection(Cfg: TConfig; ToolsEnabled: Boolean;
+                                    Mode: TPasClawMode): string;
+begin
+  Result := '';
+  if (Cfg = nil) or (not Cfg.OrientTaskAware) then Exit;
+  { Plan mode already produces a plan as its deliverable; a tool-less run
+    has no "diving into work" to preface. }
+  if (Mode = pmPlan) or (not ToolsEnabled) then Exit;
+  Result :=
+    '## Before you start' + sLineBreak +
+    'Open each task with a brief plan -- 1-3 lines on what you understand ' +
+    'the goal to be and the steps you''ll take -- BEFORE calling any tools, ' +
+    'then carry it out. Keep it short: it''s a heads-up for the operator so ' +
+    'they can see your intent, not a document, and not a request for ' +
+    'approval. Skip it for a trivial one-step reply.';
+end;
+
 function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
                            ToolsEnabled: Boolean; const TaskHint: string;
                            Mode: TPasClawMode;
@@ -837,6 +865,10 @@ begin
     section never adds whitespace to the prompt unnecessarily. }
   if ToolsEnabled then
     Result := AppendSection(Result, BuildDeferredToolsSection);
+  { Orient transparency preamble (opt-in via Cfg.OrientTaskAware): ask the
+    model to announce a short plan before it starts using tools. Grouped
+    with the behaviour rules below. }
+  Result := AppendSection(Result, BuildOrientPreambleSection(Cfg, ToolsEnabled, Mode));
   Result := AppendSection(Result, BuildRulesSection(ToolsEnabled));
   if Trim(UserSys) <> '' then
     Result := AppendSection(Result, Trim(UserSys));

--- a/src/tests/orient_preamble_tests.pas
+++ b/src/tests/orient_preamble_tests.pas
@@ -1,0 +1,70 @@
+program orient_preamble_tests;
+(*
+  Covers BuildOrientPreambleSection -- the opt-in "announce a short plan
+  before using tools" instruction that the orient feature adds to the
+  system prompt so the agent doesn't silently dive into work.
+
+  Contracts pinned:
+    - Off by default (orient off) and for a nil config -> ''
+    - On (Cfg.OrientTaskAware) + build mode + tools -> the instruction
+    - Suppressed in plan mode (the planner already produces a plan)
+    - Suppressed without tools (nothing to preface)
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Agent.Mode,
+  PasClaw.Agent.Prompt;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+function Has(const Hay, Needle: string): Boolean;
+begin Result := Pos(Needle, Hay) > 0; end;
+
+var
+  Cfg: TConfig;
+  S: string;
+begin
+  { nil config -> empty (no crash). }
+  AssertTrue(BuildOrientPreambleSection(nil, True, pmBuild) = '',
+    'nil config -> empty');
+
+  Cfg := TConfig.Create;
+  try
+    { Orient off (the default) -> empty regardless of mode/tools. }
+    Cfg.OrientTaskAware := False;
+    AssertTrue(BuildOrientPreambleSection(Cfg, True, pmBuild) = '',
+      'orient off -> empty');
+
+    { Orient on, build mode, tools -> the instruction is emitted. }
+    Cfg.OrientTaskAware := True;
+    S := BuildOrientPreambleSection(Cfg, True, pmBuild);
+    AssertTrue(S <> '', 'orient on + build + tools -> non-empty');
+    AssertTrue(Has(S, 'Before you start'), 'has the heading');
+    AssertTrue(Has(S, 'plan'), 'mentions a plan');
+    AssertTrue(Has(S, 'before calling any tools') or Has(S, 'BEFORE calling any tools'),
+      'tells the model to plan before tools');
+
+    { Plan mode already produces a plan -> suppressed. }
+    AssertTrue(BuildOrientPreambleSection(Cfg, True, pmPlan) = '',
+      'plan mode -> empty (planner already plans)');
+
+    { No tools -> nothing to preface. }
+    AssertTrue(BuildOrientPreambleSection(Cfg, False, pmBuild) = '',
+      'no tools -> empty');
+  finally
+    Cfg.Free;
+  end;
+
+  WriteLn('  ok: orient preamble (off/on, plan-mode + no-tools suppression)');
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## Why

Orient is off everywhere because, although it usefully slices task-relevant MEMORY into the prompt, the agent then "just launched into the work" with no visible intent — the operator couldn't tell what it was about to do. This adds the missing **transparency half** so orient becomes usable again.

## What

When orient is on, the system prompt now asks the model to **open each task with a brief (1–3 line) plan before it starts calling tools**, then proceed — a heads-up for the operator, *not* an approval gate.

- New `BuildOrientPreambleSection(Cfg, ToolsEnabled, Mode)`, gated on `Cfg.OrientTaskAware`.
- Returns `''` when:
  - orient is **off** (the default — so **no behaviour change for any existing install or profile**),
  - **plan mode** (the planner already produces a plan), or
  - **no tools** (nothing to preface).
- Wired into `BuildSystemPrompt` alongside the behaviour rules.
- **Couples to the existing orient flag** (per the chosen design): turning orient on now gives both the MEMORY slicing *and* the launch preamble.

## Scope / safety

Purely additive and opt-in — it only changes what happens when someone sets `orient_task_aware: true`. It doesn't touch the tool loop, providers, gateway, or any default code path; it's a system-prompt section like the others.

## Test

- New `make test-orient-preamble`: off/nil-config → empty; on + build + tools → the instruction; plan-mode and no-tools → suppressed.
- FPC `make all` clean; `test-orient` and `test-plan-build-mode` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_