### PR TITLE
tools: verb_noun file-tool names + append_file + edit_file str-replace + apply_patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -746,6 +746,13 @@ test-fs-grep-tier1-4: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier1_4_tests.pas -o$(BUILDDIR)/fs_grep_tier1_4_tests
 	@$(BUILDDIR)/fs_grep_tier1_4_tests
 
+# Verb_noun file-tool rename + hidden aliases + append_file + edit_file
+# string-replacement mode.
+test-fs-tool-naming: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/fs_tool_naming_tests.pas -o$(BUILDDIR)/fs_tool_naming_tests
+	@$(BUILDDIR)/fs_tool_naming_tests
+
 # Logger level suppression: pins the contract PasClaw.dpr's
 # IsQuietInvocation branch depends on (SetLogLevel(llError) drops
 # Debug/Info/Warn while keeping Error). Without this regression
@@ -815,4 +822,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ See [Build](#build) for Delphi / cross-compile / Windows-on-ARM.
 
 | Tool | What it does |
 |---|---|
-| `fs_read` / `fs_write` / `fs_list` | sandboxed filesystem access |
-| `fs_grep` | recursive substring search, returns hashline-formatted matches |
-| `fs_edit_hashline` | patch by line-anchor + file-hash header, race-safe |
+| `read_file` / `write_file` / `append_file` / `list_dir` | sandboxed filesystem access (`append_file` builds large files incrementally) |
+| `grep_files` | recursive substring search, returns line-numbered matches |
+| `edit_file` | `old_text`→`new_text` string replacement (default); optional hashline `patch` mode for line-anchored, hash-verified edits |
 | `shell_exec` | `/bin/sh -c` (or `cmd.exe`), output capped at 1 MiB, denylist-gated |
 | `web_search` | DuckDuckGo / Brave / Tavily / SearXNG / Perplexity / Gemini-grounding — 6 providers |
 | `web_fetch` | HTTP GET → readable plain text (HTML stripped, entities decoded), SSRF-guarded |
@@ -65,11 +65,11 @@ See [Build](#build) for Delphi / cross-compile / Windows-on-ARM.
 | `skills_list` / `skills_view` / `skill_manage` | self-improving skills (progressive disclosure + model-authored skills; opt-in) |
 | MCP-bridged | every tool a configured MCP server exports — see below |
 
-**Parallel dispatch** — when the model returns multiple `tool_use` blocks in one turn, read-only tools (`web_search`, `web_fetch`, `fs_read`/`grep`/`list`, `memory_search`) fan out on worker threads; mutating tools (`fs_write`, `fs_edit_hashline`, `shell_exec`) stay serial. ~50% wall-clock win on multi-network-tool turns.
+**Parallel dispatch** — when the model returns multiple `tool_use` blocks in one turn, read-only tools (`web_search`, `web_fetch`, `read_file`/`grep_files`/`list_dir`, `memory_search`) fan out on worker threads; mutating tools (`write_file`, `append_file`, `edit_file`, `shell_exec`) stay serial. ~50% wall-clock win on multi-network-tool turns. (The former `fs_read`/`fs_write`/`fs_list`/`fs_grep`/`fs_edit_hashline` names remain as hidden back-compat aliases.)
 
 **MCP** — both transports. Stdio MCP via spawned subprocess + JSON-RPC over pipes, and Streamable HTTP MCP (handles SSE-framed responses, Bearer-token auth). `pasclaw mcp catalog` queries the pasclaw.dev MCP registry (`GET /api/public/v1/mcp`) with a 5 s timeout and falls back to the bundled 5-entry list (`replicate`, `digitalocean-apps`, `digitalocean-databases`, `runpod-docs`, `huggingface`) when the hub is unreachable — source attribution (`hub` / `built-in`) shown in the output. `pasclaw mcp search <q>` searches the hub directly (no fallback — bundled list is too small to search). `pasclaw mcp install <slug>` tries the hub first so any registered server is installable, falls back to the bundled catalog when the hub doesn't have it. Reads the right env var, writes the right Authorization header, never preloaded. **Progressive disclosure** (on by default, `mcp_progressive_disclosure`) keeps fat catalogs cheap: MCP tools register *deferred* (name-only in the prompt), and the model loads schemas on demand via `tool_search` — a one-turn cost only on turns that actually touch MCP, instead of paying for every schema every turn. PasClaw is also an MCP **server** (`POST /mcp`), exposing `memory_search` / `kb_search` / `session_search` to other MCP clients (Claude Desktop, Cursor, Codex).
 
-**Skills** — markdown manifests under `$PASCLAW_HOME/workspace/skills/` advertised in the system prompt; the model loads the body via `fs_read` on demand. Install from GitHub (`pasclaw skills install owner/repo[/path][@ref]` — codeload zip, FPC's `Zipper.TUnZipper` or Delphi's `System.Zip.TZipFile`); from the pasclaw.dev hub (`pasclaw skills install hub:<slug>[@<version>]`, or just `pasclaw skills install <slug>` which tries pasclaw.dev first then falls back to ClawHub); or from ClawHub directly (`pasclaw skills install clawhub:<slug>[@<version>]`). `pasclaw skills search <q>` queries both hubs and aggregates the results (pasclaw.dev first, ClawHub deduped). Malware-flagged skills refused; suspicious-flagged install with a warning.
+**Skills** — markdown manifests under `$PASCLAW_HOME/workspace/skills/` advertised in the system prompt; the model loads the body via `read_file` on demand. Install from GitHub (`pasclaw skills install owner/repo[/path][@ref]` — codeload zip, FPC's `Zipper.TUnZipper` or Delphi's `System.Zip.TZipFile`); from the pasclaw.dev hub (`pasclaw skills install hub:<slug>[@<version>]`, or just `pasclaw skills install <slug>` which tries pasclaw.dev first then falls back to ClawHub); or from ClawHub directly (`pasclaw skills install clawhub:<slug>[@<version>]`). `pasclaw skills search <q>` queries both hubs and aggregates the results (pasclaw.dev first, ClawHub deduped). Malware-flagged skills refused; suspicious-flagged install with a warning.
 
 **Code Vault** — the pasclaw.dev Code Vault hosts Object Pascal source code (sample programs, reusable components, libraries) as GitHub-backed entries. `pasclaw vault search <q>` and `pasclaw vault show <slug>` discover; `pasclaw vault install <slug> [<dest>]` `git clone`s the entry's `repoUrl` into `$PASCLAW_HOME/workspace/vault/<slug>` (or a path you pass). The agent gets two **opt-in** tools — `vault_search` and `vault_get` — registered only when `vault_tools_enabled: true` in config.json; `pasclaw onboard` asks during setup with a default-yes prompt. Both tools are read-only HTTP GETs against the vault registry; obtaining the code itself is a separate `shell_exec git clone` call the model makes after `vault_get` returns the `repoUrl`.
 
@@ -81,7 +81,7 @@ See [Build](#build) for Delphi / cross-compile / Windows-on-ARM.
 
 **Memory** — SQLite FTS5 BM25 index over `workspace/memory/*.md` and `MEMORY.md`. `pasclaw migrate` (re-)indexes; `pasclaw membench --records N` benchmarks. Conversation history compaction (`pasclaw compaction.threshold_tokens`) kicks in mid-loop, summarises the older portion via the same provider, folds the summary into the system prompt, falls back to verbatim on summariser failure (no silent context loss). `memory_fetch(url, name?)` (registered when `web_fetch_enabled: true`) fetches a URL and writes it to `workspace/memory/fetched-<sanitised>.md` with a 4-line provenance header — the body never enters context; the next `memory_search` indexes it via SyncDir. **Auto-dedup**: a second `memory_fetch` against the same URL within 24h short-circuits the HTTP and returns "already indexed (cached Nh ago)" — the existing cached file's `source:` and `fetched_at:` header lines are matched against the request before any network round-trip. Inspired by [chopratejas/headroom](https://github.com/chopratejas/headroom)'s cross-agent memory dedup.
 
-**Working-state snapshot** — each session's `meta.working_state` records the last 8 file paths edited via `fs_write`/`fs_edit_hashline`, the most recent `shell_exec` command, and the most recent tool-call error. Persisted under the session JSON's `meta.working_state` object; rebuilt after every successful tool loop and re-injected as a system-prompt prefix on the next turn. Survives `/quit`-and-resume, compaction, and `pasclaw agent --session <id>` so the agent picks up with structured edit/shell/error context even when the conversation transcript no longer carries it.
+**Working-state snapshot** — each session's `meta.working_state` records the last 8 file paths edited via `write_file`/`append_file`/`edit_file`, the most recent `shell_exec` command, and the most recent tool-call error. Persisted under the session JSON's `meta.working_state` object; rebuilt after every successful tool loop and re-injected as a system-prompt prefix on the next turn. Survives `/quit`-and-resume, compaction, and `pasclaw agent --session <id>` so the agent picks up with structured edit/shell/error context even when the conversation transcript no longer carries it.
 
 **Sandbox + safety** — read/write path allowlists, shell-command denylist (separate `restrict_to_workspace` denylist + `shell_deny_enabled` global), SSRF guard on `web_fetch` (IPv4 blocklist incl. `169.254.169.254`, redirect re-check), hashline patches require matching file-hash header (stale patches abort without writing). TLS required for HTTPS provider/MCP calls via Indy's OpenSSL IO handler.
 
@@ -138,7 +138,7 @@ The running `pasclaw agent --session <id>` drains the queue at the top of its NE
   { "name": "coder",
     "description": "Code editor",
     "system_prompt": "You edit code precisely using hashline patches...",
-    "tools": ["fs_read", "fs_write", "fs_grep", "fs_edit_hashline"] }
+    "tools": ["read_file", "write_file", "grep_files", "edit_file"] }
 ]
 ```
 
@@ -154,7 +154,7 @@ A spawn can also run in the **background** (`spawn_background` → handle; `spaw
 
 **Profiles** — named config layers (`pasclaw profile list/show/use/diff/bench`). Built-ins `baseline | low-token | security | max-build | all-on` plus user JSON under `$PASCLAW_HOME/profiles/` with `_inherits` composition. Precedence: `--profile` > `$PASCLAW_PROFILE` > `config.json`'s `profile` > none. `profile bench` A/B-runs a task across profiles and prints a turn/token/tool-call table.
 
-**Plan / Build mode** — `--mode plan` (or `pasclaw plan`) is a read-only lens: `fs_read` / `fs_grep` / `memory` / `kb` / `session` work, but `fs_write` / `shell_exec` / `execute_code` are blocked, and a `plan_write` tool drafts `workspace/PLAN.md`. `--mode build` (default) is full access. The auto-router never downgrades Plan-mode turns. `pasclaw build` / `pasclaw plan` add a `workspace.zip` in/out handshake for CI / cloud (Replicate, k8s) runs.
+**Plan / Build mode** — `--mode plan` (or `pasclaw plan`) is a read-only lens: `read_file` / `grep_files` / `memory` / `kb` / `session` work, but `write_file` / `edit_file` / `shell_exec` / `execute_code` are blocked, and a `plan_write` tool drafts `workspace/PLAN.md`. `--mode build` (default) is full access. The auto-router never downgrades Plan-mode turns. `pasclaw build` / `pasclaw plan` add a `workspace.zip` in/out handshake for CI / cloud (Replicate, k8s) runs.
 
 **Heartbeat** — `pasclaw heartbeat` is a proactive daemon: on an interval it feeds `workspace/heartbeat.md` to the model, runs a loop, and posts the result to a named channel (or logs it) — agendas, monitors, periodic digests without an inbound trigger.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [Build](#build) for Delphi / cross-compile / Windows-on-ARM.
 | `read_file` / `write_file` / `append_file` / `list_dir` | sandboxed filesystem access (`append_file` builds large files incrementally) |
 | `grep_files` | recursive substring search, returns line-numbered matches |
 | `edit_file` | `old_text`→`new_text` string replacement (default); optional hashline `patch` mode for line-anchored, hash-verified edits |
+| `apply_patch` | multi-file, context-anchored patch (Codex/OpenClaw format: add/update/delete/move in one atomic call) |
 | `shell_exec` | `/bin/sh -c` (or `cmd.exe`), output capped at 1 MiB, denylist-gated |
 | `web_search` | DuckDuckGo / Brave / Tavily / SearXNG / Perplexity / Gemini-grounding — 6 providers |
 | `web_fetch` | HTTP GET → readable plain text (HTML stripped, entities decoded), SSRF-guarded |

--- a/src/cmd/PasClaw.Cmd.Build.pas
+++ b/src/cmd/PasClaw.Cmd.Build.pas
@@ -228,7 +228,7 @@ begin
   PrintLn('                             ignored when --goal is absent.');
   PrintLn('  --workspace-in <zip>       Unzip this into PASCLAW_HOME first.');
   PrintLn('  --workspace-out <zip>      Zip PASCLAW_HOME here after the run.');
-  PrintLn('  --cwd <dir>                cwd for fs_write (default: ');
+  PrintLn('  --cwd <dir>                cwd for write_file (default: ');
   PrintLn('                             $PASCLAW_HOME/workspace).');
   PrintLn('  --home <dir>               Override PASCLAW_HOME (default: env');
   PrintLn('                             or a fresh tempdir).');

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -939,30 +939,33 @@ var
   Choice: string;
 begin
   PrintLn;
-  PrintLn(Ansi.Bold + 'fs_edit_hashline (surgical patches)' + Ansi.Reset);
+  PrintLn(Ansi.Bold + 'edit_file hashline mode (surgical patches)' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'Hashline-format anchored edits. Big models (Opus / Sonnet / GPT-4) ' +
-    'use it' + Ansi.Reset);
+    'edit_file always offers old_text->new_text string edits. This adds its ' +
+    'advanced' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'correctly; smaller models (Haiku, gpt-4o-mini, Llama 3.x 8B) sometimes ' +
+    'hashline-anchored patch mode (+ line-numbered read_file output). Big ' +
+    'models use' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'it correctly; smaller models (Haiku, gpt-4o-mini, Llama 3.x 8B) sometimes ' +
     'mis-author' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'the anchor/payload format and waste turns. Answer N on small-model ' +
-    'deployments;' + Ansi.Reset);
+    'the anchor/payload format. Answer N on small-model deployments; the agent ' +
+    'then' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'the agent then uses fs_write rewrites instead. fs_grep is always on.' +
+    'uses string edits + write_file rewrites instead. grep_files is always on.' +
     Ansi.Reset);
   PrintLn;
