### PR TITLE
stream: retry Gemini MALFORMED_FUNCTION_CALL empty turns with a nudge

### DIFF
--- a/src/pkg/stream/PasClaw.Stream.Reliability.pas
+++ b/src/pkg/stream/PasClaw.Stream.Reliability.pas
@@ -87,9 +87,11 @@ function DefaultStreamReliabilityConfig: TStreamReliabilityConfig;
 function LoadStreamReliabilityFromEnv(
   const Defaults: TStreamReliabilityConfig): TStreamReliabilityConfig;
 
-{ The empty-turn shape: provider returned 2xx with no text, no tool
-  calls, and a non-error finish_reason. This is the surface symptom
-  of an upstream brownout. }
+{ The empty-turn shape: provider returned 2xx with no text and no tool
+  calls, and a finish_reason that is either non-error (a brownout: stop /
+  '' / end_turn) or Gemini's MALFORMED_FUNCTION_CALL (an unparseable /
+  oversized function call that yielded nothing usable). Both surface as a
+  turn that produced no work and is worth re-issuing. }
 function IsEmptyTurn(const R: TLLMResponse): Boolean;
 
 { Drop-in wrapper around Provider.Chat that retries empty turns.
@@ -199,7 +201,19 @@ begin
   Result := (R.Content = '')
         and (Length(R.ToolCalls) = 0)
         and ((R.FinishReason = 'stop') or (R.FinishReason = '') or
-             (R.FinishReason = 'end_turn'));
+             (R.FinishReason = 'end_turn') or
+             { Gemini returns MALFORMED_FUNCTION_CALL when it generated a
+               function call it could not itself serialise -- classically a
+               single tool argument that was too large (a whole inline HTML
+               file crammed into fs_write.content). The candidate carries no
+               text and no usable functionCall, so the shape is exactly an
+               empty turn: no content, no tool calls. Without this the turn
+               falls through to RunToolLoop's clean-stop exit and the agent
+               dies with "(no content returned by the model)", forcing the
+               user to hand-type "continue". Treating it as retryable lets
+               ChatWithEmptyRetry re-issue the turn (with a corrective nudge
+               -- see there) instead of silently giving up mid-task. }
+             (R.FinishReason = 'MALFORMED_FUNCTION_CALL'));
 end;
 
 function ChatWithEmptyRetry(Provider: ILLMProvider;
@@ -211,6 +225,9 @@ function ChatWithEmptyRetry(Provider: ILLMProvider;
 var
   Attempt: Integer;
   Backoff: Integer;
+  i: Integer;
+  RetryMsgs: TMessageArray;   { original history + a corrective nudge, built
+                                lazily the first time we retry a malformed call }
 begin
   if Provider = nil then
   begin
@@ -227,15 +244,43 @@ begin
   Attempt := 0;
   Backoff := Cfg.EmptyRetryBackoffMs;
   if Backoff < 50 then Backoff := 50;
+  SetLength(RetryMsgs, 0);
   while (Attempt < Cfg.EmptyRetryAttempts) and
         (Result.StatusCode >= 200) and (Result.StatusCode < 300) and
         IsEmptyTurn(Result) do
   begin
     Inc(Attempt);
-    LogWarn('stream-reliability: empty turn from %s/%s, retry %d/%d after %dms',
-            [Provider.GetName, Model, Attempt, Cfg.EmptyRetryAttempts, Backoff]);
+    { A MALFORMED_FUNCTION_CALL is usually not a brownout -- the model
+      produced a call it could not serialise (typically an oversized
+      argument), so a bare re-send of the identical history tends to
+      reproduce it verbatim. Append a one-shot corrective user turn that
+      tells the model to stop narrating and re-issue a smaller, well-formed
+      call (write a stub, then extend with fs_edit_hashline). Built once and
+      reused across attempts. Plain brownout empties (finish=stop/'') are
+      genuinely transient and get a clean re-send with no nudge. }
+    if (Result.FinishReason = 'MALFORMED_FUNCTION_CALL')
+       and (Length(RetryMsgs) = 0) then
+    begin
+      SetLength(RetryMsgs, Length(Messages) + 1);
+      for i := 0 to High(Messages) do RetryMsgs[i] := Messages[i];
+      RetryMsgs[High(RetryMsgs)] := MakeMessage(mrUser,
+        'Your previous response was not a valid tool call -- the function ' +
+        'call could not be parsed, usually because a single argument was too ' +
+        'large (for example a whole file crammed into fs_write.content). Do ' +
+        'NOT describe the work in prose or paste file contents into the chat. ' +
+        'Re-issue ONE well-formed tool call now. If you are creating a large ' +
+        'file, write a short first version with fs_write, then grow it in ' +
+        'steps with fs_edit_hashline instead of emitting the whole file in a ' +
+        'single call.');
+    end;
+    LogWarn('stream-reliability: empty turn (finish=%s, nudge=%s) from %s/%s, retry %d/%d after %dms',
+            [Result.FinishReason, BoolToStr(Length(RetryMsgs) > 0, True),
+             Provider.GetName, Model, Attempt, Cfg.EmptyRetryAttempts, Backoff]);
     Sleep(Backoff);
-    Result := Provider.Chat(Messages, Tools, Model, Options);
+    if Length(RetryMsgs) > 0 then
+      Result := Provider.Chat(RetryMsgs, Tools, Model, Options)
+    else
+      Result := Provider.Chat(Messages, Tools, Model, Options);
     Backoff := Backoff * 2;
     if Backoff > 16000 then Backoff := 16000;
   end;

--- a/src/pkg/stream/PasClaw.Stream.Reliability.pas
+++ b/src/pkg/stream/PasClaw.Stream.Reliability.pas
@@ -216,6 +216,22 @@ begin
              (R.FinishReason = 'MALFORMED_FUNCTION_CALL'));
 end;
 
+function FirstToolPresent(const Tools: array of TToolDefinition;
+                          const Candidates: array of string): string;
+{ Return the first Candidate name that is actually in the supplied Tools
+  list, or '' when none are. Lets the malformed-call nudge name only tools
+  the model can really call -- a --no-hashline session omits the hashline
+  editor, so a nudge naming it would steer Gemini toward an undeclared
+  function. Candidate order is preference (best incremental option first). }
+var
+  i, j: Integer;
+begin
+  Result := '';
+  for j := 0 to High(Candidates) do
+    for i := 0 to High(Tools) do
+      if Tools[i].Name = Candidates[j] then Exit(Candidates[j]);
+end;
+
 function ChatWithEmptyRetry(Provider: ILLMProvider;
                             const Messages: array of TMessage;
                             const Tools:    array of TToolDefinition;
@@ -228,6 +244,7 @@ var
   i: Integer;
   RetryMsgs: TMessageArray;   { original history + a corrective nudge, built
                                 lazily the first time we retry a malformed call }
+  WriteTool, EditTool, Nudge, WriteClause: string;
 begin
   if Provider = nil then
   begin
@@ -255,23 +272,37 @@ begin
       argument), so a bare re-send of the identical history tends to
       reproduce it verbatim. Append a one-shot corrective user turn that
       tells the model to stop narrating and re-issue a smaller, well-formed
-      call (write a stub, then extend with fs_edit_hashline). Built once and
-      reused across attempts. Plain brownout empties (finish=stop/'') are
-      genuinely transient and get a clean re-send with no nudge. }
+      call. The "how to write a large file" hint names ONLY tools present in
+      the supplied Tools list (a --no-hashline session has no hashline
+      editor), falling back to a tool-agnostic "split into smaller calls"
+      when no incremental editor is registered. Built once and reused across
+      attempts. Plain brownout empties (finish=stop/'') are genuinely
+      transient and get a clean re-send with no nudge. }
     if (Result.FinishReason = 'MALFORMED_FUNCTION_CALL')
        and (Length(RetryMsgs) = 0) then
     begin
