### PR TITLE
config: per-fallback model override (Opus-tapped → Sonnet on one key)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -595,6 +595,13 @@ test-autoroute-apply: $(BIN) | $(BUILDDIR) $(INDY_DIR)
 	  src/tests/autoroute_apply_tests.pas -o$(BUILDDIR)/autoroute_apply_tests
 	@$(BUILDDIR)/autoroute_apply_tests
 
+# Per-fallback model override (config round-trip + lockstep ResolveFallbacks).
+test-fallback-models: $(BIN) | $(BUILDDIR) $(INDY_DIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) \
+	  src/tests/fallback_models_tests.pas -o$(BUILDDIR)/fallback_models_tests
+	@$(BUILDDIR)/fallback_models_tests
+
 # Orient launch-preamble section (opt-in "announce a plan before tools").
 test-orient-preamble: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
@@ -802,4 +809,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -402,7 +402,7 @@ begin
   Result.Model         := Model;
   Result.MaxIterations := A.MaxIterations;
   Result.Parallel := True;
-  Result.Fallbacks     := ResolveFallbacks(Cfg);
+  Result.Fallbacks     := ResolveFallbacks(Cfg, Result.FallbackModels);
   Result.Options       := DefaultChatOptions;
   { ToolsEnabled tracks the registry we are about to hand RunToolLoop
     so the system prompt stays in sync with what the model can

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -359,7 +359,7 @@ begin
   Result := nil;
   if (Reg = nil) or (Length(Cfg.Subagents) = 0) then Exit;
   Ctx.Provider       := Provider;
-  Ctx.Fallbacks      := ResolveFallbacks(Cfg);
+  Ctx.Fallbacks      := ResolveFallbacks(Cfg, Ctx.FallbackModels);
   Ctx.ParentRegistry := Reg;
   Ctx.DefaultModel   := Model;
   Ctx.PromptCache    := Cfg.PromptCache;
@@ -376,7 +376,7 @@ begin
   Result := nil;
   if (Reg = nil) or (Length(Cfg.Subagents) = 0) then Exit;
   Ctx.Provider       := Provider;
-  Ctx.Fallbacks      := ResolveFallbacks(Cfg);
+  Ctx.Fallbacks      := ResolveFallbacks(Cfg, Ctx.FallbackModels);
   Ctx.ParentRegistry := Reg;
   Ctx.DefaultModel   := Model;
   Ctx.PromptCache    := Cfg.PromptCache;

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -1238,6 +1238,35 @@ begin
   end;
 end;
 
+{ Append (or update) a fallback entry plus its per-fallback model override,
+  keeping Cfg.Fallbacks and Cfg.FallbackModels aligned by index. De-dupes by
+  name: an existing entry just gets its model override refreshed. A non-empty
+  Model is what makes a SAME-provider fallback useful -- "anthropic" +
+  "claude-sonnet-4-6" retries Sonnet on one key when Opus is rate-limited
+  (#398). Empty Model -> the fallback uses its catalog/stored default. }
+procedure AppendFallbackWithModel(Cfg: TConfig; const Name, Model: string);
+var
+  i: Integer;
+begin
+  { Pad FallbackModels up to Fallbacks length so index assignment stays aligned
+    even if an earlier path appended a bare fallback. }
+  while Length(Cfg.FallbackModels) < Length(Cfg.Fallbacks) do
+  begin
+    SetLength(Cfg.FallbackModels, Length(Cfg.FallbackModels) + 1);
+    Cfg.FallbackModels[High(Cfg.FallbackModels)] := '';
+  end;
+  for i := 0 to High(Cfg.Fallbacks) do
+    if SameText(Cfg.Fallbacks[i], Name) then
+    begin
+      if Model <> '' then Cfg.FallbackModels[i] := Model;
+      Exit;
+    end;
+  SetLength(Cfg.Fallbacks, Length(Cfg.Fallbacks) + 1);
+  Cfg.Fallbacks[High(Cfg.Fallbacks)] := Name;
+  SetLength(Cfg.FallbackModels, Length(Cfg.Fallbacks));
+  Cfg.FallbackModels[High(Cfg.FallbackModels)] := Model;
+end;
+
 
 procedure PromptAutoRouter(Cfg: TConfig);
 { Configure a cheap-tier fallback + the auto-router (UltraCode-Shim
@@ -1256,7 +1285,7 @@ var
   Catalog, Pool: TProviderSpecArray;
   Spec: TProviderSpec;
   i: Integer;
-  AlreadyInFallbacks, SameAsPrimary: Boolean;
+  SameAsPrimary: Boolean;
 begin
   PrintLn;
   PrintLn(Ansi.Bold + 'Cheaper model for simple turns' + Ansi.Reset);
@@ -1349,21 +1378,10 @@ begin
   begin
     UpsertProvider(Cfg, Spec, Model, Key);
 
-    { Append to Cfg.Fallbacks unless it's already there. The retry
-      chain is keyed on Name == Spec.Kind by NewProviderFromConfig,
-      so we de-dupe by Kind. }
-    AlreadyInFallbacks := False;
-    for i := 0 to High(Cfg.Fallbacks) do
-      if SameText(Cfg.Fallbacks[i], Spec.Kind) then
-      begin
-        AlreadyInFallbacks := True;
-        Break;
-      end;
-    if not AlreadyInFallbacks then
-    begin
-      SetLength(Cfg.Fallbacks, Length(Cfg.Fallbacks) + 1);
-      Cfg.Fallbacks[High(Cfg.Fallbacks)] := Spec.Kind;
-    end;
+    { Add to the error-retry chain, recording the picked model as the
+      per-fallback override so the chain retries exactly that model (de-dupes
+      by name). }
+    AppendFallbackWithModel(Cfg, Spec.Kind, Model);
     PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
             ' added ' + Spec.DisplayName + ' to fallback chain');
   end;
@@ -1383,14 +1401,31 @@ begin
     PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
             ' auto-router on; easy turns route to ' + Spec.Kind);
   end
-  else if SameAsPrimary then
-    PrintLn('  ' + Ansi.Dim +
-            '(router off -- nothing else to set up for a same-provider pick. ' +
-            'Flip auto_router.enabled in config.json to enable.)' + Ansi.Reset)
-  else
+  else if not SameAsPrimary then
     PrintLn('  ' + Ansi.Dim +
             '(router off -- fallback still used on primary errors. ' +
             'Flip auto_router.enabled in config.json to enable.)' + Ansi.Reset);
+
+  { Same-provider capacity fallback (#398). Retrying the SAME provider only
+    helps when it's a DIFFERENT model -- "Opus rate-limited -> Sonnet on one
+    key" -- since per-model rate/capacity limits are real on subscription and
+    API. A different provider already went into the chain above. Offer it only
+    when the picked model is distinct and non-empty (else it's a same-model
+    retry, which buys nothing). }
+  if SameAsPrimary and (Model <> '') and (not SameText(Model, Cfg.DefaultModel)) then
+  begin
+    PrintLn;
+    Choice := Trim(LowerCase(ReadLineEcho(
+      '  Also retry ' + Model +
+      ' when your primary is rate-limited (capacity fallback)? [y/N]: ')));
+    if (Choice = 'y') or (Choice = 'yes') then
+    begin
+      AppendFallbackWithModel(Cfg, Spec.Kind, Model);
+      PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+              ' capacity fallback on; ' + Spec.DisplayName + ' retries ' + Model +
+              ' when the primary is rate-limited');
+    end;
+  end;
 end;
 
 procedure PromptVectorSearch(Cfg: TConfig);

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -213,7 +213,7 @@ begin
     if (Reg <> nil) and (Provider <> nil) and (Length(Cfg.Subagents) > 0) then
     begin
       SubCtx.Provider       := Provider;
-      SubCtx.Fallbacks      := ResolveFallbacks(Cfg);
+      SubCtx.Fallbacks      := ResolveFallbacks(Cfg, SubCtx.FallbackModels);
       SubCtx.ParentRegistry := Reg;
       SubCtx.DefaultModel   := Model;
       SubCtx.PromptCache    := Cfg.PromptCache;

--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -57,6 +57,7 @@ type
   TSubagentContext = record
     Provider:       ILLMProvider;
     Fallbacks:      TLLMProviderArray;
+    FallbackModels: TStringArray;   { lockstep per-fallback model overrides }
     ParentRegistry: TToolRegistry;
     DefaultModel:   string;
     (* Operator's prompt-cache config propagated from the parent so
@@ -335,6 +336,7 @@ begin
     ChildCfg.MaxIterations := MaxIter;
     ChildCfg.Parallel      := True;
     ChildCfg.Fallbacks     := FCtx.Fallbacks;
+    ChildCfg.FallbackModels := FCtx.FallbackModels;
     ChildCfg.Options       := DefaultChatOptions;
     ApplyPromptCacheConfig(ChildCfg.Options, FCtx.PromptCache);
     ChildCfg.Options.SystemPrompt := Spec.SystemPrompt;

--- a/src/pkg/agent/PasClaw.Agent.SubagentBg.pas
+++ b/src/pkg/agent/PasClaw.Agent.SubagentBg.pas
@@ -493,6 +493,7 @@ begin
     Box.Cfg.MaxIterations := MaxIter;
     Box.Cfg.Parallel      := True;
     Box.Cfg.Fallbacks     := FCtx.Fallbacks;
+    Box.Cfg.FallbackModels := FCtx.FallbackModels;
     Box.Cfg.Options       := DefaultChatOptions;
     ApplyPromptCacheConfig(Box.Cfg.Options, FCtx.PromptCache);
     Box.Cfg.Options.SystemPrompt := Spec.SystemPrompt;

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -804,7 +804,7 @@ begin
   Cfg.Model         := ModelName;
   Cfg.MaxIterations := FMaxIterations;
   Cfg.Parallel := True;
-  Cfg.Fallbacks     := ResolveFallbacks(FConfig);
+  Cfg.Fallbacks     := ResolveFallbacks(FConfig, Cfg.FallbackModels);
   Cfg.Hooks         := BuildHookArray;
   Cfg.Options       := DefaultChatOptions;
   ApplyPromptCacheConfig(Cfg.Options, FConfig.PromptCache);

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -602,7 +602,7 @@ begin
   if (Length(FConfig.Subagents) > 0) and (FProvider <> nil) then
   begin
     FSubagentCtx.Provider       := FProvider;
-    FSubagentCtx.Fallbacks      := ResolveFallbacks(FConfig);
+    FSubagentCtx.Fallbacks      := ResolveFallbacks(FConfig, FSubagentCtx.FallbackModels);
     FSubagentCtx.ParentRegistry := FRegistry;
     FSubagentCtx.PromptCache    := FConfig.PromptCache;
     if FModel <> '' then
@@ -634,7 +634,7 @@ begin
     on PR #107.) }
   if (FSpawnTool = nil) or (FProvider = nil) then Exit;
   FSubagentCtx.Provider       := FProvider;
-  FSubagentCtx.Fallbacks      := ResolveFallbacks(FConfig);
+  FSubagentCtx.Fallbacks      := ResolveFallbacks(FConfig, FSubagentCtx.FallbackModels);
   FSubagentCtx.ParentRegistry := FRegistry;
   FSubagentCtx.PromptCache    := FConfig.PromptCache;
   if FModel <> '' then

--- a/src/pkg/channels/PasClaw.Channels.Email.pas
+++ b/src/pkg/channels/PasClaw.Channels.Email.pas
@@ -419,7 +419,7 @@ begin
             LoopCfg.Model         := FCfg.DefaultModel;
             LoopCfg.MaxIterations := 6;
             LoopCfg.Parallel      := True;
-            LoopCfg.Fallbacks     := ResolveFallbacks(FCfg);
+            LoopCfg.Fallbacks     := ResolveFallbacks(FCfg, LoopCfg.FallbackModels);
             LoopCfg.Options       := DefaultChatOptions;
             ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
             LoopCfg.OnText        := nil;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -1662,6 +1662,14 @@ begin
       finally
         Arr.Free;
       end;
+      { FromJSON is merge-style (LoadConfig layers profile JSON, then
+        config.json). A later layer that overrides "fallbacks" but omits
+        "fallback_models" must NOT keep an inherited model array -- it would be
+        index-paired with the NEW providers and apply one provider's model to
+        another. Clear it here; the block below repopulates if this layer
+        actually carries fallback_models. }
+      if not Root.Has('fallback_models') then
+        SetLength(FallbackModels, 0);
     end;
     if Root.Has('fallback_models') then
     begin

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -526,6 +526,16 @@ type
       directly. Configured via `pasclaw auth fallback openai gemini`
       or by editing config.json's "fallbacks": ["openai","gemini"]. }
     Fallbacks:  array of string;
+    { Optional per-fallback model override, parallel to Fallbacks by index.
+      When FallbackModels[i] is non-empty the loop retries Fallbacks[i] with
+      THAT model instead of the provider's catalog default. This is what makes
+      a same-provider fallback useful: "fallbacks":["anthropic"] +
+      "fallback_models":["claude-sonnet-4-6"] retries Sonnet on one key when
+      Opus is rate-limited / overloaded (per-model limits are real on both the
+      subscription and the API). Empty entry / shorter array -> that fallback
+      uses its catalog default, exactly as before. Configured by editing
+      config.json's "fallback_models". }
+    FallbackModels: array of string;
     Gateway:    TGatewayConfig;
     Diagnostics: TDiagnosticsConfig;  { OpenTelemetry traces -- see TOtelDiagnosticsConfig }
     Sandbox:    TSandboxPolicy;
@@ -1175,6 +1185,15 @@ begin
         and (A.Threshold = B.Threshold);
 end;
 
+function AnyNonEmpty(const A: array of string): Boolean;
+var
+  i: Integer;
+begin
+  for i := Low(A) to High(A) do
+    if A[i] <> '' then Exit(True);
+  Result := False;
+end;
+
 function TConfig.ToJSON: string;
 var
   Root, Gw, Tmp, Tmp2, Diag, OtelHdrs, WTmp: TJsonObject;
@@ -1196,6 +1215,16 @@ begin
       for i := 0 to High(Fallbacks) do
         FallbacksArr.AddStr(Fallbacks[i]);
       Root.PutArray('fallbacks', FallbacksArr);  { takes ownership; sets FallbacksArr := nil }
+    end;
+    { Per-fallback model overrides, parallel to fallbacks. Emit only when at
+      least one entry is non-empty so configs without model overrides stay
+      tidy. }
+    if AnyNonEmpty(FallbackModels) then
+    begin
+      FallbacksArr := TJsonArray.Create;
+      for i := 0 to High(FallbackModels) do
+        FallbacksArr.AddStr(FallbackModels[i]);
+      Root.PutArray('fallback_models', FallbacksArr);
     end;
 
     Gw := TJsonObject.Create;
@@ -1630,6 +1659,18 @@ begin
         SetLength(Fallbacks, Arr.Count);
         for i := 0 to Arr.Count - 1 do
           Fallbacks[i] := Arr.ItemStr(i);
+      finally
+        Arr.Free;
+      end;
+    end;
+    if Root.Has('fallback_models') then
+    begin
+      Arr := Root.ChildArray('fallback_models');
+      if Arr <> nil then
+      try
+        SetLength(FallbackModels, Arr.Count);
+        for i := 0 to Arr.Count - 1 do
+          FallbackModels[i] := Arr.ItemStr(i);
       finally
         Arr.Free;
       end;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -93,6 +93,7 @@ type
        consistent (primary, fallbacks) pair via SnapshotProviders. *)
     FApplyLock: TCriticalSection;
     FFallbacks: TLLMProviderArray;
+    FFallbackModels: TStringArray;   { per-fallback model overrides, lockstep with FFallbacks }
     (* Per-process scoped credential. Random hex generated in Create
        once per `pasclaw serve` / `pasclaw gateway` startup. Gates the
        /v1/relay/* surface independently of Cfg.Gateway.Token so an
@@ -240,7 +241,7 @@ type
       primary, fallback chain, and default model copied together so a swap can't
       split them across a starting request. }
     procedure SnapshotRuntime(out Prim: ILLMProvider; out FB: TLLMProviderArray;
-                              out DefModel: string);
+                              out FBModels: TStringArray; out DefModel: string);
     { Rebuild + swap the live provider/fallbacks from a saved config. Returns
       False (and keeps the current provider) if the new primary won't build. }
     function ApplyProviderConfig(NewCfg: TConfig): Boolean;
@@ -742,7 +743,7 @@ begin
   { Live provider hot-swap state. Cache the fallback chain now (relay queue is
     registered above, so a relay fallback resolves) -- rebuilt on config write. }
   FApplyLock := TCriticalSection.Create;
-  FFallbacks := ResolveFallbacks(FCfg);
+  FFallbacks := ResolveFallbacks(FCfg, FFallbackModels);
 
   { Generate a fresh per-process relay-scoped token. Format is
     phone-typable: two 4-char groups separated by a hyphen
@@ -781,7 +782,7 @@ begin
 end;
 
 procedure TGatewayServer.SnapshotRuntime(out Prim: ILLMProvider;
-  out FB: TLLMProviderArray; out DefModel: string);
+  out FB: TLLMProviderArray; out FBModels: TStringArray; out DefModel: string);
 { Copy the primary provider, fallback chain, AND default model together under
   the lock so a concurrent ApplyProviderConfig swap can't tear them apart -- a
   request must not end up sending the new model to the old provider (or vice
@@ -794,6 +795,7 @@ begin
   try
     Prim     := FProvider;
     FB       := Copy(FFallbacks);
+    FBModels := Copy(FFallbackModels);
     DefModel := FCfg.DefaultModel;
   finally
     FApplyLock.Release;
@@ -808,6 +810,7 @@ function TGatewayServer.ApplyProviderConfig(NewCfg: TConfig): Boolean;
 var
   NewProv: ILLMProvider;
   NewFB: TLLMProviderArray;
+  NewFBModels: TStringArray;
   Err: string;
 begin
   Result := False;
@@ -817,11 +820,12 @@ begin
             [Err]);
     Exit;
   end;
-  NewFB := ResolveFallbacks(NewCfg);
+  NewFB := ResolveFallbacks(NewCfg, NewFBModels);
   FApplyLock.Acquire;
   try
     FProvider  := NewProv;
     FFallbacks := NewFB;
+    FFallbackModels := NewFBModels;
     { Keep the in-memory display/model fields in step so /v1/status and the
       legacy /v1/chat model reflect the switch immediately. }
     FCfg.DefaultProvider := NewCfg.DefaultProvider;
@@ -4306,6 +4310,7 @@ var
   LoopCfg: TToolLoopConfig;
   Prim: ILLMProvider;
   FB: TLLMProviderArray;
+  FBModels: TStringArray;
   DefModel: string;
 begin
   Body := '';
@@ -4345,7 +4350,7 @@ begin
 
   { Snapshot provider + fallbacks + default model together (one lock) so a live
     /v1/config swap can't pair the new model with the old provider. }
-  SnapshotRuntime(Prim, FB, DefModel);
+  SnapshotRuntime(Prim, FB, FBModels, DefModel);
   LoopCfg.Provider := Prim;
   if LoopCfg.Provider = nil then
   begin
@@ -4366,6 +4371,7 @@ begin
     plan keep working unchanged. }
   LoopCfg.Mode          := ParseModeFromBody(Body);
   LoopCfg.Fallbacks     := FB;
+  LoopCfg.FallbackModels := FBModels;
   LoopCfg.Options       := DefaultChatOptions;
   ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
   LoopCfg.Options.SystemPrompt := BuildSystemPrompt(FCfg, '',
@@ -4914,6 +4920,7 @@ var
   ActivityCollector: TToolActivityCollector;
   Prim: ILLMProvider;
   FB: TLLMProviderArray;
+  FBModels: TStringArray;
   SnapModel: string;
   function SanitizeStreamError(const S: string): string;
   begin
@@ -5003,7 +5010,7 @@ begin
 
     { Provider + fallbacks snapshotted together (model is the request's
       ReqModel, resolved at parse). }
-    SnapshotRuntime(Prim, FB, SnapModel);
+    SnapshotRuntime(Prim, FB, FBModels, SnapModel);
     LoopCfg.Provider := Prim;
     if LoopCfg.Provider = nil then
     begin
@@ -5020,6 +5027,7 @@ begin
     LoopCfg.Parallel := True;
     LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
     LoopCfg.Fallbacks     := FB;
+    LoopCfg.FallbackModels := FBModels;
     LoopCfg.Options       := DefaultChatOptions;
     ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
     if GetEffectiveGatewayToken(FCfg) <> '' then
@@ -6282,6 +6290,7 @@ var
   FcCallIdVal, FcSignatureVal: string;
   Prim: ILLMProvider;   { live-provider snapshot for this request (hot-swap safe) }
   FB: TLLMProviderArray;
+  FBModels: TStringArray;
   SnapModel: string;
 
   procedure AppendMessage(Role: TMsgRole; const Content: string);
@@ -6622,7 +6631,7 @@ begin
     finally
       ToolsArrIn.Free;
     end;
-    SnapshotRuntime(Prim, FB, SnapModel);
+    SnapshotRuntime(Prim, FB, FBModels, SnapModel);
     if Prim = nil then
     begin
       WriteJSON(AResp, 503,
@@ -6775,6 +6784,7 @@ begin
       LoopCfg.Parallel := True;
       LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
       LoopCfg.Fallbacks     := FB;
+      LoopCfg.FallbackModels := FBModels;
       LoopCfg.Options       := DefaultChatOptions;
       ApplyPromptCacheConfig(LoopCfg.Options, FCfg.PromptCache);
       if GetEffectiveGatewayToken(FCfg) <> '' then

--- a/src/pkg/providers/PasClaw.Providers.Factory.pas
+++ b/src/pkg/providers/PasClaw.Providers.Factory.pas
@@ -13,6 +13,9 @@ interface
 uses
   SysUtils,
   PasClaw.Config,
+  PasClaw.Tools.Registry,   { TStringArray -- same named type TToolLoopConfig
+                              .FallbackModels uses, so the out-param binds
+                              under dcc64's strict named-type matching }
   PasClaw.Providers.Intf;
 
 { TLLMProviderArray moved to PasClaw.Providers.Intf so both this unit
@@ -30,7 +33,16 @@ function NewDefaultProvider(Cfg: TConfig; out Provider: ILLMProvider; out ErrMsg
    silently skipped (a logged warning is the only feedback) so a typo
    in config.json doesn't break the loop. Returns an empty array when
    Cfg.Fallbacks is empty. *)
-function ResolveFallbacks(Cfg: TConfig): TLLMProviderArray;
+function ResolveFallbacks(Cfg: TConfig): TLLMProviderArray; overload;
+
+(* As above, additionally returning the per-fallback model overrides
+   (TConfig.FallbackModels) in LOCKSTEP with the resolved providers -- the
+   same skip logic applies to both, so FallbackModels[i] always lines up with
+   the returned providers[i]. Drop both into TToolLoopConfig.Fallbacks /
+   .FallbackModels so the loop retries each fallback with its configured model
+   (empty -> the provider's catalog default, as before). *)
+function ResolveFallbacks(Cfg: TConfig;
+                          out FallbackModels: TStringArray): TLLMProviderArray; overload;
 
 (* True iff RawKind/RawName identify the catalog's genuine OpenAI
    entry -- NOT "openai-compat" or any other catalog member of the
@@ -226,13 +238,15 @@ begin
   Result := NewProviderFromConfig(Cfg, Cfg.DefaultProvider, Provider, ErrMsg);
 end;
 
-function ResolveFallbacks(Cfg: TConfig): TLLMProviderArray;
+function ResolveFallbacks(Cfg: TConfig;
+                          out FallbackModels: TStringArray): TLLMProviderArray;
 var
   i, Out_: Integer;
   P: ILLMProvider;
   Err: string;
 begin
   SetLength(Result, Length(Cfg.Fallbacks));
+  SetLength(FallbackModels, Length(Cfg.Fallbacks));
   Out_ := 0;
   for i := 0 to High(Cfg.Fallbacks) do
   begin
@@ -247,9 +261,25 @@ begin
       Continue;
     end;
     Result[Out_] := P;
+    { Carry the per-fallback model override in lockstep with the resolved
+      provider so the indices stay aligned even when entries are skipped.
+      Empty (or absent) -> the loop falls through to the provider's catalog
+      default, exactly as before. }
+    if i <= High(Cfg.FallbackModels) then
+      FallbackModels[Out_] := Cfg.FallbackModels[i]
+    else
+      FallbackModels[Out_] := '';
     Inc(Out_);
   end;
   SetLength(Result, Out_);
+  SetLength(FallbackModels, Out_);
+end;
+
+function ResolveFallbacks(Cfg: TConfig): TLLMProviderArray;
+var
+  IgnoredModels: TStringArray;
+begin
+  Result := ResolveFallbacks(Cfg, IgnoredModels);
 end;
 
 end.

--- a/src/tests/fallback_models_tests.pas
+++ b/src/tests/fallback_models_tests.pas
@@ -157,11 +157,36 @@ begin
   end;
 end;
 
+procedure TestLayeredOverrideClearsStaleModels;
+{ FromJSON is merge-style (LoadConfig layers profile JSON then config.json). A
+  later layer that overrides "fallbacks" but omits "fallback_models" must not
+  keep the inherited model array -- it would be index-paired with the new
+  providers and misapply a model. (Review fix on PR #398.) }
+var
+  Cfg: TConfig;
+begin
+  Cfg := TConfig.Create;
+  try
+    Cfg.FromJSON('{"fallbacks":["anthropic"],"fallback_models":["claude-sonnet-4-6"]}');
+    AssertTrue((Length(Cfg.FallbackModels) = 1)
+               and (Cfg.FallbackModels[0] = 'claude-sonnet-4-6'),
+               'layer 1 sets fallback_models');
+    { Later layer overrides fallbacks, omits fallback_models. }
+    Cfg.FromJSON('{"fallbacks":["groq","openai"]}');
+    AssertTrue(Length(Cfg.Fallbacks) = 2, 'layer 2 replaced fallbacks');
+    AssertTrue(Length(Cfg.FallbackModels) = 0,
+               'stale fallback_models cleared when the overriding layer omits them');
+  finally
+    Cfg.Free;
+  end;
+end;
+
 begin
   TestRoundTrip;
   TestNotEmittedWhenAllBlank;
   TestResolveLockstep;
   TestResolveSkipKeepsAlignment;
   TestBackCompatOverloadStillWorks;
+  TestLayeredOverrideClearsStaleModels;
   WriteLn('fallback_models_tests: OK');
 end.

--- a/src/tests/fallback_models_tests.pas
+++ b/src/tests/fallback_models_tests.pas
@@ -1,0 +1,167 @@
+program fallback_models_tests;
+(*
+  Covers the per-fallback model override (TConfig.FallbackModels) end to end:
+    - config round-trip: fallback_models serializes only when populated and
+      parses back parallel to fallbacks;
+    - ResolveFallbacks(Cfg, out Models) returns the models in LOCKSTEP with the
+      resolved providers, including when an unresolvable entry is skipped;
+    - an empty / missing override leaves that slot blank (the loop then falls
+      through to the provider's catalog default).
+
+  This is what makes a same-provider fallback useful -- "Opus tapped -> Sonnet
+  on one key" -- since per-model rate/capacity limits are real on both the
+  subscription and the API.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils,
+  PasClaw.Config,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Factory;
+
+procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+procedure AssertTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")');
+end;
+
+{ Seed a groq provider so NewProviderFromConfig resolves without network. }
+procedure SeedGroq(Cfg: TConfig);
+begin
+  SetLength(Cfg.Providers, 1);
+  Cfg.Providers[0].Name   := 'groq';
+  Cfg.Providers[0].Kind   := 'groq';
+  Cfg.Providers[0].APIKey := 'gsk-test';   { construction only; no network }
+end;
+
+procedure TestRoundTrip;
+var
+  Cfg, Cfg2: TConfig;
+  S: string;
+begin
+  Cfg := TConfig.Create;
+  try
+    SetLength(Cfg.Fallbacks, 2);
+    Cfg.Fallbacks[0] := 'anthropic';
+    Cfg.Fallbacks[1] := 'groq';
+    SetLength(Cfg.FallbackModels, 2);
+    Cfg.FallbackModels[0] := 'claude-sonnet-4-6';
+    Cfg.FallbackModels[1] := '';   { blank -> catalog default for groq }
+    S := Cfg.ToJSON;
+    AssertTrue(Pos('fallback_models', S) > 0, 'fallback_models emitted when populated');
+
+    Cfg2 := TConfig.Create;
+    try
+      Cfg2.FromJSON(S);
+      AssertTrue(Length(Cfg2.FallbackModels) = 2, 'fallback_models parses with 2 entries');
+      AssertEqStr(Cfg2.FallbackModels[0], 'claude-sonnet-4-6', 'override[0] round-trips');
+      AssertEqStr(Cfg2.FallbackModels[1], '', 'blank override[1] round-trips');
+      AssertEqStr(Cfg2.Fallbacks[0], 'anthropic', 'fallbacks still parse');
+    finally
+      Cfg2.Free;
+    end;
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestNotEmittedWhenAllBlank;
+var
+  Cfg: TConfig;
+  S: string;
+begin
+  Cfg := TConfig.Create;
+  try
+    SetLength(Cfg.Fallbacks, 1);
+    Cfg.Fallbacks[0] := 'groq';
+    SetLength(Cfg.FallbackModels, 1);
+    Cfg.FallbackModels[0] := '';   { all blank -> don't clutter the file }
+    S := Cfg.ToJSON;
+    AssertTrue(Pos('fallback_models', S) = 0,
+               'all-blank fallback_models is not emitted');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestResolveLockstep;
+var
+  Cfg: TConfig;
+  Provs: TLLMProviderArray;
+  Models: array of string;
+begin
+  Cfg := TConfig.Create;
+  try
+    SeedGroq(Cfg);
+    SetLength(Cfg.Fallbacks, 1);
+    Cfg.Fallbacks[0] := 'groq';
+    SetLength(Cfg.FallbackModels, 1);
+    Cfg.FallbackModels[0] := 'llama-3.1-8b-instant';
+    Provs := ResolveFallbacks(Cfg, Models);
+    AssertTrue(Length(Provs) = 1, 'one provider resolved');
+    AssertEqStr(Provs[0].GetName, 'groq', 'resolved provider is groq');
+    AssertTrue(Length(Models) = 1, 'one model in lockstep');
+    AssertEqStr(Models[0], 'llama-3.1-8b-instant', 'override carried in lockstep');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestResolveSkipKeepsAlignment;
+{ An unresolvable first entry must be skipped from BOTH arrays so the model
+  stays aligned with its provider. }
+var
+  Cfg: TConfig;
+  Provs: TLLMProviderArray;
+  Models: array of string;
+begin
+  Cfg := TConfig.Create;
+  try
+    SeedGroq(Cfg);
+    SetLength(Cfg.Fallbacks, 2);
+    Cfg.Fallbacks[0] := 'phantom';   { unresolvable -> skipped }
+    Cfg.Fallbacks[1] := 'groq';
+    SetLength(Cfg.FallbackModels, 2);
+    Cfg.FallbackModels[0] := 'ignored-because-phantom-skipped';
+    Cfg.FallbackModels[1] := 'llama-3.1-8b-instant';
+    Provs := ResolveFallbacks(Cfg, Models);
+    AssertTrue(Length(Provs) = 1, 'only groq resolves');
+    AssertTrue(Length(Models) = 1, 'models compacted in lockstep');
+    AssertEqStr(Provs[0].GetName, 'groq', 'surviving provider is groq');
+    AssertEqStr(Models[0], 'llama-3.1-8b-instant',
+                'surviving model stays aligned with its provider');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestBackCompatOverloadStillWorks;
+var
+  Cfg: TConfig;
+  Provs: TLLMProviderArray;
+begin
+  Cfg := TConfig.Create;
+  try
+    SeedGroq(Cfg);
+    SetLength(Cfg.Fallbacks, 1);
+    Cfg.Fallbacks[0] := 'groq';
+    Provs := ResolveFallbacks(Cfg);   { old no-models overload }
+    AssertTrue(Length(Provs) = 1, 'back-compat overload resolves providers');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+begin
+  TestRoundTrip;
+  TestNotEmittedWhenAllBlank;
+  TestResolveLockstep;
+  TestResolveSkipKeepsAlignment;
+  TestBackCompatOverloadStillWorks;
+  WriteLn('fallback_models_tests: OK');
+end.


### PR DESCRIPTION
Makes a same-provider fallback genuinely useful: when **Opus** is rate-limited / overloaded, retry **Sonnet** on the *same key* — because per-model rate and capacity limits are real on both the subscription and the API (Anthropic and Gemini). Previously the fallback chain was provider-names-only and each fallback resolved to its *catalog-default* model, so a same-provider entry just retried the same model — useless. This wires the missing config half.

## What's added

- **`TConfig.FallbackModels`** — a per-fallback model override, parallel-by-index to `fallbacks`, parsed/serialized as `"fallback_models"`. Example:
  ```jsonc
  "fallbacks":       ["anthropic"],
  "fallback_models": ["claude-sonnet-4-6"]
  ```
  Empty / missing entry → that fallback uses its catalog default, exactly as before (existing configs unchanged). Emitted only when at least one entry is non-empty.
- **`ResolveFallbacks` overload** returning the models in **lockstep** with the resolved providers — the same skip logic applies to both arrays, so indices stay aligned even when an entry is unresolvable. The old no-models overload delegates to it.
- **All loop builders thread it through:** CLI `BuildLoopConfig`, the embeddable component (`TPasClawAgent`), the email channel, and the gateway (new `FFallbackModels` field, `SnapshotRuntime` out-param, live `/v1/config` hot-swap, and all three chat handlers).

The runtime half already existed — `TToolLoopConfig.FallbackModels`, honored by `RunToolLoop`'s fallback walk since the auto-router model-preservation work (#393/#395). This PR just supplies it from config.

## Tests
New `test-fallback-models`: config round-trip (emitted only when populated, parses parallel), lockstep resolution, skip-keeps-alignment (unresolvable entry drops from both arrays), and the back-compat overload. Existing autoroute/config tests still pass; full native build green.

## Not included (deliberately, to keep this small)
Onboarding doesn't yet *offer* to set up a same-provider capacity fallback — for now it's a config edit. Easy follow-up now that the same-provider easy-tier onboarding (#397) has landed: a "also fall back to a smaller model on this provider when it's rate-limited?" prompt that populates `fallback_models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_