### PR TITLE
mcp: tool_search explains an empty deferred set (disabled/unloaded servers)

### DIFF
--- a/src/pkg/mcp/PasClaw.MCP.Disclosure.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Disclosure.pas
@@ -124,6 +124,15 @@ uses
 
 var
   GRegistry: TToolRegistry = nil;
+  { Snapshot of the configured MCP servers captured at registration so
+    tool_search can explain an empty deferred set: "no MCP tools active --
+    replicate is DISABLED" beats a bare "No deferred tools to search," which
+    reads as "there are none" and sends the model off inventing CLI/Python
+    workarounds. Cfg is only available at registration, not in the stateless
+    handler, hence the module globals (same pattern as GRegistry). }
+  GMCPConfigured:    Integer = 0;   { total configured servers (any enabled state) }
+  GMCPDisabledList:  string  = '';  { comma-joined names with enabled=false }
+  GMCPEnabledList:   string  = '';  { comma-joined names with enabled=true }
 
 { ---- query parsing ---- }
 
@@ -222,6 +231,27 @@ begin
   end;
 end;
 
+{ Actionable message for an empty deferred set. Progressive disclosure is on
+  (tool_search wouldn't be registered otherwise), so "nothing to search" means
+  no MCP tool is currently revealed-able -- explain WHY using the configured
+  server snapshot, instead of a dead end that reads as "no such capability." }
+function EmptyDeferredMessage: string;
+begin
+  if GMCPConfigured = 0 then
+    Exit('No MCP tools are configured, so there is nothing to search. '
+       + 'Add an MCP server (e.g. `pasclaw mcp add`) to gain external tools.');
+  Result := 'No MCP tools are active right now.';
+  if GMCPDisabledList <> '' then
+    Result := Result + ' Configured but DISABLED: ' + GMCPDisabledList
+            + ' -- set "enabled": true for it in mcp_servers in config.json '
+            + 'and restart pasclaw to use its tools.';
+  if GMCPEnabledList <> '' then
+    Result := Result + ' Enabled but no tools loaded yet (still connecting, or '
+            + 'the server failed to start): ' + GMCPEnabledList
+            + ' -- retry tool_search in a moment, or check the logs for an '
+            + 'mcp[...] error.';
+end;
+
 { ---- handler ---- }
 
 function ToolSearchHandler(const ArgsJSON: string; out ErrMsg: string): string;
@@ -275,7 +305,7 @@ begin
   DeferredNames := GRegistry.DeferredNames;
   if Length(DeferredNames) = 0 then
   begin
-    Result := 'No deferred tools to search.';
+    Result := EmptyDeferredMessage;
     Exit;
   end;
 
@@ -450,11 +480,29 @@ end;
 procedure RegisterMCPDisclosureTools(Reg: TToolRegistry; const Cfg: TConfig);
 var
   T: TTool;
+  i: Integer;
 begin
   if Reg = nil then Exit;
   if not Cfg.MCPProgressiveDisclosure then Exit;
 
   GRegistry := Reg;
+
+  { Capture the configured MCP servers so an empty deferred set can name the
+    disabled / not-yet-loaded ones instead of a dead-end message. }
+  GMCPConfigured   := Length(Cfg.MCPServers);
+  GMCPDisabledList := '';
+  GMCPEnabledList  := '';
+  for i := 0 to High(Cfg.MCPServers) do
+    if Cfg.MCPServers[i].Enabled then
+    begin
+      if GMCPEnabledList <> '' then GMCPEnabledList := GMCPEnabledList + ', ';
+      GMCPEnabledList := GMCPEnabledList + Cfg.MCPServers[i].Name;
+    end
+    else
+    begin
+      if GMCPDisabledList <> '' then GMCPDisabledList := GMCPDisabledList + ', ';
+      GMCPDisabledList := GMCPDisabledList + Cfg.MCPServers[i].Name;
+    end;
 
   T.Name        := 'tool_search';
   T.Description := ToolSearchDesc;

--- a/src/pkg/mcp/PasClaw.MCP.Disclosure.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Disclosure.pas
@@ -236,16 +236,30 @@ end;
   no MCP tool is currently revealed-able -- explain WHY using the configured
   server snapshot, instead of a dead end that reads as "no such capability." }
 function EmptyDeferredMessage: string;
+var
+  Revealed: Boolean;
 begin
   if GMCPConfigured = 0 then
     Exit('No MCP tools are configured, so there is nothing to search. '
        + 'Add an MCP server (e.g. `pasclaw mcp add`) to gain external tools.');
-  Result := 'No MCP tools are active right now.';
+  { An empty deferred set after tools were revealed means the MCP tools loaded
+    fine and are already active -- not that a server failed. Distinguish the
+    two so a follow-up search after revealing the last tool doesn't slander a
+    healthy server. }
+  Revealed := (GRegistry <> nil) and GRegistry.AnyRevealed;
+  if Revealed then
+    Result := 'No remaining deferred MCP tools to load -- the available MCP '
+            + 'tools have already been revealed and are active; call the one '
+            + 'you need directly by name.'
+  else
+    Result := 'No MCP tools are active right now.';
   if GMCPDisabledList <> '' then
     Result := Result + ' Configured but DISABLED: ' + GMCPDisabledList
             + ' -- set "enabled": true for it in mcp_servers in config.json '
             + 'and restart pasclaw to use its tools.';
