### PR TITLE
gateway: honor the component's in-memory config for tools (server half)

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -1080,6 +1080,12 @@ begin
   FServer := TGatewayServer.Create(FConfig, FProvider, FRegistry);
   FServer.DebugIO := FDebug;
   FServer.MaxIter := FMaxIter;
+  { Code-driven embed: thread this server's in-memory config into each
+    request's tool loop so config-driven tools (web_search/send_message/
+    memory/kb) honour it instead of LoadConfig-ing from disk -- the server
+    half of the no-disk story. Safe alongside a live TPasClawAgent because the
+    override is thread-scoped per dispatch (see DispatchOneToolCall). }
+  FServer.ToolsHonorInMemoryConfig := True;
 
   FLastError := '';
   FThread := TServerWorker.Create(FServer, FBindAddr, FPort);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -73,6 +73,12 @@ type
     FCfg:      TConfig;
     FProvider: ILLMProvider;
     FRegistry: TToolRegistry;
+    { When True, each request's tool loop carries FCfg as ActiveConfig so
+      config-driven tools (web_search/send_message/memory/kb) honour this
+      gateway's in-memory config instead of LoadConfig-ing from disk. Set by
+      the TPasClawServer component (code-driven / no-disk embed); left False
+      for `pasclaw serve` / `pasclaw gateway`, which keep the disk hot-reload. }
+    FToolsHonorInMemoryConfig: Boolean;
     FStarted:  Boolean;
     FStopFlag: TEvent;
     FDebugIO:  Boolean;
@@ -355,6 +361,12 @@ type
       and the response body via LogDebug. Off by default; the `serve`
       subcommand flips it on with --debug. }
     property DebugIO: Boolean read FDebugIO write FDebugIO;
+    { Opt-in: thread this gateway's in-memory FCfg into each request's tool
+      loop so config-driven tools honour it instead of LoadConfig-ing from
+      disk. The TPasClawServer component sets this True for a code-driven /
+      no-disk embed; bare `serve` leaves it False to keep disk hot-reload. }
+    property ToolsHonorInMemoryConfig: Boolean
+      read FToolsHonorInMemoryConfig write FToolsHonorInMemoryConfig;
     { Cap on tool-loop iterations for /v1/chat/completions. Defaults to 25
       to match what typical code agents need for read-debug-edit cycles;
       legacy /v1/chat keeps its 8-iteration cap unchanged. }
@@ -4290,6 +4302,7 @@ begin
   Msgs[0] := MakeMessage(mrUser, Prompt);
 
   LoopCfg.Registry      := FRegistry;
+  if FToolsHonorInMemoryConfig then LoopCfg.ActiveConfig := FCfg;
   LoopCfg.Model         := DefModel;
   LoopCfg.MaxIterations := 8;
   LoopCfg.Parallel := True;
@@ -4946,6 +4959,7 @@ begin
     end;
 
     LoopCfg.Registry      := FRegistry;
+    if FToolsHonorInMemoryConfig then LoopCfg.ActiveConfig := FCfg;
     LoopCfg.Model         := ReqModel;
     LoopCfg.MaxIterations := FMaxIter;
     LoopCfg.Parallel := True;
@@ -6700,6 +6714,7 @@ begin
         string) working as before. }
       LoopCfg.Provider      := Prim;
       LoopCfg.Registry      := FRegistry;
+      if FToolsHonorInMemoryConfig then LoopCfg.ActiveConfig := FCfg;
       LoopCfg.Model         := ReqModel;
       LoopCfg.MaxIterations := FMaxIter;
       LoopCfg.Parallel := True;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1052,7 +1052,18 @@ begin
     Exit;
   end;
 
-  RespLine := Core.HandleRequest(Body);
+  { The MCP core dispatches tools/call straight through FRegistry.RunTool --
+    it does NOT go through the agent loop's DispatchOneToolCall, so publish
+    the active config on this request thread here too, otherwise an external
+    /mcp caller's config-driven tools (memory_search/kb_search/web_search)
+    would LoadConfig from disk even for a no-disk embed. Thread-scoped +
+    cleared in finally, same contract as DispatchOneToolCall. }
+  if FToolsHonorInMemoryConfig then SetActiveConfig(FCfg);
+  try
+    RespLine := Core.HandleRequest(Body);
+  finally
+    if FToolsHonorInMemoryConfig then SetActiveConfig(nil);
+  end;
   if RespLine = '' then
   begin
     { Notification path -- spec says no body. 204 No Content. }


### PR DESCRIPTION
## Why

Completes the no-disk code-config story. #388 made `TPasClawAgent`'s tools honor its in-memory `Config`, but **reverted `TPasClawServer`** to disk-config (its tools `LoadConfig`-ed each call) to avoid the cross-component stomp. Now that the override is **thread-scoped per dispatch** (not a process global), re-enabling the server half is safe — so this wires it back in.

## How

- `TGatewayServer` gains **`ToolsHonorInMemoryConfig`** (default `False`). When `True`, each request threads `FCfg` into the request's tool loop as `TToolLoopConfig.ActiveConfig`, so config-driven tools (`web_search`, `send_message`, `memory`, `kb`) honor the gateway's in-memory config via `LoadEffectiveConfig` instead of `LoadConfig`-ing from disk. (Set at all three request-loop sites: `/v1/chat`, `/v1/chat/completions`, `/v1/responses`.)
- `TPasClawServer.Start` sets it `True` → the no-disk / code-driven **server** embed now reaches its tools, matching `TPasClawAgent`.
- **`pasclaw serve` / `pasclaw gateway` leave it `False`** → their tools keep the disk `config.json` hot-reload exactly as before.

Safe alongside a live `TPasClawAgent`: the override is per-request and thread-scoped in `DispatchOneToolCall`, never a shared global, so concurrent agent + server loops can't read each other's config.

## Stacking ⚠️

This **builds on #388** (it uses the `TToolLoopConfig.ActiveConfig` / `LoadEffectiveConfig` infra added there). Merge **#388 first**; until then this PR's diff also shows #388's commits, and it reduces to just the gateway/component change once #388 lands. Happy to retarget the base to #388's branch if you'd prefer a clean isolated diff now.

## Test

`make all` clean; `component-config`, `plan-build-mode`, `gateway-token`, `session-endpoints` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_