-  Choice := Trim(LowerCase(ReadLineEcho('  Enable fs_edit_hashline [Y/n]: ')));
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable edit_file hashline mode [Y/n]: ')));
   if (Choice = '') or (Choice = 'y') or (Choice = 'yes') then
   begin
     Cfg.HashlineEnabled := True;
-    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' fs_edit_hashline enabled');
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' edit_file hashline mode enabled');
   end
   else
   begin
     Cfg.HashlineEnabled := False;
-    PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses fs_write rewrites)' + Ansi.Reset);
+    PrintLn('  ' + Ansi.Dim + '(skipped -- the model uses string edits + write_file)' + Ansi.Reset);
   end;
 end;
 

--- a/src/cmd/PasClaw.Cmd.Plan.pas
+++ b/src/cmd/PasClaw.Cmd.Plan.pas
@@ -378,7 +378,7 @@ const
   PlanDirectiveHeader =
     'You are running under `pasclaw plan` -- your deliverable is a ' +
     'markdown plan, NOT actually doing the work. Read the codebase as ' +
-    'needed (fs_read, fs_grep, memory_search), then SAVE the plan via ' +
+    'needed (read_file, grep_files, memory_search), then SAVE the plan via ' +
     'the `plan_write` tool with the full markdown as the `content` ' +
     'argument. After plan_write returns, end your turn with a short ' +
     'confirmation -- do NOT restate the plan in your reply.' + sLineBreak + sLineBreak +

--- a/src/cmd/PasClaw.Cmd.Runbook.pas
+++ b/src/cmd/PasClaw.Cmd.Runbook.pas
@@ -84,7 +84,7 @@ begin
        'visible from .editorconfig / .prettierrc / linter configs, and ' +
        'the recent git history shape (`git log --oneline -10` and ' +
        '`git status`).' + sLineBreak +
-    '2. Use `fs_read` on any small config / docs file you want to quote ' +
+    '2. Use `read_file` on any small config / docs file you want to quote ' +
        'verbatim.' + sLineBreak +
     '3. Write a single ' + TargetFile + ' covering these sections, in ' +
        'this order, with a single one-line description per item ' +
@@ -100,7 +100,7 @@ begin
     '   - Gotchas (the "I would have lost an hour without this" notes -- ' +
        'omit the section if you find nothing)' + sLineBreak +
     sLineBreak +
-    'Use `fs_write` to create the file. Do NOT use ' +
+    'Use `write_file` to create the file. Do NOT use ' +
     '`pasclaw export` or any related tool -- this is a one-shot bootstrap, ' +
     'not a refresh.' + sLineBreak +
     sLineBreak +

--- a/src/pkg/agent/PasClaw.Agent.AutoRouter.pas
+++ b/src/pkg/agent/PasClaw.Agent.AutoRouter.pas
@@ -133,8 +133,10 @@ const
     read-only loops can still be "easy"; once we see one of these
     in the tool registry the bar goes up unless the message is
     visibly read-only (handled below via the keyword sweep). }