-      SetLength(RetryMsgs, Length(Messages) + 1);
-      for i := 0 to High(Messages) do RetryMsgs[i] := Messages[i];
-      RetryMsgs[High(RetryMsgs)] := MakeMessage(mrUser,
+      Nudge :=
         'Your previous response was not a valid tool call -- the function ' +
         'call could not be parsed, usually because a single argument was too ' +
-        'large (for example a whole file crammed into fs_write.content). Do ' +
-        'NOT describe the work in prose or paste file contents into the chat. ' +
-        'Re-issue ONE well-formed tool call now. If you are creating a large ' +
-        'file, write a short first version with fs_write, then grow it in ' +
-        'steps with fs_edit_hashline instead of emitting the whole file in a ' +
-        'single call.');
+        'large (for example a whole file crammed into one write). Do NOT ' +
+        'describe the work in prose or paste file contents into the chat. ' +
+        'Re-issue ONE well-formed tool call now.';
+      WriteTool := FirstToolPresent(Tools, ['write_file', 'fs_write']);
+      EditTool  := FirstToolPresent(Tools, ['append_file', 'edit_file', 'fs_edit_hashline']);
+      if EditTool <> '' then
+      begin
+        WriteClause := 'write a short first version';
+        if WriteTool <> '' then WriteClause := WriteClause + ' with ' + WriteTool;
+        Nudge := Nudge + ' If you are creating a large file, ' + WriteClause +
+                 ', then extend it in smaller steps with ' + EditTool +
+                 ' rather than emitting the whole file in one call.';
+      end
+      else
+        Nudge := Nudge + ' If a single argument was too large, split the work ' +
+                 'into smaller tool calls rather than emitting it all at once.';
+      SetLength(RetryMsgs, Length(Messages) + 1);
+      for i := 0 to High(Messages) do RetryMsgs[i] := Messages[i];
+      RetryMsgs[High(RetryMsgs)] := MakeMessage(mrUser, Nudge);
     end;
     LogWarn('stream-reliability: empty turn (finish=%s, nudge=%s) from %s/%s, retry %d/%d after %dms',
             [Result.FinishReason, BoolToStr(Length(RetryMsgs) > 0, True),

--- a/src/tests/stream_reliability_tests.pas
+++ b/src/tests/stream_reliability_tests.pas
@@ -89,6 +89,8 @@ type
   private
     FScript:      array of TLLMResponse;
     FCallCount:   Integer;
+    FLastMsgCount: Integer;   { #messages seen on the most recent Chat call }
+    FLastMsgTail:  string;    { content of the last message on that call }
     FSleepBefore: Integer;  { ms per Chat / ChatStream call }
     FChunkText:   string;   { if non-empty, ChatStream emits this as one chunk
                               before returning the scripted response }
@@ -105,6 +107,9 @@ type
   public
     constructor Create;
     function ChatCallCount: Integer;
+    function LastMsgCount: Integer;
+    function LastMsgTail: string;
+    procedure AddScriptedMalformed;
     procedure SetSleepBeforeMs(MS: Integer);
     procedure SetChunkText(const Text: string);
     procedure SetProtocolOnlyChunks(V: Boolean);
@@ -139,6 +144,23 @@ begin
 end;
 
 function TScriptedProvider.ChatCallCount: Integer; begin Result := FCallCount; end;
+function TScriptedProvider.LastMsgCount: Integer;  begin Result := FLastMsgCount; end;
+function TScriptedProvider.LastMsgTail: string;    begin Result := FLastMsgTail; end;
+
+procedure TScriptedProvider.AddScriptedMalformed;
+{ Gemini's empty MALFORMED_FUNCTION_CALL shape: 200, no content, no tool
+  calls, finish_reason carries the malformed marker. }
+var
+  R: TLLMResponse;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode   := 200;
+  R.FinishReason := 'MALFORMED_FUNCTION_CALL';
+  R.Content      := '';
+  SetLength(R.ToolCalls, 0);
+  SetLength(FScript, Length(FScript) + 1);
+  FScript[High(FScript)] := R;
+end;
 
 procedure TScriptedProvider.SetSleepBeforeMs(MS: Integer);
 begin FSleepBefore := MS; end;
@@ -187,6 +209,9 @@ var
 begin
   if FSleepBefore > 0 then Sleep(FSleepBefore);
   Inc(FCallCount);
+  FLastMsgCount := Length(Messages);
+  if Length(Messages) > 0 then FLastMsgTail := Messages[High(Messages)].Content
+                          else FLastMsgTail := '';
   if Length(FScript) = 0 then
   begin
     Result := Default(TLLMResponse);
@@ -276,6 +301,53 @@ begin
   SetLength(R.ToolCalls, 1);
   R.ToolCalls[0] := Tc;
   AssertFalse(IsEmptyTurn(R), 'has tool calls not empty turn');
+
+  { Gemini's MALFORMED_FUNCTION_CALL with no content and no tool calls is a
+    retryable empty turn (the fix for the "(no content returned)" dead turn). }
+  R := Default(TLLMResponse);
+  R.StatusCode := 200;
+  R.Content := '';
+  SetLength(R.ToolCalls, 0);
+  R.FinishReason := 'MALFORMED_FUNCTION_CALL';
+  AssertTrue(IsEmptyTurn(R), 'Gemini MALFORMED_FUNCTION_CALL is an empty turn');
+
+  { ...but only when it truly produced nothing: a malformed marker alongside
+    salvaged text or a tool call is not empty. }
+  R.Content := 'partial';
+  AssertFalse(IsEmptyTurn(R), 'MALFORMED with salvaged content is not empty');
+end;
+
+procedure TestMalformedFunctionCallRetriedWithNudge;
+var
+  P: TScriptedProvider;
+  Pi: ILLMProvider;
+  Cfg: TStreamReliabilityConfig;
+  Msgs: array of TMessage;
+  Tools: array of TToolDefinition;
+  R: TLLMResponse;
+begin
+  P := TScriptedProvider.Create;
+  Pi := P;
+  P.AddScriptedMalformed;               { first turn: Gemini malformed call }
+  P.AddScriptedContent('index.html written');  { retry recovers }
+
+  Cfg := DefaultStreamReliabilityConfig;
+  Cfg.EmptyRetryAttempts  := 2;
+  Cfg.EmptyRetryBackoffMs := 50;
+
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'build the site');
+  SetLength(Tools, 0);
+
+  R := ChatWithEmptyRetry(Pi, Msgs, Tools, 'fake', DefaultChatOptions, Cfg);
+
+  AssertEqStr(R.Content, 'index.html written', 'malformed call retried to a real answer');
+  AssertEqInt(P.ChatCallCount, 2, 'one malformed + one retry');
+  { The retry carried a corrective nudge appended to the history (original 1
+    message + 1 nudge = 2), steering the model to a smaller, valid call. }
+  AssertEqInt(P.LastMsgCount, 2, 'retry history has the corrective nudge appended');
+  AssertTrue(Pos('fs_edit_hashline', P.LastMsgTail) > 0,
+    'nudge tells the model to write incrementally with fs_edit_hashline');
 end;
 
 procedure TestChatWithEmptyRetryHappyPath;
@@ -663,6 +735,7 @@ end;
 
 begin
   TestIsEmptyTurn;                       WriteLn('  ok: IsEmptyTurn');
+  TestMalformedFunctionCallRetriedWithNudge; WriteLn('  ok: MALFORMED_FUNCTION_CALL retried with nudge');
   TestChatWithEmptyRetryHappyPath;       WriteLn('  ok: ChatWithEmptyRetry happy path');
   TestChatWithEmptyRetryExhaustion;      WriteLn('  ok: ChatWithEmptyRetry exhaustion');
   TestChatWithEmptyRetryDisabled;        WriteLn('  ok: ChatWithEmptyRetry disabled');

--- a/src/tests/stream_reliability_tests.pas
+++ b/src/tests/stream_reliability_tests.pas
@@ -337,7 +337,10 @@ begin
 
   SetLength(Msgs, 1);
   Msgs[0] := MakeMessage(mrUser, 'build the site');
-  SetLength(Tools, 0);
+  { Advertise write + an incremental editor so the nudge can name real tools. }
+  SetLength(Tools, 2);
+  Tools[0] := Default(TToolDefinition); Tools[0].Name := 'write_file';
+  Tools[1] := Default(TToolDefinition); Tools[1].Name := 'edit_file';
 
   R := ChatWithEmptyRetry(Pi, Msgs, Tools, 'fake', DefaultChatOptions, Cfg);
 
@@ -346,8 +349,31 @@ begin
   { The retry carried a corrective nudge appended to the history (original 1
     message + 1 nudge = 2), steering the model to a smaller, valid call. }
   AssertEqInt(P.LastMsgCount, 2, 'retry history has the corrective nudge appended');
-  AssertTrue(Pos('fs_edit_hashline', P.LastMsgTail) > 0,
-    'nudge tells the model to write incrementally with fs_edit_hashline');
+  { The nudge names ONLY tools present in the Tools list -- here write_file +
+    edit_file, never a tool that wasn't advertised. }
+  AssertTrue(Pos('edit_file', P.LastMsgTail) > 0,
+    'nudge names the registered incremental editor (edit_file)');
+  AssertTrue(Pos('write_file', P.LastMsgTail) > 0,
+    'nudge names the registered writer (write_file)');
+  AssertTrue(Pos('fs_edit_hashline', P.LastMsgTail) = 0,
+    'nudge does NOT name an unregistered tool');
+
+  { With NO incremental editor advertised (e.g. --no-hashline), the nudge
+    falls back to tool-agnostic guidance and names no unavailable tool. }
+  P := TScriptedProvider.Create;
+  Pi := P;
+  P.AddScriptedMalformed;
+  P.AddScriptedContent('done');
+  SetLength(Tools, 1);
+  Tools[0] := Default(TToolDefinition); Tools[0].Name := 'write_file';
+  R := ChatWithEmptyRetry(Pi, Msgs, Tools, 'fake', DefaultChatOptions, Cfg);
+  AssertEqStr(R.Content, 'done', 'malformed retried with no editor advertised');
+  AssertTrue(Pos('fs_edit_hashline', P.LastMsgTail) = 0,
+    'no-editor nudge names no hashline tool');
+  AssertTrue(Pos('edit_file', P.LastMsgTail) = 0,
+    'no-editor nudge names no edit_file');
+  AssertTrue(Pos('smaller tool calls', P.LastMsgTail) > 0,
+    'no-editor nudge falls back to generic split guidance');
 end;
 
 procedure TestChatWithEmptyRetryHappyPath;


### PR DESCRIPTION
## The bug

A `pasclaw serve` + web UI run with Gemini (`gemini-3.5-flash`) repeatedly stalled with **`(no content returned by the model; finish_reason=MALFORMED_FUNCTION_CALL)`**, forcing the user to hand-type "continue" over and over while the deliverable never landed.

Root cause: Gemini returns `finish_reason=MALFORMED_FUNCTION_CALL` when it emits a function call it can't itself serialise — classically a single oversized argument (a whole inline HTML file crammed into `write_file.content`). The candidate carries no text and no usable `functionCall`, so the turn is empty. But `IsEmptyTurn`'s finish-reason whitelist only covered `stop` / `''` / `end_turn`:

```pascal
Result := (R.Content = '') and (Length(R.ToolCalls) = 0)
      and ((R.FinishReason = 'stop') or (R.FinishReason = '') or (R.FinishReason = 'end_turn'));
```

So `MALFORMED_FUNCTION_CALL` fell through, `ChatWithEmptyRetry` skipped it, and `RunToolLoop` treated it as a clean stop — the turn died with empty content. The empty-turn retry machinery (default 2 attempts) that exists precisely to recover this was being bypassed on a technicality.

## The fix

1. **`IsEmptyTurn` recognises `MALFORMED_FUNCTION_CALL`** as a retryable empty turn.
2. Because a bare re-send of a *deterministically* malformed oversized call just reproduces it, the retry appends a **one-shot corrective nudge**: stop narrating, re-issue one well-formed call, and build large files incrementally (`write_file` stub → `edit_file` / `append_file`) rather than in a single call. Plain brownout empties (`finish=stop`) still get a clean, no-nudge re-send.

Both apply to the `pasclaw serve` / gateway path, where `StreamReliability` (default `EmptyRetryAttempts=2`) is already wired.

## Tests

`stream_reliability_tests` extended: `MALFORMED_FUNCTION_CALL` with no content/calls is an empty turn (but not when it salvaged text); a malformed-then-content script recovers in 2 calls with the nudge appended to the retry history. Full build + `make test-stream-reliability` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_