### PR TITLE
embeddings: fix dcc64 build — drop DefaultFormatSettings from /v1/embeddings

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -6862,7 +6862,7 @@ procedure TGatewayServer.HandleEmbeddings(ARequest: TIdHTTPRequestInfo;
   OpenAI Python SDK asks for). No outbound call -- vectors are computed
   on-host and never leave. }
 var
-  Body, EncFmt, ReqModel, ModelId, OneInput, VecJson: string;
+  Body, EncFmt, ReqModel, ModelId, OneInput, VecJson, NumStr: string;
   Req, Root, Item, Usage: TJsonObject;
   InArr, DataArr: TJsonArray;
   Inputs: array of string;
@@ -6870,7 +6870,6 @@ var
   Dim, i, j, ApproxTokens: Integer;
   AsBase64: Boolean;
   Bytes: TBytes;
-  Fmt: TFormatSettings;
 begin
   Body := ReadRequestBody(ARequest);
   if Trim(Body) = '' then
@@ -6940,12 +6939,6 @@ begin
     AsBase64 := SameText(EncFmt, 'base64');
     ReqModel := Req.GetStr('model', '');
 
-    { JSON numbers must use '.' regardless of host locale; 7 significant
-      digits matches the float32 the model actually produces. }
-    Fmt := DefaultFormatSettings;
-    Fmt.DecimalSeparator  := '.';
-    Fmt.ThousandSeparator := #0;
-
     ApproxTokens := 0;
     DataArr := TJsonArray.Create;
     try
@@ -6972,7 +6965,13 @@ begin
           for j := 0 to High(Vec) do
           begin
             if j > 0 then VecJson := VecJson + ',';
-            VecJson := VecJson + FloatToStrF(Vec[j], ffGeneral, 7, 0, Fmt);
+            { Str() always emits a '.' decimal regardless of host locale, on
+              both FPC and Delphi -- no TFormatSettings needed (dcc64 didn't
+              resolve DefaultFormatSettings here, and FPC 3.2.2 has no
+              parameterless TFormatSettings.Create). 7 decimals comfortably
+              covers a unit-normalised float32 component. }
+            Str(Vec[j]:0:7, NumStr);
+            VecJson := VecJson + Trim(NumStr);
           end;
           VecJson := VecJson + ']';
           Item.PutRaw('embedding', VecJson);


### PR DESCRIPTION
## Problem

```
[dcc64 Error] PasClaw.Gateway.Server.pas(6945): E2003 Undeclared identifier: 'DefaultFormatSettings'
```

The `/v1/embeddings` float-array formatter (from #391) built `TFormatSettings` from the `DefaultFormatSettings` global, which dcc64 didn't resolve in that Delphi build. The obvious swap to `TFormatSettings.Create` doesn't work either — **FPC 3.2.2 has no parameterless `TFormatSettings.Create`**.

## Fix

Drop `TFormatSettings`/`FloatToStrF` entirely and format each component with **`Str(value:0:7, s)`**, which always emits a `.` decimal regardless of host locale on **both** FPC and Delphi. 7 decimals comfortably covers a unit-normalised float32 component. (The `base64` encoding path is byte-exact and unaffected.)

## Test

Verified live against the provisioned local model: `/v1/embeddings` float output parses as valid JSON, 384-dim, norm ≈ 1.0. `make all` clean on FPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_