### PR TITLE
gateway: OpenAI-compatible /v1/embeddings over the local ONNX model

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -345,6 +345,11 @@ type
                               out AWasStreamingRequest: Boolean;
                               out AResponseStarted: Boolean);
     procedure HandleModels(AResp: TIdHTTPResponseInfo);
+    { POST /v1/embeddings -- OpenAI-compatible embeddings computed with
+      PasClaw's local ONNX model (no outbound call; vectors never leave the
+      host). 503 when the model isn't provisioned. }
+    procedure HandleEmbeddings(ARequest: TIdHTTPRequestInfo;
+                               AResp: TIdHTTPResponseInfo);
     { GET /v1/providers/catalog -- the static provider catalog (names, default
       base/model, auth requirement) so the web onboarding wizard can offer a
       provider picker without hardcoding the list client-side. No secrets. }
@@ -1208,6 +1213,7 @@ begin
     else if (ARequest.Command = 'POST') and ((Doc = '/mcp') or (Doc = '/v1/mcp/rpc')) then
       HandleMCPRequest(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/models')  then HandleModels(AResponse)
+    else if (ARequest.Command = 'POST') and (Doc = '/v1/embeddings') then HandleEmbeddings(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/providers/catalog') then HandleProvidersCatalog(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/mcp')     then HandleMCPList(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/cron')    then HandleCronList(AResponse)
@@ -1271,7 +1277,7 @@ begin
     end
     else if Doc = '/v1' then
       WriteJSON(AResponse, 200,
-        '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat","/v1/chat/completions","/v1/responses","/v1/models"]}')
+        '{"name":"pasclaw","routes":["/v1/health","/v1/version","/v1/status","/v1/tools","/v1/chat","/v1/chat/completions","/v1/responses","/v1/models","/v1/embeddings"]}')
     else if not DispatchWebhook(AContext, ARequest, AResponse) then
       WriteJSON(AResponse, 404, '{"error":"not found","path":"' + Doc + '"}');
   except
@@ -6818,6 +6824,161 @@ begin
       finally
         ReplyObj.Free;
       end;
+    end;
+  finally
+    Req.Free;
+  end;
+end;
+
+procedure TGatewayServer.HandleEmbeddings(ARequest: TIdHTTPRequestInfo;
+                                          AResp: TIdHTTPResponseInfo);
+{ OpenAI-compatible embeddings over PasClaw's local ONNX model. Accepts the
+  standard body fields input (string or array of strings), optional model,
+  and optional encoding_format, and returns the usual object:list / data /
+  model / usage shape. encoding_format "float" (default) emits a JSON number
+  array; "base64" emits base64 of the float32 little-endian bytes (what the
+  OpenAI Python SDK asks for). No outbound call -- vectors are computed
+  on-host and never leave. }
+var
+  Body, EncFmt, ReqModel, ModelId, OneInput, VecJson: string;
+  Req, Root, Item, Usage: TJsonObject;
+  InArr, DataArr: TJsonArray;
+  Inputs: array of string;
+  Vec: TArray<Single>;
+  Dim, i, j, ApproxTokens: Integer;
+  AsBase64: Boolean;
+  Bytes: TBytes;
+  Fmt: TFormatSettings;
+begin
+  Body := ReadRequestBody(ARequest);
+  if Trim(Body) = '' then
+  begin
+    WriteJSON(AResp, 400,
+      '{"error":{"message":"empty body","type":"invalid_request_error"}}');
+    Exit;
+  end;
+
+  Req := nil;
+  try
+    try
+      Req := TJsonObject.Parse(Body);
+    except
+      on E: Exception do
+      begin
+        WriteJSON(AResp, 400,
+          '{"error":{"message":"invalid JSON","type":"invalid_request_error"}}');
+        Exit;
+      end;
+    end;
+
+    { input: a single string OR an array of strings. }
+    SetLength(Inputs, 0);
+    InArr := Req.ChildArray('input');
+    if InArr <> nil then
+    begin
+      for i := 0 to InArr.Count - 1 do
+      begin
+        OneInput := InArr.ItemStr(i, '');
+        if OneInput <> '' then
+        begin
+          SetLength(Inputs, Length(Inputs) + 1);
+          Inputs[High(Inputs)] := OneInput;
+        end;
+      end;
+    end
+    else
+    begin
+      OneInput := Req.GetStr('input', '');
+      if OneInput <> '' then
+      begin
+        SetLength(Inputs, 1);
+        Inputs[0] := OneInput;
+      end;
+    end;
+
+    if Length(Inputs) = 0 then
+    begin
+      WriteJSON(AResp, 400,
+        '{"error":{"message":"input is required (a string or array of strings)",' +
+        '"type":"invalid_request_error"}}');
+      Exit;
+    end;
+
+    if not LocalEmbedAvailable(GetHome) then
+    begin
+      WriteJSON(AResp, 503,
+        '{"error":{"message":"local embeddings not provisioned -- run ' +
+        '`pasclaw memory provision` to download the ONNX model",' +
+        '"type":"server_error"}}');
+      Exit;
+    end;
+
+    LocalEmbedModelInfo(GetHome, ModelId, Dim);
+    EncFmt   := Req.GetStr('encoding_format', 'float');
+    AsBase64 := SameText(EncFmt, 'base64');
+    ReqModel := Req.GetStr('model', '');
+
+    { JSON numbers must use '.' regardless of host locale; 7 significant
+      digits matches the float32 the model actually produces. }
+    Fmt := DefaultFormatSettings;
+    Fmt.DecimalSeparator  := '.';
+    Fmt.ThousandSeparator := #0;
+
+    ApproxTokens := 0;
+    DataArr := TJsonArray.Create;
+    try
+      for i := 0 to High(Inputs) do
+      begin
+        if not LocalEmbed(GetHome, Inputs[i], Vec) then
+        begin
+          WriteJSON(AResp, 500,
+            '{"error":{"message":"embedding failed","type":"server_error"}}');
+          Exit;
+        end;
+        Item := TJsonObject.Create;
+        Item.PutStr('object', 'embedding');
+        Item.PutInt('index', i);
+        if AsBase64 then
+        begin
+          SetLength(Bytes, Length(Vec) * SizeOf(Single));
+          if Length(Vec) > 0 then Move(Vec[0], Bytes[0], Length(Bytes));
+          Item.PutStr('embedding', BytesToBase64(Bytes));
+        end
+        else
+        begin
+          VecJson := '[';
+          for j := 0 to High(Vec) do
+          begin
+            if j > 0 then VecJson := VecJson + ',';
+            VecJson := VecJson + FloatToStrF(Vec[j], ffGeneral, 7, 0, Fmt);
+          end;
+          VecJson := VecJson + ']';
+          Item.PutRaw('embedding', VecJson);
+        end;
+        DataArr.AddObject(Item);   { takes ownership; Item := nil }
+        { Rough token estimate -- the endpoint doesn't expose the tokenizer's
+          count and most clients ignore embedding usage. }
+        Inc(ApproxTokens, (Length(Inputs[i]) + 3) div 4);
+      end;
+
+      Root := TJsonObject.Create;
+      try
+        Root.PutStr('object', 'list');
+        Root.PutArray('data', DataArr);   { takes ownership; DataArr := nil }
+        if ReqModel <> '' then
+          Root.PutStr('model', ReqModel)   { echo the requested model id }
+        else
+          Root.PutStr('model', 'pasclaw-local-' + ModelId);
+        Usage := TJsonObject.Create;
+        Usage.PutInt('prompt_tokens', ApproxTokens);
+        Usage.PutInt('total_tokens',  ApproxTokens);
+        Root.PutObject('usage', Usage);
+        WriteJSON(AResp, 200, Root.ToJSON);
+      finally
+        Root.Free;
+      end;
+    finally
+      DataArr.Free;   { nil after PutArray's ownership transfer -- safe }
     end;
   finally
     Req.Free;

--- a/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
@@ -31,6 +31,21 @@ interface
   embeddings are active, False (graceful) when artifacts are missing. }
 function EnableFactEmbeddings(const HomeDir: string): Boolean;
 
+{ True when the local ONNX embedder is loadable for HomeDir (model + vocab
+  + runtime provisioned). Same gate EnableFactEmbeddings uses. }
+function LocalEmbedAvailable(const HomeDir: string): Boolean;
+
+{ Active local-embedding model id + dimension (e.g. 'minilm', 384). False
+  when the embedder isn't provisioned. For the /v1/embeddings response. }
+function LocalEmbedModelInfo(const HomeDir: string; out ModelId: string;
+                            out Dim: Integer): Boolean;
+
+{ One-shot text -> unit-normalised embedding using the local ONNX model.
+  Ensures the embedder is loaded for HomeDir, then embeds Text. False
+  (graceful) when the model isn't provisioned or the embed fails. Serialised
+  internally, so it's safe to call from concurrent gateway worker threads. }
+function LocalEmbed(const HomeDir, Text: string; out Vec: TArray<Single>): Boolean;
+
 implementation
 
 uses
@@ -78,6 +93,32 @@ begin
   finally
     GLock.Release;
   end;
+end;
+
+function LocalEmbedAvailable(const HomeDir: string): Boolean;
+begin
+  Result := EnableFactEmbeddings(HomeDir);
+end;
+
+function LocalEmbedModelInfo(const HomeDir: string; out ModelId: string;
+                            out Dim: Integer): Boolean;
+begin
+  ModelId := '';
+  Dim     := 0;
+  if not EnableFactEmbeddings(HomeDir) then Exit(False);
+  { GSpec is set once under GLock during enable and never mutated after, so
+    reading it here without the lock is safe. }
+  ModelId := GSpec.Key;
+  Dim     := GSpec.Dim;
+  Result  := True;
+end;
+
+function LocalEmbed(const HomeDir, Text: string; out Vec: TArray<Single>): Boolean;
+begin
+  Vec := nil;
+  if not EnableFactEmbeddings(HomeDir) then Exit(False);
+  Vec := DoFactEmbed(Text);   { acquires GLock itself; EnableFactEmbeddings already released it }
+  Result := Length(Vec) > 0;
 end;
 
 function EnableFactEmbeddings(const HomeDir: string): Boolean;

--- a/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
+++ b/src/pkg/memory/PasClaw.Memory.Facts.Embed.pas
@@ -68,6 +68,27 @@ var
   GSpec:  TModelSpec;
   GReady: Boolean = False;
   GTried: Boolean = False;
+  { True when the latched failure was specifically "artifacts not on disk"
+    (vs a genuine load failure). Lets LocalEmbedAvailable clear the latch and
+    retry once after `pasclaw memory provision` writes the model, without
+    re-attempting a broken load on every /v1/embeddings request. }
+  GTriedWithoutArtifacts: Boolean = False;
+
+{ Recompute the model + vocab paths for HomeDir and report whether both are
+  present. Used to detect provisioning that happened AFTER a latched
+  artifacts-missing failure. }
+function EmbedArtifactsExist(const HomeDir: string): Boolean;
+var
+  Spec: TModelSpec;
+  ModelDir: string;
+begin
+  Result := False;
+  if not FindModelSpec(DEFAULT_MODEL, Spec) then Exit;
+  ModelDir := JoinPath(JoinPath(JoinPath(JoinPath(HomeDir, 'cache'),
+                       'localvector'), 'models'), Spec.SubDir);
+  Result := FileExists(JoinPath(ModelDir, 'model.onnx'))
+        and FileExists(JoinPath(ModelDir, 'vocab.txt'));
+end;
 
 function DoFactEmbed(const Text: string): TArray<Single>;
 { Registered as the TFactEmbedFn. Serialised; returns [] on any failure
@@ -97,6 +118,24 @@ end;
 
 function LocalEmbedAvailable(const HomeDir: string): Boolean;
 begin
+  Result := EnableFactEmbeddings(HomeDir);
+  if Result then Exit;
+  { EnableFactEmbeddings latches its first failure (GTried) and won't re-probe
+    the filesystem -- so a gateway that started BEFORE `pasclaw memory
+    provision` ran would 503 forever despite the 503 telling the operator to
+    provision. If that latched failure was "artifacts missing" AND they now
+    exist on disk, clear the latch and try once more so /v1/embeddings
+    recovers in-process. A genuine load failure (GTriedWithoutArtifacts=False)
+    is NOT retried, so a broken runtime can't trigger a reload per request. }
+  GLock.Acquire;
+  try
+    if GReady then Exit(True);   { another thread may have loaded it meanwhile }
+    if not (GTriedWithoutArtifacts and EmbedArtifactsExist(HomeDir)) then
+      Exit(False);
+    GTried := False;             { artifacts appeared -- allow one more attempt }
+  finally
+    GLock.Release;
+  end;
   Result := EnableFactEmbeddings(HomeDir);
 end;
 
@@ -143,14 +182,19 @@ begin
     if not FileExists(ModelP) then
     begin
       LogDebug('fact-embed: model not found at %s -- semantic layer off', [ModelP]);
+      GTriedWithoutArtifacts := True;   { provisioning may add it later }
       Exit(False);
     end;
     if not FileExists(VocabP) then
     begin
       LogDebug('fact-embed: vocab not found at %s -- semantic layer off', [VocabP]);
+      GTriedWithoutArtifacts := True;
       Exit(False);
     end;
 
+    { Artifacts are present -- any failure past here is a genuine load
+      failure, not a missing-artifacts one, so don't mark it retryable. }
+    GTriedWithoutArtifacts := False;
     try
       EnsureOnnxRuntime(Cache, {AAllowDownload=} False, {AVerbose=} False);
       GTok := TBertTokenizer.Create(VocabP, GSpec.DoLowerCase);


### PR DESCRIPTION
## What

PasClaw already ships a local MiniLM ONNX embedder (for hybrid `memory_search`). This exposes it as a standard **`POST /v1/embeddings`** so any OpenAI-SDK client can get embeddings from PasClaw — **no outbound call; vectors are computed on-host and never leave.**

## How

- `PasClaw.Memory.Facts.Embed` gains public `LocalEmbedAvailable` / `LocalEmbedModelInfo` / `LocalEmbed` wrappers around the existing (lock-serialised) ONNX path.
- `HandleEmbeddings` accepts the standard body: `input` (string **or** array of strings), optional `model` (echoed back), and `encoding_format`:
  - **`float`** (default) → JSON number array
  - **`base64`** → base64 of the float32 little-endian bytes (what the OpenAI Python SDK requests)
  
  Returns the usual `object:"list"` / `data[]` / `model` / `usage` shape.
- **503** when the model isn't provisioned (points at `pasclaw memory provision`); **400** on empty/missing input. Added to the capability route list.

## Test

Verified live after `pasclaw memory provision` (downloads sqlite-vec + ONNX Runtime 1.20.1 + all-MiniLM-L6-v2):
- single input, `float`: `object=list`, 384-dim vector, `model` echoed, `usage` present.
- batch of 2, `base64`: 2 items, each decodes to a 384-dim float32 vector with **norm ≈ 1.0** (unit-normalized, byte order correct), `model=pasclaw-local-minilm` (default when none requested).
- error paths: empty body → 400, missing `input` → 400, unprovisioned → 503.

`make all` clean.

## Notes

- `usage` token counts are a rough estimate (the endpoint doesn't surface the tokenizer's count; most clients ignore embedding usage).
- The model is fixed to the provisioned local one; a requested `model` is echoed in the response but doesn't change which model runs. A `dimensions` param isn't honored (MiniLM isn't matryoshka) — the full 384-dim vector is always returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_