### PR TITLE
tools: schema trim + error-message audit (C4 + B3)

### DIFF
--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -803,6 +803,43 @@ begin
   Metric('realtask.max_request_body_bytes', GMaxBody);
 end;
 
+function H_ErrorGuidance(N: Integer; const EnvJSON: string): string;
+begin
+  case N of
+    1: Result := RoundOf([OneCall('read_files', '{"path":"whatever.txt"}')]);   { typo'd tool }
+    2: Result := RoundOf([OneCall('read_file', ArgsPathPlain('sub-dir-page.html'))]); { wrong dir }
+  else
+    Result := StopOf('guidance received.');
+  end;
+end;
+
+procedure ScenarioErrorGuidance;
+{ B3: the errors a model actually loops on must carry the next move --
+  through the real gateway dispatch, not just unit-level. }
+var
+  S: TStringList;
+begin
+  WriteLn;
+  WriteLn('== scenario: error-guidance (errors state the next move) ==');
+  ForceDirectories(GHomeDir + '/workspace/pages');
+  S := TStringList.Create;
+  try
+    S.Text := '<p>hi</p>';
+    S.SaveToFile(GHomeDir + '/workspace/pages/sub-dir-page.html');
+  finally
+    S.Free;
+  end;
+  ResetScenario(H_ErrorGuidance);
+  Chat('[' + MsgObjJSON('user', 'open that page file') + ']', 'bench-errs');
+  Check(Has(EnvLastMessage(EnvAt(1)), 'did you mean'),
+    'unknown tool error suggests similar names');
+  Check(Has(EnvLastMessage(EnvAt(1)), 'read_file'),
+    'suggestion includes the real tool name');
+  Check(Has(EnvLastMessage(EnvAt(2)), 'Did you mean') and
+        Has(EnvLastMessage(EnvAt(2)), 'pages/sub-dir-page.html'),
+    'no-such-file error names the actual location');
+end;
+
 { ---- gateway lifecycle ---------------------------------------------------- }
 var
   GW: TProcess;
@@ -916,6 +953,7 @@ begin
     ScenarioFatRead;
     ScenarioRepeatRead;
     ScenarioRealTask;
+    ScenarioErrorGuidance;
 
     WriteLn;
     WriteLn('== metrics ==');

--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -516,6 +516,9 @@ begin
   Check(Has(EnvLastMessage(EnvAt(3)), 'bench-demo.html'),
     'find_files locates the file by glob in one call');
   Metric('build-site.provider_calls', EnvCount);
+  { C4 baseline: the fixed per-request overhead every call pays -- system
+    prompt + full tool schemas + one user message. Schema fat shows here. }
+  Metric('build-site.first_request_bytes', Length(EnvAt(0)));
 end;
 
 function H_Malformed(N: Integer; const EnvJSON: string): string;

--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -578,17 +578,11 @@ begin
   GRunners.Add(Runner);
 
   T.Name        := 'execute_code';
-  T.Description := 'Run a multi-line bash or PowerShell script. Use when ' +
-                   'you need a loop, heredoc, or fan-out that would be ' +
-                   'awkward to express as a single shell_exec command. ' +
-                   'Script body is written to a temp file then executed; ' +
-                   'returns combined stdout+stderr and exit code. Subject ' +
-                   'to the same sandbox + denylist as shell_exec. ' +
-                   'INSIDE the script you can call back into any of your ' +
-                   'other tools by running `pasclaw __tool <name> ''<json-args>''` ' +
-                   '-- the call hits the same registry you''re using now. ' +
-                   'Use this to fan out: e.g. list files, then memory_search ' +
-                   'each, then read_file the top hits, all in one script.';
+  T.Description := 'Run a multi-line bash or PowerShell script (loops, heredocs, ' +
+                   'fan-out a single shell_exec can''t express). Returns combined ' +
+                   'stdout+stderr and exit code; same sandbox/denylist as ' +
+                   'shell_exec. Inside the script, `pasclaw __tool <name> ' +
+                   '''<json-args>''` calls back into your own tools.';
   T.Schema      :=
     '{"type":"object",' +
      '"properties":{' +

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -186,6 +186,65 @@ begin
   Result := False;
 end;
 
+function SuggestSimilarFiles(const MissingPath: string): string;
+{ Error-path helper for "no such file": a bounded walk from the working
+  directory for names containing the missing basename, so the model's
+  next call is the right path instead of another guess. Cap 3 matches,
+  cap 400 dirs visited -- this only ever runs when a read already
+  failed, and a giant tree shouldn't turn one error into a crawl. }
+const
+  MaxHits = 3;
+  MaxDirs = 400;
+var
+  Base, Root, Hits: string;
+  DirsSeen, Found: Integer;
+
+  procedure Walk(const Dir: string);
+  var
+    SR: TSearchRec;
+  begin
+    if (Found >= MaxHits) or (DirsSeen >= MaxDirs) then Exit;
+    Inc(DirsSeen);
+    if FindFirst(Dir + PathDelim + '*', faAnyFile, SR) = 0 then
+    try
+      repeat
+        if (SR.Name = '.') or (SR.Name = '..') then Continue;
+        if (SR.Attr and faDirectory) <> 0 then
+        begin
+          if (SR.Name <> '') and (SR.Name[1] = '.') then Continue;
+          if IsBlockedGrepDir(SR.Name) then Continue;
+          Walk(Dir + PathDelim + SR.Name);
+        end
+        else if MatchesMask(SR.Name, '*' + Base + '*') then
+        begin
+          Inc(Found);
+          if Hits <> '' then Hits := Hits + ', ';
+          Hits := Hits + Copy(Dir + PathDelim + SR.Name, Length(Root) + 2, MaxInt);
+        end;
+        if Found >= MaxHits then Break;
+      until FindNext(SR) <> 0;
+    finally
+      FindClose(SR);
+    end;
+  end;
+
+begin
+  Result := '';
+  Base := ExtractFileName(MissingPath);
+  if Length(Base) < 3 then Exit;   { too short to suggest anything sane }
+  Root := ExcludeTrailingPathDelimiter(ResolveWorkspacePath('.'));
+  if not DirectoryExists(Root) then Exit;
+  Hits := '';
+  DirsSeen := 0;
+  Found := 0;
+  Walk(Root);
+  if Hits <> '' then
+    Result := ' Did you mean: ' + Hits +
+              '? (find_files locates files by name glob.)'
+  else
+    Result := ' Use find_files with a glob (e.g. "*' + Base + '*") to locate it.';
+end;
+
 function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
 var
   Path, Body, Reason: string;
@@ -207,7 +266,7 @@ begin
   end;
   if not FileExists(Path) then
   begin
-    ErrMsg := 'no such file: ' + Path;
+    ErrMsg := 'no such file: ' + Path + '.' + SuggestSimilarFiles(Path);
     Exit('');
   end;
   Body := ReadFileText(Path);
@@ -1025,7 +1084,11 @@ begin
         if Idx < 0 then Idx := ApFindBlock(CurLines, OldB, 0);   { anchor may have over-advanced }
         if Idx < 0 then
         begin
-          ErrMsg := 'apply_patch: context not found in ' + Path + ' near: ' + OldB[0];
+          ErrMsg := 'apply_patch: context not found in ' + Path + ' near: ' + OldB[0] +
+                    '. The context and "-" lines must match the CURRENT file ' +
+                    'byte-exactly -- re-read the region (read_file with ' +
+                    'start_line/end_line) and rebuild the hunk from what is ' +
+                    'actually there.';
           Exit;
         end;
         ApSplice(CurLines, Idx, Length(OldB), NewB);
@@ -1380,7 +1443,8 @@ begin
   end;
   if not FileExists(Path) then
   begin
-    ErrMsg := 'no such file: ' + Path + ' (use write_file to create it)';
+    ErrMsg := 'no such file: ' + Path + ' (use write_file to create it).' +
+              SuggestSimilarFiles(Path);
     Exit('');
   end;
   Content := ReadFileText(Path);
@@ -1535,17 +1599,16 @@ begin
     grep equivalent the agent has (Windows ships no grep). }
   T := Default(TTool);
   T.Name        := 'grep_files';
-  T.Description := 'Search files for a substring. Recursive when path is a directory. ' +
-                   'Skips dotdirs, well-known build/VCS/deps dirs (.git, node_modules, target, build, ' +
-                   'dist, vendor, .venv, __pycache__, .gradle, .next), binary files (NUL-byte detection ' +
-                   'in first 1 KiB), and files larger than max_file_bytes (default 10 MiB). Returns ' +
-                   'matches with LINENO:line per hit, one section per file.';
+  T.Description := 'Search file CONTENTS for a substring, recursively (skips VCS/build/deps ' +
+                   'dirs and binaries). Returns LINENO:line matches grouped per file -- feed ' +
+                   'the line numbers to read_file start_line/end_line. Use find_files to ' +
+                   'locate files by NAME.';
   T.Schema      := '{"type":"object","properties":{' +
                    '"path":{"type":"string"},' +
                    '"pattern":{"type":"string"},' +
                    '"ignore_case":{"type":"boolean"},' +
                    '"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"},' +
-                   '"max_file_bytes":{"type":"integer","description":"Skip files larger than this (default 10485760 = 10 MiB). Override for grepping into giant log files."}' +
+                   '"max_file_bytes":{"type":"integer","description":"Skip files larger than this (default 10 MiB)."}' +
                    '},"required":["path","pattern"]}';
   T.Handler     := Tool_FSGrep;
   T.IsCore      := True;
@@ -1581,13 +1644,15 @@ begin
   T.Name := 'edit_file';
   if UseHashline then
   begin
-    T.Description := 'Edit a file. Default: replace an exact snippet -- pass old_text (the existing text, ' +
-                     'verbatim including whitespace) and new_text. The match must be unique unless ' +
-                     'replace_all is set; omit new_text to delete. Advanced: pass a hashline `patch` instead ' +
-                     'for line-anchored multi-hunk edits -- first read the file with {"hashline":true} to ' +
-                     'get the ' + HL_FILE_PREFIX + 'path#hash header, then send "42:" anchors + ' +
-                     HL_PAYLOAD_REPLACE + '/' + HL_PAYLOAD_ABOVE + '/' + HL_PAYLOAD_BELOW +
-                     ' payload markers (header hash must match disk).';
+    { C4: the full hashline patch grammar used to live here and was re-sent
+      on EVERY request. It now lives where it's needed -- the format-error
+      messages (PreflightToolCall / PasClaw.Hashline validators) teach the
+      exact syntax the moment a patch is malformed. }
+    T.Description := 'Edit a file by replacing an exact snippet: pass old_text (verbatim, ' +
+                     'including whitespace) and new_text; unique match unless replace_all; ' +
+                     'omit new_text to delete. Advanced: a hashline `patch` (read the file ' +
+                     'with hashline:true first) does line-anchored multi-hunk edits; format ' +
+                     'errors reply with the exact patch syntax.';
     T.Schema      := '{"type":"object","properties":{' +
                      '"path":{"type":"string"},' +
                      '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace)."},' +
@@ -1639,16 +1704,12 @@ begin
   T := Default(TTool);
   T.Name := 'apply_patch';
   T.Description :=
-    'Apply a multi-file patch in ONE call (Codex / OpenClaw apply_patch format). ' +
-    'Wrap everything between a "*** Begin Patch" line and a "*** End Patch" line. ' +
-    'Inside, one or more file sections: "*** Add File: <path>" then the new content ' +
-    'as lines each prefixed with "+"; "*** Delete File: <path>"; or "*** Update File: ' +
-    '<path>" (optionally followed by "*** Move to: <newpath>") then hunks. In a hunk, ' +
-    'optional "@@ <context>" lines help locate the region, then each change line starts ' +
-    'with " " (unchanged context), "-" (remove) or "+" (add). Edits are located by their ' +
-    'context and removed lines, NOT by line number. All-or-nothing: if any hunk fails to ' +
-    'locate, nothing is written. Prefer this over several edit_file calls when a change ' +
-    'spans multiple files or many hunks.';
+    'Apply a multi-file patch in ONE call (Codex apply_patch format): "*** Begin Patch" ' +
+    '... "*** End Patch" wrapping "*** Add File:" / "*** Update File:" (+ optional ' +
+    '"*** Move to:") / "*** Delete File:" sections; update hunks use " "/"-"/"+" lines ' +
+    'and optional "@@ context" anchors, located by content not line numbers. ' +
+    'All-or-nothing. Prefer over several edit_file calls for multi-file changes; ' +
+    'format errors reply with the exact expected syntax.';
   T.Schema :=
     '{"type":"object","properties":{"patch":{"type":"string",' +
     '"description":"Full patch text, from *** Begin Patch through *** End Patch."}},' +

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -72,6 +72,9 @@ type
     function  Count: Integer;
     function  ToProviderDefs: TToolDefinitionArray;
     function  RunTool(const Name, ArgsJSON: string; out ErrMsg: string): string;
+    { Up to 3 similar registered names for an unknown-tool error ('' when
+      nothing plausible). Public for tests. }
+    function  SimilarToolNames(const Name: string): string;
     { Progressive-disclosure surface (PasClaw.MCP.Disclosure / tool_search).
 
       DeferredNames returns the registered tool names whose IsDeferred is
@@ -353,6 +356,38 @@ begin
   end;
 end;
 
+function TToolRegistry.SimilarToolNames(const Name: string): string;
+{ Error-message helper: up to 3 registered (non-hidden -- Names already
+  filters aliases) tool names that look like a typo/half-memory of Name,
+  appended to the unknown-tool error so the model's next call is the
+  right one instead of a guess. "Similar" = one contains the other, or a
+  shared 4-char prefix -- cheap, and it catches the real cases
+  (old fs_* era names, singular/plural slips, truncations). }
+var
+  All: TStringArray;
+  i, Hits: Integer;
+  L, C: string;
+begin
+  Result := '';
+  L := LowerCase(Name);
+  if L = '' then Exit;
+  All := Names;
+  Hits := 0;
+  for i := 0 to High(All) do
+  begin
+    C := LowerCase(All[i]);
+    if (Pos(L, C) > 0) or (Pos(C, L) > 0) or
+       ((Length(L) >= 4) and (Copy(C, 1, 4) = Copy(L, 1, 4))) then
+    begin
+      if Result = '' then Result := ' -- did you mean: ' + All[i]
+      else Result := Result + ', ' + All[i];
+      Inc(Hits);
+      if Hits >= 3 then Break;
+    end;
+  end;
+  if Result <> '' then Result := Result + '?';
+end;
+
 function TToolRegistry.RunTool(const Name, ArgsJSON: string; out ErrMsg: string): string;
 var
   T: TTool;
@@ -364,7 +399,7 @@ begin
     every concurrent gateway request through it. }
   if not Find(Name, T) then
   begin
-    ErrMsg := 'unknown tool: ' + Name;
+    ErrMsg := 'unknown tool: ' + Name + SimilarToolNames(Name);
     Exit('');
   end;
   if (not Assigned(T.Handler)) and (not Assigned(T.HandlerObj)) then

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -684,13 +684,17 @@ begin
     begin
       Reason := 'refused: command contains forbidden token "' + Hit +
                 '" (built-in shell denylist; toggle off via sandbox.shell_deny_enabled=false ' +
-                'in config.json -- strongly discouraged)';
+                'in config.json -- strongly discouraged). Rewrite the command without "' + Hit +
+                '", or use the dedicated tools instead (read_file / write_file / edit_file / ' +
+                'find_files / grep_files cover most file work without the shell).';
       Exit(False);
     end;
     if MatchesAnySubstring(Cmd, Hit) then
     begin
       Reason := 'refused: command contains forbidden pattern "' + Hit +
-                '" (built-in shell denylist)';
+                '" (built-in shell denylist). Rewrite without "' + Hit +
+                '" -- e.g. avoid command substitution / pipes-to-shell; plain loops like ' +
+                '`yes X | head -N` or the dedicated file tools usually cover it.';
       Exit(False);
     end;
   end;

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -27,9 +27,11 @@ uses
   {$IFDEF UNIX}cthreads,{$ENDIF}
   SysUtils,
   PasClaw.Utils,
+  PasClaw.Config,
   PasClaw.Providers.Types,
   PasClaw.Tools.Types,
   PasClaw.Tools.Registry,
+  PasClaw.Tools.Sandbox,
   PasClaw.Tools.FS;
 
 procedure Fail_(const Msg: string);
@@ -100,9 +102,14 @@ var
   Defs: TToolDefinitionArray;
   Dir, PathA, PathB, PathC, PathN, Patch, R, Err: string;
   T: TTool;
+  Pol: TSandboxPolicy;
 begin
   Dir := JoinPath(GetTempDir, 'pcfsnaming');
   ForceDirectories(Dir);
+  { Pin the workspace to the fixture dir so the B3 nearest-match walk is
+    deterministic (it searches from the working directory). }
+  Pol := Default(TSandboxPolicy);
+  ConfigureSandbox(Pol, Dir);
   PathA := JoinPath(Dir, 'a.txt');
   PathB := JoinPath(Dir, 'b.txt');
   if FileExists(PathA) then DeleteFile(PathA);
@@ -231,6 +238,29 @@ begin
     AssertContains(R, 'grep_files', 'empty result points at the contents-search sibling');
     WriteLn('  ok: find_files globs by name, skips deps dirs');
 
+    { --- 4c. B3: errors state the next move. --- }
+    { Wrong directory, right name: nearest-match suggestion (deep.pas lives
+      in sub/ from 4b, requested at the root). }
+    Reg.RunTool('read_file', '{"path":"' + JEsc(Dir + PathDelim + 'deep.pas') + '"}', Err);
+    AssertContains(Err, 'Did you mean', 'no-such-file suggests nearby names');
+    AssertContains(Err, 'deep.pas', 'suggestion names the actual location');
+    { Nothing similar: point at find_files instead. }
+    Reg.RunTool('read_file', '{"path":"' + JEsc(Dir + PathDelim + 'zzqq-none.pas') + '"}', Err);
+    AssertContains(Err, 'find_files', 'no-match error points at find_files');
+    { Unknown tool: suggest similar registered names. }
+    Reg.RunTool('read_files', '{}', Err);
+    AssertContains(Err, 'unknown tool', 'unknown tool still errors');
+    AssertContains(Err, 'did you mean', 'unknown tool suggests');
+    AssertContains(Err, 'read_file', 'suggestion includes the real name');
+    { Shell denial carries a remediation. }
+    Pol.ShellDenyEnabled := True;
+    ConfigureSandbox(Pol, Dir);
+    AssertTrue(not ShellAllowed('sudo ls', R), 'denylist still refuses');
+    AssertContains(R, 'dedicated tools', 'denial suggests the tool alternatives');
+    Pol.ShellDenyEnabled := False;
+    ConfigureSandbox(Pol, Dir);
+    WriteLn('  ok: errors carry the next move (nearest file / similar tool / shell alternative)');
+
     { --- 5. apply_patch: multi-file (update + add + delete) in one call. --- }
     AssertTrue(DefsHasName(Reg.ToProviderDefs, 'apply_patch'), 'apply_patch advertised');
     PathC := JoinPath(Dir, 'c.txt');
@@ -265,6 +295,7 @@ begin
       '{"patch":"' + JEsc('*** Begin Patch'#10'*** Update File: ' + PathA + #10'-nope'#10'+yep'#10'*** End Patch'#10) + '"}',
       Err);
     AssertContains(Err, 'context not found', 'apply_patch reports a missing-context failure');
+    AssertContains(Err, 'start_line', 'context failure tells the model to re-read the region');
     AssertEqStr(ReadBack(Reg, PathA), 'unchanged', 'apply_patch wrote nothing on failure');
 
     { Add File onto an existing path must refuse (not silently clobber). PathN


### PR DESCRIPTION
The last two items of the effectiveness queue, based on merged main (#415). Three commits: C4, B3, and the bench scenario that proves B3 end-to-end.

> C5 (promptware scoping) is **deliberately dropped**: `web_fetch save_to` / `shell curl > file` followed by `read_file` would launder fetched content past any trust-local-reads exemption, so the injection scan keeps covering all tool output.

## Harness-verified — same bench binary, before = merged main (#415), after = this branch

| metric | before | after |
|---|---|---|
| `build-site.first_request_bytes` (fixed cost **every** call pays) | 18,726 | **17,780** (~240 tokens/request) |
| `realtask.total_request_bytes` (original pasclaw.dev prompt, 11 calls) | 296,859 | **286,453** |
| `error-guidance` scenario (typo'd tool + wrong-dir read through real dispatch) | **2 FAIL** — bare `unknown tool: X` / `no such file: Y` | **PASS** — "did you mean: read_file", "Did you mean: pages/sub-dir-page.html" |
| `realtask` deliverable (`index.html`) | byte-identical either way — same output, cheaper production | |

## C4 — trim always-sent schemas; formats teach on the error path

- **`edit_file`**: the full hashline patch grammar leaves the description — `PreflightToolCall` + the `PasClaw.Hashline` validators reply with the exact syntax the moment a patch is malformed, the only time the model needs it.
- **`grep_files`**: skip-list enumeration collapses; gains `read_file start_line/end_line` and `find_files` cross-references.
- **`apply_patch`**: keeps the envelope shape, drops the tutorial.
- **`execute_code`**: keeps the `pasclaw __tool` callback contract, drops the fan-out story.

## B3 — every tool error states the next move

- **`no such file`** (`read_file`/`edit_file`) → bounded walk (3 hits, 400 dirs, error-path only) appends *"Did you mean: `pages/sub-dir-page.html`?"* — right name, wrong directory is the dominant real case. Nothing similar → a concrete `find_files` glob.
- **unknown tool** → up to 3 similar registered names (containment or shared 4-char prefix; hidden aliases excluded): *"unknown tool: read_files — did you mean: read_file?"*
- **`apply_patch` context-not-found** → context must match the **current** file byte-exactly; re-read the region with `read_file start_line/end_line` first.
- **shell denylist refusals** → name the rewrite and the dedicated-tool alternatives instead of just refusing.

## Tests

`fs_tool_naming_tests` gains the B3 section (nearest-file, `find_files` fallback, similar-tool, shell-denial remediation, `apply_patch` re-read hint); new `error-guidance` bench scenario fails on main and passes here. Full bench (7 scenarios) + regression sweep green on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6