### PR TITLE
tui: fix dcc64 E2169 (field after method) in TTUI

### DIFF
--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -87,7 +87,9 @@ type
       so a session-lifetime snapshot is correct and matches the CLI's
       session-scoped easy-provider cache. }
     FRouteCfg: TConfig;
-    function RouteConfig: TConfig;
+    { NB: RouteConfig is declared further down, after every field -- dcc64
+      (E2169) forbids a field definition after a method/property in the same
+      visibility section, and the build branches below add more fields. }
     {$IFNDEF FPC}
     { positioned-TUI state -- see Run() for the per-frame loop }
     FFocus:             TFocus;
@@ -216,6 +218,10 @@ type
     procedure HandleRedoCommand(const Args: string);
     procedure HandleUserInput(const Text: string);
     {$ENDIF}
+    { Common to both builds; declared here (after all fields) so dcc64's
+      field-before-method rule isn't broken by the conditional field blocks
+      above. Lazily loads + caches FRouteCfg for the per-turn auto-router. }
+    function RouteConfig: TConfig;
   public
     (* Operator's prompt-cache settings. Defaults to default-on (matches
        DefaultChatOptions). Cmd_TUI_Run copies Cfg.PromptCache into this


### PR DESCRIPTION
## Problem

dcc64 fails to compile the TUI:

```
[dcc64 Error] PasClaw.TUI.pas(93): E2169 Field definition not allowed after methods or properties
```

The `RouteConfig` method (added in #395 for the per-turn auto-router config cache) was declared in the private section immediately after the `FRouteCfg` field but **before** the `{$IFNDEF FPC}` / `{$IFDEF FPC}` blocks, which themselves declare more fields (`FFocus`, `FSession`, the FPC REPL state, …). dcc64 enforces the Delphi rule that all fields in a visibility section must precede any method/property declaration, so those later fields tripped E2169. FPC is permissive about ordering, so the native build never caught it.

## Fix

Keep `FRouteCfg` in the field area and move the `function RouteConfig: TConfig;` declaration to the end of the private section (just before `public`, after every conditional field block). Pure declaration reordering — no behavior change; the implementation is untouched.

FPC build verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_