### PR TITLE
types: one canonical TStringArray in PasClaw.Utils (fix dcc64 collisions)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Profile.pas
+++ b/src/cmd/PasClaw.Cmd.Profile.pas
@@ -423,14 +423,11 @@ type
   end;
   TBenchAggArray = array of TBenchAgg;
 
-  (* dcc64 E2003 fix: FPC accepted the bare `array of string` return
-     type via name-equivalence with a TStringArray declared somewhere
-     reachable through the uses chain, but Delphi requires the
-     identifier be in scope locally. Declare it here so the two
-     compilers agree without dragging an unrelated unit into the
-     uses block. Same idiom PasClaw.Tools.Registry / PasClaw.Tools.
-     Shell.Filters / MVCFramework.Console.pas use. *)
-  TStringArray = array of string;
+  (* Alias the canonical PasClaw.Utils.TStringArray (already in this unit's
+     implementation uses) so the identifier is in scope for dcc64 while keeping
+     a single type identity across the codebase. On FPC it resolves to the RTL
+     SysUtils.TStringArray via the Utils alias. *)
+  TStringArray = PasClaw.Utils.TStringArray;
 
 (* Split "a,b,c" into ['a','b','c'], trimming each entry. *)
 function SplitCSV(const S: string): TStringArray;

--- a/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.RelayQueue.pas
@@ -81,6 +81,7 @@ interface
 
 uses
   SysUtils, Classes, SyncObjs,
+  PasClaw.Utils,            { canonical TStringArray (Delphi side) }
   PasClaw.Providers.Types;
 
 const
@@ -108,12 +109,11 @@ const
 
 type
   {$IFNDEF FPC}
-  { Delphi's RTL doesn't declare TStringArray (FPC's SysUtils does);
-    declare it locally so the cross-compiler signatures below resolve.
-    Same pattern PasClaw.Tools.Registry + PasClaw.Tools.Shell.Filters
-    use for the same gap. dcc64 E2003 / E2005 errors at every signature
-    that references TStringArray cascade until this is in scope. }
-  TStringArray = array of string;
+  { Delphi's RTL doesn't declare TStringArray (FPC's SysUtils does). Alias the
+    canonical PasClaw.Utils definition so RelayQueue.TStringArray is the SAME
+    type as Registry's etc. -- the gateway uses both, and distinct named types
+    here caused dcc64 E2010/E2250 on the fallback-model arrays. }
+  TStringArray = PasClaw.Utils.TStringArray;
   {$ENDIF}
 
   TRelayRequestId = string;

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -13,14 +13,17 @@ interface
 
 uses
   SysUtils, Classes, SyncObjs,
+  PasClaw.Utils,            { canonical TStringArray (Delphi side) }
   PasClaw.Tools.Types,
   PasClaw.Providers.Types;
 
 type
   {$IFNDEF FPC}
-  { Delphi's RTL doesn't declare TStringArray (FPC's SysUtils does); declare
-    it locally so the cross-compiler signature below resolves. }
-  TStringArray = array of string;
+  { Delphi's RTL doesn't declare TStringArray (FPC's SysUtils does). Alias the
+    one canonical definition in PasClaw.Utils so every unit's TStringArray is
+    the SAME type identity -- otherwise dcc64 rejects cross-unit array passes
+    (E2010/E2250). }
+  TStringArray = PasClaw.Utils.TStringArray;
   {$ENDIF}
 
   TToolRegistry = class

--- a/src/pkg/tools/PasClaw.Tools.Shell.Filters.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.Filters.pas
@@ -71,17 +71,16 @@ implementation
 
 uses
   Classes, StrUtils,
+  PasClaw.Utils,           { canonical TStringArray (Delphi side) }
   PasClaw.Condense.JSON;   { FilterAws routes JSON-shaped aws CLI
                              output through the shared condenser }
 
 {$IFNDEF FPC}
 type
-  { FPC's SysUtils declares TStringArray; Delphi's RTL doesn't,
-    so dcc64 errors on the SplitTokens return type and every
-    downstream LowerCase(Tokens[i]) call below. Declare it
-    locally for the Delphi build only -- same pattern PasClaw
-    uses in PasClaw.Tools.Registry. }
-  TStringArray = array of string;
+  { FPC's SysUtils declares TStringArray; Delphi's RTL doesn't. Alias the
+    canonical PasClaw.Utils definition (Delphi build only) instead of a fresh
+    local one -- keeps a single type identity across the codebase. }
+  TStringArray = PasClaw.Utils.TStringArray;
 {$ENDIF}
 
 var

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -12,6 +12,22 @@ interface
 uses
   SysUtils, Classes, DateUtils;
 
+type
+  (* Canonical dynamic string array. FPC's SysUtils already exports a
+     TStringArray that every FPC unit shares, so the per-unit local defs were
+     all Delphi-only -- the duplication (and dcc64's E2010/E2250 "distinct
+     named type" collisions) only ever bit the Delphi build. Mirror that here:
+     alias the RTL type on FPC (so PasClaw.Utils.TStringArray is literally
+     SysUtils.TStringArray and adds no second type), and provide the ONE
+     canonical definition on Delphi, which the former definers now alias.
+     PasClaw.Utils depends only on the RTL, so it is safe to use anywhere
+     without a cycle. *)
+  {$IFDEF FPC}
+  TStringArray = SysUtils.TStringArray;
+  {$ELSE}
+  TStringArray = array of string;
+  {$ENDIF}
+
 function DupStr(const S: string; Count: Integer): string;
 function VisibleLength(const S: string): Integer;
 (* Right-pad S with spaces until its visible length reaches W. Same


### PR DESCRIPTION
## Problem
dcc64 fails to compile the gateway after #398:
```
[dcc64 Error] PasClaw.Gateway.Server.pas(746): E2250 no overloaded version of 'ResolveFallbacks' ...
[dcc64 Error] PasClaw.Gateway.Server.pas(4374): E2010 Incompatible types:
              'PasClaw.Tools.Registry.TStringArray' and 'PasClaw.Gateway.RelayQueue.TStringArray'
```
Four units each declared their own `TStringArray = array of string` (Registry, RelayQueue, Shell.Filters, Cmd.Profile) — all gated Delphi-only, because FPC's `SysUtils` already exports one that every FPC unit shares. dcc64 treats each local declaration as a **distinct named type**, so when the gateway uses both Registry and RelayQueue, the per-fallback model arrays don't match. FPC was permissive, which is why this only ever broke the Delphi build.

## Fix
Define `TStringArray` **once** in `PasClaw.Utils`:
- **FPC:** `TStringArray = SysUtils.TStringArray` — literally the RTL type every FPC unit already uses, so no second type is introduced.
- **Delphi:** `TStringArray = array of string` — the single canonical definition.

The four former definers now **alias** `PasClaw.Utils.TStringArray` (Delphi side), so every unit has one type identity. Because these are aliases (not `type X = type Y`), they re-export the same type — **consumers are untouched**, and the gateway needs no change since `Registry.TStringArray` and `RelayQueue.TStringArray` are now the same type. `PasClaw.Utils` depends only on the RTL, so the added `uses` are cycle-free.

## Verification
I can't run dcc64 here, but this is the canonical disambiguation (single named type). FPC build green; `fallback-models`, `config-profile`, `auto-router`, `shell-filters`, `provider-catalog` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_