-  WriteOrRunTools: array[0..3] of string = (
-    'shell_exec', 'execute_code', 'fs_write', 'fs_edit_hashline'
+  WriteOrRunTools: array[0..6] of string = (
+    'shell_exec', 'execute_code',
+    'write_file', 'append_file', 'edit_file',
+    'fs_write', 'fs_edit_hashline'   { back-compat aliases in older sessions }
   );
 
   EasyKeywords: array[0..7] of string = (

--- a/src/pkg/agent/PasClaw.Agent.AutoRouter.pas
+++ b/src/pkg/agent/PasClaw.Agent.AutoRouter.pas
@@ -133,9 +133,9 @@ const
     read-only loops can still be "easy"; once we see one of these
     in the tool registry the bar goes up unless the message is
     visibly read-only (handled below via the keyword sweep). }
-  WriteOrRunTools: array[0..6] of string = (
+  WriteOrRunTools: array[0..7] of string = (
     'shell_exec', 'execute_code',
-    'write_file', 'append_file', 'edit_file',
+    'write_file', 'append_file', 'edit_file', 'apply_patch',
     'fs_write', 'fs_edit_hashline'   { back-compat aliases in older sessions }
   );
 

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -60,7 +60,7 @@ uses
   as the final section if non-empty. Pass '' if there's nothing extra.
 
   ToolsEnabled controls whether tool-dependent sections (the skill
-  catalog, the "ALWAYS use tools" rule, the truncated-fs_write rule,
+  catalog, the "ALWAYS use tools" rule, the truncated-write_file rule,
   the verify-by-running-checks rule, the update-MEMORY.md rule) are
   emitted. Callers running `--no-tools` (or constructing the component
   with UseTools=False) MUST pass False here -- otherwise the prompt
@@ -410,7 +410,7 @@ begin
   begin
     Body := Copy(Body, 1, ProjectRulesMaxBytes) + sLineBreak + sLineBreak +
             Format('(... %d byte(s) elided -- AGENTS.md exceeded the %d byte ' +
-                   'cap; read the full file with fs_read if you need the tail)',
+                   'cap; read the full file with read_file if you need the tail)',
                    [Original - ProjectRulesMaxBytes, ProjectRulesMaxBytes]);
   end;
 
@@ -470,11 +470,11 @@ begin
     Lines.Add('## Skills');
     Lines.Add('');
     if HasCallable and HasKnowledge then
-      Lines.Add('Skills extend your capabilities. Callable skills register as `skill_<name>` tools you invoke directly; knowledge-only skills are markdown bodies -- read each one''s SKILL.md with `fs_read` when the matching task comes up.')
+      Lines.Add('Skills extend your capabilities. Callable skills register as `skill_<name>` tools you invoke directly; knowledge-only skills are markdown bodies -- read each one''s SKILL.md with `read_file` when the matching task comes up.')
     else if HasCallable then
       Lines.Add('The following skills register as `skill_<name>` tools you can call directly.')
     else
-      Lines.Add('Knowledge-only skills are markdown bodies. Read each SKILL.md with `fs_read` for the procedural context the model needs.');
+      Lines.Add('Knowledge-only skills are markdown bodies. Read each SKILL.md with `read_file` for the procedural context the model needs.');
     Lines.Add('');
     for i := 0 to High(Skills) do
     begin
@@ -492,7 +492,7 @@ begin
       else
       begin
         { Knowledge-only skill -- surface the SKILL.md path so the model
-          can fs_read it on demand. Picoclaw and nanobot do the same: the
+          can read_file it on demand. Picoclaw and nanobot do the same: the
           system prompt lists the catalog, the body loads lazily. }
         if Desc = '' then
           Lines.Add('- **' + Skills[i].Name + '**: read `' + Skills[i].Source + '`')
@@ -521,7 +521,7 @@ var
 begin
   if not ToolsEnabled then
   begin
-    { No-tools mode: the model cannot call fs_write, fs_edit_hashline,
+    { No-tools mode: the model cannot call write_file, edit_file,
       skills, or anything else. Rules 1, 3, 4, and 5 all assume tool
       access -- emitting them would tell the model to do things the
       tool loop is configured to refuse. Keep the precision rule
@@ -555,11 +555,11 @@ begin
     'run a targeted check (build, test, search). Do not assume the edit ' +
     'landed correctly because the tool returned success.' + sLineBreak +
     sLineBreak +
-    '4. **Truncated tool calls** -- if a `fs_write` call comes back with a ' +
+    '4. **Truncated tool calls** -- if a `write_file` call comes back with a ' +
     '"missing required argument: content" error, your previous response was ' +
     'truncated mid-tool_call (you hit max_tokens). Re-emit with the full ' +
-    'content, or switch to `fs_edit_hashline` for incremental edits on ' +
-    'large files.' + sLineBreak +
+    'content, or build the file incrementally with `append_file` (add a chunk ' +
+    'per turn) or `edit_file` for large files.' + sLineBreak +
     sLineBreak +
     '5. **Memory** -- when the user mentions something worth keeping across ' +
     'sessions (preferences, project facts, conventions), update ' +
@@ -571,7 +571,7 @@ begin
     'have written down on an earlier turn. **`memory_search` / ' +
     '`kb_search` return bounded snippets (a token window centred on the ' +
     'matched terms) -- if the answer line might fall just outside the ' +
-    'window, follow up with `fs_read` (or `kb_get` for the KB) on the ' +
+    'window, follow up with `read_file` (or `kb_get` for the KB) on the ' +
     'cited path to surface the surrounding paragraphs. A snippet that ' +
     'shows the right file but not quite the right line is a hit, not a ' +
     'miss.**' + sLineBreak +
@@ -772,7 +772,7 @@ begin
      gate refuses on category, not arguments). Codex P2 on PR #290.
 
      Read-only (loadable):
-       fs_read / fs_list / fs_grep
+       read_file / list_dir / grep_files
        memory_search / kb_search
        web_search        (HTTP GETs only, tcReadOnly)
        vault_search / vault_get
@@ -781,17 +781,17 @@ begin
        tool_output_get
 
      Refused under Plan (tcMutating):
-       fs_write / fs_edit_hashline
+       write_file / append_file / edit_file
        shell_exec / execute_code / delphi_build
        send_message
        web_fetch / memory_fetch   (save_to writes a file)
        skills_manage / kb_upload *)
   Result :=
     '## Plan Mode' + sLineBreak + sLineBreak +
-    'You are in **PLAN** mode. Read-only tools (fs_read, fs_list, fs_grep, ' +
+    'You are in **PLAN** mode. Read-only tools (read_file, list_dir, grep_files, ' +
     'memory_search, kb_search, web_search, skills_list, skills_view, ' +
     'vault_search, vault_get, session_search, ...) work normally; ' +
-    'mutating tools (fs_write, fs_edit_hashline, shell_exec, ' +
+    'mutating tools (write_file, append_file, edit_file, shell_exec, ' +
     'execute_code, delphi_build, send_message, web_fetch, memory_fetch, ' +
     'skills_manage, kb_upload, ...) are REFUSED at the dispatch layer.' +
     sLineBreak + sLineBreak +

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -781,7 +781,7 @@ begin
        tool_output_get
 
      Refused under Plan (tcMutating):
-       write_file / append_file / edit_file
+       write_file / append_file / edit_file / apply_patch
        shell_exec / execute_code / delphi_build
        send_message
        web_fetch / memory_fetch   (save_to writes a file)
@@ -791,9 +791,9 @@ begin
     'You are in **PLAN** mode. Read-only tools (read_file, list_dir, grep_files, ' +
     'memory_search, kb_search, web_search, skills_list, skills_view, ' +
     'vault_search, vault_get, session_search, ...) work normally; ' +
-    'mutating tools (write_file, append_file, edit_file, shell_exec, ' +
-    'execute_code, delphi_build, send_message, web_fetch, memory_fetch, ' +
-    'skills_manage, kb_upload, ...) are REFUSED at the dispatch layer.' +
+    'mutating tools (write_file, append_file, edit_file, apply_patch, ' +
+    'shell_exec, execute_code, delphi_build, send_message, web_fetch, ' +
+    'memory_fetch, skills_manage, kb_upload, ...) are REFUSED at the dispatch layer.' +
     sLineBreak + sLineBreak +
     'Note: web_fetch and memory_fetch are mutating because they can ' +
     'persist results to disk (`save_to`). To read a URL in Plan mode, ' +

--- a/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
@@ -190,15 +190,17 @@ begin
       on EPasClawJSON do
         Obj := nil;
     end;
-    if Name = 'fs_read' then
+    if (Name = 'read_file') or (Name = 'fs_read') then
     begin
       Summary := ArgStr(Obj, 'path');
       if (Obj <> nil) and Obj.GetBool('plain', False) then
         Summary := Summary + ', plain';
     end
-    else if (Name = 'fs_write') or (Name = 'fs_list') then
+    else if (Name = 'write_file') or (Name = 'append_file') or
+            (Name = 'list_dir') or
+            (Name = 'fs_write') or (Name = 'fs_list') then
       Summary := ArgStr(Obj, 'path')
-    else if Name = 'fs_grep' then
+    else if (Name = 'grep_files') or (Name = 'fs_grep') then
     begin
       Pattern := ArgStr(Obj, 'pattern');
       Path    := ArgStr(Obj, 'path');
@@ -207,8 +209,12 @@ begin
       Inc_ := ArgStr(Obj, 'include');
       if Inc_ <> '' then Summary := Summary + ' (' + Inc_ + ')';
     end
-    else if Name = 'fs_edit_hashline' then
-      Summary := FirstPatchPath(ArgStr(Obj, 'patch'))
+    else if (Name = 'edit_file') or (Name = 'fs_edit_hashline') then
+    begin
+      { str-replace mode carries a path; hashline mode carries a patch. }
+      Summary := ArgStr(Obj, 'path');
+      if Summary = '' then Summary := FirstPatchPath(ArgStr(Obj, 'patch'));
+    end
     else if Name = 'shell_exec' then
       Summary := ArgStr(Obj, 'command')
     else

--- a/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.ToolView.pas
@@ -215,6 +215,8 @@ begin
       Summary := ArgStr(Obj, 'path');
       if Summary = '' then Summary := FirstPatchPath(ArgStr(Obj, 'patch'));
     end
+    else if Name = 'apply_patch' then
+      Summary := FirstPatchPath(ArgStr(Obj, 'patch'))
     else if Name = 'shell_exec' then
       Summary := ArgStr(Obj, 'command')
     else

--- a/src/pkg/hashline/PasClaw.Hashline.pas
+++ b/src/pkg/hashline/PasClaw.Hashline.pas
@@ -715,7 +715,7 @@ begin
           fs_read's "N:content" display). Anchors take no trailing text. }
         ErrMsg := Format('line %d: anchor line must be JUST the line number(s) -- ' +
                          '"%s" should be e.g. "10:" or "7-10:" with nothing after ' +
-                         'the colon. Do not copy the "N:content" form from fs_read ' +
+                         'the colon. Do not copy the "N:content" form from read_file ' +
                          'onto the anchor; put the replacement text on the next ' +
                          'line(s) prefixed with %s (replace).',
                          [i + 1, Trim(Lines[i]), HL_PAYLOAD_REPLACE])

--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -679,7 +679,10 @@ begin
     for k := 0 to High(Hist[i].ToolCalls) do
     begin
       Call := Hist[i].ToolCalls[k];
-      if (Call.Func.Name = 'fs_write') or
+      if (Call.Func.Name = 'write_file') or
+         (Call.Func.Name = 'append_file') or
+         (Call.Func.Name = 'edit_file') or
+         (Call.Func.Name = 'fs_write') or          { back-compat aliases }
          (Call.Func.Name = 'fs_edit_hashline') then
       begin
         Path := ParseFsArg(Call.Func.Arguments, 'path');

--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -588,7 +588,7 @@ begin
                    'other tools by running `pasclaw __tool <name> ''<json-args>''` ' +
                    '-- the call hits the same registry you''re using now. ' +
                    'Use this to fan out: e.g. list files, then memory_search ' +
-                   'each, then fs_read the top hits, all in one script.';
+                   'each, then read_file the top hits, all in one script.';
   T.Schema      :=
     '{"type":"object",' +
      '"properties":{' +

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -768,6 +768,308 @@ begin
   end;
 end;
 
+{ ===== apply_patch: multi-file, context-anchored patches (Codex / OpenClaw
+  apply_patch format) ===================================================== }
+type
+  TLineArray = array of string;
+  TPatchOpKind = (pokAdd, pokUpdate, pokDelete);
+  TPatchAction = record
+    Kind:    TPatchOpKind;
+    Path:    string;
+    MoveTo:  string;
+    Content: string;
+  end;
+  TPatchActionArray = array of TPatchAction;
+
+function ApSplitLF(const S: string): TLineArray;
+{ Split on LF (CRLF/CR normalised first), keeping empty segments so a
+  join round-trips exactly, including a trailing newline. }
+var
+  T: string;
+  i, StartPos: Integer;
+begin
+  SetLength(Result, 0);
+  T := StringReplace(S, #13#10, #10, [rfReplaceAll]);
+  T := StringReplace(T, #13, #10, [rfReplaceAll]);
+  StartPos := 1;
+  for i := 1 to Length(T) do
+    if T[i] = #10 then
+    begin
+      SetLength(Result, Length(Result) + 1);
+      Result[High(Result)] := Copy(T, StartPos, i - StartPos);
+      StartPos := i + 1;
+    end;
+  SetLength(Result, Length(Result) + 1);
+  Result[High(Result)] := Copy(T, StartPos, Length(T) - StartPos + 1);
+end;
+
+function ApJoinLF(const A: TLineArray): string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 0 to High(A) do
+  begin
+    if i > 0 then Result := Result + #10;
+    Result := Result + A[i];
+  end;
+end;
+
+function ApFindBlock(const Hay, Needle: TLineArray; StartAt: Integer): Integer;
+var
+  i, j: Integer;
+  Ok: Boolean;
+begin
+  Result := -1;
+  if Length(Needle) = 0 then Exit(StartAt);
+  if StartAt < 0 then StartAt := 0;
+  for i := StartAt to Length(Hay) - Length(Needle) do
+  begin
+    Ok := True;
+    for j := 0 to High(Needle) do
+      if Hay[i + j] <> Needle[j] then begin Ok := False; Break; end;
+    if Ok then Exit(i);
+  end;
+end;
+
+procedure ApSplice(var Arr: TLineArray; StartIdx, RemoveCount: Integer; const Ins: TLineArray);
+var
+  Res: TLineArray;
+  i, k: Integer;
+begin
+  SetLength(Res, Length(Arr) - RemoveCount + Length(Ins));
+  k := 0;
+  for i := 0 to StartIdx - 1 do begin Res[k] := Arr[i]; Inc(k); end;
+  for i := 0 to High(Ins) do begin Res[k] := Ins[i]; Inc(k); end;
+  for i := StartIdx + RemoveCount to High(Arr) do begin Res[k] := Arr[i]; Inc(k); end;
+  Arr := Res;
+end;
+
+procedure ApAppend(var A: TLineArray; const S: string);
+begin
+  SetLength(A, Length(A) + 1);
+  A[High(A)] := S;
+end;
+
+function ApStarts(const S, Prefix: string): Boolean;
+begin
+  Result := Copy(S, 1, Length(Prefix)) = Prefix;
+end;
+
+function ParseApplyPatch(const PatchText: string; out Actions: TPatchActionArray;
+                         out ErrMsg: string): Boolean;
+var
+  P: TLineArray;
+  n, i, Idx: Integer;
+  Line, Path, MoveTo, Anchor, Reason: string;
+  CurLines, OldB, NewB, Content: TLineArray;
+  CurSearch: Integer;
+  Act: TPatchAction;
+
+  procedure AddAction;
+  begin
+    SetLength(Actions, Length(Actions) + 1);
+    Actions[High(Actions)] := Act;
+  end;
+
+begin
+  Result := False;
+  ErrMsg := '';
+  SetLength(Actions, 0);
+  P := ApSplitLF(PatchText);
+  { Drop the trailing '' ApSplitLF adds when the patch ends in a newline --
+    a split artifact, not a blank line. }
+  if (Length(P) > 0) and (P[High(P)] = '') then SetLength(P, Length(P) - 1);
+  n := Length(P);
+  i := 0;
+  while (i < n) and (Trim(P[i]) = '') do Inc(i);
+  if (i >= n) or (Trim(P[i]) <> '*** Begin Patch') then
+  begin
+    ErrMsg := 'apply_patch: missing "*** Begin Patch" header';
+    Exit;
+  end;
+  Inc(i);
+
+  while i < n do
+  begin
+    Line := P[i];
+    if Trim(Line) = '*** End Patch' then Exit(True);
+
+    if ApStarts(Line, '*** Add File: ') then
+    begin
+      Path := Trim(Copy(Line, Length('*** Add File: ') + 1, MaxInt));
+      Inc(i);
+      SetLength(Content, 0);
+      while (i < n) and (not ApStarts(P[i], '*** ')) do
+      begin
+        if P[i] = '' then
+          ApAppend(Content, '')
+        else if P[i][1] = '+' then
+          ApAppend(Content, Copy(P[i], 2, MaxInt))
+        else
+        begin
+          ErrMsg := 'apply_patch: Add File body lines must start with "+" (' + Path + ')';
+          Exit;
+        end;
+        Inc(i);
+      end;
+      Act.Kind := pokAdd; Act.Path := Path; Act.MoveTo := '';
+      Act.Content := ApJoinLF(Content);
+      if Length(Content) > 0 then Act.Content := Act.Content + #10;
+      AddAction;
+    end
+    else if ApStarts(Line, '*** Delete File: ') then
+    begin
+      Path := Trim(Copy(Line, Length('*** Delete File: ') + 1, MaxInt));
+      Act.Kind := pokDelete; Act.Path := Path; Act.MoveTo := ''; Act.Content := '';
+      AddAction;
+      Inc(i);
+    end
+    else if ApStarts(Line, '*** Update File: ') then
+    begin
+      Path := Trim(Copy(Line, Length('*** Update File: ') + 1, MaxInt));
+      Inc(i);
+      MoveTo := '';
+      if (i < n) and ApStarts(P[i], '*** Move to: ') then
+      begin
+        MoveTo := Trim(Copy(P[i], Length('*** Move to: ') + 1, MaxInt));
+        Inc(i);
+      end;
+      if not CanReadPath(Path, Reason) then begin ErrMsg := 'apply_patch: ' + Reason; Exit; end;
+      if not FileExists(Path) then
+      begin ErrMsg := 'apply_patch: no such file to update: ' + Path; Exit; end;
+      CurLines := ApSplitLF(ReadFileText(Path));
+      CurSearch := 0;
+      while (i < n) and (not ApStarts(P[i], '*** ')) do
+      begin
+        if ApStarts(P[i], '@@') then
+        begin
+          Anchor := Trim(Copy(P[i], 3, MaxInt));
+          Inc(i);
+          if Anchor <> '' then
+          begin
+            Idx := CurSearch;
+            while (Idx < Length(CurLines)) and (Pos(Anchor, CurLines[Idx]) = 0) do Inc(Idx);
+            if Idx < Length(CurLines) then CurSearch := Idx;
+          end;
+          Continue;
+        end;
+        SetLength(OldB, 0); SetLength(NewB, 0);
+        while (i < n) and (not ApStarts(P[i], '@@')) and (not ApStarts(P[i], '*** ')) do
+        begin
+          if P[i] = '' then
+          begin ApAppend(OldB, ''); ApAppend(NewB, ''); end
+          else
+            case P[i][1] of
+              '+': ApAppend(NewB, Copy(P[i], 2, MaxInt));
+              '-': ApAppend(OldB, Copy(P[i], 2, MaxInt));
+              ' ': begin ApAppend(OldB, Copy(P[i], 2, MaxInt)); ApAppend(NewB, Copy(P[i], 2, MaxInt)); end;
+            else
+              begin
+                ErrMsg := 'apply_patch: hunk line must start with " ", "+" or "-" (' + Path + '): ' + P[i];
+                Exit;
+              end;
+            end;
+          Inc(i);
+        end;
+        if Length(OldB) = 0 then
+        begin
+          ErrMsg := 'apply_patch: a hunk in ' + Path + ' has no context or "-" lines to locate the edit';
+          Exit;
+        end;
+        Idx := ApFindBlock(CurLines, OldB, CurSearch);
+        if Idx < 0 then Idx := ApFindBlock(CurLines, OldB, 0);   { anchor may have over-advanced }
+        if Idx < 0 then
+        begin
+          ErrMsg := 'apply_patch: context not found in ' + Path + ' near: ' + OldB[0];
+          Exit;
+        end;
+        ApSplice(CurLines, Idx, Length(OldB), NewB);
+        CurSearch := Idx + Length(NewB);
+      end;
+      Act.Kind := pokUpdate; Act.Path := Path; Act.MoveTo := MoveTo;
+      Act.Content := ApJoinLF(CurLines);
+      AddAction;
+    end
+    else if Trim(Line) = '' then
+      Inc(i)   { tolerate blank lines between sections }
+    else
+    begin
+      ErrMsg := 'apply_patch: unexpected line (want *** Add/Update/Delete File or *** End Patch): ' + Line;
+      Exit;
+    end;
+  end;
+
+  ErrMsg := 'apply_patch: missing "*** End Patch" terminator';
+  Result := False;
+end;
+
+function Tool_FSApplyPatch(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  PatchText, Reason: string;
+  Actions: TPatchActionArray;
+  i, nAdd, nUpd, nDel: Integer;
+begin
+  ErrMsg := '';
+  if not HasJSONKey(ArgsJSON, 'patch') then
+  begin
+    ErrMsg := 'missing required argument: patch';
+    Exit('');
+  end;
+  ParseStringArg(ArgsJSON, 'patch', PatchText);
+  { Parse + locate every hunk BEFORE touching disk. A failure here writes
+    nothing, so a multi-file patch is all-or-nothing. }
+  if not ParseApplyPatch(PatchText, Actions, ErrMsg) then Exit('');
+
+  { Sandbox-gate every target up front, still before any write. }
+  for i := 0 to High(Actions) do
+  begin
+    if not CanWritePath(Actions[i].Path, Reason) then
+    begin ErrMsg := 'apply_patch: ' + Reason; Exit(''); end;
+    if (Actions[i].MoveTo <> '') and (not CanWritePath(Actions[i].MoveTo, Reason)) then
+    begin ErrMsg := 'apply_patch: ' + Reason; Exit(''); end;
+  end;
+
+  nAdd := 0; nUpd := 0; nDel := 0;
+  try
+    for i := 0 to High(Actions) do
+      case Actions[i].Kind of
+        pokAdd:
+          begin
+            SnapshotBeforeWrite(Actions[i].Path);
+            WriteFileText(Actions[i].Path, Actions[i].Content);
+            Inc(nAdd);
+          end;
+        pokDelete:
+          begin
+            SnapshotBeforeWrite(Actions[i].Path);
+            if FileExists(Actions[i].Path) then DeleteFile(Actions[i].Path);
+            Inc(nDel);
+          end;
+        pokUpdate:
+          begin
+            SnapshotBeforeWrite(Actions[i].Path);
+            if Actions[i].MoveTo <> '' then
+            begin
+              SnapshotBeforeWrite(Actions[i].MoveTo);
+              WriteFileText(Actions[i].MoveTo, Actions[i].Content);
+              if FileExists(Actions[i].Path) then DeleteFile(Actions[i].Path);
+            end
+            else
+              WriteFileText(Actions[i].Path, Actions[i].Content);
+            Inc(nUpd);
+          end;
+      end;
+  except
+    on E: Exception do
+    begin
+      ErrMsg := 'apply_patch: ' + E.Message;
+      Exit('');
+    end;
+  end;
+  Result := Format('applied patch: %d added, %d updated, %d deleted', [nAdd, nUpd, nDel]);
+end;
+
 function Tool_FSAppend(const ArgsJSON: string; out ErrMsg: string): string;
 { append_file: add content to the end of a file (creating it + parent dirs
   when absent). The incremental-write escape hatch -- build a large file
@@ -1052,6 +1354,29 @@ begin
   T.IsCore   := True;
   T.Category := tcMutating;
   Emit('fs_edit_hashline');
+
+  { apply_patch (new) -- multi-file, context-anchored patches in one call. }
+  T := Default(TTool);
+  T.Name := 'apply_patch';
+  T.Description :=
+    'Apply a multi-file patch in ONE call (Codex / OpenClaw apply_patch format). ' +
+    'Wrap everything between a "*** Begin Patch" line and a "*** End Patch" line. ' +
+    'Inside, one or more file sections: "*** Add File: <path>" then the new content ' +
+    'as lines each prefixed with "+"; "*** Delete File: <path>"; or "*** Update File: ' +
+    '<path>" (optionally followed by "*** Move to: <newpath>") then hunks. In a hunk, ' +
+    'optional "@@ <context>" lines help locate the region, then each change line starts ' +
+    'with " " (unchanged context), "-" (remove) or "+" (add). Edits are located by their ' +
+    'context and removed lines, NOT by line number. All-or-nothing: if any hunk fails to ' +
+    'locate, nothing is written. Prefer this over several edit_file calls when a change ' +
+    'spans multiple files or many hunks.';
+  T.Schema :=
+    '{"type":"object","properties":{"patch":{"type":"string",' +
+    '"description":"Full patch text, from *** Begin Patch through *** End Patch."}},' +
+    '"required":["patch"]}';
+  T.Handler  := Tool_FSApplyPatch;
+  T.IsCore   := True;
+  T.Category := tcMutating;
+  R.Register(T);
 end;
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1021,13 +1021,30 @@ begin
     nothing, so a multi-file patch is all-or-nothing. }
   if not ParseApplyPatch(PatchText, Actions, ErrMsg) then Exit('');
 
-  { Sandbox-gate every target up front, still before any write. }
+  { Sandbox-gate every target up front, still before any write. Also refuse
+    create-targets that already exist: WriteFileText opens with fmCreate, so
+    an "Add File" (or a "Move to" destination) pointing at an existing path
+    would silently truncate the user's file and report it as "added". Make
+    that a hard failure so a model that used Add File instead of Update File
+    can't clobber content -- and abort before touching disk (atomic). }
   for i := 0 to High(Actions) do
   begin
     if not CanWritePath(Actions[i].Path, Reason) then
     begin ErrMsg := 'apply_patch: ' + Reason; Exit(''); end;
     if (Actions[i].MoveTo <> '') and (not CanWritePath(Actions[i].MoveTo, Reason)) then
     begin ErrMsg := 'apply_patch: ' + Reason; Exit(''); end;
+    if (Actions[i].Kind = pokAdd) and FileExists(Actions[i].Path) then
+    begin
+      ErrMsg := 'apply_patch: Add File target already exists: ' + Actions[i].Path +
+                ' (use "*** Update File" to modify an existing file)';
+      Exit('');
+    end;
+    if (Actions[i].Kind = pokUpdate) and (Actions[i].MoveTo <> '')
+       and FileExists(Actions[i].MoveTo) then
+    begin
+      ErrMsg := 'apply_patch: Move to target already exists: ' + Actions[i].MoveTo;
+      Exit('');
+    end;
   end;
 
   nAdd := 0; nUpd := 0; nDel := 0;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -189,7 +189,7 @@ end;
 function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
 var
   Path, Body, Reason: string;
-  Plain: Boolean;
+  Hashline: Boolean;
 begin
   ErrMsg := '';
   if not ParseStringArg(ArgsJSON, 'path', Path) then
@@ -208,18 +208,19 @@ begin
     Exit('');
   end;
   Body := ReadFileText(Path);
-  { When hashline is disabled at register time, force plain regardless of
-    the per-call flag: there's no fs_edit_hashline registered to consume
-    a header, so emitting one would just confuse the model. The per-call
-    plain=true escape hatch still works in hashline-on mode. }
-  if not GHashlineEnabled then
-    Plain := True
+  { Plain text is the default -- clean content is what edit_file's
+    old_text/new_text string replacement matches against, and it's what
+    smaller models handle best. The hashline #hash + LINENO:line format is
+    now OPT-IN via a hashline:true arg (mirrors edit_file's advanced patch
+    mode), and only when hashline was enabled at register time (otherwise
+    there's no patch consumer, so a header would just be noise). The legacy
+    plain:true arg is still accepted and, since plain is now the default,
+    is a harmless no-op. }
+  Hashline := GHashlineEnabled and ParseBoolArg(ArgsJSON, 'hashline', False);
+  if Hashline then
+    Result := FormatHashlineRead(Path, Body)
   else
-    Plain := ParseBoolArg(ArgsJSON, 'plain', False);
-  if Plain then
-    Result := Body
-  else
-    Result := FormatHashlineRead(Path, Body);
+    Result := Body;
 end;
 
 function Tool_FSWrite(const ArgsJSON: string; out ErrMsg: string): string;
@@ -934,9 +935,11 @@ begin
   T.Name := 'read_file';
   if UseHashline then
   begin
-    T.Description := 'Read a file. Returns hashline format: a ' + HL_FILE_PREFIX +
-                     'path#hash header followed by LINENO:line per source line. Pass {"plain":true} for raw bytes.';
-    T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"plain":{"type":"boolean","description":"Return raw file bytes instead of hashline-prefixed output."}},"required":["path"]}';
+    T.Description := 'Read the contents of a file. Returns plain text by default. ' +
+                     'Pass {"hashline":true} for the ' + HL_FILE_PREFIX +
+                     'path#hash header + LINENO:line format used to build an ' +
+                     'edit_file `patch` (advanced).';
+    T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"hashline":{"type":"boolean","description":"Return the hashline #hash+LINENO format for edit_file patch edits, instead of plain text."}},"required":["path"]}';
   end
   else
   begin
@@ -1019,11 +1022,12 @@ begin
   if UseHashline then
   begin
     T.Description := 'Edit a file. Default: replace an exact snippet -- pass old_text (the existing text, ' +
-                     'verbatim including whitespace; do NOT include read_file''s "N:" line-number prefixes) ' +
-                     'and new_text. The match must be unique unless replace_all is set; omit new_text to ' +
-                     'delete. Advanced: pass a hashline `patch` instead for line-anchored multi-hunk edits (' +
-                     HL_FILE_PREFIX + 'path#hash header, "42:" anchors, ' + HL_PAYLOAD_REPLACE + '/' +
-                     HL_PAYLOAD_ABOVE + '/' + HL_PAYLOAD_BELOW + ' payload markers; header hash must match disk).';
+                     'verbatim including whitespace) and new_text. The match must be unique unless ' +
+                     'replace_all is set; omit new_text to delete. Advanced: pass a hashline `patch` instead ' +
+                     'for line-anchored multi-hunk edits -- first read the file with {"hashline":true} to ' +
+                     'get the ' + HL_FILE_PREFIX + 'path#hash header, then send "42:" anchors + ' +
+                     HL_PAYLOAD_REPLACE + '/' + HL_PAYLOAD_ABOVE + '/' + HL_PAYLOAD_BELOW +
+                     ' payload markers (header hash must match disk).';
     T.Schema      := '{"type":"object","properties":{' +
                      '"path":{"type":"string"},' +
                      '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace)."},' +

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -253,8 +253,8 @@ begin
       "content":"" explicitly to legitimately clear a file. }
     ErrMsg := 'missing required argument: content. ' +
               'If your previous response was truncated mid-tool_call (model hit max_tokens), ' +
-              're-emit fs_write with the full content as a string, or use fs_edit_hashline ' +
-              'to apply incremental edits. Pass "content":"" explicitly to clear a file.';
+              're-emit write_file with the full content as a string, or build the file ' +
+              'incrementally with append_file / edit_file. Pass "content":"" explicitly to clear a file.';
     Exit('');
   end;
   ParseStringArg(ArgsJSON, 'content', Content);
@@ -767,13 +767,171 @@ begin
   end;
 end;
 
+function Tool_FSAppend(const ArgsJSON: string; out ErrMsg: string): string;
+{ append_file: add content to the end of a file (creating it + parent dirs
+  when absent). The incremental-write escape hatch -- build a large file
+  across several turns instead of one oversized write_file arg that a
+  provider may fail to serialise. Unlike write_file it does NOT strip
+  hashline prefixes: an append chunk is content the model just generated,
+  taken verbatim. }
+var
+  Path, Content, Existing, Reason: string;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'path', Path) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not CanWritePath(Path, Reason) then
+  begin
+    ErrMsg := Reason;
+    Exit('');
+  end;
+  if not HasJSONKey(ArgsJSON, 'content') then
+  begin
+    ErrMsg := 'missing required argument: content. If your previous response was ' +
+              'truncated mid-tool_call (model hit max_tokens), re-emit append_file with ' +
+              'the next chunk as a string.';
+    Exit('');
+  end;
+  ParseStringArg(ArgsJSON, 'content', Content);
+  try
+    if FileExists(Path) then Existing := ReadFileText(Path) else Existing := '';
+    SnapshotBeforeWrite(Path);
+    WriteFileText(Path, Existing + Content);
+    Result := Format('appended %d bytes to %s (now %d bytes)',
+                     [Length(Content), Path, Length(Existing) + Length(Content)]);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := E.Message;
+      Result := '';
+    end;
+  end;
+end;
+
+function CountSubstr(const S, Sub: string): Integer;
+{ Non-overlapping occurrence count. Sub is assumed non-empty. }
+var
+  Rest: string;
+  P: Integer;
+begin
+  Result := 0;
+  Rest := S;
+  repeat
+    P := Pos(Sub, Rest);
+    if P = 0 then Break;
+    Inc(Result);
+    Rest := Copy(Rest, P + Length(Sub), MaxInt);
+  until False;
+end;
+
+function Tool_FSEdit(const ArgsJSON: string; out ErrMsg: string): string;
+{ edit_file: two modes.
+    1. Plain string replacement (default): old_text -> new_text, the form
+       every model authors natively. Requires a unique match unless
+       replace_all is set.
+    2. Hashline patch (advanced): when a `patch` argument is present, defer
+       to the line-anchored applier (Tool_FSEditHashline) for precise
+       multi-hunk edits. }
+var
+  Path, OldText, NewText, Content, Reason: string;
+  ReplaceAll: Boolean;
+  Cnt: Integer;
+begin
+  ErrMsg := '';
+  { Hashline mode wins when a patch is supplied. }
+  if HasJSONKey(ArgsJSON, 'patch') then
+    Exit(Tool_FSEditHashline(ArgsJSON, ErrMsg));
+
+  if not ParseStringArg(ArgsJSON, 'path', Path) then
+  begin
+    ErrMsg := 'missing required argument: path';
+    Exit('');
+  end;
+  if not CanWritePath(Path, Reason) then
+  begin
+    ErrMsg := Reason;
+    Exit('');
+  end;
+  if not HasJSONKey(ArgsJSON, 'old_text') then
+  begin
+    ErrMsg := 'missing required argument: old_text. Provide old_text + new_text for a ' +
+              'string replacement, or a `patch` for a hashline edit.';
+    Exit('');
+  end;
+  ParseStringArg(ArgsJSON, 'old_text', OldText);
+  { new_text may be omitted -> treated as '' (a deletion). }
+  NewText := '';
+  ParseStringArg(ArgsJSON, 'new_text', NewText);
+  ReplaceAll := ParseBoolArg(ArgsJSON, 'replace_all', False);
+  if OldText = '' then
+  begin
+    ErrMsg := 'old_text must not be empty';
+    Exit('');
+  end;
+  if not FileExists(Path) then
+  begin
+    ErrMsg := 'no such file: ' + Path + ' (use write_file to create it)';
+    Exit('');
+  end;
+  Content := ReadFileText(Path);
+  Cnt := CountSubstr(Content, OldText);
+  if Cnt = 0 then
+  begin
+    ErrMsg := 'old_text not found in ' + Path + '. The match must be exact, including ' +
+              'whitespace and indentation; do not include read_file''s "N:" line-number ' +
+              'prefixes in old_text.';
+    Exit('');
+  end;
+  if (Cnt > 1) and (not ReplaceAll) then
+  begin
+    ErrMsg := Format('old_text matches %d times in %s. Add surrounding context to make it ' +
+                     'unique, or pass "replace_all":true to replace every occurrence.',
+                     [Cnt, Path]);
+    Exit('');
+  end;
+  if ReplaceAll then
+    Content := StringReplace(Content, OldText, NewText, [rfReplaceAll])
+  else
+    Content := StringReplace(Content, OldText, NewText, []);
+  try
+    SnapshotBeforeWrite(Path);
+    WriteFileText(Path, Content);
+    Result := Format('edited %s (replaced %d occurrence(s))', [Path, Cnt]);
+  except
+    on E: Exception do
+    begin
+      ErrMsg := E.Message;
+      Result := '';
+    end;
+  end;
+end;
+
 procedure RegisterFSTools(R: TToolRegistry; UseHashline: Boolean);
 var
   T: TTool;
+
+  { Register the canonical tool T, then a hidden back-compat alias under the
+    old name pointing at the same handler. Old configs / sessions / muscle-
+    memory keep working; the model only ever sees the new canonical name. }
+  procedure Emit(const OldName: string);
+  var
+    A: TTool;
+  begin
+    R.Register(T);
+    A := T;
+    A.Name := OldName;
+    R.RegisterHidden(A);
+  end;
+
 begin
   GHashlineEnabled := UseHashline;
 
-  T.Name := 'fs_read';
+  { read_file (was fs_read) }
+  T := Default(TTool);
+  T.Name := 'read_file';
   if UseHashline then
   begin
     T.Description := 'Read a file. Returns hashline format: a ' + HL_FILE_PREFIX +
@@ -788,9 +946,11 @@ begin
   T.Handler  := Tool_FSRead;
   T.IsCore   := True;
   T.Category := tcReadOnly;
-  R.Register(T);
+  Emit('fs_read');
 
-  T.Name := 'fs_write';
+  { write_file (was fs_write) }
+  T := Default(TTool);
+  T.Name := 'write_file';
   if UseHashline then
     T.Description := 'Write a string to a file (overwrites). Creates parent dirs. ' +
                      'Strips hashline LINENO: prefixes from `content` when every non-empty line carries one.'
@@ -800,35 +960,42 @@ begin
   T.Handler  := Tool_FSWrite;
   T.IsCore   := True;
   T.Category := tcMutating;
+  Emit('fs_write');
+
+  { append_file (new) -- the incremental-write escape hatch for large files. }
+  T := Default(TTool);
+  T.Name        := 'append_file';
+  T.Description := 'Append a string to the end of a file (creates it and parent dirs when missing). ' +
+                   'Use this to build a large file across several turns instead of one huge write_file ' +
+                   'call, which a provider may fail to serialise.';
+  T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}';
+  T.Handler     := Tool_FSAppend;
+  T.IsCore      := True;
+  T.Category    := tcMutating;
   R.Register(T);
 
