### PR TITLE
gateway: derive /v1/chat/completions session from the OpenAI user field

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -435,6 +435,18 @@ procedure AccumulateGatewayStatsRaw(const Cfg: TConfig;
    slip past the lexical compare. Exposed for tests. *)
 function IsRestrictedFsPath(const Path: string): Boolean;
 
+(* Derive a session id from the OpenAI-standard `user` field (the same
+   trick OpenClaw's gateway uses): when a /v1/chat/completions request
+   carries no X-PasClaw-Session header but does carry `user`, hash it so
+   repeated calls with the same value share an agent session -- a
+   spec-clean client gets continuity without any custom header. Hashed
+   rather than used raw: `user` is arbitrary client data (often an email
+   or account id), and hashing keeps ids filesystem-uniform and keeps the
+   raw value out of session listings and checkpoint paths. '' in -> ''
+   out (no user field means stateless, exactly as before). Exposed for
+   tests. *)
+function SessionFromUserField(const UserVal: string): string;
+
 (* Resolve a /v1/responses request's tool_choice into the
    TChatOptions.ToolChoice convention: '' when absent/unrecognised (the
    provider default applies), 'auto'/'none'/'required', or a tool NAME to
@@ -647,6 +659,21 @@ begin
   for i := 1 to Length(S) do
     if S[i] <> '-' then
       Result := Result + UpCase(S[i]);
+end;
+
+function SessionFromUserField(const UserVal: string): string;
+var
+  Digest: TBytes;
+  i: Integer;
+begin
+  Result := '';
+  if Trim(UserVal) = '' then Exit;
+  Digest := SHA256Bytes(TEncoding.UTF8.GetBytes(Trim(UserVal)));
+  { 8 bytes = 16 hex chars -- ample for distinguishing client sessions,
+    short enough to stay readable in /v1/sessions listings. }
+  Result := 'user-';
+  for i := 0 to 7 do
+    Result := Result + LowerCase(IntToHex(Digest[i], 2));
 end;
 
 function CheckpointSessionId(const ReqSession: string): string;
@@ -4971,7 +4998,7 @@ procedure TGatewayServer.HandleChatCompletions(AContext: TIdContext;
    chunk, and the [DONE] terminator. The non-streaming path is
    unchanged: build the full chat.completion JSON and reply once. *)
 var
-  Body, ReqModel, FinishReason, CompId: string;
+  Body, ReqModel, FinishReason, CompId, ReqSession: string;
   Bytes: TBytes;
   Req, MsgObj: TJsonObject;
   MsgArr: TJsonArray;
@@ -5040,6 +5067,21 @@ begin
     ReqModel    := Req.GetStr('model', FCfg.DefaultModel);
     WantsStream := Req.GetBool('stream', False);
     AWasStreamingRequest := WantsStream;
+    { Session selection: an explicit X-PasClaw-Session header always wins
+      (the web UI and anything else that wants precise control). Without
+      one, derive a stable session from the OpenAI `user` field so
+      spec-compliant clients (SweetConsole, openai-python, ...) share an
+      agent session across calls just by reusing the same user string --
+      OpenClaw-compatible behaviour. Neither present -> '' = stateless,
+      the pre-existing default. }
+    ReqSession := ReqSessionId(ARequest);
+    if ReqSession = '' then
+    begin
+      ReqSession := SessionFromUserField(Req.GetStr('user', ''));
+      if (ReqSession <> '') and FDebugIO then
+        LogDebug('chat/completions: session derived from user field -> %s',
+                 [ReqSession]);
+    end;
     if FDebugIO then
       LogDebug('chat/completions: model=%s stream=%s temperature=%g max_tokens=%d',
                [ReqModel, BoolToStr(WantsStream, True),
@@ -5172,7 +5214,7 @@ begin
       LoopCfg.OnToolCall   := Streamer.NoteToolCall;
       LoopCfg.OnToolResult := Streamer.NoteToolResult;
       Streamer.WriteComment('connected');
-      if not RunCheckpointedLoop(ReqSessionId(ARequest), LoopCfg, Msgs, Loop) then
+      if not RunCheckpointedLoop(ReqSession, LoopCfg, Msgs, Loop) then
       begin
         if FDebugIO then LogDebug('chat/completions -> 502 (tool loop failed)');
         Streamer.WriteError('tool loop failed');
@@ -5245,7 +5287,7 @@ begin
     LoopCfg.OnToolCall   := ActivityCollector.OnToolCall;
     LoopCfg.OnToolResult := ActivityCollector.OnToolResult;
 
-    if not RunCheckpointedLoop(ReqSessionId(ARequest), LoopCfg, Msgs, Loop) then
+    if not RunCheckpointedLoop(ReqSession, LoopCfg, Msgs, Loop) then
     begin
       if FDebugIO then LogDebug('chat/completions -> 502 (tool loop failed)');
       WriteJSON(AResp, 502,

--- a/src/tests/gateway_stats_buckets_tests.pas
+++ b/src/tests/gateway_stats_buckets_tests.pas
@@ -263,11 +263,41 @@ begin
   end;
 end;
 
+procedure TestSessionFromUserField;
+{ /v1/chat/completions derives a session from the OpenAI `user` field
+  when no X-PasClaw-Session header is present (OpenClaw-compatible).
+  Pin the contract: stable per value, distinct across values, hashed
+  (raw user string never appears in the id), '' / blank -> stateless. }
+var
+  A, B: string;
+  i: Integer;
+begin
+  AssertEqStr(SessionFromUserField(''), '', 'no user field -> stateless');
+  AssertEqStr(SessionFromUserField('   '), '', 'blank user field -> stateless');
+
+  A := SessionFromUserField('sweetconsole-tasker');
+  B := SessionFromUserField('sweetconsole-tasker');
+  AssertEqStr(A, B, 'same user value -> same session across calls');
+  AssertTrue(A <> SessionFromUserField('sweetconsole-other'),
+             'different user values -> different sessions');
+  AssertEqStr(SessionFromUserField('  sweetconsole-tasker  '), A,
+              'surrounding whitespace does not change the session');
+
+  AssertEqStr(Copy(A, 1, 5), 'user-', 'derived id carries the user- prefix');
+  AssertEqInt(Length(A), 5 + 16, 'user- prefix + 16 hex chars');
+  for i := 6 to Length(A) do
+    AssertTrue(CharInSet(A[i], ['0'..'9', 'a'..'f']),
+               'hash part is lowercase hex');
+  AssertTrue(Pos('sweetconsole', A) = 0,
+             'raw user string never appears in the session id');
+end;
+
 begin
   TestLeadingUnderscoreIdIsSafe;
   TestBucketAccumulatesAcrossCalls;
   TestDistinctBucketsDontInterfere;
   TestRawHelperAccumulatesPassthroughTraffic;
   TestRawHelperRespectsStatsFlag;
+  TestSessionFromUserField;
   WriteLn('gateway_stats_buckets_tests: OK');
 end.


### PR DESCRIPTION
OpenAI's Chat Completions shape has no session field — the spec-standard identity-ish field is `user`. PasClaw kept session continuity behind the custom `X-PasClaw-Session` header, which spec-clean clients never send, so e.g. SweetConsole's per-project `session_id` (a nanobot extension pasclaw ignores) silently got a fresh session every call.

This adopts OpenClaw's convention:

- `X-PasClaw-Session` header present → wins, exactly as before (web UI unchanged).
- No header, but the standard `user` string present → derive a stable session id (`user-` + first 16 hex of SHA-256) so repeated calls with the same `user` share an agent session. Hashed rather than raw: `user` is arbitrary client data (often an account id/email) and the hash keeps it out of session listings and checkpoint paths.
- Neither present → stateless, the pre-existing default.

Scoped to `/v1/chat/completions` (both stream and non-stream paths) per request; `/v1/responses` could adopt the same two lines later.

## Verification

**Unit** — new `TestSessionFromUserField` in `gateway_stats_buckets_tests`: stable per value, distinct across values, whitespace-insensitive, `user-` + 16 lowercase hex shape, raw string never leaks into the id, empty/blank stays stateless. Suite green.

**Live** — `pasclaw serve --debug` + four curls:

```
{"user":"sweetconsole-tasker"}  -> session derived from user field -> user-87596bb9afd5ef57
{"user":"sweetconsole-tasker"}  -> session derived from user field -> user-87596bb9afd5ef57   (same)
{"user":"another-project"}      -> session derived from user field -> user-e1ef683353831756   (different)
X-PasClaw-Session: explicit-chat-7 + user field -> no derivation line (header wins)
```

With this, SweetConsole gets real cross-shot session continuity by sending `user` (or keeping its `session_id` value in `user`) — a one-line client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_