### PR TITLE
fs/gateway: resolve relative paths to the workspace, not the launch CWD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -753,6 +753,13 @@ test-fs-tool-naming: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_tool_naming_tests.pas -o$(BUILDDIR)/fs_tool_naming_tests
 	@$(BUILDDIR)/fs_tool_naming_tests
 
+# Workspace-relative path resolution: fs tools resolve relative paths against
+# the configured workspace, not the launch CWD.
+test-workspace-paths: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/workspace_paths_tests.pas -o$(BUILDDIR)/workspace_paths_tests
+	@$(BUILDDIR)/workspace_paths_tests
+
 # Logger level suppression: pins the contract PasClaw.dpr's
 # IsQuietInvocation branch depends on (SetLogLevel(llError) drops
 # Debug/Info/Warn while keeping Error). Without this regression
@@ -822,4 +829,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -207,7 +207,11 @@ begin
   if Trim(Cfg.Sandbox.Workspace) <> '' then
     ConfigureSandbox(Cfg.Sandbox, '')
   else
+  begin
+    { Ensure the default work area exists so shell_exec can start there too. }
+    ForceDirectories(IncludeTrailingPathDelimiter(GetHome) + 'workspace');
     ConfigureSandbox(Cfg.Sandbox, IncludeTrailingPathDelimiter(GetHome) + 'workspace');
+  end;
   ShellSessionId := '';
   try
     Args := ParseGw(Argv, Cfg);

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -200,7 +200,14 @@ begin
       Break;
     end;
   Cfg := LoadConfig(ProfileName);
-  ConfigureSandbox(Cfg.Sandbox, '');
+  { Default the working directory to $PASCLAW_HOME/workspace -- the dir the
+    web UI Files tab browses -- rather than the launch CWD, so a relative
+    write_file("index.html") lands where the operator sees it. An explicit
+    sandbox.workspace still wins. }
+  if Trim(Cfg.Sandbox.Workspace) <> '' then
+    ConfigureSandbox(Cfg.Sandbox, '')
+  else
+    ConfigureSandbox(Cfg.Sandbox, IncludeTrailingPathDelimiter(GetHome) + 'workspace');
   ShellSessionId := '';
   try
     Args := ParseGw(Argv, Cfg);

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -158,7 +158,13 @@ begin
       Break;
     end;
   Cfg := LoadConfig(ProfileName);
-  ConfigureSandbox(Cfg.Sandbox, '');
+  { Default the working directory to $PASCLAW_HOME/workspace (the operator's
+    work area) rather than the launch CWD, so a relative write_file path lands
+    somewhere predictable. An explicit sandbox.workspace still wins. }
+  if Trim(Cfg.Sandbox.Workspace) <> '' then
+    ConfigureSandbox(Cfg.Sandbox, '')
+  else
+    ConfigureSandbox(Cfg.Sandbox, IncludeTrailingPathDelimiter(GetHome) + 'workspace');
   ShellSessionId := '';
   Scheduler := nil;   { so the finally is safe if we Exit before starting it }
   try

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -164,7 +164,11 @@ begin
   if Trim(Cfg.Sandbox.Workspace) <> '' then
     ConfigureSandbox(Cfg.Sandbox, '')
   else
+  begin
+    { Ensure the default work area exists so shell_exec can start there too. }
+    ForceDirectories(IncludeTrailingPathDelimiter(GetHome) + 'workspace');
     ConfigureSandbox(Cfg.Sandbox, IncludeTrailingPathDelimiter(GetHome) + 'workspace');
+  end;
   ShellSessionId := '';
   Scheduler := nil;   { so the finally is safe if we Exit before starting it }
   try

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -177,6 +177,7 @@ uses
   PasClaw.Skills.Loader,
   PasClaw.Agent.Orient,   { task-aware MEMORY slicing (Cfg.OrientTaskAware) }
   PasClaw.Memory.Facts,   { distilled-fact injection (Cfg.MemoryDistillEnabled) }
+  PasClaw.Tools.Sandbox,  { CurrentWorkspace -- the working dir the prompt advertises }
   PasClaw.MCP.Disclosure; { deferred-tools section (Cfg.MCPProgressiveDisclosure) }
 
 const
@@ -239,12 +240,22 @@ end;
 
 function BuildWorkspaceSection: string;
 var
-  Home: string;
+  Home, WorkDir: string;
 begin
   Home := GetHome;