-  T.Name        := 'fs_list';
+  { list_dir (was fs_list) }
+  T := Default(TTool);
+  T.Name        := 'list_dir';
   T.Description := 'List entries in a directory. Returns "d name" or "- name  size" lines.';
   T.Schema      := '{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}';
   T.Handler     := Tool_FSList;
   T.IsCore      := True;
   T.Category    := tcReadOnly;
-  R.Register(T);
+  Emit('fs_list');
 
-  { fs_grep registers UNCONDITIONALLY -- the six ripgrep-inspired
-    optimisations (skip lists, BMH, binary detection, byte-walking,
-    file-size cap, deferred hashing) make it 10-50x faster than
-    shell_exec grep on real codebases, and on Windows it's the only
-    grep equivalent the agent has (Windows ships no grep). The
-    bench's "shell_exec grep wins by 1 turn" finding measured the
-    one-shot UX advantage of `>` redirect on a tiny 8-file fixture --
-    it does NOT generalise to larger repos where fs_grep's speed
-    dominates, and it does not apply at all on Windows. So the gate
-    used to bundle fs_grep with fs_edit_hashline has been split:
-    UseHashline now controls ONLY fs_edit_hashline (plus the hashline
-    format of fs_read), and fs_grep registers unconditionally. }
-  T.Name        := 'fs_grep';
+  { grep_files (was fs_grep) -- registers UNCONDITIONALLY -- the six
+    ripgrep-inspired optimisations (skip lists, BMH, binary detection,
+    byte-walking, file-size cap, deferred hashing) make it 10-50x faster
+    than shell_exec grep on real codebases, and on Windows it's the only
+    grep equivalent the agent has (Windows ships no grep). }
+  T := Default(TTool);
+  T.Name        := 'grep_files';
   T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
                    'Skips dotdirs, well-known build/VCS/deps dirs (.git, node_modules, target, build, ' +
                    'dist, vendor, .venv, __pycache__, .gradle, .next), binary files (NUL-byte detection ' +
                    'in first 1 KiB), and files larger than max_file_bytes (default 10 MiB). Returns ' +