-  if GMCPEnabledList <> '' then
+  { Only warn about not-loaded servers when nothing has been revealed -- if a
+    reveal has happened, the enabled servers did load. }
+  if (not Revealed) and (GMCPEnabledList <> '') then
     Result := Result + ' Enabled but no tools loaded yet (still connecting, or '
             + 'the server failed to start): ' + GMCPEnabledList
             + ' -- retry tool_search in a moment, or check the logs for an '

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -85,6 +85,10 @@ type
     function  DeferredNames: TStringArray;
     function  DeferredFind(const Name: string; out T: TTool): Boolean;
     procedure Reveal(const Name: string);
+    { True once any deferred tool has been revealed (FRevealed non-empty).
+      Lets tool_search distinguish "deferred set empty because all MCP tools
+      are revealed + active" from "empty because none ever loaded". }
+    function  AnyRevealed: Boolean;
   end;
 
 implementation
@@ -197,6 +201,16 @@ begin
   FLock.Acquire;
   try
     Result := Length(FTools);
+  finally
+    FLock.Release;
+  end;
+end;
+
+function TToolRegistry.AnyRevealed: Boolean;
+begin
+  FLock.Acquire;
+  try
+    Result := Length(FRevealed) > 0;
   finally
     FLock.Release;
   end;

--- a/src/tests/mcp_disclosure_tests.pas
+++ b/src/tests/mcp_disclosure_tests.pas
@@ -331,6 +331,39 @@ begin
   WriteLn('  ok: tool_search names a configured-but-disabled MCP server');
 end;
 
+procedure TestToolSearchEmptyAfterAllRevealed;
+{ Review fix: once an enabled server's deferred tools are all revealed,
+  DeferredNames is empty but the tools are ACTIVE. tool_search must report
+  "already revealed / active," not slander the healthy server as failed. }
+var
+  Reg: TToolRegistry;
+  Cfg: TConfig;
+  Result_, ErrMsg: string;
+begin
+  Reg := TToolRegistry.Create;
+  Cfg := TConfig.Create;
+  try
+    Cfg.MCPProgressiveDisclosure := True;
+    SetLength(Cfg.MCPServers, 1);
+    Cfg.MCPServers[0].Name    := 'replicate';
+    Cfg.MCPServers[0].Enabled := True;
+    RegisterMCPDisclosureTools(Reg, Cfg);
+    RegisterDeferredTool(Reg, 'replicate_create_predictions', 'Create a prediction');
+    { Reveal the only deferred tool, then search again -> deferred set empty. }
+    Reg.RunTool('tool_search', '{"query":"select:replicate_create_predictions"}', ErrMsg);
+    Result_ := Reg.RunTool('tool_search', '{"query":"nothing-left"}', ErrMsg);
+    AssertTrue(ErrMsg = '', 'all-revealed: no error');
+    AssertContains(Result_, 'already been revealed',
+                   'all-revealed: reports tools active, not failed');
+    AssertTrue(Pos('failed to start', Result_) = 0,
+               'all-revealed: does NOT claim the server failed');
+  finally
+    Cfg.Free;
+    Reg.Free;
+  end;
+  WriteLn('  ok: tool_search reports all-revealed servers as active, not failed');
+end;
+
 procedure TestToolSearchEmptyDeferredEnabledButUnloaded;
 { Enabled server but no tools registered yet (cold cache / still connecting /
   failed). tool_search should say so and suggest a retry, not a dead end. }
@@ -427,6 +460,7 @@ begin
   TestToolSearchEmptyDeferred;
   TestToolSearchEmptyDeferredDisabledServer;
   TestToolSearchEmptyDeferredEnabledButUnloaded;
+  TestToolSearchEmptyAfterAllRevealed;
   TestToolSearchSkipsRegistrationWhenDisabled;
   TestConfigRoundTrip;
   WriteLn('ok - mcp disclosure tests passed');

--- a/src/tests/mcp_disclosure_tests.pas
+++ b/src/tests/mcp_disclosure_tests.pas
@@ -292,13 +292,71 @@ begin
     RegisterMCPDisclosureTools(Reg, Cfg);
     Result_ := Reg.RunTool('tool_search', '{"query":"anything"}', ErrMsg);
     AssertTrue(ErrMsg = '', 'empty-deferred: no error');
-    AssertContains(Result_, 'No deferred tools',
-                   'empty-deferred: clean text result');
+    { No MCP servers configured at all -> explain that, not a bare dead end. }
+    AssertContains(Result_, 'No MCP tools are configured',
+                   'empty-deferred (none configured): explains nothing is configured');
   finally
     Cfg.Free;
     Reg.Free;
   end;
-  WriteLn('  ok: tool_search with no deferred tools returns clean text');
+  WriteLn('  ok: tool_search with no MCP configured returns an explanatory message');
+end;
+
+procedure TestToolSearchEmptyDeferredDisabledServer;
+{ The case that produced the 25-call flail: an MCP server is configured but
+  disabled, so no tools register. tool_search must NAME it as disabled with the
+  fix, instead of "No deferred tools to search" (which reads as "no such
+  capability"). }
+var
+  Reg: TToolRegistry;
+  Cfg: TConfig;
+  Result_, ErrMsg: string;
+begin
+  Reg := TToolRegistry.Create;
+  Cfg := TConfig.Create;
+  try
+    Cfg.MCPProgressiveDisclosure := True;
+    SetLength(Cfg.MCPServers, 1);
+    Cfg.MCPServers[0].Name    := 'replicate';
+    Cfg.MCPServers[0].Enabled := False;
+    RegisterMCPDisclosureTools(Reg, Cfg);
+    Result_ := Reg.RunTool('tool_search', '{"query":"flux image"}', ErrMsg);
+    AssertTrue(ErrMsg = '', 'disabled-server: no error');
+    AssertContains(Result_, 'DISABLED', 'disabled-server: flags a disabled server');
+    AssertContains(Result_, 'replicate', 'disabled-server: names the disabled server');
+  finally
+    Cfg.Free;
+    Reg.Free;
+  end;
+  WriteLn('  ok: tool_search names a configured-but-disabled MCP server');
+end;
+
+procedure TestToolSearchEmptyDeferredEnabledButUnloaded;
+{ Enabled server but no tools registered yet (cold cache / still connecting /
+  failed). tool_search should say so and suggest a retry, not a dead end. }
+var
+  Reg: TToolRegistry;
+  Cfg: TConfig;
+  Result_, ErrMsg: string;
+begin
+  Reg := TToolRegistry.Create;
+  Cfg := TConfig.Create;
+  try
+    Cfg.MCPProgressiveDisclosure := True;
+    SetLength(Cfg.MCPServers, 1);
+    Cfg.MCPServers[0].Name    := 'replicate';
+    Cfg.MCPServers[0].Enabled := True;
+    RegisterMCPDisclosureTools(Reg, Cfg);
+    Result_ := Reg.RunTool('tool_search', '{"query":"flux image"}', ErrMsg);
+    AssertTrue(ErrMsg = '', 'enabled-unloaded: no error');
+    AssertContains(Result_, 'no tools loaded yet',
+                   'enabled-unloaded: explains the server has not loaded tools');
+    AssertContains(Result_, 'replicate', 'enabled-unloaded: names the server');
+  finally
+    Cfg.Free;
+    Reg.Free;
+  end;
+  WriteLn('  ok: tool_search explains an enabled-but-unloaded MCP server');
 end;
 
 procedure TestToolSearchSkipsRegistrationWhenDisabled;
@@ -367,6 +425,8 @@ begin
   TestToolSearchKeywordQueryRanksAndCaps;
   TestToolSearchRequiredTerm;
   TestToolSearchEmptyDeferred;
+  TestToolSearchEmptyDeferredDisabledServer;
+  TestToolSearchEmptyDeferredEnabledButUnloaded;
   TestToolSearchSkipsRegistrationWhenDisabled;
   TestConfigRoundTrip;
   WriteLn('ok - mcp disclosure tests passed');


### PR DESCRIPTION
## Why
A user asked PasClaw to generate an image (Replicate MCP). It flailed for ~25 calls — `tool_search("replicate")`/`"flux"` kept returning **"No deferred tools to search,"** so the model gave up on tools and started inventing a `pasclaw __tool` CLI and writing Python.

Root cause: the Replicate server was **disabled** in config. `ConnectMCPServers` skips disabled servers *before* the cache pass, so no tools (deferred or otherwise) register — and the bare "No deferred tools" message reads as "this capability doesn't exist," giving the model no reason to retry or any hint that a server is just turned off.

## What
Capture the configured MCP servers (names + `enabled` flags) at `RegisterMCPDisclosureTools` time — `Cfg` is available there but not in the stateless handler — and replace the empty-deferred message with an actionable one:
- **none configured** → "No MCP tools are configured … add one with `pasclaw mcp add`."
- **configured but DISABLED** → names them: "Configured but DISABLED: replicate — set `enabled: true` in `mcp_servers` and restart."
- **enabled but no tools loaded yet** (cold cache / still connecting / failed) → names them and says retry / check logs.

Cycle-free: it only reads `Cfg` (already passed in), with no dependency on the bridge's live `GStates` (which would create a Disclosure↔Bridge cycle). It can't split "loading" vs "failed" precisely, but "still connecting or failed — retry / check logs" is actionable for both.

## Tests
Extended `mcp_disclosure_tests` (calls `tool_search` via `RunTool`): none-configured, configured-but-disabled (names it + "DISABLED"), and enabled-but-unloaded. Updated the existing empty-deferred test for the new message. All pass; FPC build green.

This would have turned that 25-call episode into one turn: *"replicate is DISABLED — enable it and restart."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_