### PR TITLE
loop: progress ledger — goal anchor, todo checklist, resume summary (+ /v1/chat cap fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,6 +760,13 @@ test-workspace-paths: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/workspace_paths_tests.pas -o$(BUILDDIR)/workspace_paths_tests
 	@$(BUILDDIR)/workspace_paths_tests
 
+# Progress ledger: goal anchor + todo checklist fold, nothing-written nudge,
+# max-iter resume summary (A1/A2).
+test-progress-ledger: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/progress_ledger_tests.pas -o$(BUILDDIR)/progress_ledger_tests
+	@$(BUILDDIR)/progress_ledger_tests
+
 # Logger level suppression: pins the contract PasClaw.dpr's
 # IsQuietInvocation branch depends on (SetLogLevel(llError) drops
 # Debug/Info/Warn while keeping Error). Without this regression
@@ -829,4 +836,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -403,6 +403,11 @@ function BuildLoopConfig(const Cfg: TConfig;
                          Handlers: TLoopHandlers;
                          const TaskHint: string = ''): TToolLoopConfig;
 begin
+  { Function results of record type are as uninitialized as locals: any
+    field this builder doesn't set (e.g. DisableProgressLedger) would read
+    garbage and flip features at random on the CLI path. Same fix shape as
+    the gateway/TUI Default-inits. }
+  Result := Default(TToolLoopConfig);
   Result.Provider      := Provider;
   Result.Registry      := Reg;
   Result.Model         := Model;

--- a/src/pkg/agent/PasClaw.Agent.Subagent.pas
+++ b/src/pkg/agent/PasClaw.Agent.Subagent.pas
@@ -464,6 +464,8 @@ begin
         SysPrompt := SysPrompt + sLineBreak + sLineBreak + DeferredSec;
     end;
 
+    { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+    ChildCfg := Default(TToolLoopConfig);
     ChildCfg.Provider      := FCtx.Provider;
     ChildCfg.Registry      := ChildReg;
     ChildCfg.Model         := Model;

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -802,6 +802,8 @@ begin
 
   if FModel <> '' then ModelName := FModel else ModelName := FConfig.DefaultModel;
 
+  { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+  Cfg := Default(TToolLoopConfig);
   Cfg.Provider      := FProvider;
   Cfg.Registry      := FRegistry;
   Cfg.Model         := ModelName;

--- a/src/pkg/channels/PasClaw.Channels.Discord.pas
+++ b/src/pkg/channels/PasClaw.Channels.Discord.pas
@@ -233,6 +233,8 @@ begin
           Continue;
         end;
 
+        { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+        LoopCfg := Default(TToolLoopConfig);
         LoopCfg.Identity := MakeIdentity('discord', AuthorId, AuthorName, FChannel);
         if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
         begin

--- a/src/pkg/channels/PasClaw.Channels.Email.pas
+++ b/src/pkg/channels/PasClaw.Channels.Email.pas
@@ -400,6 +400,8 @@ begin
 
             { Run through the agent loop. }
             SetLength(RToolMsgs, 1);
+            { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+            LoopCfg := Default(TToolLoopConfig);
             LoopCfg.Identity := MakeIdentity('email', FromAddr);
             if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
             begin

--- a/src/pkg/channels/PasClaw.Channels.IRC.pas
+++ b/src/pkg/channels/PasClaw.Channels.IRC.pas
@@ -218,6 +218,8 @@ begin
     Exit;
   end;
 
+  { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+  LoopCfg := Default(TToolLoopConfig);
   LoopCfg.Identity := MakeIdentity('irc', SenderNick, SenderNick, ReplyTarget);
   if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
   begin

--- a/src/pkg/channels/PasClaw.Channels.LINE.pas
+++ b/src/pkg/channels/PasClaw.Channels.LINE.pas
@@ -284,6 +284,8 @@ begin
     Exit;
   end;
 
+  { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+  LoopCfg := Default(TToolLoopConfig);
   LoopCfg.Identity := MakeIdentity('line', SourceId);
   if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
   begin

--- a/src/pkg/channels/PasClaw.Channels.Matrix.pas
+++ b/src/pkg/channels/PasClaw.Channels.Matrix.pas
@@ -386,6 +386,8 @@ begin
     Exit;
   end;
 
+  { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+  LoopCfg := Default(TToolLoopConfig);
   LoopCfg.Identity := MakeIdentity('matrix', Sender, '', RoomId);
   if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
   begin

--- a/src/pkg/channels/PasClaw.Channels.Telegram.pas
+++ b/src/pkg/channels/PasClaw.Channels.Telegram.pas
@@ -175,6 +175,8 @@ begin
     Exit;
   end;
 
+  { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+  LoopCfg := Default(TToolLoopConfig);
   LoopCfg.Identity := MakeIdentity('telegram', FromId, FromName, IntToStr(ChatId));
   if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
   begin

--- a/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
+++ b/src/pkg/channels/PasClaw.Channels.WhatsApp.pas
@@ -309,6 +309,8 @@ begin
     Exit;
   end;
 
+  { Default-init: locals are not zero-initialized; unset fields (e.g. DisableProgressLedger) would read stack garbage. }
+  LoopCfg := Default(TToolLoopConfig);
   LoopCfg.Identity := MakeIdentity('whatsapp', FromNumber);
   if not IsAllowedSender(LoopCfg.Identity, FCfg.AllowSenders) then
   begin

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -374,9 +374,10 @@ type
       no-disk embed; bare `serve` leaves it False to keep disk hot-reload. }
     property ToolsHonorInMemoryConfig: Boolean
       read FToolsHonorInMemoryConfig write FToolsHonorInMemoryConfig;
-    { Cap on tool-loop iterations for /v1/chat/completions. Defaults to 25
-      to match what typical code agents need for read-debug-edit cycles;
-      legacy /v1/chat keeps its 8-iteration cap unchanged. }
+    { Cap on tool-loop iterations for /v1/chat/completions, /v1/responses
+      AND the legacy /v1/chat (which historically had its own 8-iteration
+      cap -- below what one read-plan-edit-verify cycle needs). Defaults to
+      25; --max-iter / max_iterations raise all three together. }
     property MaxIter: Integer read FMaxIter write FMaxIter;
     { Random per-process token that gates /v1/relay/* in addition to
       the main Cfg.Gateway.Token. Printed at startup so external
@@ -4383,6 +4384,8 @@ begin
   { Snapshot provider + fallbacks + default model together (one lock) so a live
     /v1/config swap can't pair the new model with the old provider. }
   SnapshotRuntime(Prim, FB, FBModels, DefModel);
+  { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+  LoopCfg := Default(TToolLoopConfig);
   LoopCfg.Provider := Prim;
   if LoopCfg.Provider = nil then
   begin
@@ -4396,7 +4399,10 @@ begin
   LoopCfg.Registry      := FRegistry;
   if FToolsHonorInMemoryConfig then LoopCfg.ActiveConfig := FCfg;
   LoopCfg.Model         := DefModel;
-  LoopCfg.MaxIterations := 8;
+  { Same cap as /v1/chat/completions (FMaxIter, default 25; --max-iter /
+    max_iterations raise both). The historical 8 was below what one
+    read-plan-edit-verify cycle needs. }
+  LoopCfg.MaxIterations := FMaxIter;
   LoopCfg.Parallel := True;
   { PR #290: per-request Plan/Build. Defaults to pmBuild when the body
     omits "mode", so OpenAI-compatible clients that don't know about
@@ -5043,6 +5049,8 @@ begin
     { Provider + fallbacks snapshotted together (model is the request's
       ReqModel, resolved at parse). }
     SnapshotRuntime(Prim, FB, FBModels, SnapModel);
+    { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+    LoopCfg := Default(TToolLoopConfig);
     LoopCfg.Provider := Prim;
     if LoopCfg.Provider = nil then
     begin
@@ -6808,6 +6816,8 @@ begin
         internal tool loop and surface its text. This keeps the
         non-Codex flows (curl /v1/responses with just an input
         string) working as before. }
+      { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+      LoopCfg := Default(TToolLoopConfig);
       LoopCfg.Provider      := Prim;
       LoopCfg.Registry      := FRegistry;
       if FToolsHonorInMemoryConfig then LoopCfg.ActiveConfig := FCfg;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1240,6 +1240,34 @@ begin
   end;
 end;
 
+function Tool_TodoWrite(const ArgsJSON: string; out ErrMsg: string): string;
+{ todo_write -- the model's working checklist for the current task. The
+  handler itself only validates and acknowledges: the REAL consumer is
+  RunToolLoop (PasClaw.Tools.ToolLoop), which watches dispatched calls for
+  this name, keeps the latest checklist in its per-loop progress ledger,
+  and folds it back into the system prompt each iteration. That design
+  needs no shared state between the tool and the loop -- the checklist
+  rides in the call's own arguments -- so concurrent gateway sessions and
+  subagent child loops each track their own list for free. }
+var
+  CL: string;
+  i, Lines: Integer;
+begin
+  ErrMsg := '';
+  if not ParseStringArg(ArgsJSON, 'checklist', CL) then
+  begin
+    ErrMsg := 'missing required argument: checklist. Pass the FULL current ' +
+              'checklist as markdown "- [ ] step" / "- [x] done step" lines; ' +
+              'it replaces the previous one.';
+    Exit('');
+  end;
+  Lines := 1;
+  for i := 1 to Length(CL) do
+    if CL[i] = #10 then Inc(Lines);
+  Result := Format('checklist recorded (%d line(s)); it is shown back to you ' +
+                   'each turn in the progress ledger', [Lines]);
+end;
+
 procedure RegisterFSTools(R: TToolRegistry; UseHashline: Boolean);
 var
   T: TTool;
@@ -1382,6 +1410,28 @@ begin
   T.IsCore   := True;
   T.Category := tcMutating;
   Emit('fs_edit_hashline');
+
+  { todo_write -- task checklist for the progress ledger. Registered here
+    (not in a unit of its own) because RegisterFSTools is the one
+    registration path every surface -- CLI, TUI, serve, gateway, heartbeat,
+    component -- already calls, and subagent child registries inherit it via
+    the '*' expansion. tcReadOnly on purpose: updating the checklist is
+    bookkeeping, so it can run in a parallel batch and never counts as
+    "progress" for the ledger's nothing-written-yet nudge. }
+  T := Default(TTool);
+  T.Name        := 'todo_write';
+  T.Description := 'Maintain your working checklist for the current task. Pass ' +
+                   'the FULL checklist each call as markdown lines ("- [ ] step" / ' +
+                   '"- [x] done step") -- it replaces the previous one and is shown ' +
+                   'back to you every turn in the progress ledger. Write it at the ' +
+                   'start of multi-step work; update it as steps complete.';
+  T.Schema      := '{"type":"object","properties":{"checklist":{"type":"string",' +
+                   '"description":"The complete current checklist, markdown - [ ] / - [x] lines."}},' +
+                   '"required":["checklist"]}';
+  T.Handler     := Tool_TodoWrite;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;
+  R.Register(T);
 
   { apply_patch (new) -- multi-file, context-anchored patches in one call. }
   T := Default(TTool);

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -122,6 +122,18 @@ type
        background subagents installed for this session. Cmd.Agent
        sets this to Session.Meta.Id, same as SteeringKey. *)
     BackgroundDrainKey: string;
+    (* Progress ledger opt-out. The loop tallies what the model has
+       actually done this turn (files written, its todo_write checklist)
+       and folds a compact, CACHE-STABLE block into each iteration's
+       system prompt from iteration 2 onward -- the goal stays in front
+       of the model on long turns (anti goal-drift), and a "you have
+       written nothing yet" progress check fires after several tool
+       calls with zero mutating calls. On a max-iterations stop the
+       full tally lands in Loop.LedgerSummary so FormatMaxIterNotice
+       can tell a resumed turn what NOT to redo. Default False = ledger
+       on everywhere (managed-record zero); embedders and tests that
+       want the pre-ledger prompt shape set True. *)
+    DisableProgressLedger: Boolean;
     (* Tool output truncation cap in bytes. When > 0, RunToolLoop
        runs each tool's ResultText through StashAndMaybeTruncate
        (PasClaw.Tools.OutputCache) before appending it to history:
@@ -207,6 +219,13 @@ type
        when HitMaxIterations -- the "what it was doing when it stopped"
        detail for the notice. Empty otherwise. *)
     PendingToolNames: TArray<string>;
+    (* Progress-ledger tally formatted for the max-iter notice: files
+       written, commands run (with exit codes), files read, checklist
+       state. FormatMaxIterNotice appends it with a "do NOT redo this on
+       continue" instruction, so a resumed turn picks up where it stopped
+       instead of re-exploring. Empty on a clean stop or when
+       Cfg.DisableProgressLedger. *)
+    LedgerSummary: string;
   end;
 
 function RunToolLoop(const Cfg: TToolLoopConfig;
@@ -724,6 +743,17 @@ begin
   if Names <> '' then
     Result := Result + sLineBreak +
       'It was mid-way through: ' + Names + '.';
+  { Progress ledger (A2): tell the RESUMED turn what already happened so
+    "continue" picks up at the next step instead of re-reading the same
+    files and re-running the same commands -- the observed failure mode
+    was a model that restarted exploration after every cap. The block
+    rides in the notice (which lands in the assistant turn and therefore
+    in the carried-over history), so it needs no storage of its own and
+    works identically for CLI, TUI and gateway callers. }
+  if Loop.LedgerSummary <> '' then
+    Result := Result + sLineBreak +
+      'Work already completed before the stop -- do NOT redo any of it ' +
+      'when continuing:' + sLineBreak + Loop.LedgerSummary;
   if Resumable then
   begin
     { History carries over -- a follow-up turn resumes from here. }
@@ -746,6 +776,343 @@ begin
   end;
 end;
 
+{ ===== Progress ledger (goal anchor + resume summary) ====================
+
+  Tallies what the model has ACTUALLY done during one RunToolLoop call.
+  Two consumers:
+
+    1. Per-iteration fold (FormatLedgerBlock) -- a compact block appended
+       ephemerally to the system prompt from iteration 2 onward. Its job
+       is salience, not information: everything in it is already in the
+       history, but on long turns the goal and the "have I produced
+       anything yet?" signal drift out of the model's focus -- the
+       observed failure was 50 tool calls of competent exploration that
+       never wrote the deliverable until a human intervened.
+
+       CACHE STABILITY IS A HARD CONSTRAINT here: the fold lands in the
+       system prompt, which is the very first thing in the provider
+       request, so any byte that changes per-iteration would invalidate
+       the provider's prefix cache on EVERY call. The block therefore
+       carries NO counters or other per-iteration volatiles -- only the
+       goal (constant per turn), the files-written list (changes only on
+       iterations that write, which are rare relative to reads), the
+       model's own checklist (changes only when it calls todo_write) and
+       a STICKY nudge whose wording never varies once triggered. Between
+       changes the folded system prompt is byte-identical across
+       iterations and the prefix cache keeps hitting.
+
+    2. Max-iter summary (FormatLedgerSummary -> Loop.LedgerSummary) --
+       the full tally including commands + read files, appended to
+       FormatMaxIterNotice so a "continue" resumes instead of
+       re-exploring. End-of-turn, so no cache concern; this is where the
+       detail lives. }
+type
+  TProgressLedger = record
+    Goal:          string;            { last substantive user message, squashed }
+    FilesWritten:  TArray<string>;    { unique, capped }
+    FilesRead:     TArray<string>;    { unique names, capped; ReadsTotal counts all }
+    ReadsTotal:    Integer;
+    Commands:      TArray<string>;    { "cmd -- exit=N", keep-last, capped }
+    Checklist:     string;            { verbatim from the model's last todo_write }
+    MutatingCalls: Integer;
+    TotalCalls:    Integer;
+  end;
+
+const
+  LedgerGoalMax      = 300;    { chars of goal echoed per iteration }
+  LedgerMaxFiles     = 12;
+  LedgerMaxReads     = 15;     { read NAMES kept for the resume summary }
+  LedgerMaxCmds      = 6;
+  LedgerChecklistMax = 1200;
+  { After this many tool calls with zero mutating calls, the fold adds the
+    "start writing or answer now" progress check. }
+  LedgerNudgeAfter   = 8;
+
+function LedgerSquash(const S: string; MaxLen: Integer): string;
+{ One-line, bounded: collapse whitespace runs, truncate with ellipsis.
+  Pre-truncates so a pathological multi-megabyte input doesn't feed the
+  O(n) StringReplace passes. }
+var
+  W: string;
+begin
+  W := Copy(S, 1, MaxLen * 4);
+  W := StringReplace(W, #13, ' ', [rfReplaceAll]);
+  W := StringReplace(W, #10, ' ', [rfReplaceAll]);
+  W := StringReplace(W, #9,  ' ', [rfReplaceAll]);
+  while Pos('  ', W) > 0 do
+    W := StringReplace(W, '  ', ' ', [rfReplaceAll]);
+  W := Trim(W);
+  if Length(W) > MaxLen then W := Copy(W, 1, MaxLen) + '...';
+  Result := W;
+end;
+
+procedure LedgerAddUnique(var A: TArray<string>; const S: string; Cap: Integer);
+var
+  i: Integer;
+begin
+  if S = '' then Exit;
+  for i := 0 to High(A) do
+    if A[i] = S then Exit;
+  if Length(A) >= Cap then Exit;
+  SetLength(A, Length(A) + 1);
+  A[High(A)] := S;
+end;
+
+procedure LedgerPushCmd(var A: TArray<string>; const S: string);
+{ Keep-LAST semantics -- the most recent commands are the useful ones for
+  a resume ("the last build failed with exit=2"). }
+var
+  i: Integer;
+begin
+  if S = '' then Exit;
+  if Length(A) >= LedgerMaxCmds then
+  begin
+    for i := 0 to High(A) - 1 do A[i] := A[i + 1];
+    A[High(A)] := S;
+  end
+  else
+  begin
+    SetLength(A, Length(A) + 1);
+    A[High(A)] := S;
+  end;
+end;
+
+function LedgerArg(const ArgsJSON, Key: string): string;
+var
+  Obj: TJsonObject;
+begin
+  Result := '';
+  if Trim(ArgsJSON) = '' then Exit;
+  try
+    Obj := TJsonObject.Parse(ArgsJSON);
+    if Obj = nil then Exit;
+    try
+      Result := Obj.GetStr(Key, '');
+    finally
+      Obj.Free;
+    end;
+  except
+    Result := '';
+  end;
+end;
+
+function ExtractLoopGoal(const Messages: array of TMessage): string;
+{ The task this turn is anchored to: the last SUBSTANTIVE user message.
+  Trailing micro-turns ("continue", "yes", "ok") are skipped so a resumed
+  run anchors to the real task, not to the word "continue"; when every
+  user turn is tiny, the last one wins as a fallback. }
+var
+  i: Integer;
+  T, Fallback: string;
+begin
+  Fallback := '';
+  for i := High(Messages) downto Low(Messages) do
+    if Messages[i].Role = mrUser then
+    begin
+      T := Trim(Messages[i].Content);
+      if Fallback = '' then Fallback := T;
+      if Length(T) >= 24 then
+        Exit(LedgerSquash(T, LedgerGoalMax));
+    end;
+  Result := LedgerSquash(Fallback, LedgerGoalMax);
+end;
+
+function LedgerPatchFirstPath(const Patch: string): string;
+{ Target path from a hashline patch header (first line: <prefix>path#hash). }
+var
+  Line: string;
+  P: Integer;
+begin
+  Line := Patch;
+  P := Pos(#10, Line);
+  if P > 0 then Line := Copy(Line, 1, P - 1);
+  Line := Trim(StringReplace(Line, #13, '', [rfReplaceAll]));
+  if Copy(Line, 1, Length(HL_FILE_PREFIX)) = HL_FILE_PREFIX then
+    Line := Copy(Line, Length(HL_FILE_PREFIX) + 1, MaxInt);
+  P := Pos(HL_FILE_HASH_SEP, Line);
+  if P > 0 then Line := Copy(Line, 1, P - 1);
+  Result := Trim(Line);
+end;
+
+procedure LedgerCollectApplyPatchPaths(var L: TProgressLedger; const Patch: string);
+{ Every Add/Update/Move target in a Codex-format apply_patch envelope. }
+var
+  Rest, Line: string;
+  P: Integer;
+
+  procedure TryPrefix(const Pref: string);
+  begin
+    if Copy(Line, 1, Length(Pref)) = Pref then
+      LedgerAddUnique(L.FilesWritten,
+        LedgerSquash(Copy(Line, Length(Pref) + 1, MaxInt), 120), LedgerMaxFiles);
+  end;
+
+begin
+  Rest := StringReplace(Patch, #13, '', [rfReplaceAll]);
+  while Rest <> '' do
+  begin
+    P := Pos(#10, Rest);
+    if P > 0 then
+    begin
+      Line := Copy(Rest, 1, P - 1);
+      Delete(Rest, 1, P);
+    end
+    else
+    begin
+      Line := Rest;
+      Rest := '';
+    end;
+    TryPrefix('*** Add File: ');
+    TryPrefix('*** Update File: ');
+    TryPrefix('*** Move to: ');
+  end;
+end;
+
+procedure LedgerHarvest(var L: TProgressLedger;
+                        const Dispatches: array of TToolCallDispatch;
+                        Reg: TToolRegistry; PlanMode: Boolean);
+{ Fold one dispatch round into the tally. Failed calls (Err set) and
+  hook-cancelled calls count as calls but record no progress; in plan
+  mode file-write recording is skipped entirely (mutating tools are
+  refused at dispatch, so their "result" is the refusal text). }
+var
+  i, P: Integer;
+  Nm, Args, S, ExitLine: string;
+  T: TTool;
+begin
+  for i := 0 to High(Dispatches) do
+  begin
+    Nm := Dispatches[i].Call.Func.Name;
+    if Nm = '' then Continue;
+    Inc(L.TotalCalls);
+    { Mutating classification via the registry's own category so MCP /
+      skill tools count too; todo_write is tcReadOnly by design, so
+      checklist upkeep never masquerades as progress. }
+    if (not PlanMode) and (Dispatches[i].Err = '')
+       and (not Dispatches[i].Cancelled)
+       and (Reg <> nil) and Reg.Find(Nm, T) and (T.Category = tcMutating) then
+      Inc(L.MutatingCalls);
+    if (Dispatches[i].Err <> '') or Dispatches[i].Cancelled then Continue;
+    Args := Dispatches[i].Call.Func.Arguments;
+
+    if (Nm = 'write_file') or (Nm = 'append_file') or (Nm = 'fs_write') then
+    begin
+      if not PlanMode then
+        LedgerAddUnique(L.FilesWritten,
+          LedgerSquash(LedgerArg(Args, 'path'), 120), LedgerMaxFiles);
+    end
+    else if (Nm = 'edit_file') or (Nm = 'fs_edit_hashline') then
+    begin
+      if not PlanMode then
+      begin
+        S := LedgerArg(Args, 'path');
+        if S = '' then S := LedgerPatchFirstPath(LedgerArg(Args, 'patch'));
+        LedgerAddUnique(L.FilesWritten, LedgerSquash(S, 120), LedgerMaxFiles);
+      end;
+    end
+    else if Nm = 'apply_patch' then
+    begin
+      if not PlanMode then
+        LedgerCollectApplyPatchPaths(L, LedgerArg(Args, 'patch'));
+    end
+    else if (Nm = 'read_file') or (Nm = 'fs_read') then
+    begin
+      Inc(L.ReadsTotal);
+      LedgerAddUnique(L.FilesRead,
+        LedgerSquash(LedgerArg(Args, 'path'), 120), LedgerMaxReads);
+    end
+    else if (Nm = 'shell_exec') or (Nm = 'execute_code') then
+    begin
+      if Nm = 'shell_exec' then S := LedgerArg(Args, 'command')
+                           else S := LedgerArg(Args, 'code');
+      S := LedgerSquash(S, 60);
+      { shell results lead with "exit=N" on the first line. }
+      ExitLine := Dispatches[i].ResultText;
+      P := Pos(#10, ExitLine);
+      if P > 0 then ExitLine := Copy(ExitLine, 1, P - 1);
+      if Copy(ExitLine, 1, 5) = 'exit=' then
+        S := S + ' -- ' + Trim(ExitLine);
+      LedgerPushCmd(L.Commands, S);
+    end
+    else if Nm = 'todo_write' then
+    begin
+      S := LedgerArg(Args, 'checklist');
+      if Trim(S) <> '' then L.Checklist := Copy(S, 1, LedgerChecklistMax);
+    end;
+  end;
+end;
+
+function LedgerJoin(const A: TArray<string>; const Sep: string): string;
+var
+  i: Integer;
+begin
+  Result := '';
+  for i := 0 to High(A) do
+  begin
+    if Result <> '' then Result := Result + Sep;
+    Result := Result + A[i];
+  end;
+end;
+
+function FormatLedgerBlock(const L: TProgressLedger; PlanMode: Boolean): string;
+{ The per-iteration fold. See the cache-stability constraint in the
+  section header: NO counters, no timestamps -- only slow-changing state,
+  so consecutive iterations usually produce a byte-identical system
+  prompt and the provider prefix cache keeps hitting. }
+begin
+  Result := '';
+  if L.TotalCalls = 0 then Exit;
+  Result := '[progress ledger -- this turn so far]';
+  if L.Goal <> '' then
+    Result := Result + sLineBreak + 'Goal: ' + L.Goal;
+  if Length(L.FilesWritten) > 0 then
+    Result := Result + sLineBreak +
+      'Files written/edited: ' + LedgerJoin(L.FilesWritten, ', ')
+  else
+    Result := Result + sLineBreak + 'Files written/edited: (none yet)';
+  if L.Checklist <> '' then
+    Result := Result + sLineBreak +
+      'Your checklist (rewrite with todo_write as steps complete):' +
+      sLineBreak + L.Checklist;
+  { Sticky wording: once triggered it never varies (no counts), so the
+    fold stays cache-stable while the condition holds. It clears itself
+    the moment a mutating call lands -- that iteration rewrites the
+    files line anyway. Plan mode is exempt: producing no files is the
+    entire point of plan mode. }
+  if (not PlanMode) and (L.MutatingCalls = 0)
+     and (L.TotalCalls >= LedgerNudgeAfter) then
+    Result := Result + sLineBreak +
+      'Progress check: many tool calls so far and nothing written. If this ' +
+      'task requires producing code or files, start writing now (write_file ' +
+      'first, then extend with edit_file / append_file); if it is a ' +
+      'read-only question, stop exploring and give your final answer.';
+end;
+
+function FormatLedgerSummary(const L: TProgressLedger): string;
+{ The end-of-turn tally for FormatMaxIterNotice -- full detail, including
+  the read-file names a resumed turn must not re-read. }
+begin
+  Result := '';
+  if L.TotalCalls = 0 then Exit;
+  if Length(L.FilesWritten) > 0 then
+    Result := 'wrote: ' + LedgerJoin(L.FilesWritten, ', ')
+  else
+    Result := 'wrote: (nothing yet)';
+  if Length(L.Commands) > 0 then
+    Result := Result + sLineBreak + 'ran: ' + LedgerJoin(L.Commands, '; ');
+  if L.ReadsTotal > 0 then
+  begin
+    Result := Result + sLineBreak + Format('read %d file(s)', [L.ReadsTotal]);
+    if Length(L.FilesRead) > 0 then
+    begin
+      Result := Result + ': ' + LedgerJoin(L.FilesRead, ', ');
+      if L.ReadsTotal > Length(L.FilesRead) then Result := Result + ', ...';
+    end;
+  end;
+  if L.Checklist <> '' then
+    Result := Result + sLineBreak + 'checklist state:' + sLineBreak + L.Checklist;
+end;
+
 function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
@@ -766,6 +1133,8 @@ var
   Batch: TToolBatch;
   Workers: array of TToolCallWorker;
   Steering, BatchSteering, HistSystem, LastProviderErrText, BgBlock, PersistentSP: string;
+  Ledger: TProgressLedger;
+  LedgerBlock: string;
   Steers: TSteeringMessageArray;
   InContext: string;       { tool output cap (#PR new): in-context
                              body that lands in Hist after the
@@ -824,6 +1193,12 @@ begin
   else
     SetLength(Tools, 0);
 
+  { Progress ledger: anchor this turn to its goal once, up front. The
+    tally itself accumulates per dispatch round below. }
+  Ledger := Default(TProgressLedger);
+  if not Cfg.DisableProgressLedger then
+    Ledger.Goal := ExtractLoopGoal(Messages);
+
   Iter := 0;
   { When progressive disclosure is on (PasClaw.MCP.Disclosure), the
     model can call tool_search mid-loop to reveal deferred tools.
@@ -872,6 +1247,23 @@ begin
       meant to survive into Loop.FinalSystemPrompt; everything the
       ephemeral drains do below is one-turn-only. }
     PersistentSP := LiveOptions.SystemPrompt;
+
+    { Progress-ledger fold (A1). Ephemeral like the drains below --
+      restored to PersistentSP after the provider call. Skipped on
+      iteration 1: there is no progress to report yet, and keeping the
+      first call's system prompt pristine preserves the cross-turn
+      prefix-cache hit (the block only exists on iterations >= 2 and is
+      deliberately cache-stable across them; see FormatLedgerBlock). }
+    if (not Cfg.DisableProgressLedger) and (Iter > 1) then
+    begin
+      LedgerBlock := FormatLedgerBlock(Ledger, Cfg.Mode = pmPlan);
+      if LedgerBlock <> '' then
+      begin
+        if LiveOptions.SystemPrompt <> '' then
+          LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + sLineBreak + sLineBreak;
+        LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + LedgerBlock;
+      end;
+    end;
 
     { Mid-loop steering: drain any user follow-ups that arrived
       while we were busy (CLI `pasclaw steer <id> "..."`, channels
@@ -1412,6 +1804,12 @@ begin
           LiveOptions.SystemPrompt := BatchSteering;
       end;
     end;
+
+    { Progress-ledger harvest: fold this round's dispatches into the
+      tally AFTER all batches joined, so the next iteration's fold (and
+      a max-iter summary) see them. }
+    if not Cfg.DisableProgressLedger then
+      LedgerHarvest(Ledger, Dispatches, Cfg.Registry, Cfg.Mode = pmPlan);
   end;
 
   { Max iterations exhausted; return whatever we last got. The loop only
@@ -1423,6 +1821,8 @@ begin
   Loop.FinalMessages    := Hist;
   Loop.FinalSystemPrompt := LiveOptions.SystemPrompt;
   Loop.HitMaxIterations := Length(Resp.ToolCalls) > 0;
+  if not Cfg.DisableProgressLedger then
+    Loop.LedgerSummary := FormatLedgerSummary(Ledger);
   if Loop.HitMaxIterations then
     Loop.PendingToolNames := CollectToolNames(Resp.ToolCalls);
   Result := True;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1326,6 +1326,8 @@ begin
   SetLength(FSession.Messages, Length(FSession.Messages) + 1);
   FSession.Messages[High(FSession.Messages)] := MakeMessage(mrUser, UserText);
 
+  { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+  Cfg := Default(TToolLoopConfig);
   Cfg.Provider      := FProvider;
   Cfg.Registry      := FRegistry;
   Cfg.Model         := FModel;
@@ -2839,6 +2841,8 @@ begin
   SetLength(Msgs, 1);
   Msgs[0] := MakeMessage(mrUser, Text);
 
+  { Default-init: locals are not zero-initialized in Pascal, so any field this block doesn't set (e.g. DisableProgressLedger) would read stack garbage. }
+  Cfg := Default(TToolLoopConfig);
   Cfg.Provider      := FProvider;
   Cfg.Registry      := FRegistry;
   Cfg.Model         := FModel;

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -1,0 +1,374 @@
+program progress_ledger_tests;
+(*
+  Covers the RunToolLoop progress ledger (goal anchor + todo checklist +
+  resume summary):
+
+    * Iteration 1's system prompt is pristine (no ledger -- keeps the
+      cross-turn prefix-cache hit); iteration 2+ carries the
+      "[progress ledger" block with the goal, the files written so far,
+      and the model's todo_write checklist.
+    * The base system prompt is preserved: the fold is appended after it
+      and restored afterwards (Loop.FinalSystemPrompt = base).
+    * The nothing-written nudge fires only after LedgerNudgeAfter (8)
+      tool calls with zero mutating calls -- and not before.
+    * A max-iterations stop fills Loop.LedgerSummary (files written, reads)
+      and FormatMaxIterNotice appends it with the do-NOT-redo instruction.
+    * The goal is the last SUBSTANTIVE user message -- a trailing
+      "continue" micro-turn does not become the goal.
+    * DisableProgressLedger switches all of it off.
+
+  Strategy: scripted ILLMProvider that records each provider call's
+  Options.SystemPrompt and returns canned tool-call rounds against a real
+  registry (RegisterFSTools on a temp workspace), so the write_file /
+  read_file / todo_write dispatches the ledger harvests are the real ones.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  PasClaw.Utils,
+  PasClaw.Config,
+  PasClaw.Agent.Mode,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Types,
+  PasClaw.Tools.Types,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.Sandbox,
+  PasClaw.Tools.FS,
+  PasClaw.Tools.ToolLoop;
+
+procedure Fail_(const Msg: string);
+begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure AssertTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure AssertHas(const Hay, Needle, Msg: string);
+begin
+  if Pos(Needle, Hay) <= 0 then
+    Fail_(Msg + ' (needle "' + Needle + '" missing from "' + Copy(Hay, 1, 400) + '")');
+end;
+
+procedure AssertNot(const Hay, Needle, Msg: string);
+begin
+  if Pos(Needle, Hay) > 0 then
+    Fail_(Msg + ' (unexpected "' + Needle + '" in "' + Copy(Hay, 1, 400) + '")');
+end;
+
+type
+  { Scripted provider: returns Script[i] on call i (clamping to the last
+    entry) and records every call's Options.SystemPrompt. }
+  TScripted = class(TInterfacedObject, ILLMProvider)
+  public
+    Script:  array of TLLMResponse;
+    Prompts: array of string;
+    procedure AddToolRound(const Calls: array of TToolCall);
+    procedure AddStop(const Text: string);
+    function Chat(const Messages: array of TMessage;
+                  const Tools:    array of TToolDefinition;
+                  const Model:    string;
+                  const Options:  TChatOptions): TLLMResponse;
+    function ChatStream(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions;
+                        OnChunk: TStreamCallback): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+  end;
+
+procedure TScripted.AddToolRound(const Calls: array of TToolCall);
+var
+  R: TLLMResponse;
+  i: Integer;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode := 200;
+  R.FinishReason := 'tool_calls';
+  SetLength(R.ToolCalls, Length(Calls));
+  for i := 0 to High(Calls) do R.ToolCalls[i] := Calls[i];
+  SetLength(Script, Length(Script) + 1);
+  Script[High(Script)] := R;
+end;
+
+procedure TScripted.AddStop(const Text: string);
+var
+  R: TLLMResponse;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode := 200;
+  R.FinishReason := 'stop';
+  R.Content := Text;
+  SetLength(Script, Length(Script) + 1);
+  Script[High(Script)] := R;
+end;
+
+function TScripted.Chat(const Messages: array of TMessage;
+                        const Tools:    array of TToolDefinition;
+                        const Model:    string;
+                        const Options:  TChatOptions): TLLMResponse;
+var
+  Idx: Integer;
+begin
+  SetLength(Prompts, Length(Prompts) + 1);
+  Prompts[High(Prompts)] := Options.SystemPrompt;
+  Idx := High(Prompts);
+  if Idx > High(Script) then Idx := High(Script);
+  if Idx < 0 then
+  begin
+    Result := Default(TLLMResponse);
+    Result.StatusCode := 200;
+    Result.FinishReason := 'stop';
+    Exit;
+  end;
+  Result := Script[Idx];
+end;
+
+function TScripted.ChatStream(const Messages: array of TMessage;
+                              const Tools:    array of TToolDefinition;
+                              const Model:    string;
+                              const Options:  TChatOptions;
+                              OnChunk: TStreamCallback): TLLMResponse;
+begin
+  Result := Chat(Messages, Tools, Model, Options);
+end;
+
+function TScripted.GetDefaultModel: string;      begin Result := 'scripted'; end;
+function TScripted.GetName: string;              begin Result := 'scripted'; end;
+function TScripted.SupportsThinking: Boolean;     begin Result := False; end;
+function TScripted.SupportsNativeSearch: Boolean; begin Result := False; end;
+function TScripted.SupportsStreaming: Boolean;    begin Result := False; end;
+
+function MkCall(const Name, ArgsJSON: string): TToolCall;
+begin
+  Result := Default(TToolCall);
+  Result.Id := 'c_' + Name;
+  Result.Kind := 'function';
+  Result.Func.Name := Name;
+  Result.Func.Arguments := ArgsJSON;
+end;
+
+var
+  WsDir, FileA: string;
+
+function BaseCfg(P: TScripted): TToolLoopConfig;
+begin
+  Result := Default(TToolLoopConfig);
+  Result.Provider      := P;
+  Result.Model         := 'scripted';
+  Result.MaxIterations := 10;
+  Result.Options       := DefaultChatOptions;
+  Result.Options.SystemPrompt := 'BASE-PROMPT';
+  Result.Parallel      := False;
+  Result.Mode          := pmBuild;
+end;
+
+procedure TestFoldGoalFilesChecklist;
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    P.AddToolRound([
+      MkCall('write_file', '{"path":"' + FileA + '","content":"hello"}'),
+      MkCall('todo_write', '{"checklist":"- [x] write a.txt\n- [ ] verify it"}')
+    ]);
+    P.AddToolRound([MkCall('read_file', '{"path":"' + FileA + '","plain":true}')]);
+    P.AddStop('done');
+
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'build me a small demo page in the workspace please');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    AssertTrue(Length(P.Prompts) = 3, 'three provider calls');
+
+    { Iteration 1: pristine prompt (cache-friendly, nothing to report). }
+    AssertHas(P.Prompts[0], 'BASE-PROMPT', 'call 1 carries the base prompt');
+    AssertNot(P.Prompts[0], '[progress ledger', 'no ledger on iteration 1');
+
+    { Iteration 2: ledger with goal + written file + checklist, appended
+      after the base prompt. }
+    AssertHas(P.Prompts[1], 'BASE-PROMPT', 'call 2 keeps the base prompt');
+    AssertHas(P.Prompts[1], '[progress ledger', 'ledger folded on iteration 2');
+    AssertHas(P.Prompts[1], 'build me a small demo page', 'goal anchored');
+    AssertHas(P.Prompts[1], 'a.txt', 'written file listed');
+    AssertHas(P.Prompts[1], '- [ ] verify it', 'todo_write checklist folded');
+    AssertNot(P.Prompts[1], 'Progress check', 'no nudge -- a mutating call landed');
+
+    { Ephemeral: the fold never leaks into the persisted prompt. }
+    AssertTrue(Loop.FinalSystemPrompt = 'BASE-PROMPT',
+      'FinalSystemPrompt restored to the base (fold is ephemeral)');
+    WriteLn('  ok: fold carries goal + files + checklist from iteration 2, ephemerally');
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestNudgeAfterReadOnlyCalls;
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  ListCall: TToolCall;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    ListCall := MkCall('list_dir', '{"path":"' + WsDir + '"}');
+    { 3 rounds x 3 read-only calls = 9 >= LedgerNudgeAfter (8). }
+    P.AddToolRound([ListCall, ListCall, ListCall]);
+    P.AddToolRound([ListCall, ListCall, ListCall]);
+    P.AddToolRound([ListCall, ListCall, ListCall]);
+    P.AddStop('answer');
+
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'please build the demo site now, files required');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    AssertTrue(Length(P.Prompts) = 4, 'four provider calls');
+    AssertNot(P.Prompts[1], 'Progress check', 'no nudge at 3 calls');
+    AssertNot(P.Prompts[2], 'Progress check', 'no nudge at 6 calls');
+    AssertHas(P.Prompts[3], 'Progress check', 'nudge fires at 9 read-only calls');
+    AssertHas(P.Prompts[3], '(none yet)', 'files line reports none written');
+    WriteLn('  ok: nothing-written nudge fires only past the threshold');
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestMaxIterSummaryAndNotice;
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  Notice: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    Cfg.MaxIterations := 2;
+    P.AddToolRound([MkCall('write_file', '{"path":"' + FileA + '","content":"x"}')]);
+    P.AddToolRound([MkCall('read_file', '{"path":"' + FileA + '","plain":true}')]);
+
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'multi step task that will hit the iteration cap');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    AssertTrue(Loop.HitMaxIterations, 'hit the cap');
+    AssertHas(Loop.LedgerSummary, 'a.txt', 'summary lists the written file');
+    AssertHas(Loop.LedgerSummary, 'read 1 file', 'summary counts the read');
+
+    Notice := FormatMaxIterNotice(Loop, 2, '--max-iter', True);
+    AssertHas(Notice, 'do NOT redo', 'notice forbids redoing completed work');
+    AssertHas(Notice, 'a.txt', 'notice carries the ledger detail');
+    AssertHas(Notice, 'continue', 'notice still offers the resume');
+    WriteLn('  ok: max-iter stop carries the resume ledger into the notice');
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestGoalSkipsMicroTurns;
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    P.AddToolRound([MkCall('list_dir', '{"path":"' + WsDir + '"}')]);
+    P.AddStop('done');
+
+    SetLength(Msgs, 3);
+    Msgs[0] := MakeMessage(mrUser, 'refactor the parser module to use the new tokenizer');
+    Msgs[1] := MakeMessage(mrAssistant, '[stopped: hit the tool-call limit]');
+    Msgs[2] := MakeMessage(mrUser, 'continue');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    AssertHas(P.Prompts[1], 'refactor the parser module',
+      'goal anchors to the substantive task, not to "continue"');
+    WriteLn('  ok: goal extraction skips trailing micro-turns');
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestDisableSwitch;
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  i: Integer;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    Cfg.DisableProgressLedger := True;
+    Cfg.MaxIterations := 2;
+    P.AddToolRound([MkCall('write_file', '{"path":"' + FileA + '","content":"x"}')]);
+    P.AddToolRound([MkCall('read_file', '{"path":"' + FileA + '","plain":true}')]);
+
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'a long enough task message for goal capture');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    for i := 0 to High(P.Prompts) do
+      AssertNot(P.Prompts[i], '[progress ledger', 'no ledger when disabled');
+    AssertTrue(Loop.LedgerSummary = '', 'no summary when disabled');
+    WriteLn('  ok: DisableProgressLedger turns the ledger off');
+  finally
+    Reg.Free;
+  end;
+end;
+
+var
+  Pol: TSandboxPolicy;
+begin
+  WsDir := IncludeTrailingPathDelimiter(GetTempDir) + 'pcledger';
+  ForceDirectories(WsDir);
+  FileA := WsDir + PathDelim + 'a.txt';
+  Pol := Default(TSandboxPolicy);
+  Pol.RestrictToWorkspace := False;
+  ConfigureSandbox(Pol, WsDir);
+
+  TestFoldGoalFilesChecklist;
+  TestNudgeAfterReadOnlyCalls;
+  TestMaxIterSummaryAndNotice;
+  TestGoalSkipsMicroTurns;
+  TestDisableSwitch;
+
+  if FileExists(FileA) then DeleteFile(FileA);
+  RemoveDir(WsDir);
+  WriteLn('PASS');
+end.


### PR DESCRIPTION
## Why

The observed failure on real coding tasks (the pasclaw.dev build transcript) was **goal drift**: 50+ tool calls of competent-looking exploration that never wrote the deliverable until a human typed *"you still haven't created the index.html"* — and after every max-iter "continue", the model **restarted exploration** (re-`list_dir`, re-read the same files) instead of resuming. Nothing in the loop pushed back; only `pasclaw build --goal` had any goal anchoring.

## What

`RunToolLoop` now keeps a per-turn **progress ledger**:

- **Goal anchor + fold (A1).** From iteration 2 onward an ephemeral block is appended to the system prompt: the goal (last *substantive* user message — trailing `continue`/`yes` micro-turns are skipped), the files written so far, and the model's own checklist. **Cache-stable by design:** no counters or volatiles, so consecutive iterations produce a byte-identical system prompt and the provider prefix cache keeps hitting; iteration 1 stays pristine to preserve the cross-turn hit.
- **`todo_write` tool.** The model maintains a markdown checklist (`- [ ]` / `- [x]`); the loop harvests it **from the call's own arguments** — no shared state, so concurrent gateway sessions and subagent child loops each track their own — and folds it back every turn. `tcReadOnly`, so checklist upkeep never counts as progress.
- **Nothing-written nudge.** After 8 tool calls with zero mutating calls, the fold adds a sticky progress check: start writing (write_file → edit_file/append_file), or give the final answer. Plan mode is exempt. Sticky wording (no counts) keeps it cache-stable.
- **Resume summary (A2).** On a max-iterations stop, the full tally (files written, commands + exit codes, files read **by name**) lands in `Loop.LedgerSummary`, and `FormatMaxIterNotice` appends it with *"do NOT redo any of it when continuing"*. It rides in the notice — which lands in the assistant turn and therefore in carried-over history — so it needs no storage and works identically for CLI, TUI and gateway.
- **`/v1/chat` cap 8 → `FMaxIter` (A3).** The legacy endpoint now shares `/v1/chat/completions`' 25-iteration default; `--max-iter` / `max_iterations` raise both.

## Bonus hardening (found live)

Gateway/TUI/agent/subagent built `TToolLoopConfig` **field-by-field on uninitialized stack records**, so any field a caller didn't explicitly set read stack garbage. Live-verified: the new `DisableProgressLedger` Boolean came up True at random on the gateway and silently switched the feature off — the same latent trap applied to `ToolOutputCap` and every other plain field added since the record's creation. All callers now `Default()`-init the record first (heartbeat and the tests already did).

Opt-out for embedders/tests: `TToolLoopConfig.DisableProgressLedger`.

## Tests

`progress_ledger_tests` (new, in `make test`): fold appears from iteration 2 with goal/files/checklist while iteration 1 stays pristine and `FinalSystemPrompt` is restored (ephemeral); nudge fires at 9 read-only calls and not at 6; max-iter stop fills `LedgerSummary` and the notice carries the do-not-redo block; goal extraction skips a trailing "continue"; the disable switch works. Regression sweep green (max-iter-notice, subagent-default/bg, plan-build-mode, autoroute-apply, toolview, fs-tool-naming, workspace-paths, gateway-token, session-endpoints, loop-shaping).

**Verified live through the relay harness**: on a real gateway run, request 2's system prompt carries:
```
[progress ledger -- this turn so far]
Goal: build a small landing page for the demo project in the workspace
Files written/edited: demo.html
Your checklist (rewrite with todo_write as steps complete):
- [x] write demo.html
- [ ] add styles
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_