-                   'hashline-formatted matches (one section per file, header + LINENO:line per match) ' +
-                   'so you can paste anchors directly into fs_edit_hashline (when registered).';
+                   'matches with LINENO:line per hit, one section per file.';
   T.Schema      := '{"type":"object","properties":{' +
                    '"path":{"type":"string"},' +
                    '"pattern":{"type":"string"},' +
@@ -839,36 +1006,48 @@ begin
   T.Handler     := Tool_FSGrep;
   T.IsCore      := True;
   T.Category    := tcReadOnly;
-  R.Register(T);
+  Emit('fs_grep');
 
-  { fs_edit_hashline: gated on UseHashline (PR #314 / bench finding --
-    smaller models mis-author the anchor/payload format and burn turns
-    recovering). When UseHashline is False we don't expose the tool at
-    all so the model never sees it in the tool list and doesn't try a
-    hashless patch that we'd reject. }
+  { edit_file (was fs_edit_hashline) -- now registered UNCONDITIONALLY. The
+    default old_text->new_text string-replacement mode works for every
+    model; the hashline `patch` mode is advanced and only advertised (in
+    the schema/description) when UseHashline is on, so smaller models that
+    mis-author the anchor format don't see it. The handler still accepts a
+    patch either way, so the fs_edit_hashline alias keeps working. }
+  T := Default(TTool);
+  T.Name := 'edit_file';
   if UseHashline then
   begin
-    T.Name        := 'fs_edit_hashline';
-    T.Description := 'Apply a hashline-format patch. Begins with a ' + HL_FILE_PREFIX +
-                     'path#hash header, then one or more blocks. Each block is an anchor line ' +
-                     'that is JUST the line number(s) -- "42:" for one line, "7-10:" for a ' +
-                     'range -- with NOTHING after the colon. Do NOT copy fs_read''s "N:content" ' +
-                     'display onto the anchor (write "42:", not "42:  the old text"). The ' +
-                     'anchor is followed by payload lines, and EVERY payload line must start ' +
-                     'with its own marker: ' + HL_PAYLOAD_REPLACE +
-                     ' to replace, ' + HL_PAYLOAD_ABOVE + ' to insert above the anchor, ' +
-                     HL_PAYLOAD_BELOW + ' to insert below. A multi-line replacement repeats ' +
-                     HL_PAYLOAD_REPLACE + ' on every line (a 3-line replacement has three ' +
-                     HL_PAYLOAD_REPLACE + ' lines) -- never a bare line. Example: "' +
-                     HL_FILE_PREFIX + 'foo.pas#ab12" / "10:" / "' + HL_PAYLOAD_REPLACE +
-                     '  new line 10 text". The header hash must match the file on disk; ' +
-                     'stale patches abort without writing.';
-    T.Schema      := '{"type":"object","properties":{"patch":{"type":"string","description":"Hashline-format patch text."}},"required":["patch"]}';
-    T.Handler     := Tool_FSEditHashline;
-    T.IsCore      := True;
-    T.Category    := tcMutating;
-    R.Register(T);
+    T.Description := 'Edit a file. Default: replace an exact snippet -- pass old_text (the existing text, ' +
+                     'verbatim including whitespace; do NOT include read_file''s "N:" line-number prefixes) ' +
+                     'and new_text. The match must be unique unless replace_all is set; omit new_text to ' +
+                     'delete. Advanced: pass a hashline `patch` instead for line-anchored multi-hunk edits (' +
+                     HL_FILE_PREFIX + 'path#hash header, "42:" anchors, ' + HL_PAYLOAD_REPLACE + '/' +
+                     HL_PAYLOAD_ABOVE + '/' + HL_PAYLOAD_BELOW + ' payload markers; header hash must match disk).';
+    T.Schema      := '{"type":"object","properties":{' +
+                     '"path":{"type":"string"},' +
+                     '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace)."},' +
+                     '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text."},' +
+                     '"replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring a unique match."},' +
+                     '"patch":{"type":"string","description":"Advanced: a hashline-format patch, used INSTEAD of old_text/new_text."}' +
+                     '}}';
+  end
+  else
+  begin
+    T.Description := 'Edit a file by replacing an exact snippet: pass old_text (the existing text, verbatim ' +
+                     'including whitespace) and new_text. The match must be unique unless replace_all is set; ' +
+                     'omit new_text to delete text.';
+    T.Schema      := '{"type":"object","properties":{' +
+                     '"path":{"type":"string"},' +
+                     '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace)."},' +
+                     '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text."},' +
+                     '"replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring a unique match."}' +
+                     '},"required":["path","old_text"]}';
   end;
+  T.Handler  := Tool_FSEdit;
+  T.IsCore   := True;
+  T.Category := tcMutating;
+  Emit('fs_edit_hashline');
 end;
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -205,12 +205,25 @@ end;
 
 function TToolRegistry.Names: TStringArray;
 var
-  i: Integer;
+  i, k: Integer;
 begin
   FLock.Acquire;
   try
+    { Skip hidden back-compat aliases. Names feeds model-facing listings --
+      the subagent '*' expansion (BuildFilteredRegistry), the MCP server's
+      tools/list, the TUI/CLI tool rosters -- so an alias here would re-
+      surface the old fs_* name the Hidden flag exists to suppress. Dispatch
+      goes through Find (which still resolves hidden names), so back-compat
+      is unaffected. }
     SetLength(Result, Length(FTools));
-    for i := 0 to High(FTools) do Result[i] := FTools[i].Name;
+    k := 0;
+    for i := 0 to High(FTools) do
+      if not FTools[i].Hidden then
+      begin
+        Result[k] := FTools[i].Name;
+        Inc(k);
+      end;
+    SetLength(Result, k);
   finally
     FLock.Release;
   end;

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -57,6 +57,10 @@ type
       explicit value. This mirrors the existing HandlerObj defensive
       clear: same risk shape, same fix shape. }
     procedure Register(const T: TTool);