+  { The directory relative file paths resolve to. CurrentWorkspace is the
+    configured sandbox.workspace, or the launch dir when unset; empty only
+    if the sandbox was never configured (fall back to the current dir).
+    Advertising it here keeps the prompt honest -- a model that writes
+    write_file("index.html") lands the file exactly where we say it will,
+    instead of silently in the process's launch directory. }
+  WorkDir := CurrentWorkspace;
+  if Trim(WorkDir) = '' then WorkDir := GetCurrentDir;
   Result :=
     '## Workspace' + sLineBreak +
-    'Your workspace is at: ' + Home + sLineBreak +
+    'Your working directory is: ' + WorkDir + sLineBreak +
+    'Relative file paths (e.g. write_file "index.html") resolve here; pass an '
+    + 'absolute path to write elsewhere.' + sLineBreak +
     '- Memory: ' + JoinPath(Home, 'workspace/memory/MEMORY.md') + sLineBreak +
     '- Skills: ' + JoinPath(Home, 'workspace/skills') + '/{skill-name}/SKILL.md' + sLineBreak +
     '- Logs:   ' + JoinPath(Home, 'logs');

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -197,6 +197,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  Path := ResolveWorkspacePath(Path);
   if not CanReadPath(Path, Reason) then
   begin
     ErrMsg := Reason;
@@ -235,6 +236,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  Path := ResolveWorkspacePath(Path);
   if not CanWritePath(Path, Reason) then
   begin
     ErrMsg := Reason;
@@ -330,6 +332,11 @@ begin
     ErrMsg := 'patch contained no sections; expected one or more lines starting with ' + HL_FILE_PREFIX + 'path#hash';
     Exit('');
   end;
+
+  { Resolve each section's ¶path against the workspace so a relative header
+    (¶index.html#hash) lands in the same place read_file / write_file do. }
+  for i := 0 to High(Sections) do
+    Sections[i].Path := ResolveWorkspacePath(Sections[i].Path);
 
   { Pass 1: validate every section and stage the new body in memory.
     No writes happen during this pass, so a stale hash / missing file /
@@ -659,6 +666,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  Root := ResolveWorkspacePath(Root);
   if not CanReadPath(Root, ErrMsg) then Exit('');
   if not ParseStringArg(ArgsJSON, 'pattern', Pattern) then
   begin
@@ -740,6 +748,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  Path := ResolveWorkspacePath(Path);
   if not CanReadPath(Path, ErrMsg) then Exit('');
   if not DirectoryExists(Path) then
   begin
@@ -897,7 +906,7 @@ begin
 
     if ApStarts(Line, '*** Add File: ') then
     begin
-      Path := Trim(Copy(Line, Length('*** Add File: ') + 1, MaxInt));
+      Path := ResolveWorkspacePath(Trim(Copy(Line, Length('*** Add File: ') + 1, MaxInt)));
       Inc(i);
       SetLength(Content, 0);
       while (i < n) and (not ApStarts(P[i], '*** ')) do
@@ -920,19 +929,19 @@ begin
     end
     else if ApStarts(Line, '*** Delete File: ') then
     begin
-      Path := Trim(Copy(Line, Length('*** Delete File: ') + 1, MaxInt));
+      Path := ResolveWorkspacePath(Trim(Copy(Line, Length('*** Delete File: ') + 1, MaxInt)));
       Act.Kind := pokDelete; Act.Path := Path; Act.MoveTo := ''; Act.Content := '';
       AddAction;
       Inc(i);
     end
     else if ApStarts(Line, '*** Update File: ') then
     begin
-      Path := Trim(Copy(Line, Length('*** Update File: ') + 1, MaxInt));
+      Path := ResolveWorkspacePath(Trim(Copy(Line, Length('*** Update File: ') + 1, MaxInt)));
       Inc(i);
       MoveTo := '';
       if (i < n) and ApStarts(P[i], '*** Move to: ') then
       begin
-        MoveTo := Trim(Copy(P[i], Length('*** Move to: ') + 1, MaxInt));
+        MoveTo := ResolveWorkspacePath(Trim(Copy(P[i], Length('*** Move to: ') + 1, MaxInt)));
         Inc(i);
       end;
       if not CanReadPath(Path, Reason) then begin ErrMsg := 'apply_patch: ' + Reason; Exit; end;
@@ -1103,6 +1112,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  Path := ResolveWorkspacePath(Path);
   if not CanWritePath(Path, Reason) then
   begin
     ErrMsg := Reason;
@@ -1170,6 +1180,7 @@ begin
     ErrMsg := 'missing required argument: path';
     Exit('');
   end;
+  Path := ResolveWorkspacePath(Path);
   if not CanWritePath(Path, Reason) then
   begin
     ErrMsg := Reason;

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -102,6 +102,17 @@ function CanReadPathHTTP(const Path: string; out Reason: string): Boolean;
   ConfigureSandbox has not been called yet. }
 function CurrentWorkspace: string;
 
+{ Resolve a possibly-relative file path to an absolute one. Absolute paths
+  pass through (canonicalised). A RELATIVE path resolves against the
+  configured workspace (CurrentWorkspace) rather than the process's current
+  directory -- so a model that writes `write_file("index.html")` on a gateway
+  / serve run lands the file in the operator's workspace, not wherever the
+  service happened to be launched. When no workspace is configured
+  CurrentWorkspace already defaults to the launch dir, so CLI-in-a-project
+  behaviour (relative = the project dir) is unchanged. Tools call this before
+  the CanRead/CanWritePath gate so the sandbox sees the same resolved path. }
+function ResolveWorkspacePath(const Path: string): string;
+
 { True iff Path canonicalises to a child of Workspace. Exposed for
   testing and for the rare caller that wants to know without going
   through the policy layer. }
@@ -155,6 +166,32 @@ end;
 function CurrentWorkspace: string;
 begin
   Result := GWorkspace;
+end;
+
+function IsAbsolutePath(const P: string): Boolean;
+begin
+  {$IFDEF MSWINDOWS}
+  { Drive-letter (C:\...), or a leading slash / backslash (root or UNC). }
+  Result := ((Length(P) >= 2) and (P[2] = ':')) or
+            ((Length(P) >= 1) and ((P[1] = '\') or (P[1] = '/')));
+  {$ELSE}
+  Result := (Length(P) >= 1) and (P[1] = '/');
+  {$ENDIF}
+end;
+
+function ResolveWorkspacePath(const Path: string): string;
+var
+  Base: string;
+begin
+  if Trim(Path) = '' then Exit(Path);
+  if IsAbsolutePath(Path) then
+    Result := ExpandFileName(Path)
+  else
+  begin
+    Base := GWorkspace;
+    if Trim(Base) = '' then Base := GetCurrentDir;
+    Result := ExpandFileName(IncludeTrailingPathDelimiter(Base) + Path);
+  end;
 end;
 
 function RestrictionActive: Boolean;

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -94,16 +94,19 @@ begin
     ErrMsg := Reason;
     Exit('');
   end;
-  { Pin the shell's cwd to the workspace when restriction is on. Paired
-    with the cd / chdir / pushd / popd token denylist and the '..'
-    traversal check in ShellAllowed, this closes the relative-path
-    bypass: a sandboxed model has no way to read or write files
-    outside the workspace via shell_exec. When restriction is off,
-    WorkDir is empty and RunOneShot inherits the parent's cwd
-    (legacy behaviour, byte-identical to the previous release). }
-  if RestrictionActive then
-    WorkDir := CurrentWorkspace
-  else
+  { Start the shell in the SAME directory relative file paths resolve to
+    (CurrentWorkspace), so write_file("x") and shell_exec("cat x") agree --
+    otherwise, with restriction off, the FS tools wrote into the workspace
+    while the shell inherited the launch cwd, and the two looked in different
+    places. CurrentWorkspace defaults to the launch dir when no workspace is
+    configured, so CLI runs are byte-identical to before; the gateway/serve
+    default ($PASCLAW_HOME/workspace) now applies to the shell too. When
+    restriction is on this cwd ALSO pins the boundary, paired with the
+    cd / chdir / pushd / popd denylist and the '..' check in ShellAllowed.
+    Fall back to inheriting the parent cwd if the workspace dir does not
+    exist yet (nothing to chdir into). }
+  WorkDir := CurrentWorkspace;
+  if (WorkDir <> '') and (not DirectoryExists(WorkDir)) then
     WorkDir := '';
   LogDebug('shell exec (cwd=%s): %s', [WorkDir, Cmd]);
   ExitCode := RunOneShotViaBackend(GetCurrentSessionId, Cmd, WorkDir, Out_);

--- a/src/tests/workspace_paths_tests.pas
+++ b/src/tests/workspace_paths_tests.pas
@@ -1,0 +1,92 @@
+program workspace_paths_tests;
+(*
+  Pins that fs tools resolve RELATIVE paths against the configured workspace
+  (CurrentWorkspace) rather than the process's launch directory. Before this,
+  a gateway/serve run with sandbox.workspace set still wrote write_file("x")
+  into the launch CWD (the repo root), diverging from what the system prompt
+  advertised.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.Sandbox,
+  PasClaw.Tools.FS;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertFalse(Cond: Boolean; const Msg: string);
+begin if Cond then Fail_(Msg); end;
+
+procedure AssertEqStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")');
+end;
+
+var
+  Pol: TSandboxPolicy;
+  Reg: TToolRegistry;
+  WsDir, AbsPath, Err, R: string;
+begin
+  WsDir := JoinPath(GetTempDir, 'pcwsrel');
+  ForceDirectories(WsDir);
+  { fresh }
+  if FileExists(JoinPath(WsDir, 'rel.txt')) then DeleteFile(JoinPath(WsDir, 'rel.txt'));
+  if FileExists(JoinPath(GetCurrentDir, 'rel.txt')) then DeleteFile(JoinPath(GetCurrentDir, 'rel.txt'));
+
+  Pol := Default(TSandboxPolicy);
+  Pol.RestrictToWorkspace := False;   { test resolution, not restriction }
+  ConfigureSandbox(Pol, WsDir);
+
+  { ResolveWorkspacePath: relative -> workspace; absolute -> itself. }
+  AssertEqStr(ResolveWorkspacePath('rel.txt'),
+              ExpandFileName(JoinPath(WsDir, 'rel.txt')),
+              'ResolveWorkspacePath resolves relative against the workspace');
+  AbsPath := ExpandFileName(JoinPath(WsDir, 'abs.txt'));
+  AssertEqStr(ResolveWorkspacePath(AbsPath), AbsPath,
+              'ResolveWorkspacePath passes an absolute path through');
+  WriteLn('  ok: ResolveWorkspacePath (relative -> workspace, absolute -> itself)');
+
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+
+    { A relative write must land in the workspace, NOT the launch dir. }
+    R := Reg.RunTool('write_file', '{"path":"rel.txt","content":"hi"}', Err);
+    AssertEqStr(Err, '', 'write_file relative no error');
+    AssertTrue(FileExists(JoinPath(WsDir, 'rel.txt')),
+      'relative write_file landed in the workspace');
+    AssertFalse(FileExists(JoinPath(GetCurrentDir, 'rel.txt')),
+      'relative write_file did NOT land in the launch CWD');
+
+    { A relative read resolves to the same place. }
+    AssertEqStr(Reg.RunTool('read_file', '{"path":"rel.txt","plain":true}', Err), 'hi',
+      'relative read_file resolves to the workspace');
+
+    { append_file relative resolves too. }
+    Reg.RunTool('append_file', '{"path":"rel.txt","content":"!"}', Err);
+    AssertEqStr(Reg.RunTool('read_file', '{"path":"rel.txt","plain":true}', Err), 'hi!',
+      'relative append_file resolves to the workspace');
+
+    WriteLn('  ok: write/read/append relative paths resolve to the workspace');
+  finally
+    Reg.Free;
+    if FileExists(JoinPath(WsDir, 'rel.txt')) then DeleteFile(JoinPath(WsDir, 'rel.txt'));
+    RemoveDir(WsDir);
+  end;
+
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## The problem

On a `pasclaw gateway` / `serve` run (the web UI path), a relative `write_file("index.html")` landed in **the process's launch directory** — wherever the service happened to be started — not the workspace the web UI **Files tab** shows. Meanwhile the system prompt advertised a *third* location (`~/.pasclaw`, the config dir) as "your workspace". So an un-steered write vanished somewhere the UI never displays, and the operator had to hand-supply an absolute path (or tell the model "use the workspace") on every build.

Root cause: the fs tools resolved a relative `path` arg with `ExpandFileName` — i.e. against the process CWD — and ignored the configured workspace entirely.

## The fix

- **`Sandbox.ResolveWorkspacePath`** — relative paths resolve against `CurrentWorkspace` (the configured `sandbox.workspace`, or the launch dir when unset); absolute paths pass through canonicalised. All fs tools call it before the `CanRead`/`CanWritePath` gate: `read_file` / `write_file` / `append_file` / `edit_file` (string **and** hashline patch) / `list_dir` / `grep_files` / `apply_patch`.
- **gateway + serve** now default the working directory to `$PASCLAW_HOME/workspace` (the dir the Files tab browses) when `sandbox.workspace` is unset, instead of the launch CWD. An explicit `sandbox.workspace` still wins. **CLI `agent`/`tui`/`build` are unchanged** — they keep resolving relative paths against the project CWD, which is what a user in their repo expects.
- The system prompt's **Workspace** section now advertises the actual working directory and states that relative paths resolve there, so the model writes to the right place without being told.

## Tests

`workspace_paths_tests` — `ResolveWorkspacePath` (relative → workspace, absolute → itself) and write/read/append relative paths land in the configured workspace, **not** the launch CWD.

Verified end-to-end through the relay with a **default** gateway (no `sandbox.workspace`) launched from an unrelated directory: a relative `write_file("probe.html")` with no workspace instruction landed in `$PASCLAW_HOME/workspace`, and the model's system prompt showed the correct working directory.

> Note: this is the Tier-3 workspace/CWD item from the earlier "why the web build failed" diagnosis; it's independent of #406/#407 (already merged) and touches disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_