### PR TITLE
gateway: reflect the live provider hot-swap in GET /v1/config

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -843,6 +843,15 @@ begin
     FCfg.Fallbacks       := Copy(NewCfg.Fallbacks);
     FCfg.FallbackModels  := Copy(NewCfg.FallbackModels);
     FCfg.AutoRouter      := NewCfg.AutoRouter;
+    { Provider-WIDE construction knobs that NewProviderFromConfig bakes into
+      the live provider objects (and into auto-routed easy providers built from
+      FCfg) -- mirror them too, or GET would report stale values for settings
+      that are already active and the router's easy provider would keep the old
+      server-tool/relay options until restart. }
+    FCfg.AnthropicServerTools := NewCfg.AnthropicServerTools;
+    FCfg.OpenAIServerTools    := NewCfg.OpenAIServerTools;
+    FCfg.GeminiServerTools    := NewCfg.GeminiServerTools;
+    FCfg.RelayWaitTimeoutMs   := NewCfg.RelayWaitTimeoutMs;
   finally
     FApplyLock.Release;
   end;
@@ -2516,7 +2525,17 @@ begin
     OPENAI_API_KEY=, GITHUB_TOKEN=, etc. for stdio MCP servers.
     Mask any non-empty secret field with "•••" so the UI can show
     "set vs unset" without leaking the value. }
-  Body := FCfg.ToJSON;
+  { Serialize under the hot-swap lock: ApplyProviderConfig mutates FCfg's
+    providers/fallbacks/fallback_models/auto_router (+ the provider-wide
+    server-tool/relay knobs) live, so an overlapping PUT could otherwise make
+    ToJSON traverse a dynamic array/refcounted string mid-replacement -- a torn
+    body or an access violation. The lock window is just the snapshot. }
+  FApplyLock.Acquire;
+  try
+    Body := FCfg.ToJSON;
+  finally
+    FApplyLock.Release;
+  end;
   Root := TJsonObject.Parse(Body);
   if Root = nil then
   begin

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -826,10 +826,23 @@ begin
     FProvider  := NewProv;
     FFallbacks := NewFB;
     FFallbackModels := NewFBModels;
-    { Keep the in-memory display/model fields in step so /v1/status and the
-      legacy /v1/chat model reflect the switch immediately. }
+    { Mirror the LIVE-swapped surface into FCfg so GET /v1/config (which
+      serializes FCfg) reflects what is actually running now, and so the
+      per-turn router -- which reads FCfg.AutoRouter / the fallback config --
+      picks up the change without a restart. Only the fields this swap truly
+      applies live are copied: provider/model, the provider catalog the live
+      objects were built from, the fallback chain + per-fallback models, and
+      the auto-router. Everything else (sandbox, mcp, crons, gateway, ...) is
+      established at boot and still needs a restart, so we deliberately leave
+      FCfg's copies of those untouched -- GET then stays honest about what is
+      actually active vs merely saved to disk. Copy() the dynamic arrays so we
+      don't alias NewCfg (the caller frees it on return). }
     FCfg.DefaultProvider := NewCfg.DefaultProvider;
     FCfg.DefaultModel    := NewCfg.DefaultModel;
+    FCfg.Providers       := Copy(NewCfg.Providers);
+    FCfg.Fallbacks       := Copy(NewCfg.Fallbacks);
+    FCfg.FallbackModels  := Copy(NewCfg.FallbackModels);
+    FCfg.AutoRouter      := NewCfg.AutoRouter;
   finally
     FApplyLock.Release;
   end;


### PR DESCRIPTION
## Problem
`ApplyProviderConfig` hot-swaps the primary provider + fallback chain on a `/v1/config` write, but only mirrored `DefaultProvider`/`DefaultModel` back into `FCfg`. Two consequences:
- `GET /v1/config` serializes `FCfg`, so after a live save it showed **stale** `providers` / `auto_router` / `fallbacks` / `fallback_models` (the web wizard's save looked like it "lost" everything when read back).
- The per-turn router reads `FCfg.AutoRouter`, so a routing change saved via `/v1/config` kept using the **boot-time** value until restart — even though the provider/fallback objects had already switched live.

## Fix
Mirror the fields this swap actually applies live — `providers`, `fallbacks`, `fallback_models`, `auto_router` — into `FCfg` under the same `FApplyLock` (`Copy()` the dynamic arrays so we don't alias the caller's `TConfig`, which it frees on return). Non-provider settings (sandbox, mcp, crons, gateway) are established at boot and still need a restart, so they're deliberately **left untouched** — `GET` stays honest about what's actually active vs merely saved. `GET /v1/config` now also reads `FCfg.ToJSON` under the lock so it can't observe a half-applied swap.

Bonus: `auto_router` changes via `/v1/config` now take effect live (the router reads the mirrored `FCfg.AutoRouter`), consistent with how the provider/fallback swap already worked.

## Verification
Drove it live: `PUT /v1/config` with `providers`/`auto_router`/`fallbacks`/`fallback_models`, then `GET /v1/config` returns all of them (previously empty/stale). FPC build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_