+    { Register a hidden back-compat alias (old tool name -> same handler).
+      Dispatches normally via Find / RunTool but is skipped by
+      ToProviderDefs, so the model only ever sees the new canonical name. }
+    procedure RegisterHidden(const T: TTool);
     { Register a tool with an explicit IsDeferred override. Used by
       PasClaw.MCP.Bridge when Cfg.MCPProgressiveDisclosure is on so
       newly-registered MCP tools are stripped from ToProviderDefs
@@ -153,6 +157,22 @@ begin
     False here; MCP -- the only legitimate IsDeferred=True path --
     goes through RegisterDeferred instead. }
   Modified.IsDeferred := False;
+  { Same defensive clear for the Hidden alias flag -- legacy stack-built
+    records never set it, so garbage there could silently drop a core tool
+    from ToProviderDefs. Aliases go through RegisterHidden instead. }
+  Modified.Hidden := False;
+  RegisterImpl(Modified);
+end;
+
+procedure TToolRegistry.RegisterHidden(const T: TTool);
+{ Register a back-compat alias: dispatches via Find / RunTool but is hidden
+  from ToProviderDefs so the model only sees the new canonical name. }
+var
+  Modified: TTool;
+begin
+  Modified := T;
+  Modified.IsDeferred := False;
+  Modified.Hidden     := True;
   RegisterImpl(Modified);
 end;
 
