### PR TITLE
gateway/fs: show the agent workspace in the Files tab from any launch dir

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -125,6 +125,14 @@ uses
 var
   GPolicy:    TSandboxPolicy;
   GWorkspace: string;
+  { The agent's own home workspace ($PASCLAW_HOME/workspace -- where memory,
+    skills, sessions, checkpoints and generated files live). CanReadPathHTTP
+    (the operator-facing /v1/fs browse, NOT the model's CanReadPath) allows
+    reads here IN ADDITION to GWorkspace, so the web UI's Files tab can show
+    the agent workspace even when it sits outside the launch directory (the
+    common case: `pasclaw serve` run from anywhere, or a Docker boot). Set in
+    ConfigureSandbox. }
+  GOperatorBrowseRoot: string;
 
 procedure ConfigureSandbox(const Policy: TSandboxPolicy; const Workspace: string);
 begin
@@ -136,6 +144,10 @@ begin
   else
     GWorkspace := GetCurrentDir;
   GWorkspace := ExcludeTrailingPathDelimiter(ExpandFileName(GWorkspace));
+  { Independent of the sandbox workspace -- always the agent's data home, so
+    the operator Files browser can reach it from any launch directory. }
+  GOperatorBrowseRoot := ExcludeTrailingPathDelimiter(ExpandFileName(
+    IncludeTrailingPathDelimiter(GetHome) + 'workspace'));
   if Policy.RestrictToWorkspace then
     LogDebug('sandbox: restrict_to_workspace=true workspace=%s', [GWorkspace]);
 end;
@@ -255,10 +267,19 @@ begin
   end;
   Canon := Canonicalize(Path);
   if PathInsideDirectory(Canon, GWorkspace) then Exit(True);
+  { Also allow the agent's own home workspace ($PASCLAW_HOME/workspace) so the
+    operator Files browser can reach memory / skills / sessions / generated
+    files even when the launch directory (GWorkspace) is elsewhere. Operator
+    endpoint only -- the model's CanReadPath is unchanged. Secrets live at the
+    home ROOT (config.json / .env), outside this subtree, and are additionally
+    hidden by IsRestrictedFsPath. }
+  if (GOperatorBrowseRoot <> '') and PathInsideDirectory(Canon, GOperatorBrowseRoot) then
+    Exit(True);
   if AnyRegexMatches(Canon, GPolicy.AllowReadPaths) then Exit(True);
   Reason := 'refused: path "' + Canon + '" is outside the workspace "' +
-            GWorkspace + '" -- gateway file access is confined to the ' +
-            'workspace (independent of sandbox.restrict_to_workspace)';
+            GWorkspace + '" and the agent home workspace "' +
+            GOperatorBrowseRoot + '" -- gateway file access is confined to ' +
+            'those (independent of sandbox.restrict_to_workspace)';
   Result := False;
 end;
 


### PR DESCRIPTION
## Problem

The web UI Files tab never showed the **Workspace** chip when `pasclaw` ran from anywhere other than the agent home — e.g. plain `pasclaw` / `pasclaw serve` on the command line (your Windows local run), or a Docker boot.

**Cause:** `CanReadPathHTTP` (the operator-facing `/v1/fs` browse) confines reads to `GWorkspace`, which defaults to the **launch directory**. `$PASCLAW_HOME/workspace` sits outside it, so the workspace listing was refused — and #390 only emits the `workspace_root` chip when the listing is permitted. (This is *independent* of `restrict_to_workspace` — the confinement is always to `GWorkspace`.)

## Fix

`ConfigureSandbox` now records the agent home workspace (`$PASCLAW_HOME/workspace`) as `GOperatorBrowseRoot`, and `CanReadPathHTTP` allows reads inside it **in addition to** `GWorkspace`.

- **Operator endpoint only** — the model-facing `CanReadPath` is unchanged, so `sandbox.restrict_to_workspace` still governs the model's tools exactly as before.
- **No secret exposure** — `config.json` / `.env` live at the home *root* (outside this subtree) and are additionally filtered by `IsRestrictedFsPath`.
- `Canonicalize` is lexical (`ExpandFileName`), so `..` escapes still fall through to refusal.

Result: the Files tab shows the **Workspace** chip (and defaults to it), and view/download inside the workspace work, from any launch directory.

## Test

Verified live: launched from `/usr` with `$PASCLAW_HOME` elsewhere → `/v1/fs` returns a populated `workspace_root` and lists inside the workspace (200), while `cwd_root=/usr` (Launch dir). `fs-secret-gate` and `fs-grep` suites pass; `make all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_