### PR TITLE
subagents: never return an empty result from a finished spawn (fix "(no output)")

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -46,6 +46,16 @@ uses
   PasClaw.Tools.Registry,
   PasClaw.Tools.Obj;
 
+const
+  { Default per-spawn tool-iteration cap used when a subagent spec leaves
+    MaxIter unset (0). Matches picoclaw's `max_tool_iterations: 20` default
+    -- subagents there inherit the same cap -- and openclaw's docs, which
+    put the practical ceiling at 15-20 (most tasks finish under 10). The
+    old default of 4 was far too tight: a general-purpose agent that reads
+    a couple of files and runs a command would trip the cap before it ever
+    produced an answer. }
+  DefaultSubagentMaxIter = 20;
+
 type
   { TSubagentSpecArray now lives in PasClaw.Config alongside
     TSubagentSpec -- see comment there for the dcc64 named-type
@@ -435,7 +445,7 @@ begin
   Model := Spec.Model;
   if Model = '' then Model := FCtx.DefaultModel;
   MaxIter := Spec.MaxIter;
-  if MaxIter <= 0 then MaxIter := 4;
+  if MaxIter <= 0 then MaxIter := DefaultSubagentMaxIter;
 
   ChildReg := BuildFilteredRegistry(FCtx.ParentRegistry, Spec.Tools);
   ChildDisc := nil;

--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -474,7 +474,7 @@ begin
     LogInfo('subagent spawn: name=%s model=%s tools=%d',
             [AgentName, Model, ChildReg.Count]);
     if RunToolLoop(ChildCfg, ChildHist, Loop) then
-      Result := Loop.Content
+      Result := LoopResultText(Loop)   { never a bare '' for a successful run }
     else
       ErrMsg := Format('spawn: subagent "%s" failed', [AgentName]);
   finally

--- a/src/pkg/agent/PasClaw.Agent.SubagentBg.pas
+++ b/src/pkg/agent/PasClaw.Agent.SubagentBg.pas
@@ -256,7 +256,7 @@ begin
     else if Ok then
     begin
       FState      := bjDone;
-      FResultText := Loop.Content;
+      FResultText := LoopResultText(Loop);   { never a bare '' for a done job }
     end
     else
     begin

--- a/src/pkg/agent/PasClaw.Agent.SubagentBg.pas
+++ b/src/pkg/agent/PasClaw.Agent.SubagentBg.pas
@@ -490,7 +490,7 @@ begin
     Model := Spec.Model;
     if Model = '' then Model := FCtx.DefaultModel;
     MaxIter := Spec.MaxIter;
-    if MaxIter <= 0 then MaxIter := 4;
+    if MaxIter <= 0 then MaxIter := DefaultSubagentMaxIter;
 
     Job := TBgJob.Create(True);   { suspended }
     Job.FStateLock := TCriticalSection.Create;

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -678,18 +678,25 @@ var
 begin
   Result := Loop.Content;
   if Trim(Result) <> '' then Exit;
-  { Loop ended without a closing text turn (last round was a tool call, or it
-    hit MaxIterations). Recover the last assistant text from history. }
-  for i := High(Loop.FinalMessages) downto Low(Loop.FinalMessages) do
-    if (Loop.FinalMessages[i].Role = mrAssistant)
-       and (Trim(Loop.FinalMessages[i].Content) <> '') then
-      Exit(Loop.FinalMessages[i].Content);
-  { Genuinely no text at all -- explain rather than return ''. }
+  { Empty Content. Recover the last assistant text from history ONLY when the
+    loop ended on a tool call (HitMaxIterations) -- there the final turn was a
+    tool call rather than a closing answer, so the most recent assistant text
+    is the best "what it produced before it ran out". A CLEAN stop with empty
+    Content is different: the model deliberately ended its turn with no text and
+    no tool call, so scanning back for earlier progress text ("let me check
+    X...") would misreport that throwaway line as the completed answer. Leave
+    the clean empty stop to the no-answer note below. }
+  if Loop.HitMaxIterations then
+    for i := High(Loop.FinalMessages) downto Low(Loop.FinalMessages) do
+      if (Loop.FinalMessages[i].Role = mrAssistant)
+         and (Trim(Loop.FinalMessages[i].Content) <> '') then
+        Exit(Loop.FinalMessages[i].Content);
+  { Genuinely no usable text -- explain rather than return ''. }
   if Loop.HitMaxIterations then
     Result := Format('(no final answer: hit the %d-iteration limit after %d tool call(s) -- raise max_iterations or narrow the task)',
                      [Loop.Iterations, Integer(Loop.ToolCallsDispatched)])
   else
-    Result := Format('(no final answer: ended after %d iteration(s) and %d tool call(s) without producing text)',
+    Result := Format('(no final answer: the agent ended its turn without producing text, after %d iteration(s) and %d tool call(s))',
                      [Loop.Iterations, Integer(Loop.ToolCallsDispatched)]);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -213,6 +213,14 @@ function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
 
+{ The textual result of a finished loop. Loop.Content is the final assistant
+  text, but it is EMPTY when the loop ended on a tool-call round or hit
+  MaxIterations without a closing text turn -- which makes a subagent's
+  spawn_wait return a bare "(no output)" even though the job ran. Fall back to
+  the last non-empty assistant text in history, then to a clear note explaining
+  there was no final answer (so callers never surface emptiness as success). }
+function LoopResultText(const Loop: TToolLoopResult): string;
+
 { Build the operator-facing "stopped at the tool-iteration limit" notice
   from a finished loop result, or '' when the loop did NOT hit the cap (so
   callers can append it unconditionally). MaxIter is the configured cap;
@@ -662,6 +670,27 @@ begin
     SetLength(Result, Length(Result) + 1);
     Result[High(Result)] := Nm;
   end;
+end;
+
+function LoopResultText(const Loop: TToolLoopResult): string;
+var
+  i: Integer;
+begin
+  Result := Loop.Content;
+  if Trim(Result) <> '' then Exit;
+  { Loop ended without a closing text turn (last round was a tool call, or it
+    hit MaxIterations). Recover the last assistant text from history. }
+  for i := High(Loop.FinalMessages) downto Low(Loop.FinalMessages) do
+    if (Loop.FinalMessages[i].Role = mrAssistant)
+       and (Trim(Loop.FinalMessages[i].Content) <> '') then
+      Exit(Loop.FinalMessages[i].Content);
+  { Genuinely no text at all -- explain rather than return ''. }
+  if Loop.HitMaxIterations then
+    Result := Format('(no final answer: hit the %d-iteration limit after %d tool call(s) -- raise max_iterations or narrow the task)',
+                     [Loop.Iterations, Integer(Loop.ToolCallsDispatched)])
+  else
+    Result := Format('(no final answer: ended after %d iteration(s) and %d tool call(s) without producing text)',
+                     [Loop.Iterations, Integer(Loop.ToolCallsDispatched)]);
 end;
 
 function FormatMaxIterNotice(const Loop: TToolLoopResult; MaxIter: Integer;

--- a/src/tests/max_iter_notice_tests.pas
+++ b/src/tests/max_iter_notice_tests.pas
@@ -11,6 +11,7 @@ program max_iter_notice_tests;
 
 uses
   SysUtils,
+  PasClaw.Providers.Types,
   PasClaw.Tools.ToolLoop;
 
 procedure Fail_(const Msg: string);
@@ -68,5 +69,35 @@ begin
   AssertTrue(Has(S, '--max-iterations N'), 'stateless notice keeps the how-to-raise hint');
 
   WriteLn('  ok: format max-iter notice (clean / fields / resumable vs stateless)');
+
+  { LoopResultText: a subagent that finished with no closing text turn must not
+    yield a bare '' (the spawn_wait "(no output)" bug). }
+  Loop := Default(TToolLoopResult);
+  Loop.Content := 'the answer is 42';
+  AssertTrue(LoopResultText(Loop) = 'the answer is 42',
+    'LoopResultText returns Content when present');
+
+  { Empty Content but an earlier assistant text in history -> recover it. }
+  Loop := Default(TToolLoopResult);
+  Loop.Content := '';
+  SetLength(Loop.FinalMessages, 3);
+  Loop.FinalMessages[0] := MakeMessage(mrUser, 'q');
+  Loop.FinalMessages[1] := MakeMessage(mrAssistant, 'sum is 76127');
+  Loop.FinalMessages[2] := MakeMessage(mrAssistant, '');   { final turn: tool-call only }
+  AssertTrue(LoopResultText(Loop) = 'sum is 76127',
+    'LoopResultText recovers the last non-empty assistant text');
+
+  { Empty Content, no assistant text, hit the cap -> a clear note, never ''. }
+  Loop := Default(TToolLoopResult);
+  Loop.Content := '';
+  Loop.HitMaxIterations := True;
+  Loop.Iterations := 4;
+  Loop.ToolCallsDispatched := 4;
+  S := LoopResultText(Loop);
+  AssertTrue(S <> '', 'LoopResultText never returns empty for a finished run');
+  AssertTrue(Has(S, 'no final answer') and Has(S, 'limit'),
+    'LoopResultText explains a max-iter empty result');
+
+  WriteLn('  ok: LoopResultText (content / recovered text / no-answer note)');
   WriteLn('PASS');
 end.

--- a/src/tests/max_iter_notice_tests.pas
+++ b/src/tests/max_iter_notice_tests.pas
@@ -77,15 +77,35 @@ begin
   AssertTrue(LoopResultText(Loop) = 'the answer is 42',
     'LoopResultText returns Content when present');
 
-  { Empty Content but an earlier assistant text in history -> recover it. }
+  { Hit the cap with empty Content but an earlier assistant text in history
+    -> recover it (the final turn was a tool call, not a closing answer). }
   Loop := Default(TToolLoopResult);
   Loop.Content := '';
+  Loop.HitMaxIterations := True;
   SetLength(Loop.FinalMessages, 3);
   Loop.FinalMessages[0] := MakeMessage(mrUser, 'q');
   Loop.FinalMessages[1] := MakeMessage(mrAssistant, 'sum is 76127');
   Loop.FinalMessages[2] := MakeMessage(mrAssistant, '');   { final turn: tool-call only }
   AssertTrue(LoopResultText(Loop) = 'sum is 76127',
-    'LoopResultText recovers the last non-empty assistant text');
+    'LoopResultText recovers the last non-empty assistant text on a max-iter stop');
+
+  { CLEAN stop (no tool calls) with empty Content but stale progress text in
+    history -> must NOT return the stale text as a successful answer; report a
+    no-answer note instead. This is the review fix: history recovery is gated
+    to tool-call (max-iter) endings, never clean empty stops. }
+  Loop := Default(TToolLoopResult);
+  Loop.Content := '';
+  Loop.HitMaxIterations := False;          { clean stop }
+  Loop.Iterations := 2;
+  Loop.ToolCallsDispatched := 1;
+  SetLength(Loop.FinalMessages, 2);
+  Loop.FinalMessages[0] := MakeMessage(mrUser, 'q');
+  Loop.FinalMessages[1] := MakeMessage(mrAssistant, 'let me check the file...');
+  S := LoopResultText(Loop);
+  AssertTrue(not Has(S, 'let me check the file'),
+    'LoopResultText does NOT return stale progress text on a clean empty stop');
+  AssertTrue(Has(S, 'no final answer'),
+    'LoopResultText reports a no-answer note on a clean empty stop');
 
   { Empty Content, no assistant text, hit the cap -> a clear note, never ''. }
   Loop := Default(TToolLoopResult);


### PR DESCRIPTION
## The bug
A user spawned two background subagents; the first returned its answer via `spawn_wait`, the second showed `state=done` but `spawn_wait` returned **`(no output)`** (twice), forcing a foreground re-run. The model then invented a "buffer flush / network glitch" explanation — which is wrong.

Real cause: both spawn handlers set the result to `Loop.Content` (the loop's *final assistant text*). When a subagent ends on a **tool-call round** or **hits its iteration cap** without a closing text turn, `Loop.Content` is `""` — yet `RunToolLoop` returns success, so the job is marked `bjDone` with an empty `FResultText`. `spawn_wait` then hands back a bare empty string → `(no output)`, and `spawn_status` shows no preview. A sibling run that happens to end on a text turn looks fine, which is exactly why it presents as a flaky "only the second one failed." The sync `spawn` has the identical line and the same latent bug.

## The fix
Add `LoopResultText(Loop)` in `PasClaw.Tools.ToolLoop`:
1. `Loop.Content` if non-empty;
2. else the **last non-empty assistant text** in `Loop.FinalMessages` (recovers the answer when the final turn was tool-call-only);
3. else a clear note — e.g. *"(no final answer: hit the 4-iteration limit after 4 tool call(s) — raise max_iterations or narrow the task)"* — **never a bare `""`** for a completed run.

Both spawn handlers (`TSpawnTool.Run` sync + `TBgJob.Execute` background) now use it, so `spawn` / `spawn_wait` / `spawn_status` always return something meaningful, and a max-iter stop is surfaced honestly instead of looking like a silent failure.

## Tests
Extended `test-max-iter-notice`: `Content` passthrough, history-recovery when `Content` is empty, and the max-iter no-answer note. `subagent-bg` / `subagent-default` still pass; FPC build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_