@@ -240,6 +260,10 @@ begin
         keeps the provider's per-request `tools` array small (and the
         token bill low) while leaving the dispatcher unchanged. }
       if FTools[i].IsDeferred and (not IsRevealedLocked(FTools[i].Name)) then
+        Continue;
+      { Hidden back-compat aliases dispatch but never reach the model's
+        tool list -- only the new canonical name is advertised. }
+      if FTools[i].Hidden then
         Continue;
       Result[k].Name        := FTools[i].Name;
       Result[k].Description := FTools[i].Description;

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -390,11 +390,14 @@ var
 begin
   Result := True;
   Err := '';
-  if Name <> 'fs_edit_hashline' then Exit;
+  { edit_file (canonical) + fs_edit_hashline (back-compat alias) can carry a
+    hashline patch; str-replace calls have no `patch` key and fall through
+    the `Patch = ''` guard below untouched. }
+  if (Name <> 'edit_file') and (Name <> 'fs_edit_hashline') then Exit;
   Obj := TJsonObject.Parse(ArgsJSON);
   if Obj = nil then
   begin
-    Err := 'invalid JSON arguments for fs_edit_hashline';
+    Err := 'invalid JSON arguments for edit_file';
     Exit(False);
   end;
   try
@@ -483,7 +486,8 @@ begin
   else
     D.Err := 'no tool registry';
 
-  if (D.Call.Func.Name = 'fs_edit_hashline') and IsPatchFormatError(D.Err) then
+  if ((D.Call.Func.Name = 'edit_file') or (D.Call.Func.Name = 'fs_edit_hashline'))
+     and IsPatchFormatError(D.Err) then
   begin
     LogWarn('tool-retry attempt=1 strategy=raw_hashline normalized_patch_len=%d has_unsupported_tokens=%s class=format_error',
       [Length(NormalizePatchForCompare(RetryArgs)), BoolToStr(False, True)]);

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -61,6 +61,14 @@ type
       ToolSearch pattern. Default False -- all built-in / skill / non-
       MCP tools surface immediately. }
     IsDeferred:  Boolean;
+    { Hidden -- a back-compat alias. When True the tool is a rename shim:
+      Find / RunTool dispatch to it normally so old tool names keep working
+      for existing configs and mid-session calls, but ToProviderDefs skips
+      it so the model only ever sees the new canonical name in its tool
+      list. Unlike IsDeferred, a Hidden tool is never surfaced by
+      tool_search / DeferredNames -- it is permanently invisible to the
+      model. Default False. }
+    Hidden:      Boolean;
   end;
 
   TToolList = array of TTool;

--- a/src/pkg/tools/PasClaw.Tools.WebFetch.pas
+++ b/src/pkg/tools/PasClaw.Tools.WebFetch.pas
@@ -401,7 +401,7 @@ begin
     'file under the workspace instead -- useful for large pages, binary ' +
     'downloads, or anything that would blow the model''s context. When ' +
     'save_to is set, the tool result is a short receipt + preview, and ' +
-    'the model uses fs_read / fs_grep on the saved file.';
+    'the model uses read_file / grep_files on the saved file.';
   T.Schema      :=
     '{"type":"object",' +
     '"properties":{' +

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1363,7 +1363,7 @@ begin
       Cfg.Options.SystemPrompt :=
         '## Plan Mode' + sLineBreak + sLineBreak +
         'You are in PLAN mode (TUI Tab pressed). Read-only tools work; ' +
-        'fs_write / fs_edit_hashline / shell_exec / execute_code / ' +
+        'write_file / append_file / edit_file / shell_exec / execute_code / ' +
         'send_message / skills_manage / ... will REFUSE. Analyse the ' +
         'codebase and propose a plan; do not attempt mutating tools.' +
         sLineBreak + sLineBreak +

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -112,6 +112,14 @@ begin
     AssertEqStr(ReadBack(Reg, PathA), 'hello', 'fs_write alias actually wrote the file');
     WriteLn('  ok: old fs_* names still dispatch as hidden aliases');
 
+    { --- 2b. read_file defaults to plain; hashline is opt-in. --- }
+    R := Reg.RunTool('read_file', '{"path":"' + PathA + '"}', Err);
+    AssertEqStr(R, 'hello', 'read_file defaults to plain content (no hashline header)');
+    R := Reg.RunTool('read_file', '{"path":"' + PathA + '","hashline":true}', Err);
+    AssertContains(R, '#', 'read_file hashline:true emits the #hash header');
+    AssertContains(R, '1:hello', 'read_file hashline:true emits LINENO:line');
+    WriteLn('  ok: read_file plain by default, hashline:true opts in');
+
     { --- 3. append_file concatenates. --- }
     R := Reg.RunTool('append_file', '{"path":"' + PathA + '","content":" world"}', Err);
     AssertEqStr(Err, '', 'append_file no error');

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -1,0 +1,160 @@
+program fs_tool_naming_tests;
+(*
+  Pins the verb_noun file-tool rename + the new append_file and the
+  edit_file string-replacement mode:
+
+    * ToProviderDefs advertises ONLY the new canonical names
+      (read_file / write_file / append_file / list_dir / grep_files /
+      edit_file) and never the old fs_* names.
+    * The old fs_* names remain dispatchable as hidden aliases (Find /
+      RunTool still route them) so existing configs / sessions keep
+      working.
+    * append_file concatenates onto an existing file (and creates it
+      when absent).
+    * edit_file does old_text->new_text replacement: unique match,
+      replace_all, not-found error, ambiguous-match error, and delete
+      (omitted new_text).
+
+  Strategy: drive the tools through a real TToolRegistry via RunTool
+  with hand-built JSON args against a temp dir. No model, no provider.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  PasClaw.Utils,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.FS;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Halt(1);
+end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertFalse(Cond: Boolean; const Msg: string);
+begin if Cond then Fail_(Msg); end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Copy(Got, 1, 200) + '", want "' + Copy(Want, 1, 200) + '")');
+end;
+
+procedure AssertContains(const Haystack, Needle, Msg: string);
+begin
+  if Pos(Needle, Haystack) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' + Copy(Haystack, 1, 200) + '")');
+end;
+
+function DefsHasName(const Defs: TToolDefinitionArray; const Name: string): Boolean;
+var i: Integer;
+begin
+  Result := False;
+  for i := 0 to High(Defs) do
+    if Defs[i].Name = Name then Exit(True);
+end;
+
+{ Read a file back through read_file's plain mode so we don't need a
+  separate disk-read helper. }
+function ReadBack(Reg: TToolRegistry; const Path: string): string;
+var Err: string;
+begin
+  Result := Reg.RunTool('read_file', '{"path":"' + Path + '","plain":true}', Err);
+end;
+
+var
+  Reg: TToolRegistry;
+  Defs: TToolDefinitionArray;
+  Dir, PathA, PathB, R, Err: string;
+  T: TTool;
+begin
+  Dir := JoinPath(GetTempDir, 'pcfsnaming');
+  ForceDirectories(Dir);
+  PathA := JoinPath(Dir, 'a.txt');
+  PathB := JoinPath(Dir, 'b.txt');
+  if FileExists(PathA) then DeleteFile(PathA);
+  if FileExists(PathB) then DeleteFile(PathB);
+
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+
+    { --- 1. Provider defs advertise ONLY the new names. --- }
+    Defs := Reg.ToProviderDefs;
+    AssertTrue(DefsHasName(Defs, 'read_file'),  'read_file advertised');
+    AssertTrue(DefsHasName(Defs, 'write_file'), 'write_file advertised');
+    AssertTrue(DefsHasName(Defs, 'append_file'),'append_file advertised');
+    AssertTrue(DefsHasName(Defs, 'list_dir'),   'list_dir advertised');
+    AssertTrue(DefsHasName(Defs, 'grep_files'), 'grep_files advertised');
+    AssertTrue(DefsHasName(Defs, 'edit_file'),  'edit_file advertised');
+    AssertFalse(DefsHasName(Defs, 'fs_read'),   'fs_read hidden from provider defs');
+    AssertFalse(DefsHasName(Defs, 'fs_write'),  'fs_write hidden from provider defs');
+    AssertFalse(DefsHasName(Defs, 'fs_list'),   'fs_list hidden from provider defs');
+    AssertFalse(DefsHasName(Defs, 'fs_grep'),   'fs_grep hidden from provider defs');
+    AssertFalse(DefsHasName(Defs, 'fs_edit_hashline'), 'fs_edit_hashline hidden from provider defs');
+    WriteLn('  ok: provider defs advertise new names, hide old aliases');
+
+    { --- 2. Old names still dispatch (hidden aliases). --- }
+    AssertTrue(Reg.Find('fs_write', T), 'fs_write alias findable');
+    AssertTrue(Reg.Find('edit_file', T), 'edit_file findable');
+    R := Reg.RunTool('fs_write', '{"path":"' + PathA + '","content":"hello"}', Err);
+    AssertEqStr(Err, '', 'fs_write alias runs without error');
+    AssertEqStr(ReadBack(Reg, PathA), 'hello', 'fs_write alias actually wrote the file');
+    WriteLn('  ok: old fs_* names still dispatch as hidden aliases');
+
+    { --- 3. append_file concatenates. --- }
+    R := Reg.RunTool('append_file', '{"path":"' + PathA + '","content":" world"}', Err);
+    AssertEqStr(Err, '', 'append_file no error');
+    AssertContains(R, 'appended 6 bytes', 'append_file reports byte count');
+    AssertEqStr(ReadBack(Reg, PathA), 'hello world', 'append_file concatenated');
+    { creates when absent }
+    R := Reg.RunTool('append_file', '{"path":"' + PathB + '","content":"fresh"}', Err);
+    AssertEqStr(Err, '', 'append_file creates missing file');
+    AssertEqStr(ReadBack(Reg, PathB), 'fresh', 'append_file created + wrote');
+    WriteLn('  ok: append_file concatenates and creates');
+
+    { --- 4. edit_file string replacement. --- }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"alpha beta gamma"}', Err);
+    R := Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_text":"beta","new_text":"BETA"}', Err);
+    AssertEqStr(Err, '', 'edit_file unique replace no error');
+    AssertEqStr(ReadBack(Reg, PathA), 'alpha BETA gamma', 'edit_file replaced unique match');
+
+    { not found }
+    Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_text":"zzz","new_text":"x"}', Err);
+    AssertContains(Err, 'not found', 'edit_file not-found error');
+
+    { ambiguous -> refuse without replace_all }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"x x x"}', Err);
+    Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_text":"x","new_text":"y"}', Err);
+    AssertContains(Err, 'matches 3 times', 'edit_file ambiguous error');
+
+    { replace_all }
+    R := Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_text":"x","new_text":"y","replace_all":true}', Err);
+    AssertEqStr(Err, '', 'edit_file replace_all no error');
+    AssertEqStr(ReadBack(Reg, PathA), 'y y y', 'edit_file replaced all occurrences');
+
+    { delete (omit new_text) }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"keepDROPkeep"}', Err);
+    Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_text":"DROP"}', Err);
+    AssertEqStr(ReadBack(Reg, PathA), 'keepkeep', 'edit_file deletes when new_text omitted');
+    WriteLn('  ok: edit_file str-replace (unique / not-found / ambiguous / replace_all / delete)');
+
+  finally
+    Reg.Free;
+    if FileExists(PathA) then DeleteFile(PathA);
+    if FileExists(PathB) then DeleteFile(PathB);
+    RemoveDir(Dir);
+  end;
+
+  WriteLn('PASS');
+end.

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -79,6 +79,14 @@ begin
     if Defs[i].Name = Name then Exit(True);
 end;
 
