### PR TITLE
config: default ToolOutputCap to 24576 (C1) — 6× smaller request bodies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -767,6 +767,16 @@ test-progress-ledger: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/progress_ledger_tests.pas -o$(BUILDDIR)/progress_ledger_tests
 	@$(BUILDDIR)/progress_ledger_tests
 
+# Deterministic agent-loop harness bench (bench/agentloop) -- pure FPC, no
+# external runtime. Spawns the built binary, plays the scripted model over
+# the relay, asserts on what the loop did. Not part of `make test` (binds a
+# port + spawns a server); run when touching ToolLoop / Stream.Reliability /
+# the gateway loop paths.
+bench-agentloop: $(BIN)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) bench/agentloop/agentloop_bench.pas -o$(BUILDDIR)/agentloop_bench
+	@$(BUILDDIR)/agentloop_bench
+
 # Logger level suppression: pins the contract PasClaw.dpr's
 # IsQuietInvocation branch depends on (SetLogLevel(llError) drops
 # Debug/Info/Warn while keeping Error). Without this regression

--- a/bench/agentloop/README.md
+++ b/bench/agentloop/README.md
@@ -1,0 +1,47 @@
+# bench/agentloop — deterministic agent-loop harness benchmark
+
+Measures **harness** quality, not model quality (that's [`bench/swe`](../swe)):
+the "model" is a script played by the bench process itself through the
+**relay provider**, so every run is fully reproducible, costs zero API
+tokens, and every request envelope the loop builds is inspectable.
+
+This is the codified version of the methodology that found the
+`MALFORMED_FUNCTION_CALL` death spiral (#406), the workspace/CWD split
+(#408), and the goal-drift failure (#412): start a real gateway, connect
+as a relay worker, answer each inference request from a script, and assert
+on what the **loop** did.
+
+## Run
+
+```sh
+make bench-agentloop     # compiles bench/agentloop/agentloop_bench.pas + runs it
+```
+
+Pure FPC -- no external runtime; the harness reuses the repo's own pieces
+(`TProcess` to spawn the built binary, the `Cmd.Relay`-style Indy SSE
+client, `PasClaw.JSON`, `PostJSON`/`GetJSONURL`). Exit code 0 = all
+scenarios pass. Needs a free port 8140 and `build/pasclaw` built. Not part
+of `make test` (it binds a port and spawns a server); run it when touching
+`PasClaw.Tools.ToolLoop`, `PasClaw.Stream.Reliability`, or the gateway
+loop paths. FPC-only (`TProcess`).
+
+## Scenarios
+
+| scenario | asserts | key metric |
+|---|---|---|
+| `build-site` | progress ledger folds into iteration 2's system prompt (goal + written file + todo checklist), iteration 1 stays pristine (prefix-cache), deliverable lands on disk | `iterations_to_deliverable` |
+| `malformed-recovery` | a Gemini-shaped `MALFORMED_FUNCTION_CALL` empty turn is auto-retried with the corrective nudge naming a *registered* tool, and the turn still delivers | `retries_to_recover` |
+| `resume-after-cap` | the 25-iteration stop carries the resume ledger ("do NOT redo", written files, read counts) in the notice; a follow-up "continue" turn anchors its ledger goal to the original task, not to the word "continue" | `max_request_body_bytes` (context-growth baseline across 25 iterations) |
+
+## Adding a scenario
+
+A scenario is: a handler `function(N: Integer; const EnvJSON: string): string`
+returning the relay response JSON for the Nth provider call, registered via
+`ResetScenario(@Handler)`; then `Chat(...)` a task and assert on the
+recorded envelopes (`EnvSystemPrompt` / `EnvLastMessage` on `EnvAt(i)`),
+the returned answer text, and the workspace on disk. Responses use the
+relay envelope shape (`content`, `finish_reason`, `tool_calls[]` in
+OpenAI form — see [`docs/providers-relay.md`](../../docs/providers-relay.md)).
+
+Report numbers with `metric(name, value)` — the point of this bench is
+that harness changes land with before/after numbers, not vibes.

--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -638,7 +638,7 @@ begin
 end;
 
 var
-  BinPath, CfgJSON: string;
+  BinPath, CfgJSON, EnvLine: string;
   S: TStringList;
   Worker: TWorkerThread;
   i: Integer;
@@ -675,8 +675,20 @@ begin
   try
     GW.Executable := BinPath;
     GW.Parameters.Add('gateway');
+    { #414 review: appending PASCLAW_HOME after copying the caller's env
+      produces DUPLICATE entries when the caller has it exported, and
+      typical getenv resolution takes the FIRST -- the spawned gateway
+      would then run against the user's LIVE PasClaw home instead of the
+      throwaway bench home. Skip the caller's PASCLAW_HOME / PASCLAW_CONFIG
+      / NO_COLOR while copying so the bench's values are the only ones. }
     for i := 1 to GetEnvironmentVariableCount do
-      GW.Environment.Add(GetEnvironmentString(i));
+    begin
+      EnvLine := GetEnvironmentString(i);
+      if (Pos('PASCLAW_HOME=', EnvLine) = 1) or
+         (Pos('PASCLAW_CONFIG=', EnvLine) = 1) or
+         (Pos('NO_COLOR=', EnvLine) = 1) then Continue;
+      GW.Environment.Add(EnvLine);
+    end;
     GW.Environment.Add('PASCLAW_HOME=' + GHomeDir);
     GW.Environment.Add('NO_COLOR=1');
     GW.Options := [poUsePipes, poStderrToOutPut];

--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -506,6 +506,51 @@ begin
   Check(Has(Answer, 'recovered'), 'turn still delivered after recovery');
 end;
 
+function H_FatRead(N: Integer; const EnvJSON: string): string;
+begin
+  if N = 1 then
+    Result := RoundOf([OneCall('read_file', ArgsPathPlain('big.txt'))])
+  else if N = 2 then
+    Result := RoundOf([OneCall('list_dir', ArgsObj1('path', '.'))])
+  else
+    Result := StopOf('inspected the big file.');
+end;
+
+procedure ScenarioFatRead;
+{ C1: one oversized tool result must not ride verbatim in history for the
+  rest of the turn. With the default ToolOutputCap the 100 KB read is
+  diverted to the output cache (head + tail + tool_output_get handle) and
+  every subsequent request stays flat; without it (tool_output_cap: 0 /
+  pre-C1 builds) request 2 carries the full 100 KB. }
+var
+  S: TStringList;
+  Big: string;
+  i: Integer;
+begin
+  WriteLn;
+  WriteLn('== scenario: fat-read (tool-output cap keeps request bodies flat) ==');
+  Big := '';
+  for i := 1 to 1800 do
+    Big := Big + Format('line %4d: the quick brown fox jumps over the lazy dog again', [i]) + #10;
+  S := TStringList.Create;
+  try
+    S.Text := Big;
+    S.SaveToFile(GHomeDir + '/workspace/big.txt');
+  finally
+    S.Free;
+  end;
+
+  ResetScenario(H_FatRead);
+  Chat('[' + MsgObjJSON('user',
+    'inspect the big data file big.txt and summarise what it contains') + ']',
+    'bench-fatread');
+  Check(Has(EnvAt(1), 'tool_output_get'),
+    'oversized read was capped with a tool_output_get retrieval handle');
+  Check(GMaxBody < 60000,
+    Format('request bodies stay under 60 KB with the cap (max %d)', [GMaxBody]));
+  Metric('fatread.max_request_body_bytes', GMaxBody);
+end;
+
 function H_CapTurn1(N: Integer; const EnvJSON: string): string;
 begin
   if N = 1 then
@@ -649,6 +694,7 @@ begin
     ScenarioBuildSite;
     ScenarioMalformedRecovery;
     ScenarioResumeAfterCap;
+    ScenarioFatRead;
 
     WriteLn;
     WriteLn('== metrics ==');

--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -1,0 +1,677 @@
+program agentloop_bench;
+(*
+  bench/agentloop -- deterministic agent-loop harness benchmark, pure FPC.
+
+  Measures and pins HARNESS quality (not model quality -- that's bench/swe):
+  the scripted "model" below is played by this process through the relay
+  provider, so every run is fully reproducible, costs zero API tokens, and
+  every request envelope the loop builds is inspectable.
+
+  How it works:
+    1. Spawns `build/pasclaw gateway` (TProcess) against a throwaway
+       PASCLAW_HOME whose config.json uses the relay provider.
+    2. Connects as a relay worker -- a background thread holds the SSE GET
+       on /v1/relay/poll (same TIdHTTP + custom-TStream frame parser shape
+       as PasClaw.Cmd.Relay) and answers each inference request from a
+       per-scenario script, POSTing to /v1/relay/respond/<id>.
+    3. Fires /v1/chat/completions tasks and asserts on what the LOOP did:
+       the system prompts it built, what landed on disk, how big the
+       request bodies grew.
+
+  Scenarios:
+    build-site          write_file + todo_write on turn 1 -> the progress
+                        ledger must fold into iteration 2's system prompt
+                        (goal + file + checklist), iteration 1 must stay
+                        pristine (prefix-cache), deliverable on disk.
+    malformed-recovery  a Gemini-shaped MALFORMED_FUNCTION_CALL empty turn
+                        must be retried with the corrective nudge naming a
+                        REGISTERED tool, and the turn must still deliver.
+    resume-after-cap    run the loop into the 25-iteration cap; the reply
+                        must carry the max-iter notice WITH the resume
+                        ledger; a follow-up "continue" turn must anchor its
+                        ledger goal to the original task. Also reports max
+                        request-body bytes across the 25 iterations.
+
+  Run:  make bench-agentloop     (compiles this program, needs build/pasclaw)
+  Exit: 0 all scenarios pass; 1 otherwise. Metrics print either way.
+  FPC-only (TProcess); the shipping binary itself is what gets exercised.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes, Process, SyncObjs,
+  IdHTTP,
+  PasClaw.JSON,
+  PasClaw.Providers.HTTP;
+
+const
+  PORT = 8140;
+  BASE = 'http://127.0.0.1:8140';
+
+{ ---- assertion + metric plumbing ---------------------------------------- }
+var
+  GFailures: array of string;
+  GMetrics:  array of string;
+
+procedure Check(Cond: Boolean; const Msg: string);
+begin
+  if Cond then
+    WriteLn('  ok: ' + Msg)
+  else
+  begin
+    WriteLn('  FAIL: ' + Msg);
+    SetLength(GFailures, Length(GFailures) + 1);
+    GFailures[High(GFailures)] := Msg;
+  end;
+end;
+
+procedure Metric(const Name: string; Value: Int64);
+begin
+  SetLength(GMetrics, Length(GMetrics) + 1);
+  GMetrics[High(GMetrics)] := Format('%s = %d', [Name, Value]);
+  WriteLn('  metric: ' + GMetrics[High(GMetrics)]);
+end;
+
+function Has(const Hay, Needle: string): Boolean;
+begin
+  Result := Pos(Needle, Hay) > 0;
+end;
+
+{ ---- the scripted model: relay worker ------------------------------------ }
+type
+  { Per-scenario script: called with the 1-based call number within the
+    scenario and the raw envelope JSON; returns the response JSON to POST
+    back to /v1/relay/respond/<id>. }
+  THandler = function(N: Integer; const EnvJSON: string): string;
+
+var
+  GLock:     TCriticalSection;
+  GHandler:  THandler;
+  GEnvs:     array of string;   { raw envelopes, reset per scenario }
+  GMaxBody:  Integer;           { max envelope bytes, reset per scenario }
+
+procedure ResetScenario(H: THandler);
+begin
+  GLock.Acquire;
+  try
+    GHandler := H;
+    SetLength(GEnvs, 0);
+    GMaxBody := 0;
+  finally
+    GLock.Release;
+  end;
+end;
+
+function EnvCount: Integer;
+begin
+  GLock.Acquire;
+  try Result := Length(GEnvs); finally GLock.Release; end;
+end;
+
+function EnvAt(I: Integer): string;
+begin
+  GLock.Acquire;
+  try
+    if (I >= 0) and (I <= High(GEnvs)) then Result := GEnvs[I] else Result := '';
+  finally
+    GLock.Release;
+  end;
+end;
+
+function EnvSystemPrompt(const EnvJSON: string): string;
+var
+  Env, Opts: TJsonObject;
+begin
+  Result := '';
+  Env := TJsonObject.Parse(EnvJSON);
+  if Env = nil then Exit;
+  try
+    Opts := Env.ChildObject('options');
+    if Opts <> nil then
+    try
+      Result := Opts.GetStr('system_prompt', '');
+    finally
+      Opts.Free;
+    end;
+  finally
+    Env.Free;
+  end;
+end;
+
+function EnvLastMessage(const EnvJSON: string): string;
+var
+  Env, MsgObj: TJsonObject;
+  Arr: TJsonArray;
+begin
+  Result := '';
+  Env := TJsonObject.Parse(EnvJSON);
+  if Env = nil then Exit;
+  try
+    Arr := Env.ChildArray('messages');
+    if Arr <> nil then
+    try
+      if Arr.Count > 0 then
+      begin
+        MsgObj := Arr.ItemObject(Arr.Count - 1);
+        if MsgObj <> nil then
+        try
+          Result := MsgObj.GetStr('content', '');
+        finally
+          MsgObj.Free;
+        end;
+      end;
+    finally
+      Arr.Free;
+    end;
+  finally
+    Env.Free;
+  end;
+end;
+
+{ Dispatch one relay envelope: record it, ask the scenario script for the
+  response, POST it back. Runs synchronously inside the SSE stream's Write
+  (same back-pressure shape as PasClaw.Cmd.Relay). }
+procedure DispatchEnvelope(const Data: string);
+var
+  Env: TJsonObject;
+  Id, RespJSON: string;
+  N: Integer;
+  H: THandler;
+begin
+  Env := TJsonObject.Parse(Data);
+  if Env = nil then Exit;
+  try
+    Id := Env.GetStr('id', '');
+  finally
+    Env.Free;
+  end;
+  if Id = '' then Exit;
+
+  GLock.Acquire;
+  try
+    SetLength(GEnvs, Length(GEnvs) + 1);
+    GEnvs[High(GEnvs)] := Data;
+    N := Length(GEnvs);
+    if Length(Data) > GMaxBody then GMaxBody := Length(Data);
+    H := GHandler;
+  finally
+    GLock.Release;
+  end;
+
+  if Assigned(H) then RespJSON := H(N, Data)
+  else RespJSON := '{"content":"no handler","finish_reason":"stop"}';
+  PostJSON(BASE + '/v1/relay/respond/' + Id, RespJSON, [], 30);
+end;
+
+type
+  { SSE frame parser fed by TIdHTTP.Get -- accumulate, split on blank
+    lines, dispatch each data: payload. Same shape as Cmd.Relay's
+    TSSEStream. }
+  TBenchSSE = class(TStream)
+  private
+    FBuf: string;
+  public
+    function Write(const Buffer; Count: Longint): Longint; override;
+    function Read(var Buffer; Count: Longint): Longint; override;
+    function Seek(Offset: Longint; Origin: Word): Longint; override;
+  end;
+
+function TBenchSSE.Read(var Buffer; Count: Longint): Longint;
+begin Result := 0; end;
+
+function TBenchSSE.Seek(Offset: Longint; Origin: Word): Longint;
+begin Result := 0; end;
+
+function TBenchSSE.Write(const Buffer; Count: Longint): Longint;
+var
+  Chunk: AnsiString;
+  P: Integer;
+  Frame, Line, DataAcc: string;
+  Lines: TStringList;
+  i: Integer;
+begin
+  Result := Count;
+  if Count <= 0 then Exit;
+  SetLength(Chunk, Count);
+  Move(Buffer, Chunk[1], Count);
+  FBuf := StringReplace(FBuf + string(Chunk), #13#10, #10, [rfReplaceAll]);
+  repeat
+    P := Pos(#10#10, FBuf);
+    if P = 0 then Break;
+    Frame := Copy(FBuf, 1, P - 1);
+    Delete(FBuf, 1, P + 1);
+    DataAcc := '';
+    Lines := TStringList.Create;
+    try
+      Lines.Text := Frame;
+      for i := 0 to Lines.Count - 1 do
+      begin
+        Line := Lines[i];
+        if Copy(Line, 1, 5) = 'data:' then
+        begin
+          if DataAcc <> '' then DataAcc := DataAcc + #10;
+          DataAcc := DataAcc + Trim(Copy(Line, 6, MaxInt));
+        end;
+      end;
+    finally
+      Lines.Free;
+    end;
+    if DataAcc <> '' then DispatchEnvelope(DataAcc);
+  until False;
+end;
+
+type
+  TWorkerThread = class(TThread)
+  protected
+    procedure Execute; override;
+  end;
+
+procedure TWorkerThread.Execute;
+var
+  Http: TIdHTTP;
+  Stream: TBenchSSE;
+begin
+  { One long-lived SSE GET; when the bench kills the gateway the socket
+    drops, Get raises, and the thread ends. Reconnect once on an early
+    drop so a slow gateway start can't strand the worker. }
+  while not Terminated do
+  begin
+    Http := TIdHTTP.Create(nil);
+    Stream := TBenchSSE.Create;
+    try
+      Http.ConnectTimeout := 5000;
+      Http.ReadTimeout := 0;   { SSE: idle gaps are unbounded }
+      Http.Request.Accept := 'text/event-stream';
+      Http.Request.CustomHeaders.AddValue('X-Relay-Worker-Id', 'agentbench');
+      try
+        Http.Get(BASE + '/v1/relay/poll?worker_id=agentbench&caps=', Stream);
+      except
+        { disconnect -- fall through }
+      end;
+    finally
+      Stream.Free;
+      Http.Free;
+    end;
+    if not Terminated then Sleep(300);
+  end;
+end;
+
+{ ---- response builders ---------------------------------------------------- }
+function ArgsObj1(const K1, V1: string): string;
+var O: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try O.PutStr(K1, V1); Result := O.ToJSON; finally O.Free; end;
+end;
+
+function ArgsPathContent(const P, C: string): string;
+var O: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try O.PutStr('path', P); O.PutStr('content', C); Result := O.ToJSON;
+  finally O.Free; end;
+end;
+
+function ArgsPathPlain(const P: string): string;
+var O: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try O.PutStr('path', P); O.PutBool('plain', True); Result := O.ToJSON;
+  finally O.Free; end;
+end;
+
+function OneCall(const Name, Args: string): string;
+var O, F: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try
+    O.PutStr('id', 'c_' + Name);
+    O.PutStr('type', 'function');
+    F := TJsonObject.Create;
+    F.PutStr('name', Name);
+    F.PutStr('arguments', Args);
+    O.PutObject('function', F);
+    Result := O.ToJSON;
+  finally
+    O.Free;
+  end;
+end;
+
+function RoundOf(const Calls: array of string): string;
+var
+  O: TJsonObject;
+  Arr: string;
+  i: Integer;
+begin
+  Arr := '';
+  for i := 0 to High(Calls) do
+  begin
+    if Arr <> '' then Arr := Arr + ',';
+    Arr := Arr + Calls[i];
+  end;
+  O := TJsonObject.Create;
+  try
+    O.PutStr('content', 'working');
+    O.PutStr('finish_reason', 'tool_calls');
+    O.PutRaw('tool_calls', '[' + Arr + ']');
+    Result := O.ToJSON;
+  finally
+    O.Free;
+  end;
+end;
+
+function StopOf(const Text: string): string;
+var O: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try
+    O.PutStr('content', Text);
+    O.PutStr('finish_reason', 'stop');
+    Result := O.ToJSON;
+  finally
+    O.Free;
+  end;
+end;
+
+{ ---- chat driver ---------------------------------------------------------- }
+function MsgObjJSON(const Role, Content: string): string;
+var O: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try O.PutStr('role', Role); O.PutStr('content', Content); Result := O.ToJSON;
+  finally O.Free; end;
+end;
+
+function Chat(const MsgsJSONArr: string; const Session: string): string;
+var
+  Body: TJsonObject;
+  R: THTTPResult;
+  Root, Choice, Msg: TJsonObject;
+  Choices: TJsonArray;
+begin
+  Result := '';
+  Body := TJsonObject.Create;
+  try
+    Body.PutStr('model', 'sim');
+    Body.PutBool('stream', False);
+    Body.PutRaw('messages', MsgsJSONArr);
+    R := PostJSON(BASE + '/v1/chat/completions', Body.ToJSON,
+                  [MakeHeader('X-PasClaw-Session', Session)], 120);
+  finally
+    Body.Free;
+  end;
+  if (R.StatusCode < 200) or (R.StatusCode >= 300) then
+    Exit(Format('(http %d: %s)', [R.StatusCode, Copy(R.Body, 1, 200)]));
+  Root := TJsonObject.Parse(R.Body);
+  if Root = nil then Exit('(unparseable response)');
+  try
+    Choices := Root.ChildArray('choices');
+    if Choices <> nil then
+    try
+      if Choices.Count > 0 then
+      begin
+        Choice := Choices.ItemObject(0);
+        if Choice <> nil then
+        try
+          Msg := Choice.ChildObject('message');
+          if Msg <> nil then
+          try
+            Result := Msg.GetStr('content', '');
+          finally
+            Msg.Free;
+          end;
+        finally
+          Choice.Free;
+        end;
+      end;
+    finally
+      Choices.Free;
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+{ ---- scenarios ------------------------------------------------------------ }
+var
+  GHomeDir: string;
+
+function H_BuildSite(N: Integer; const EnvJSON: string): string;
+begin
+  case N of
+    1: Result := RoundOf([
+         OneCall('write_file', ArgsPathContent('bench-demo.html', '<h1>bench</h1>')),
+         OneCall('todo_write', ArgsObj1('checklist', '- [x] write page'#10'- [ ] verify page'))]);
+    2: Result := RoundOf([OneCall('read_file', ArgsPathPlain('bench-demo.html'))]);
+  else
+    Result := StopOf('page written and verified.');
+  end;
+end;
+
+procedure ScenarioBuildSite;
+var
+  Answer, SP2: string;
+begin
+  WriteLn;
+  WriteLn('== scenario: build-site (goal anchor + ledger fold + deliverable) ==');
+  ResetScenario(H_BuildSite);
+  Answer := Chat('[' + MsgObjJSON('user',
+    'build a small landing page named bench-demo.html for the demo project') + ']',
+    'bench-build');
+
+  Check(EnvCount = 3, Format('loop finished in 3 provider calls (got %d)', [EnvCount]));
+  Check(not Has(EnvSystemPrompt(EnvAt(0)), '[progress ledger'),
+    'iteration 1 system prompt is pristine (prefix-cache preserved)');
+  SP2 := EnvSystemPrompt(EnvAt(1));
+  Check(Has(SP2, '[progress ledger'), 'iteration 2 carries the progress ledger');
+  Check(Has(SP2, 'bench-demo.html'), 'ledger lists the written file');
+  Check(Has(SP2, '- [ ] verify page'), 'ledger folds the todo_write checklist');
+  Check(Has(SP2, 'Goal:') and Has(SP2, 'landing page'), 'ledger anchors the goal');
+  Check(FileExists(GHomeDir + '/workspace/bench-demo.html'),
+    'deliverable exists in the workspace');
+  Check(Has(Answer, 'page written'), 'final answer surfaced');
+  Metric('build-site.provider_calls', EnvCount);
+end;
+
+function H_Malformed(N: Integer; const EnvJSON: string): string;
+begin
+  case N of
+    1: Result := '{"content":"","finish_reason":"MALFORMED_FUNCTION_CALL"}';
+    2: Result := RoundOf([OneCall('write_file', ArgsPathContent('recovered.txt', 'ok'))]);
+  else
+    Result := StopOf('recovered and wrote the file.');
+  end;
+end;
+
+procedure ScenarioMalformedRecovery;
+var
+  Answer, LastMsg: string;
+begin
+  WriteLn;
+  WriteLn('== scenario: malformed-recovery (Gemini MALFORMED_FUNCTION_CALL) ==');
+  ResetScenario(H_Malformed);
+  Answer := Chat('[' + MsgObjJSON('user',
+    'write a big file for me in the workspace right now') + ']',
+    'bench-malformed');
+
+  Check(EnvCount >= 3, Format('malformed turn was retried (%d calls)', [EnvCount]));
+  LastMsg := EnvLastMessage(EnvAt(1));
+  Check(Has(LastMsg, 'not a valid tool call'), 'retry carries the corrective nudge');
+  Check(Has(LastMsg, 'write_file') or Has(LastMsg, 'edit_file') or Has(LastMsg, 'append_file'),
+    'nudge names a REGISTERED tool');
+  Check(Has(Answer, 'recovered'), 'turn still delivered after recovery');
+end;
+
+function H_CapTurn1(N: Integer; const EnvJSON: string): string;
+begin
+  if N = 1 then
+    Result := RoundOf([OneCall('write_file', ArgsPathContent('partial.txt', 'part 1'))])
+  else
+    { keep exploring forever -> the loop must hit its 25-iteration cap }
+    Result := RoundOf([OneCall('read_file', ArgsPathPlain('partial.txt'))]);
+end;
+
+function H_CapTurn2(N: Integer; const EnvJSON: string): string;
+begin
+  if N = 1 then
+    Result := RoundOf([OneCall('read_file', ArgsPathPlain('partial.txt'))])
+  else
+    Result := StopOf('resumed and finished.');
+end;
+
+procedure ScenarioResumeAfterCap;
+const
+  Task = 'produce the full multi-part report file for the quarterly numbers';
+var
+  Turn1, Turn2, SP2: string;
+begin
+  WriteLn;
+  WriteLn('== scenario: resume-after-cap (25-iter notice + resume ledger) ==');
+  ResetScenario(H_CapTurn1);
+  Turn1 := Chat('[' + MsgObjJSON('user', Task) + ']', 'bench-cap');
+
+  Check(Has(Turn1, 'hit the tool-call limit'), 'reply carries the max-iter notice');
+  Check(Has(Turn1, 'do NOT redo'), 'notice carries the resume ledger instruction');
+  Check(Has(Turn1, 'partial.txt'), 'resume ledger names the written file');
+  Check(Has(Turn1, 'read '), 'resume ledger counts the reads');
+  Metric('resume.max_request_body_bytes', GMaxBody);
+
+  { Turn 2: "continue" -- the new turn's ledger must anchor to the TASK. }
+  ResetScenario(H_CapTurn2);
+  Turn2 := Chat('[' + MsgObjJSON('user', Task) + ',' +
+                      MsgObjJSON('assistant', Turn1) + ',' +
+                      MsgObjJSON('user', 'continue') + ']', 'bench-cap');
+  SP2 := EnvSystemPrompt(EnvAt(1));
+  Check(Has(SP2, 'quarterly numbers'),
+    'turn 2 ledger anchors to the original task, not to "continue"');
+  Check(Has(Turn2, 'finished'), 'turn 2 delivered');
+end;
+
+{ ---- gateway lifecycle ---------------------------------------------------- }
+var
+  GW: TProcess;
+  Drainer: TThread;
+
+type
+  TDrainThread = class(TThread)
+  protected
+    procedure Execute; override;
+  end;
+
+procedure TDrainThread.Execute;
+{ Keep the gateway's stdout/stderr pipe drained so a chatty log can't fill
+  the pipe buffer and block the child. Output is discarded -- the bench's
+  own assertions are the signal. }
+var
+  Buf: array[0..4095] of Byte;
+begin
+  while (not Terminated) and (GW <> nil) and GW.Running do
+  begin
+    if GW.Output.NumBytesAvailable > 0 then
+      GW.Output.Read(Buf, SizeOf(Buf))
+    else
+      Sleep(50);
+  end;
+end;
+
+function WaitHealthy: Boolean;
+var
+  i: Integer;
+  R: THTTPResult;
+begin
+  Result := False;
+  for i := 1 to 40 do
+  begin
+    Sleep(250);
+    R := GetJSONURL(BASE + '/v1/health', [], 2);
+    if R.StatusCode = 200 then Exit(True);
+  end;
+end;
+
+var
+  BinPath, CfgJSON: string;
+  S: TStringList;
+  Worker: TWorkerThread;
+  i: Integer;
+begin
+  BinPath := ExpandFileName('build/pasclaw');
+  if GetEnvironmentVariable('BENCH_BIN') <> '' then
+    BinPath := GetEnvironmentVariable('BENCH_BIN');
+  if not FileExists(BinPath) then
+  begin
+    WriteLn('build/pasclaw not found -- run `make` first (looked at ', BinPath, ')');
+    Halt(2);
+  end;
+
+  GHomeDir := IncludeTrailingPathDelimiter(GetTempDir) +
+              'agentbench-' + IntToStr(GetProcessID);
+  ForceDirectories(GHomeDir + '/workspace');
+  CfgJSON :=
+    '{"default_provider":"relay","default_model":"sim",' +
+    '"providers":[{"name":"relay","kind":"relay","model":"sim"}],' +
+    '"gateway":{"bind_addr":"127.0.0.1","port":' + IntToStr(PORT) + '},' +
+    '"relay_wait_timeout_ms":3600000,"auto_router":{"enabled":false}}';
+  S := TStringList.Create;
+  try
+    S.Text := CfgJSON;
+    S.SaveToFile(GHomeDir + '/config.json');
+  finally
+    S.Free;
+  end;
+
+  GLock := TCriticalSection.Create;
+  GW := TProcess.Create(nil);
+  Worker := nil;
+  Drainer := nil;
+  try
+    GW.Executable := BinPath;
+    GW.Parameters.Add('gateway');
+    for i := 1 to GetEnvironmentVariableCount do
+      GW.Environment.Add(GetEnvironmentString(i));
+    GW.Environment.Add('PASCLAW_HOME=' + GHomeDir);
+    GW.Environment.Add('NO_COLOR=1');
+    GW.Options := [poUsePipes, poStderrToOutPut];
+    GW.Execute;
+    Drainer := TDrainThread.Create(False);
+
+    if not WaitHealthy then
+    begin
+      WriteLn('gateway did not come up on ', BASE);
+      Halt(2);
+    end;
+    Worker := TWorkerThread.Create(False);
+    Sleep(500);
+
+    ScenarioBuildSite;
+    ScenarioMalformedRecovery;
+    ScenarioResumeAfterCap;
+
+    WriteLn;
+    WriteLn('== metrics ==');
+    for i := 0 to High(GMetrics) do WriteLn('  ' + GMetrics[i]);
+    if Length(GFailures) > 0 then
+    begin
+      WriteLn;
+      WriteLn(Format('FAIL (%d):', [Length(GFailures)]));
+      for i := 0 to High(GFailures) do WriteLn('  - ' + GFailures[i]);
+      ExitCode := 1;
+    end
+    else
+    begin
+      WriteLn;
+      WriteLn('PASS: all agent-loop scenarios green');
+      ExitCode := 0;
+    end;
+  finally
+    if Worker <> nil then Worker.Terminate;
+    if Drainer <> nil then Drainer.Terminate;
+    if GW.Running then GW.Terminate(0);
+    GW.Free;
+    { Worker/Drainer block in socket reads/sleeps; the process exit reaps
+      them -- same teardown posture as the TUI's bounded-wait threads. }
+  end;
+end.

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -817,20 +817,27 @@ begin
     'can read back. Useful when a runaway grep can dump megabytes into the ' +
     'context.' + Ansi.Reset);
   PrintLn;
-  Choice := Trim(LowerCase(ReadLineEcho('  Cap tool output [y/N]: ')));
-  if (Choice = 'y') or (Choice = 'yes') then
+  { Default-on since the cap flipped to DefaultToolOutputCap: Enter keeps
+    the default, y customises the byte count, n disables (explicit 0,
+    which round-trips). }
+  Choice := Trim(LowerCase(ReadLineEcho(Format(
+    '  Cap tool output at %d bytes [Y/n/y=custom]: ', [DefaultToolOutputCap]))));
+  if (Choice = 'n') or (Choice = 'no') then
   begin
-    Input := Trim(ReadLineEcho('  Cap (bytes) [8192]: '));
-    Cap := StrToIntDef(Input, 8192);
+    Cfg.ToolOutputCap := 0;
+    PrintLn('  ' + Ansi.Dim + '(uncapped -- set tool_output_cap in config.json to re-enable)' + Ansi.Reset);
+  end
+  else if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    Input := Trim(ReadLineEcho(Format('  Cap (bytes) [%d]: ', [DefaultToolOutputCap])));
+    Cap := StrToIntDef(Input, DefaultToolOutputCap);
     if Cap < 256 then Cap := 256;
     Cfg.ToolOutputCap := Cap;
     PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + Format(' tool output cap = %d bytes', [Cap]));
   end
   else
-  begin
-    Cfg.ToolOutputCap := 0;
-    PrintLn('  ' + Ansi.Dim + '(skipped -- tool output is uncapped; flip tool_output_cap in config.json to enable later)' + Ansi.Reset);
-  end;
+    PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+            Format(' tool output cap = %d bytes (default)', [DefaultToolOutputCap]));
 end;
 
 procedure PromptOrientTaskAware(Cfg: TConfig);

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -260,7 +260,7 @@ const
     '"render_markdown":true,' +
     '"promptware_enabled":true,' +
     '"condense_reversible":false,' +
-    '"tool_output_cap":0,' +
+    '"tool_output_cap":24576,' +
     '"stats_collection_enabled":true,' +
     '"checkpoints_enabled":true,' +
     '"checkpoints_keep_last":32,' +

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -38,6 +38,14 @@ const
   EnvHome   = 'PASCLAW_HOME';
   EnvConfig = 'PASCLAW_CONFIG';
 
+  (* Default per-tool-result byte cap (TConfig.ToolOutputCap). 24 KB is
+     roughly 6K tokens -- generous enough that normal reads/greps pass
+     through verbatim, tight enough that one runaway result can't ride in
+     history for the rest of the turn (the pre-cap failure shape: a single
+     fat read inflating EVERY subsequent request). tool_output_get always
+     recovers the full text. 0 disables. *)
+  DefaultToolOutputCap = 24576;
+
 type
   TGatewayConfig = record
     LogLevel: string;
@@ -647,10 +655,10 @@ type
        When > 0, RunToolLoop diverts overlong tool outputs into the
        process-lifetime PasClaw.Tools.OutputCache and replaces the
        in-context body with a head + tail snippet plus a handle the
-       model can dereference via `tool_output_get`. Default 0 = off
-       (legacy verbatim behaviour). Operators flip it on in
-       config.json under "tool_output_cap" -- 8192 is a reasonable
-       starting cap (≈ 2K tokens). *)
+       model can dereference via `tool_output_get`. Default
+       DefaultToolOutputCap (24576 ≈ 6K tokens); 0 turns the cap off
+       (legacy verbatim behaviour) via "tool_output_cap": 0 in
+       config.json. *)
     ToolOutputCap:     Integer;
     (* Persist per-session usage counters (tokens, turns, tool calls,
        truncation savings) into the session JSON so /v1/stats can
@@ -1046,7 +1054,7 @@ begin
   MCPProgressiveDisclosure := True;  { on by default -- fat catalogs (Replicate MCP ~50 tools, GitHub MCP ~50+) make lazy reveal the right floor. The prompt cost of every MCP schema every turn dominates the bill on turns that touch zero MCP tools; tool_search loads schemas on demand at a one-turn cost per first-use. Operators with tiny catalogs flip off via onboarding (default N) or hand-edit if the +1 turn isn't worth the savings. Mirrors Claude Code's ToolSearch pattern. No-op when no MCP servers are configured. }
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   SubagentsEnabled     := True;  { on by default -- a built-in general-purpose subagent makes `spawn` available with no config. }
-  ToolOutputCap        := 0;     { off by default; operators opt in. See TConfig.ToolOutputCap. }
+  ToolOutputCap        := DefaultToolOutputCap; { on by default -- an uncapped tool result rides in history for the whole turn and was the top context-growth driver (bench/agentloop: 100 KB read -> >100 KB request bodies). tool_output_get recovers the full text; operators opt out with tool_output_cap: 0. }
   StatsCollectionEnabled := True;  { on by default -- zero prompt cost, useful for diagnosing turn-count regressions. Onboarding can flip off for privacy-conscious operators. }
   CheckpointsEnabled     := True;  { on by default -- zero prompt cost, prevents lost work on multi-edit sessions. }
   MemoryDistillEnabled   := False; { opt-in: ~one extra LLM call per turn. }
@@ -1351,10 +1359,10 @@ begin
       across SaveConfig + LoadConfig. }
     if not VectorSearchEnabled then
       Root.PutBool('vector_search_enabled', False);
-    { Tool output cap: emit only when an operator has explicitly
-      opted in. 0 (off) is the default; suppressing it from the
-      JSON keeps fresh config files clean. }
-    if ToolOutputCap > 0 then
+    { Tool output cap: emit only when it differs from the default --
+      including an explicit 0 (opt-OUT), which must round-trip or the
+      next LoadConfig would silently re-enable the cap. }
+    if ToolOutputCap <> DefaultToolOutputCap then
       Root.PutInt('tool_output_cap', ToolOutputCap);
     { stats_collection_enabled, checkpoints_enabled, orient_task_aware:
       defaults flipped to ON in PR #314 (the six free behavioral toggles

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1335,6 +1335,11 @@ begin
   Cfg.Parallel      := True;
   Cfg.Mode          := FMode;  { PR #290: thread current Plan/Build into the dispatch gate }
   Cfg.Options       := DefaultChatOptions;
+  { #414 review: the cap default flipped on, but these builders never set
+    ToolOutputCap, so TUI turns sent oversized tool output verbatim while
+    Cmd.TUI dutifully registered tool_output_get. RouteConfig is the
+    session-lifetime config snapshot the router already uses. }
+  Cfg.ToolOutputCap := RouteConfig.ToolOutputCap;
   Cfg.Options.CacheEnabled := PromptCacheEnabled;
   Cfg.Options.CacheTTL     := PromptCacheTTL;
   if FSession <> nil then
@@ -2849,6 +2854,11 @@ begin
   Cfg.MaxIterations := 6;
   Cfg.Parallel := True;
   Cfg.Options       := DefaultChatOptions;
+  { #414 review: the cap default flipped on, but these builders never set
+    ToolOutputCap, so TUI turns sent oversized tool output verbatim while
+    Cmd.TUI dutifully registered tool_output_get. RouteConfig is the
+    session-lifetime config snapshot the router already uses. }
+  Cfg.ToolOutputCap := RouteConfig.ToolOutputCap;
   Cfg.Options.CacheEnabled := PromptCacheEnabled;
   Cfg.Options.CacheTTL     := PromptCacheTTL;
   Cfg.OnText        := nil;

--- a/src/tests/loop_shaping_defaults_tests.pas
+++ b/src/tests/loop_shaping_defaults_tests.pas
@@ -13,7 +13,7 @@ program loop_shaping_defaults_tests;
     PromptwareEnabled     True
     VectorSearchEnabled   True
     RenderMarkdown        True
-    ToolOutputCap         0
+    ToolOutputCap         DefaultToolOutputCap (24576; 0 = explicit opt-out)
     OrientTaskAware       False   (off; opt in per-run with --orient)
 *)
 
@@ -44,7 +44,8 @@ begin
     AssertTrue(C.PromptwareEnabled,     'PromptwareEnabled stays True');
     AssertTrue(C.VectorSearchEnabled,   'VectorSearchEnabled stays True');
     AssertTrue(C.RenderMarkdown,        'RenderMarkdown stays True');
-    AssertTrue(C.ToolOutputCap = 0,     'ToolOutputCap stays 0');
+    AssertTrue(C.ToolOutputCap = DefaultToolOutputCap,
+               'ToolOutputCap defaults to DefaultToolOutputCap (24576)');
     AssertTrue(not C.OrientTaskAware,   'OrientTaskAware stays False');
     AssertTrue(not C.SelfImprovingSkills.SelfManage,
                'SelfImprovingSkills.SelfManage stays False');
@@ -94,7 +95,7 @@ begin
     C.RenderMarkdown     := False;
     C.CondenseReversible := True;
     C.OrientTaskAware    := True;
-    C.ToolOutputCap      := 8192;
+    C.ToolOutputCap      := 0;      { default 24576 -> explicit opt-OUT }
     S := C.ToJSON;
     { Each non-default field must be present in the serialised form,
       otherwise LoadConfig would silently fall back to the default. }
@@ -105,7 +106,7 @@ begin
     AssertTrue(Pos('"render_markdown"',       S) > 0, 'opt-out render_markdown emitted');
     AssertTrue(Pos('"condense_reversible"',   S) > 0, 'opt-in condense_reversible emitted');
     AssertTrue(Pos('"orient_task_aware"',     S) > 0, 'opt-in orient_task_aware emitted');
-    AssertTrue(Pos('"tool_output_cap"',       S) > 0, 'opt-in tool_output_cap emitted');
+    AssertTrue(Pos('"tool_output_cap"',       S) > 0, 'opt-out tool_output_cap emitted');
   finally
     C.Free;
   end;
@@ -120,7 +121,7 @@ begin
     AssertTrue(not C2.RenderMarkdown,       'RenderMarkdown round-trips False');
     AssertTrue(C2.CondenseReversible,       'CondenseReversible round-trips True');
     AssertTrue(C2.OrientTaskAware,          'OrientTaskAware round-trips True');
-    AssertTrue(C2.ToolOutputCap = 8192,     'ToolOutputCap round-trips 8192');
+    AssertTrue(C2.ToolOutputCap = 0,        'ToolOutputCap round-trips the explicit 0 opt-out');
   finally
     C2.Free;
   end;

--- a/src/tests/session_stats_tests.pas
+++ b/src/tests/session_stats_tests.pas
@@ -257,42 +257,41 @@ begin
 end;
 
 procedure TestStatsCollectionEnabledRoundTrip;
-{ Default False; explicit True survives a JSON Save / Load. We
-  pin both halves because the persistence helper for boolean
-  flags in PasClaw.Config emits ONLY when the value is non-
-  default (to keep fresh config files clean) -- so the default-
-  False case has to round-trip via "field missing, fall back to
-  the default" rather than via an explicit "false". }
+{ Default TRUE since the six-free-toggles PR (#314); an explicit
+  False (opt-out) survives a JSON Save / Load. We pin both halves
+  because the persistence helper emits ONLY the non-default value --
+  the default-on case round-trips via "field missing, fall back to
+  the default", the opt-out via an explicit "false". }
 var
   Cfg1, Cfg2, Cfg3: TConfig;
   Body: string;
 begin
   Cfg1 := TConfig.Create;
   try
-    AssertTrue(not Cfg1.StatsCollectionEnabled,
-               'default is False');
+    AssertTrue(Cfg1.StatsCollectionEnabled,
+               'default is True');
     Body := Cfg1.ToJSON;
   finally
     Cfg1.Free;
   end;
   AssertNotContains(Body, '"stats_collection_enabled"',
-                    'default-off case writes no flag (fresh config stays clean)');
+                    'default-on case writes no flag (fresh config stays clean)');
 
   Cfg2 := TConfig.Create;
   try
-    Cfg2.StatsCollectionEnabled := True;
+    Cfg2.StatsCollectionEnabled := False;
     Body := Cfg2.ToJSON;
   finally
     Cfg2.Free;
   end;
   AssertContains(Body, '"stats_collection_enabled"',
-                 'explicit-on case writes the flag');
+                 'explicit-off case writes the flag');
 
   Cfg3 := TConfig.Create;
   try
     Cfg3.FromJSON(Body);
-    AssertTrue(Cfg3.StatsCollectionEnabled,
-               'flag survives round trip');
+    AssertTrue(not Cfg3.StatsCollectionEnabled,
+               'opt-out survives round trip');
   finally
     Cfg3.Free;
   end;


### PR DESCRIPTION
First of the five queued harness-effectiveness PRs (C1 → B1 → B2 → C2+C3 → D1), each verified with before/after numbers from `bench/agentloop`.

> ⚠️ **Also carries #413's bench commit.** #413 merged into its stacked base branch (`claude/progress-ledger`) instead of `main` — GitHub only retargets a PR when its base branch is deleted — so the bench never actually landed on main. It's cherry-picked here verbatim as the first commit.

## Why

An uncapped tool result rides verbatim in history for the rest of the turn: one fat `read_file`/`grep_files` inflates **every subsequent request** — the top context-growth driver behind the 125 KB request bodies seen on real runs. Oversized histories are also what push Gemini-class models into the malformed-call behaviour in the first place (#406 made recovery work; this attacks the trigger). `ToolOutputCap` existed but defaulted to 0.

## What

- **Default `0` → `DefaultToolOutputCap` (24576 ≈ 6K tokens).** Normal reads pass verbatim; a runaway result becomes head + tail + a `tool_output_get` handle (full text always recoverable). Every surface already registers the recovery tool when the cap is on.
- **`ToJSON` emits `tool_output_cap` when ≠ default** — including an explicit `0` opt-out, which must round-trip or the next LoadConfig would silently re-enable the cap.
- **Profiles:** `stock` mirrors the new default; `baseline` keeps its explicit 0 (the "everything off" A/B floor); `low-token` 8192 / `max-build` 16384 stay as explicit choices.
- **Onboarding:** Enter keeps the default, `y` customises the byte count, `n` disables.

## Harness-verified (the point of this series)

New `fat-read` bench scenario: a 100 KB `read_file` at iteration 1, then further iterations — measuring the max request body the loop builds:

| | `fatread.max_request_body_bytes` |
|---|---|
| before (main binary) | **129,256** |
| after (this PR) | **21,502** |

**6× smaller**, and the scenario asserts the capped result carries the `tool_output_get` retrieval handle. All prior scenarios still green (20 assertions total).

## Also

- Fixes the stale `test-session-stats` assertion that has been **failing on main** ("default is False" — `StatsCollectionEnabled` flipped to True in #314; the round-trip test now exercises the explicit-off direction).
- Known follow-up (pre-existing, out of scope): the TUI's inner loop config doesn't wire `ToolOutputCap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_