### PR TITLE
auto-router: address PR #393 review follow-ups

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
+++ b/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
@@ -58,9 +58,14 @@ begin
       Exit(Messages[i].Content);
 end;
 
-{ Fingerprint of the named provider's config entry. Used to bust the per-thread
-  easy-provider cache when a /v1/config hot-swap changes the entry (kind / base
-  / key / model) without changing its name. Empty when the name is unknown. }
+{ Fingerprint of every input NewProviderFromConfig captures into the easy
+  provider object. Used to bust the per-thread cache when a /v1/config
+  hot-swap changes any of them without changing the provider name. Beyond the
+  per-provider entry (kind / base / key / model), NewProviderFromConfig also
+  bakes provider-WIDE settings into the object -- the Anthropic/OpenAI/Gemini
+  server-tool toggles and the relay wait timeout -- so those must be in the
+  key too, or a config that only flips e.g. web_search would keep reusing a
+  stale provider on a same-thread surface. Empty when the name is unknown. }
 function EasyProviderFingerprint(const Cfg: TConfig; const Name: string): string;
 var
   i: Integer;
@@ -70,7 +75,14 @@ begin
     if SameText(Cfg.Providers[i].Name, Name) then
     begin
       Result := Cfg.Providers[i].Kind + '|' + Cfg.Providers[i].APIBase + '|' +
-                Cfg.Providers[i].APIKey + '|' + Cfg.Providers[i].Model;
+                Cfg.Providers[i].APIKey + '|' + Cfg.Providers[i].Model + '|' +
+                BoolToStr(Cfg.AnthropicServerTools.WebSearch, True) + ',' +
+                IntToStr(Cfg.AnthropicServerTools.WebSearchMaxUses) + ',' +
+                BoolToStr(Cfg.AnthropicServerTools.WebFetch, True) + ',' +
+                IntToStr(Cfg.AnthropicServerTools.WebFetchMaxUses) + '|' +
+                BoolToStr(Cfg.OpenAIServerTools.WebSearch, True) + '|' +
+                BoolToStr(Cfg.GeminiServerTools.GoogleSearch, True) + '|' +
+                IntToStr(Cfg.RelayWaitTimeoutMs);
       Exit;
     end;
 end;

--- a/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
+++ b/src/pkg/agent/PasClaw.Agent.AutoRouter.Apply.pas
@@ -58,11 +58,39 @@ begin
       Exit(Messages[i].Content);
 end;
 
+{ Fingerprint of the named provider's config entry. Used to bust the per-thread
+  easy-provider cache when a /v1/config hot-swap changes the entry (kind / base
+  / key / model) without changing its name. Empty when the name is unknown. }
+function EasyProviderFingerprint(const Cfg: TConfig; const Name: string): string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 0 to High(Cfg.Providers) do
+    if SameText(Cfg.Providers[i].Name, Name) then
+    begin
+      Result := Cfg.Providers[i].Kind + '|' + Cfg.Providers[i].APIBase + '|' +
+                Cfg.Providers[i].APIKey + '|' + Cfg.Providers[i].Model;
+      Exit;
+    end;
+end;
+
+{ Per-thread cache of the last-constructed easy provider. Routing the same easy
+  provider every turn (the common case) reused one object across the session in
+  the old CLI inline code; this restores that for all surfaces without sharing
+  state across threads (the gateway routes from worker threads -- no locking,
+  each thread caches independently). Keyed on name + config fingerprint so a
+  hot-swap rebuilds correctly. }
+threadvar
+  GEasyName:        string;
+  GEasyFingerprint: string;
+  GEasyProv:        ILLMProvider;
+
 function ApplyAutoRoute(var LoopCfg: TToolLoopConfig; const Cfg: TConfig;
                         const Messages: array of TMessage;
                         out RoutedProviderName: string): Boolean;
 var
-  UserMsg, RoutedModel, Err, OrigModel: string;
+  UserMsg, RoutedModel, Err, OrigModel, Fingerprint: string;
   Names: TStringArray;
   EasyProvider, PrimaryProvider: ILLMProvider;
   PrimaryFallbacks: TLLMProviderArray;
@@ -88,15 +116,27 @@ begin
     Exit;
   end;
 