+function NamesHas(const Names: TStringArray; const Name: string): Boolean;
+var i: Integer;
+begin
+  Result := False;
+  for i := 0 to High(Names) do
+    if Names[i] = Name then Exit(True);
+end;
+
 { Read a file back through read_file's plain mode so we don't need a
   separate disk-read helper. }
 function ReadBack(Reg: TToolRegistry; const Path: string): string;
@@ -125,7 +133,12 @@ begin
     R := Reg.RunTool('fs_write', '{"path":"' + PathA + '","content":"hello"}', Err);
     AssertEqStr(Err, '', 'fs_write alias runs without error');
     AssertEqStr(ReadBack(Reg, PathA), 'hello', 'fs_write alias actually wrote the file');
-    WriteLn('  ok: old fs_* names still dispatch as hidden aliases');
+    { Registry.Names (feeds subagent '*' expansion + MCP tools/list) must also
+      exclude the hidden aliases, not just ToProviderDefs. }
+    AssertTrue(NamesHas(Reg.Names, 'write_file'), 'Names includes canonical write_file');
+    AssertFalse(NamesHas(Reg.Names, 'fs_write'),  'Names excludes hidden fs_write alias');
+    AssertFalse(NamesHas(Reg.Names, 'fs_edit_hashline'), 'Names excludes hidden fs_edit_hashline alias');
+    WriteLn('  ok: old fs_* names still dispatch as hidden aliases, hidden from Names');
 
     { --- 2b. read_file defaults to plain; hashline is opt-in. --- }
     R := Reg.RunTool('read_file', '{"path":"' + PathA + '"}', Err);
@@ -207,7 +220,15 @@ begin
       Err);
     AssertContains(Err, 'context not found', 'apply_patch reports a missing-context failure');
     AssertEqStr(ReadBack(Reg, PathA), 'unchanged', 'apply_patch wrote nothing on failure');
-    WriteLn('  ok: apply_patch (update+add+delete, atomic on failure)');
+
+    { Add File onto an existing path must refuse (not silently clobber). PathN
+      already exists ("brand new") from the successful patch above. }
+    R := Reg.RunTool('apply_patch',
+      '{"patch":"' + JEsc('*** Begin Patch'#10'*** Add File: ' + PathN + #10'+overwrite'#10'*** End Patch'#10) + '"}',
+      Err);
+    AssertContains(Err, 'already exists', 'apply_patch refuses Add File onto an existing path');
+    AssertContains(ReadBack(Reg, PathN), 'brand new', 'apply_patch did NOT clobber the existing file');
+    WriteLn('  ok: apply_patch (update+add+delete, atomic on failure, no-clobber Add)');
 
   finally
     Reg.Free;

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -56,6 +56,21 @@ begin
     Fail_(Msg + ' (needle "' + Needle + '" missing from "' + Copy(Haystack, 1, 200) + '")');
 end;
 
+function JEsc(const S: string): string;
+var i: Integer;
+begin
+  Result := '';
+  for i := 1 to Length(S) do
+    case S[i] of
+      '"': Result := Result + '\"';
+      '\': Result := Result + '\\';
+      #10: Result := Result + '\n';
+      #13: ;
+    else
+      Result := Result + S[i];
+    end;
+end;
+
 function DefsHasName(const Defs: TToolDefinitionArray; const Name: string): Boolean;
 var i: Integer;
 begin
@@ -75,7 +90,7 @@ end;
 var
   Reg: TToolRegistry;
   Defs: TToolDefinitionArray;
-  Dir, PathA, PathB, R, Err: string;
+  Dir, PathA, PathB, PathC, PathN, Patch, R, Err: string;
   T: TTool;
 begin
   Dir := JoinPath(GetTempDir, 'pcfsnaming');
@@ -157,10 +172,49 @@ begin
     AssertEqStr(ReadBack(Reg, PathA), 'keepkeep', 'edit_file deletes when new_text omitted');
     WriteLn('  ok: edit_file str-replace (unique / not-found / ambiguous / replace_all / delete)');
 
+    { --- 5. apply_patch: multi-file (update + add + delete) in one call. --- }
+    AssertTrue(DefsHasName(Reg.ToProviderDefs, 'apply_patch'), 'apply_patch advertised');
+    PathC := JoinPath(Dir, 'c.txt');
+    PathN := JoinPath(Dir, 'new.txt');
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"line1\nline2\nline3"}', Err);
+    Reg.RunTool('write_file', '{"path":"' + PathC + '","content":"doomed"}', Err);
+    if FileExists(PathN) then DeleteFile(PathN);
+    Patch :=
+      '*** Begin Patch'#10 +
+      '*** Update File: ' + PathA + #10 +
+      ' line1'#10 +
+      '-line2'#10 +
+      '+LINE2'#10 +
+      ' line3'#10 +
+      '*** Add File: ' + PathN + #10 +
+      '+brand new'#10 +
+      '*** Delete File: ' + PathC + #10 +
+      '*** End Patch'#10;
+    R := Reg.RunTool('apply_patch', '{"patch":"' + JEsc(Patch) + '"}', Err);
+    AssertEqStr(Err, '', 'apply_patch no error');
+    AssertContains(R, '1 added', 'apply_patch reports 1 added');
+    AssertContains(R, '1 updated', 'apply_patch reports 1 updated');
+    AssertContains(R, '1 deleted', 'apply_patch reports 1 deleted');
+    AssertEqStr(ReadBack(Reg, PathA), 'line1' + #10 + 'LINE2' + #10 + 'line3',
+      'apply_patch applied the context hunk');
+    AssertContains(ReadBack(Reg, PathN), 'brand new', 'apply_patch added the new file');
+    AssertFalse(FileExists(PathC), 'apply_patch deleted the file');
+
+    { A patch whose context does not match writes nothing (atomic). }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"unchanged"}', Err);
+    Reg.RunTool('apply_patch',
+      '{"patch":"' + JEsc('*** Begin Patch'#10'*** Update File: ' + PathA + #10'-nope'#10'+yep'#10'*** End Patch'#10) + '"}',
+      Err);
+    AssertContains(Err, 'context not found', 'apply_patch reports a missing-context failure');
+    AssertEqStr(ReadBack(Reg, PathA), 'unchanged', 'apply_patch wrote nothing on failure');
+    WriteLn('  ok: apply_patch (update+add+delete, atomic on failure)');
+
   finally
     Reg.Free;
     if FileExists(PathA) then DeleteFile(PathA);
     if FileExists(PathB) then DeleteFile(PathB);
+    if FileExists(PathC) then DeleteFile(PathC);
+    if FileExists(PathN) then DeleteFile(PathN);
     RemoveDir(Dir);
   end;
 


### PR DESCRIPTION
Brings the file toolset in line with the conventions models are trained on (openclaw / picoclaw / Claude Code), so a mid-tier model spends its budget on the task instead of on PasClaw's bespoke tool names/formats. Three commits.

## 1. Rename to verb_noun, with hidden back-compat aliases

`fs_read`→`read_file`, `fs_write`→`write_file`, `fs_list`→`list_dir`, `fs_grep`→`grep_files`, `fs_edit_hashline`→`edit_file`.

A new `TTool.Hidden` flag + `TToolRegistry.RegisterHidden` register the old names as **hidden aliases**: they still dispatch via `Find`/`RunTool` (existing configs, saved sessions, and mid-session calls keep working), but `ToProviderDefs` skips them so the model only ever sees the new names.

## 2. New capabilities

- **`append_file`** — append to a file (create + parent dirs when missing). The incremental-write escape hatch: build a large file across turns instead of one oversized `write_file` arg a provider may fail to serialise.
- **`edit_file` string-replacement mode** — default `old_text`→`new_text` (unique match unless `replace_all`; omit `new_text` to delete), the form every model authors natively. The hashline `patch` mode stays as an advanced opt-in, still gated to `UseHashline` in the advertised schema. `edit_file` now registers **unconditionally**, so `--no-hashline` deployments finally get a real edit tool.
- **`read_file` symmetry** — plain text is now the default; the hashline `#hash`+`LINENO` format is opt-in via `hashline:true` (mirrors `edit_file`'s advanced `patch`; the patch workflow reads with `hashline:true` first). Legacy `plain:true` still accepted as a no-op.

## 3. `apply_patch` — multi-file, context-anchored patches

New tool in the Codex/OpenClaw `apply_patch` format: one call with a `*** Begin Patch` … `*** End Patch` envelope mixing `*** Add File` / `*** Update File` (+ optional `*** Move to`) / `*** Delete File`. Update hunks use ` `/`-`/`+` lines and optional `@@` anchors; edits are located by context, not line numbers. **All-or-nothing** — the whole patch is parsed and every hunk located against the on-disk files, and every target sandbox-checked, before anything is written. Each write/delete is snapshotted for `/undo`. Fills the niche a single `edit_file` swap can't: a change spanning multiple files or many hunks.

## Wiring

Name-driven behaviour updated to the new names (keeping old ones for replayed history): the tool-loop patch preflight/format-retry, the auto-router write/run heuristic, the checkpoint mutation detector, and the gateway tool-view summary. System prompt, plan-mode text, tool descriptions, onboarding, and README updated; old names noted as hidden aliases.

## Tests

New `fs_tool_naming_tests`: provider defs advertise new names + hide aliases, old names still dispatch, `read_file` plain-by-default/`hashline:true` opt-in, `append_file` concatenate/create, `edit_file` str-replace (unique / not-found / ambiguous / replace_all / delete), and `apply_patch` (update+add+delete + atomic-on-failure). Full build + touched-subsystem suites (toolview, autoroute, hashline, subagent-default, plan-build-mode) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_