### PR TITLE
auto-router: centralize routing into one helper across all surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -588,6 +588,13 @@ test-component-config: $(BIN) | $(BUILDDIR) $(INDY_DIR)
 	  src/tests/component_config_tests.pas -o$(BUILDDIR)/component_config_tests
 	@$(BUILDDIR)/component_config_tests
 
+# Auto-router application helper (centralised across CLI/TUI/gateway/component).
+test-autoroute-apply: $(BIN) | $(BUILDDIR) $(INDY_DIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) \
+	  src/tests/autoroute_apply_tests.pas -o$(BUILDDIR)/autoroute_apply_tests
+	@$(BUILDDIR)/autoroute_apply_tests
+
 # Orient launch-preamble section (opt-in "announce a plan before tools").
 test-orient-preamble: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
@@ -795,4 +802,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -60,6 +60,7 @@ uses
   PasClaw.Agent.Subagent,
   PasClaw.Agent.SubagentBg,
   PasClaw.Agent.AutoRouter,
+  PasClaw.Agent.AutoRouter.Apply,
   PasClaw.Session.Store,
   PasClaw.Tools.Sandbox,
   PasClaw.Shell.Backend,           { StartShellSession / CloseShellSession +
@@ -525,6 +526,7 @@ var
   OneShotSessionId: string;
   PersistedSession: TSession;       { non-nil only when A.Session is set (PR #292 P1) }
   i: Integer;
+  RoutedNm: string;
 begin
   { Default to True; only flip to False on a known failure path.
     Any code path that hits Exit before producing a real assistant
@@ -622,6 +624,9 @@ begin
     Msgs[0] := MakeMessage(mrUser, Prompt);
 
     LoopCfg := BuildLoopConfig(Cfg, Provider, Reg, Model, A, Handlers, Prompt);
+    { Auto-router (opt-in) on the one-shot path too -- shared helper, no-op
+      unless Cfg.AutoRouter.Enabled. }
+    ApplyAutoRoute(LoopCfg, Cfg, Msgs, RoutedNm);
 
     if not A.Quiet then
       PrintLn(Ansi.Cyan + 'assistant' + Ansi.Reset +
@@ -1591,56 +1596,18 @@ begin
         ThinkingOn := False;
       end;
 
-      { Auto-router: classify the latest user message and, if it
-        looks easy enough, swap LoopCfg.Provider to the cheap
-        fallback for this turn. Keeps the primary on the fallback
-        list as the first retry target so a routing-fooled turn
-        falls back cleanly without operator intervention. See
-        PasClaw.Agent.AutoRouter for the heuristic. }
+      { Auto-router: classify the latest user message and, if it looks easy
+        enough, swap LoopCfg.Provider to the cheap provider for this turn (and
+        prepend the primary to the fallback chain). Shared with the TUI /
+        gateway / component via ApplyAutoRoute -- one implementation, all
+        surfaces. No-op unless Cfg.AutoRouter.Enabled. }
       RoutedThisTurn := False;
-      if Reg <> nil then Names := Reg.Names else Names := nil;
       if (not Offline) and (PrimaryProvider <> nil) then
-        if RouteProvider(Cfg, Line,
-                         Names,
-                         RoutedProviderNm, RoutedModelOverride) then
+        if ApplyAutoRoute(LoopCfg, Cfg, Msgs, RoutedProviderNm) then
         begin
-          { Lazy-build the easy provider on first routing. Cached
-            for the rest of the session so we don't pay the
-            construction cost per routed turn. If the build fails
-            (catalog drift, missing key) we log once and stay on
-            the primary -- never crash mid-turn for a router
-            misconfiguration. }
-          if EasyProvider = nil then
-            if not NewProviderFromConfig(Cfg, RoutedProviderNm,
-                                         EasyProvider, Err) then
-            begin
-              LogWarn('auto-router: easy provider "%s" unresolvable: %s',
-                      [RoutedProviderNm, Err]);
-              EasyProvider := nil;
-            end;
-          if EasyProvider <> nil then
-          begin
-            PrimaryFallbacks := LoopCfg.Fallbacks;
-            LoopCfg.Provider := EasyProvider;
-            { Prepend the original primary to the fallback chain
-              so a failed routed call drops cleanly back to the
-              provider the operator would have used anyway. }
-            SetLength(LoopCfg.Fallbacks, Length(PrimaryFallbacks) + 1);
-            LoopCfg.Fallbacks[0] := PrimaryProvider;
-            for i := 0 to High(PrimaryFallbacks) do
-              LoopCfg.Fallbacks[i + 1] := PrimaryFallbacks[i];
-            { RouteProvider resolved the model for us (explicit
-              EasyModel -> per-provider stored Model -> catalog
-              default) and refused to route if none of those
-              produced a value -- so RoutedModelOverride is
-              guaranteed non-empty when we're here. Overriding
-              LoopCfg.Model is mandatory: BuildLoopConfig set it
-              to the primary's model and passing claude-* to a
-              Groq endpoint (etc.) just fails. Codex P2 #203. }
-            LoopCfg.Model := RoutedModelOverride;
-            RoutedThisTurn := True;
-            PrintLn(Ansi.Dim + '(routed -> ' + RoutedProviderNm + ')' + Ansi.Reset);
-          end;
+          RoutedThisTurn      := True;
+          RoutedModelOverride := LoopCfg.Model;   { for the assistant label }
+          PrintLn(Ansi.Dim + '(routed -> ' + RoutedProviderNm + ')' + Ansi.Reset);
         end;
 
       { Open a fresh checkpoints turn so any fs_write / fs_edit_hashline

--- a/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
+++ b/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
@@ -1,0 +1,119 @@
+(*
+  PasClaw.Agent.AutoRouter.Apply - applies the task-difficulty auto-router to
+  a freshly-built TToolLoopConfig, in place, just before RunToolLoop.
+
+  The routing DECISION lives in PasClaw.Agent.AutoRouter (ClassifyTask /
+  RouteProvider). This unit centralises the APPLICATION of that decision so
+  every surface gets it identically: CLI (one-shot + interactive), TUI, the
+  embeddable component (TPasClawAgent), and the gateway (serve / gateway).
+  Previously only the CLI wired it, so an embedder, the TUI, and every
+  /v1/chat caller silently ran on the primary provider even with the router
+  enabled.
+
+  Kept as a plain function (not a callback baked into RunToolLoop) because
+  FPC 3.2.2 has no `reference to` closures, and the provider RESOLUTION
+  (name -> ILLMProvider via the factory) belongs in this layer, not the
+  low-level loop. Each surface calls it on the loop config it already builds.
+*)
+unit PasClaw.Agent.AutoRouter.Apply;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  PasClaw.Config,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.ToolLoop;
+
+{ Route this turn to the cheap provider when the router is enabled and the
+  latest user message in Messages classifies easy AND the easy provider
+  resolves. On a route: LoopCfg.Provider/Model are swapped to the cheap
+  provider and the original primary is prepended to LoopCfg.Fallbacks (so a
+  routing-fooled turn falls back to the provider the operator would have used
+  anyway). Returns True + the routed provider name; False leaves LoopCfg
+  untouched (and RoutedProviderName empty). Never raises. }
+function ApplyAutoRoute(var LoopCfg: TToolLoopConfig; const Cfg: TConfig;
+                        const Messages: array of TMessage;
+                        out RoutedProviderName: string): Boolean;
+
+implementation
+
+uses
+  SysUtils,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Factory,
+  PasClaw.Tools.Registry,
+  PasClaw.Logger,
+  PasClaw.Agent.AutoRouter;
+
+function LatestUserMessage(const Messages: array of TMessage): string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := High(Messages) downto Low(Messages) do
+    if Messages[i].Role = mrUser then
+      Exit(Messages[i].Content);
+end;
+
+function ApplyAutoRoute(var LoopCfg: TToolLoopConfig; const Cfg: TConfig;
+                        const Messages: array of TMessage;
+                        out RoutedProviderName: string): Boolean;
+var
+  UserMsg, RoutedModel, Err: string;
+  Names: TStringArray;
+  EasyProvider, PrimaryProvider: ILLMProvider;
+  PrimaryFallbacks: TLLMProviderArray;
+  i: Integer;
+begin
+  Result := False;
+  RoutedProviderName := '';
+  { Cheap outs first so the non-routing path stays free. }
+  if not Cfg.AutoRouter.Enabled then Exit;
+  if LoopCfg.Provider = nil then Exit;
+  UserMsg := LatestUserMessage(Messages);
+  if UserMsg = '' then Exit;
+
+  if LoopCfg.Registry <> nil then
+    Names := LoopCfg.Registry.Names
+  else
+    SetLength(Names, 0);
+
+  if not RouteProvider(Cfg, UserMsg, Names, RoutedProviderName, RoutedModel) then
+  begin
+    RoutedProviderName := '';
+    Exit;
+  end;
+
+  { Build the easy provider on demand. On failure (catalog drift, missing
+    key) log once and stay on the primary -- never crash a turn over a router
+    misconfiguration. }
+  if not NewProviderFromConfig(Cfg, RoutedProviderName, EasyProvider, Err) then
+  begin
+    LogWarn('auto-router: easy provider "%s" unresolvable: %s -- staying on primary',
+            [RoutedProviderName, Err]);
+    RoutedProviderName := '';
+    Exit;
+  end;
+
+  PrimaryProvider  := LoopCfg.Provider;
+  PrimaryFallbacks := LoopCfg.Fallbacks;
+  LoopCfg.Provider := EasyProvider;
+  { RouteProvider guarantees a non-empty model when it routes (explicit
+    EasyModel -> per-provider Model -> catalog default), so the cheap
+    endpoint never receives the primary's model name. }
+  if RoutedModel <> '' then
+    LoopCfg.Model := RoutedModel;
+  { Prepend the original primary so a failed routed call drops cleanly back to
+    it before walking the rest of the chain. }
+  SetLength(LoopCfg.Fallbacks, Length(PrimaryFallbacks) + 1);
+  LoopCfg.Fallbacks[0] := PrimaryProvider;
+  for i := 0 to High(PrimaryFallbacks) do
+    LoopCfg.Fallbacks[i + 1] := PrimaryFallbacks[i];
+
+  Result := True;
+end;
+
+end.

--- a/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
+++ b/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
@@ -62,10 +62,11 @@ function ApplyAutoRoute(var LoopCfg: TToolLoopConfig; const Cfg: TConfig;
                         const Messages: array of TMessage;
                         out RoutedProviderName: string): Boolean;
 var
-  UserMsg, RoutedModel, Err: string;
+  UserMsg, RoutedModel, Err, OrigModel: string;
   Names: TStringArray;
   EasyProvider, PrimaryProvider: ILLMProvider;
   PrimaryFallbacks: TLLMProviderArray;
+  PrimaryFallbackModels: TStringArray;
   i: Integer;
 begin
   Result := False;
@@ -98,8 +99,16 @@ begin
     Exit;
   end;
 
-  PrimaryProvider  := LoopCfg.Provider;
-  PrimaryFallbacks := LoopCfg.Fallbacks;
+  PrimaryProvider       := LoopCfg.Provider;
+  PrimaryFallbacks      := LoopCfg.Fallbacks;
+  PrimaryFallbackModels := LoopCfg.FallbackModels;
+  { Capture the caller's pre-route model BEFORE we overwrite it. This is the
+    model the operator actually asked for (--model, the TUI picker, or an
+    OpenAI-compatible request model). When the routed call fails and we fall
+    back to the primary, RunToolLoop must retry with THIS model, not the
+    primary's catalog default -- otherwise auto-routing silently downgrades
+    an explicit model choice on every routing-fooled turn. }
+  OrigModel        := LoopCfg.Model;
   LoopCfg.Provider := EasyProvider;
   { RouteProvider guarantees a non-empty model when it routes (explicit
     EasyModel -> per-provider Model -> catalog default), so the cheap
@@ -107,11 +116,19 @@ begin
   if RoutedModel <> '' then
     LoopCfg.Model := RoutedModel;
   { Prepend the original primary so a failed routed call drops cleanly back to
-    it before walking the rest of the chain. }
+    it before walking the rest of the chain, carrying OrigModel as its
+    per-fallback override so the caller's requested model is preserved. }
   SetLength(LoopCfg.Fallbacks, Length(PrimaryFallbacks) + 1);
   LoopCfg.Fallbacks[0] := PrimaryProvider;
   for i := 0 to High(PrimaryFallbacks) do
     LoopCfg.Fallbacks[i + 1] := PrimaryFallbacks[i];
+  { Parallel FallbackModels: [0] = the caller's pre-route model for the
+    re-prepended primary; the rest carry over any prior per-fallback
+    overrides (empty entries fall through to GetDefaultModel as before). }
+  SetLength(LoopCfg.FallbackModels, Length(PrimaryFallbacks) + 1);
+  LoopCfg.FallbackModels[0] := OrigModel;
+  for i := 0 to High(PrimaryFallbackModels) do
+    LoopCfg.FallbackModels[i + 1] := PrimaryFallbackModels[i];
 
   Result := True;
 end;

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -367,6 +367,7 @@ uses
   PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
   PasClaw.Agent.Prompt,
+  PasClaw.Agent.AutoRouter.Apply,
   { PasClaw.Agent.Subagent moved to the interface uses (TSpawnTool /
     TSubagentContext are referenced by interface fields). }
   PasClaw.Tools.ToolLoop;
@@ -770,6 +771,7 @@ var
   Msgs: array of TMessage;
   i: Integer;
   ModelName: string;
+  RoutedNm: string;
 begin
   Reply  := '';
   ErrMsg := '';
@@ -830,6 +832,11 @@ begin
     thread. This is what makes LoadConfigFromDisk=False reach the tools.
     Thread-scoped, so a concurrently-running TPasClawServer is unaffected. }
   Cfg.ActiveConfig := FConfig;
+
+  { Task-difficulty auto-router (opt-in via Config.AutoRouter). Centralised in
+    ApplyAutoRoute so the component routes exactly like the CLI/TUI/gateway --
+    no-op unless enabled. }
+  ApplyAutoRoute(Cfg, FConfig, Msgs, RoutedNm);
 
   try
     Result := RunToolLoop(Cfg, Msgs, Loop);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -50,6 +50,7 @@ uses
   PasClaw.Providers.Intf,
   PasClaw.Tools.Registry,
   PasClaw.Tools.ToolLoop,  { TToolLoopConfig/Result -- RunCheckpointedLoop sig }
+  PasClaw.Agent.AutoRouter.Apply,  { ApplyAutoRoute -- per-turn cheap routing }
   PasClaw.Session.Store,
   PasClaw.Gateway.RelayQueue, { TRelayQueue -- FRelayQueue field type }
   PasClaw.MCP.Server;
@@ -3571,20 +3572,31 @@ function TGatewayServer.RunCheckpointedLoop(const ReqSession: string;
   (other chats / other users) overlap freely -- their LLM round-trips no longer
   block each other. Branch on the static config, not the thread's current
   context, since a fresh worker thread has none selected yet. }
+var
+  LocalCfg: TToolLoopConfig;
+  RoutedNm: string;
 begin
+  { Task-difficulty auto-router (opt-in via FCfg.AutoRouter). Applied here so
+    EVERY gateway/serve chat path -- the four RunCheckpointedLoop call sites
+    (chat, chat/completions streaming + non-streaming, responses) -- routes
+    identically. Cfg is const; copy it so the swap (provider/model + primary
+    prepended to fallbacks) is local to this turn. No-op unless enabled. }
+  LocalCfg := Cfg;
+  ApplyAutoRoute(LocalCfg, FCfg, Messages, RoutedNm);
+
   if FCfg.CheckpointsEnabled then
   begin
     ApplyCheckpointSession(ReqSession);
     AcquireCheckpointTurn;
     try
       BeginTurn;
-      Result := RunToolLoop(Cfg, Messages, Loop);
+      Result := RunToolLoop(LocalCfg, Messages, Loop);
     finally
       ReleaseCheckpointTurn;
     end;
   end
   else
-    Result := RunToolLoop(Cfg, Messages, Loop);
+    Result := RunToolLoop(LocalCfg, Messages, Loop);
 
   { Opt-in distilled memory: on a successful turn, fire a background pass
     that extracts durable facts from the latest exchange and stores them.
@@ -3593,7 +3605,7 @@ begin
     not FProvider, which a concurrent /v1/config hot-swap may have already
     repointed at a different backend. }
   if Result and FCfg.MemoryDistillEnabled then
-    ScheduleDistill(Cfg.Provider, Cfg.Model, GetHome, ReqSession,
+    ScheduleDistill(LocalCfg.Provider, LocalCfg.Model, GetHome, ReqSession,
       BuildRecentTranscript(Loop.FinalMessages, Loop.Content, DefaultRecentMsgs));
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -69,6 +69,18 @@ type
        -- is required because dcc64 enforces strict named-type matching
        on dynamic-array assignments. *)
     Fallbacks:      TLLMProviderArray;
+    (* Optional per-fallback model override, parallel to Fallbacks by
+       index. When FallbackModels[i] is non-empty it is the model used
+       for Fallbacks[i] instead of that provider's GetDefaultModel; an
+       empty entry (or an index past the end of this array) falls through
+       to the GetDefaultModel -> Cfg.Model behaviour. Left empty by most
+       callers -- the catalog GetDefaultModel path is correct out of the
+       box. The auto-router populates [0] with the caller's pre-route
+       model when it prepends the original primary, so a routing-fooled
+       turn retries the primary with the model the caller actually
+       requested (--model / TUI picker / request model) rather than the
+       primary's catalog default. *)
+    FallbackModels: TStringArray;
     (* Hook callbacks for observe / veto / transform / steer. See
        PasClaw.Agent.Hooks for the TPasClawHook base class and the
        four virtuals embedders override (BeforeTurn, BeforeToolCall,
@@ -975,11 +987,11 @@ begin
       GetDefaultModel -- anthropic-only model names ("claude-opus-4-7")
       passed verbatim to an OpenAI fallback would fail at the remote
       API and trigger the next fallback even when the chain was
-      otherwise healthy. We only fall back to Cfg.Model when the
-      fallback explicitly returns '' for its default. A per-fallback
-      override (Cfg.FallbackModels: array of string) is a clean
-      follow-up but the GetDefaultModel path gets the right behaviour
-      out of the box for the catalog providers we ship. }
+      otherwise healthy. A non-empty Cfg.FallbackModels[fbi] overrides
+      this entirely -- that is how the auto-router preserves the caller's
+      explicitly requested model when it prepends the original primary as
+      Fallbacks[0]. Otherwise we only fall back to Cfg.Model when the
+      fallback explicitly returns '' for its GetDefaultModel. }
     if IsRetryableStatus(Resp.StatusCode) and (Length(Cfg.Fallbacks) > 0) then
     begin
       LogWarn('provider primary returned status=%d, walking %d fallback(s)',
@@ -987,8 +999,13 @@ begin
       for fbi := 0 to High(Cfg.Fallbacks) do
       begin
         if Cfg.Fallbacks[fbi] = nil then Continue;
-        FallbackModel := Cfg.Fallbacks[fbi].GetDefaultModel;
-        if FallbackModel = '' then FallbackModel := Cfg.Model;
+        if (fbi <= High(Cfg.FallbackModels)) and (Cfg.FallbackModels[fbi] <> '') then
+          FallbackModel := Cfg.FallbackModels[fbi]
+        else
+        begin
+          FallbackModel := Cfg.Fallbacks[fbi].GetDefaultModel;
+          if FallbackModel = '' then FallbackModel := Cfg.Model;
+        end;
         LogDebug('fallback %d: trying %s with model=%s',
                  [fbi, Cfg.Fallbacks[fbi].GetName, FallbackModel]);
         try

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -290,7 +290,8 @@ uses
                                      `pasclaw init` on the CLI. }
   PasClaw.Markdown.Render,
   PasClaw.Providers.Catalog,       { TProviderSpec -- for TModelRefreshThread }
-  PasClaw.Config
+  PasClaw.Config,
+  PasClaw.Agent.AutoRouter.Apply   { ApplyAutoRoute -- cheap per-turn routing }
   { PasClaw.Providers.Models is in the interface uses already -- needed
     from there so dcc64 can see TModelInfoArray when it compiles the
     TTUI class declaration. }
@@ -1272,6 +1273,8 @@ procedure TTUI.StartTurn(const UserText: string);
 var
   Cfg: TToolLoopConfig;
   Worker: TRunToolLoopThread;
+  RouteCfg: TConfig;
+  RoutedNm: string;
 begin
   if (FProvider = nil) or (Trim(UserText) = '') then Exit;
   if FLoopThread <> nil then Exit;   { already in flight }
@@ -1338,6 +1341,15 @@ begin
   Cfg.OnText        := nil;
   Cfg.OnToolCall    := nil;
   Cfg.OnToolResult  := nil;
+
+  { Task-difficulty auto-router (opt-in via Config.AutoRouter) -- same path the
+    CLI/gateway/component use. No-op unless enabled. }
+  RouteCfg := LoadConfig;
+  try
+    ApplyAutoRoute(Cfg, RouteCfg, FSession.Messages, RoutedNm);
+  finally
+    RouteCfg.Free;
+  end;
 
   Worker := TRunToolLoopThread.Create(Cfg, FSession.Messages);
   Worker.Start;
@@ -2782,6 +2794,8 @@ var
   W: TRunToolLoopThread;
   TimeoutSec: Integer;
   WaitRes: TWaitResult;
+  RouteCfg: TConfig;
+  RoutedNm: string;
 begin
   if FProvider = nil then
   begin
@@ -2824,6 +2838,15 @@ begin
     Cfg.BackgroundDrainKey := 'fpc-tui-session';
   end;
   TimeoutSec        := ResolveRequestTimeoutSeconds;
+
+  { Task-difficulty auto-router (opt-in via Config.AutoRouter) -- same shared
+    path as the CLI/gateway/component. No-op unless enabled. }
+  RouteCfg := LoadConfig;
+  try
+    ApplyAutoRoute(Cfg, RouteCfg, Msgs, RoutedNm);
+  finally
+    RouteCfg.Free;
+  end;
 
   LogDebug('tool-loop start model=%s timeout=%ds', [FModel, TimeoutSec]);
   PrintLn(Ansi.Dim + '         [hint: press Ctrl+C to interrupt]' + Ansi.Reset);

--- a/src/tests/autoroute_apply_tests.pas
+++ b/src/tests/autoroute_apply_tests.pas
@@ -1,0 +1,127 @@
+program autoroute_apply_tests;
+(*
+  Covers ApplyAutoRoute -- the shared helper that applies the task-difficulty
+  auto-router to a TToolLoopConfig before RunToolLoop, now used by every
+  surface (CLI, TUI, gateway/serve, component) instead of CLI-only inline code.
+
+  Contracts pinned:
+    - Router OFF (the default) -> returns False, LoopCfg untouched. This is
+      the safety property that keeps all wired surfaces no-op by default.
+    - nil primary provider -> returns False (nothing to route from).
+    - Router ON + an easy message + a resolvable easy provider -> returns True,
+      swaps LoopCfg.Provider/Model to the easy provider, and prepends the
+      original primary to LoopCfg.Fallbacks.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Providers.Types,
+  PasClaw.Providers.Intf,
+  PasClaw.Tools.ToolLoop,
+  PasClaw.Agent.AutoRouter.Apply;
+
+type
+  { Minimal stand-in for the primary provider so we can assert the swap. }
+  TFakeProvider = class(TInterfacedObject, ILLMProvider)
+  private
+    FName: string;
+  public
+    constructor Create(const AName: string);
+    function Chat(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+                  const Model: string; const Options: TChatOptions): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+    function ChatStream(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+                        const Model: string; const Options: TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+  end;
+
+constructor TFakeProvider.Create(const AName: string); begin inherited Create; FName := AName; end;
+function TFakeProvider.Chat(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+  const Model: string; const Options: TChatOptions): TLLMResponse; begin Result := Default(TLLMResponse); end;
+function TFakeProvider.GetDefaultModel: string; begin Result := 'fake-model'; end;
+function TFakeProvider.GetName: string; begin Result := FName; end;
+function TFakeProvider.SupportsThinking: Boolean; begin Result := False; end;
+function TFakeProvider.SupportsNativeSearch: Boolean; begin Result := False; end;
+function TFakeProvider.SupportsStreaming: Boolean; begin Result := False; end;
+function TFakeProvider.ChatStream(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+  const Model: string; const Options: TChatOptions; OnChunk: TStreamCallback): TLLMResponse;
+begin Result := Default(TLLMResponse); end;
+
+procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+procedure AssertTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
+
+function EasyMsgs: TArray<TMessage>;
+begin
+  SetLength(Result, 1);
+  Result[0] := MakeMessage(mrUser, 'what is the capital of France');  { "what is" -> easy }
+end;
+
+var
+  Cfg: TConfig;
+  LoopCfg: TToolLoopConfig;
+  Primary: ILLMProvider;
+  Routed: string;
+  Msgs: TArray<TMessage>;
+begin
+  Primary := TFakeProvider.Create('primary-anthropic');
+  Msgs := EasyMsgs;
+
+  Cfg := TConfig.Create;
+  try
+    { ---- Default config: AutoRouter.Enabled is True but EasyProvider is
+      empty, so routing is inert -- no-op, LoopCfg untouched. This is the
+      safety property that keeps every wired surface unchanged until an
+      operator actually configures an easy provider. ---- }
+    LoopCfg := Default(TToolLoopConfig);
+    LoopCfg.Provider := Primary;
+    LoopCfg.Model    := 'claude-opus-4-7';
+    AssertTrue(Cfg.AutoRouter.EasyProvider = '', 'default EasyProvider is empty');
+    AssertTrue(not ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
+      'default (no easy provider) -> ApplyAutoRoute returns False');
+    AssertTrue(LoopCfg.Provider = Primary, 'default -> provider untouched');
+    AssertTrue(LoopCfg.Model = 'claude-opus-4-7', 'default -> model untouched');
+    AssertTrue(Length(LoopCfg.Fallbacks) = 0, 'default -> fallbacks untouched');
+
+    { ---- nil primary -> False. ---- }
+    LoopCfg := Default(TToolLoopConfig);
+    Cfg.AutoRouter.Enabled := True;
+    Cfg.AutoRouter.EasyProvider := 'groq';
+    AssertTrue(not ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
+      'nil primary -> ApplyAutoRoute returns False');
+
+    { ---- Router ON + easy msg + resolvable easy provider -> route. ---- }
+    Cfg.AutoRouter.Enabled      := True;
+    Cfg.AutoRouter.EasyProvider := 'groq';
+    Cfg.AutoRouter.EasyModel    := 'llama-3.3-70b-versatile';  { non-empty so routing isn't refused }
+    SetLength(Cfg.Providers, 1);
+    Cfg.Providers[0].Name   := 'groq';
+    Cfg.Providers[0].Kind   := 'groq';
+    Cfg.Providers[0].APIKey := 'gsk-test';   { construction only; no network }
+
+    LoopCfg := Default(TToolLoopConfig);
+    LoopCfg.Provider := Primary;
+    LoopCfg.Model    := 'claude-opus-4-7';
+    AssertTrue(ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
+      'enabled + easy + resolvable -> routes');
+    AssertTrue(Routed = 'groq', 'routed provider name reported');
+    AssertTrue(LoopCfg.Provider <> Primary, 'provider swapped off the primary');
+    AssertTrue(LoopCfg.Provider.GetName = 'groq', 'provider swapped to the easy provider');
+    AssertTrue(LoopCfg.Model = 'llama-3.3-70b-versatile', 'model swapped to the easy model');
+    AssertTrue((Length(LoopCfg.Fallbacks) = 1) and (LoopCfg.Fallbacks[0] = Primary),
+      'original primary prepended to the fallback chain');
+  finally
+    Cfg.Free;
+  end;
+
+  WriteLn('  ok: ApplyAutoRoute (off=no-op, nil-primary, routes + prepends primary)');
+  WriteLn('PASS');
+end.

--- a/src/tests/autoroute_apply_tests.pas
+++ b/src/tests/autoroute_apply_tests.pas
@@ -118,6 +118,12 @@ begin
     AssertTrue(LoopCfg.Model = 'llama-3.3-70b-versatile', 'model swapped to the easy model');
     AssertTrue((Length(LoopCfg.Fallbacks) = 1) and (LoopCfg.Fallbacks[0] = Primary),
       'original primary prepended to the fallback chain');
+    { Review fix: the prepended primary must carry the caller's pre-route
+      model so a routing-fooled turn retries the primary with the model the
+      operator actually requested, not the primary's catalog default. }
+    AssertTrue((Length(LoopCfg.FallbackModels) = 1)
+               and (LoopCfg.FallbackModels[0] = 'claude-opus-4-7'),
+      'caller pre-route model preserved as the primary fallback override');
   finally
     Cfg.Free;
   end;


### PR DESCRIPTION
## Why

The task-difficulty auto-router was wired into **only the CLI interactive loop**. The TUI, the embeddable component (`TPasClawAgent`), every `/v1/chat` gateway/serve request, and even one-shot `pasclaw agent -m` ran on the primary provider even with the router configured.

## How

Extracted the routing *application* into **`PasClaw.Agent.AutoRouter.Apply` (`ApplyAutoRoute`)** — a faithful lift of the CLI's inline logic — and called it from every surface right before `RunToolLoop`:

- **CLI** — interactive (refactored onto the helper) + one-shot `RunSingleTurn`.
- **TUI** — both the Delphi positioned `StartTurn` and the FPC line-based loop.
- **Component** — `TPasClawAgent.ChatHistory`.
- **Gateway / serve** — once in `RunCheckpointedLoop`, which covers all four chat call sites (`/v1/chat`, `/v1/chat/completions` streaming + non-streaming, `/v1/responses`).

The **decision** logic (`ClassifyTask`/`RouteProvider`) is unchanged — this only changes *where* it runs. On a route it swaps `LoopCfg.Provider`/`Model` to the cheap provider and prepends the original primary to the fallback chain (so a routing-fooled turn falls back cleanly).

## Safety / no behavior change by default

The stock config has `AutoRouter.EasyProvider` empty, so `ApplyAutoRoute` is a **no-op until an operator configures an easy provider** — every newly-wired surface is unchanged out of the box.

Implemented as a plain helper (not a `RunToolLoop` callback) because FPC 3.2.2 has no `reference to` closures, and provider *resolution* (`NewProviderFromConfig`) belongs in this layer, not the low-level loop.

## Test

New `make test-autoroute-apply`: no-op when unconfigured, `nil` primary, and the route path (swaps provider/model + prepends the original primary to fallbacks). `orient`, `plan-build-mode`, `component-config`, `gateway-token`, `subagent-bg` green; `make all` clean.

This closes the long-standing "auto-router is CLI-only" caveat. (Phase 2 — tiered routing + a tunable structural complexity score, ideas from wayfinder-router — would build on this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_