-  { Build the easy provider on demand. On failure (catalog drift, missing
-    key) log once and stay on the primary -- never crash a turn over a router
+  { Resolve the easy provider, reusing the per-thread cached object when the
+    name and config fingerprint are unchanged so a long routed session doesn't
+    reconstruct it every turn. On a build failure (catalog drift, missing key)
+    log once and stay on the primary -- never crash a turn over a router
     misconfiguration. }
-  if not NewProviderFromConfig(Cfg, RoutedProviderName, EasyProvider, Err) then
+  Fingerprint := EasyProviderFingerprint(Cfg, RoutedProviderName);
+  if (GEasyProv <> nil) and (GEasyName = RoutedProviderName)
+     and (GEasyFingerprint = Fingerprint) then
+    EasyProvider := GEasyProv
+  else
   begin
-    LogWarn('auto-router: easy provider "%s" unresolvable: %s -- staying on primary',
-            [RoutedProviderName, Err]);
-    RoutedProviderName := '';
-    Exit;
+    if not NewProviderFromConfig(Cfg, RoutedProviderName, EasyProvider, Err) then
+    begin
+      LogWarn('auto-router: easy provider "%s" unresolvable: %s -- staying on primary',
+              [RoutedProviderName, Err]);
+      RoutedProviderName := '';
+      Exit;
+    end;
+    GEasyName        := RoutedProviderName;
+    GEasyFingerprint := Fingerprint;
+    GEasyProv        := EasyProvider;
   end;
 
   PrimaryProvider       := LoopCfg.Provider;
@@ -127,8 +167,13 @@ begin
     overrides (empty entries fall through to GetDefaultModel as before). }
   SetLength(LoopCfg.FallbackModels, Length(PrimaryFallbacks) + 1);
   LoopCfg.FallbackModels[0] := OrigModel;
-  for i := 0 to High(PrimaryFallbackModels) do
-    LoopCfg.FallbackModels[i + 1] := PrimaryFallbackModels[i];
+  { Bound on Fallbacks (the array we sized to), not PrimaryFallbackModels:
+    a caller that set FallbackModels longer than Fallbacks would otherwise
+    write past the end. Indices without a prior override stay '' (the
+    GetDefaultModel fall-through). }
+  for i := 0 to High(PrimaryFallbacks) do
+    if i <= High(PrimaryFallbackModels) then
+      LoopCfg.FallbackModels[i + 1] := PrimaryFallbackModels[i];
 
   Result := True;
 end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3601,11 +3601,15 @@ begin
   { Opt-in distilled memory: on a successful turn, fire a background pass
     that extracts durable facts from the latest exchange and stores them.
     Best-effort and non-blocking -- never affects the response.
-    Use Cfg.Provider/Cfg.Model -- the SNAPSHOT this turn actually ran on --
-    not FProvider, which a concurrent /v1/config hot-swap may have already
-    repointed at a different backend. }
+    Use Cfg.Provider/Cfg.Model -- the PRIMARY snapshot, NOT LocalCfg, which
+    auto-routing may have swapped to the cheap easy provider for this turn.
+    Fact extraction wants the operator's strong model regardless of which
+    model answered the (easy) turn; routing the chat reply cheaply should not
+    silently downgrade the durable memory the gateway writes. Cfg (not
+    FProvider) because a concurrent /v1/config hot-swap may have already
+    repointed FProvider at a different backend. }
   if Result and FCfg.MemoryDistillEnabled then
-    ScheduleDistill(LocalCfg.Provider, LocalCfg.Model, GetHome, ReqSession,
+    ScheduleDistill(Cfg.Provider, Cfg.Model, GetHome, ReqSession,
       BuildRecentTranscript(Loop.FinalMessages, Loop.Content, DefaultRecentMsgs));
 end;
 

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -56,6 +56,10 @@ uses
                                      BgCoordinator public field below; same
                                      dcc64 interface-visibility rule as the
                                      types above. }
+  PasClaw.Config,                  { TConfig -- the FRouteCfg auto-router
+                                     snapshot field + RouteConfig method
+                                     declared on TTUI; same interface-
+                                     visibility rule as the types above. }
   PasClaw.Session.Store;
 
 type
@@ -75,6 +79,15 @@ type
        it. Default pmBuild so the TUI's historical full-access
        behaviour is preserved. *)
     FMode:     TPasClawMode;
+    { Lazily-loaded config snapshot reused by the per-turn auto-router so we
+      don't stat+read+parse config.json on every turn (the previous code did
+      LoadConfig + Free per turn, even with the router disabled). Loaded once
+      on the first turn; freed in teardown (Delphi destructor / FPC Run exit).
+      Router config is set out-of-band -- config file / CLI, never the TUI --
+      so a session-lifetime snapshot is correct and matches the CLI's
+      session-scoped easy-provider cache. }
+    FRouteCfg: TConfig;
+    function RouteConfig: TConfig;
     {$IFNDEF FPC}
     { positioned-TUI state -- see Run() for the per-frame loop }
     FFocus:             TFocus;
@@ -290,8 +303,10 @@ uses
                                      `pasclaw init` on the CLI. }
   PasClaw.Markdown.Render,
   PasClaw.Providers.Catalog,       { TProviderSpec -- for TModelRefreshThread }
-  PasClaw.Config,
-  PasClaw.Agent.AutoRouter.Apply   { ApplyAutoRoute -- cheap per-turn routing }
+  PasClaw.Agent.AutoRouter.Apply   { ApplyAutoRoute -- cheap per-turn routing.
+                                     PasClaw.Config moved to the interface uses
+                                     (TConfig is now referenced by the TTUI
+                                     class declaration). }
   { PasClaw.Providers.Models is in the interface uses already -- needed
     from there so dcc64 can see TModelInfoArray when it compiles the
     TTUI class declaration. }
@@ -439,6 +454,16 @@ begin
   PromptCacheEnabled := True;
   PromptCacheTTL     := '';
   RenderMarkdownEnabled := True;
+  FRouteCfg := nil;
+end;
+
+{ Lazily load + cache the config used by the per-turn auto-router. Shared by
+  both TUI surfaces; loaded at most once per session. }
+function TTUI.RouteConfig: TConfig;
+begin
+  if FRouteCfg = nil then
+    FRouteCfg := LoadConfig;
+  Result := FRouteCfg;
 end;
 
 function StatusLine(Provider: ILLMProvider; const Model: string;
@@ -497,6 +522,7 @@ begin
     FModelRefreshThread := nil;
   end;
   FSession.Free;
+  FRouteCfg.Free;
   inherited Destroy;
 end;
 
@@ -1273,7 +1299,6 @@ procedure TTUI.StartTurn(const UserText: string);
 var
   Cfg: TToolLoopConfig;
   Worker: TRunToolLoopThread;
-  RouteCfg: TConfig;
   RoutedNm: string;
 begin
   if (FProvider = nil) or (Trim(UserText) = '') then Exit;
@@ -1343,13 +1368,9 @@ begin
   Cfg.OnToolResult  := nil;
 
   { Task-difficulty auto-router (opt-in via Config.AutoRouter) -- same path the
-    CLI/gateway/component use. No-op unless enabled. }
-  RouteCfg := LoadConfig;
-  try
-    ApplyAutoRoute(Cfg, RouteCfg, FSession.Messages, RoutedNm);
-  finally
-    RouteCfg.Free;
-  end;
+    CLI/gateway/component use. No-op unless enabled. Uses the cached config
+    snapshot so we don't re-read config.json every turn. }
+  ApplyAutoRoute(Cfg, RouteConfig, FSession.Messages, RoutedNm);
 
   Worker := TRunToolLoopThread.Create(Cfg, FSession.Messages);
   Worker.Start;
@@ -2794,7 +2815,6 @@ var
   W: TRunToolLoopThread;
   TimeoutSec: Integer;
   WaitRes: TWaitResult;
-  RouteCfg: TConfig;
   RoutedNm: string;
 begin
   if FProvider = nil then
@@ -2840,13 +2860,9 @@ begin
   TimeoutSec        := ResolveRequestTimeoutSeconds;
 
   { Task-difficulty auto-router (opt-in via Config.AutoRouter) -- same shared
-    path as the CLI/gateway/component. No-op unless enabled. }
-  RouteCfg := LoadConfig;
-  try
-    ApplyAutoRoute(Cfg, RouteCfg, Msgs, RoutedNm);
-  finally
-    RouteCfg.Free;
-  end;
+    path as the CLI/gateway/component. No-op unless enabled. Uses the cached
+    config snapshot so we don't re-read config.json every turn. }
+  ApplyAutoRoute(Cfg, RouteConfig, Msgs, RoutedNm);
 
   LogDebug('tool-loop start model=%s timeout=%ds', [FModel, TimeoutSec]);
   PrintLn(Ansi.Dim + '         [hint: press Ctrl+C to interrupt]' + Ansi.Reset);
@@ -2926,6 +2942,8 @@ begin
     end;
     HandleUserInput(Line);
   end;
+  FRouteCfg.Free;   { FPC has no TTUI destructor override; free the cache here }
+  FRouteCfg := nil;
   PrintLn(Ansi.Dim + 'goodbye.' + Ansi.Reset);
 end;
 

--- a/src/tests/autoroute_apply_tests.pas
+++ b/src/tests/autoroute_apply_tests.pas
@@ -124,6 +124,28 @@ begin
     AssertTrue((Length(LoopCfg.FallbackModels) = 1)
                and (LoopCfg.FallbackModels[0] = 'claude-opus-4-7'),
       'caller pre-route model preserved as the primary fallback override');
+
+    { ---- Second route reuses the per-thread easy-provider cache (same name +
+      fingerprint) and must still route correctly. ---- }
+    LoopCfg := Default(TToolLoopConfig);
+    LoopCfg.Provider := Primary;
+    LoopCfg.Model    := 'claude-opus-4-7';
+    AssertTrue(ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
+      'second route (cache hit) still routes');
+    AssertTrue(LoopCfg.Provider.GetName = 'groq', 'cache-hit route still swaps to easy provider');
+    AssertTrue((Length(LoopCfg.FallbackModels) = 1)
+               and (LoopCfg.FallbackModels[0] = 'claude-opus-4-7'),
+      'cache-hit route still preserves the caller model');
+
+    { ---- Hot-swap busts the cache: change the easy provider's config and the
+      next route must reflect it (still resolvable -> still routes). ---- }
+    Cfg.Providers[0].Model := 'llama-3.1-8b-instant';   { fingerprint changes }
+    LoopCfg := Default(TToolLoopConfig);
+    LoopCfg.Provider := Primary;
+    LoopCfg.Model    := 'claude-opus-4-7';
+    AssertTrue(ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
+      'route after config hot-swap still routes (cache rebuilt)');
+    AssertTrue(LoopCfg.Provider.GetName = 'groq', 'rebuilt route resolves the easy provider');
   finally
     Cfg.Free;
   end;

--- a/src/tests/autoroute_apply_tests.pas
+++ b/src/tests/autoroute_apply_tests.pas
@@ -146,6 +146,17 @@ begin
     AssertTrue(ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
       'route after config hot-swap still routes (cache rebuilt)');
     AssertTrue(LoopCfg.Provider.GetName = 'groq', 'rebuilt route resolves the easy provider');
+
+    { ---- A provider-wide setting (server-tool toggle) also busts the cache:
+      NewProviderFromConfig bakes these into the provider object, so the
+      fingerprint must include them. Route must still resolve. ---- }
+    Cfg.OpenAIServerTools.WebSearch := not Cfg.OpenAIServerTools.WebSearch;
+    LoopCfg := Default(TToolLoopConfig);
+    LoopCfg.Provider := Primary;
+    LoopCfg.Model    := 'claude-opus-4-7';
+    AssertTrue(ApplyAutoRoute(LoopCfg, Cfg, Msgs, Routed),
+      'route after server-tool toggle still routes (cache rebuilt)');
+    AssertTrue(LoopCfg.Provider.GetName = 'groq', 'provider-wide-change route resolves the easy provider');
   finally
     Cfg.Free;
   end;


### PR DESCRIPTION
Follow-up fixes from a deeper review of the now-merged #393 (centralized auto-router across CLI/TUI/gateway/component). The P2 "preserve the requested model on primary fallback" was already fixed in #393 itself; these address four *additional* issues that review surfaced.

## Fixes

**1. TUI — stop re-reading config.json every turn**
Both TUI surfaces did `LoadConfig` + `Free` per turn just to feed the router, even when the router is disabled (the no-op default), and in the positioned TUI that disk read + JSON parse ran on the UI thread. Added a lazily-loaded, session-lifetime config snapshot (`FRouteCfg` / `RouteConfig`), loaded once and freed in the Delphi destructor and at FPC `Run` exit. Router config is set out-of-band (config file / CLI), so a session snapshot is correct — matching the CLI's session-scoped cache.

**2. Gateway — distill on the primary model, not the routed cheap one**
`ScheduleDistill` was changed in #393 to use `LocalCfg` (the routed config), so after a turn routed to the cheap easy provider, durable-memory fact extraction ran on the weak model. Reverted to `Cfg.Provider`/`Cfg.Model` (the primary): routing the chat reply cheaply should not silently downgrade the long-term memory the gateway writes.

**3. ApplyAutoRoute — fix a latent out-of-bounds write**
The `FallbackModels` carry-over loop iterated `0..High(PrimaryFallbackModels)` while writing into an array sized to `Length(PrimaryFallbacks)+1`. A caller with `FallbackModels` longer than `Fallbacks` would write past the end. Now bounded on `High(PrimaryFallbacks)` with an inner guard (symmetric with the `Fallbacks` loop above it).

**4. ApplyAutoRoute — restore the easy-provider cache across all surfaces**
The old CLI inline code cached the constructed easy provider for the session; the centralized helper rebuilt it on every routed turn. Added a per-thread cache keyed on provider name + a fingerprint of its config entry — no locking (the gateway routes from worker threads, each caches independently), and a `/v1/config` hot-swap busts the cache.

## Tests
`make test-autoroute-apply` extended to cover the cache-hit path and a hot-swap rebuild. Full native build green; `make test-autoroute-apply` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_