### PR TITLE
toolloop: recover from a truncated no-tool-call turn instead of ending

### DIFF
--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -382,6 +382,24 @@ begin
   end;
 end;
 
+function TruncatedOf(const Text: string): string;
+{ A turn that hit the output ceiling mid-generation: prose content, no
+  tool call, finish_reason=length (the shape Gemini/OpenAI return; the
+  loop also recognises Anthropic's raw 'max_tokens'). Models this as the
+  observed real-world failure -- a model narrating code as prose until it
+  runs out of tokens. }
+var O: TJsonObject;
+begin
+  O := TJsonObject.Create;
+  try
+    O.PutStr('content', Text);
+    O.PutStr('finish_reason', 'length');
+    Result := O.ToJSON;
+  finally
+    O.Free;
+  end;
+end;
+
 { ---- chat driver ---------------------------------------------------------- }
 function MsgObjJSON(const Role, Content: string): string;
 var O: TJsonObject;
@@ -818,6 +836,65 @@ begin
     'no-such-file error names the actual location');
 end;
 
+function H_TruncationRecovery(N: Integer; const EnvJSON: string): string;
+begin
+  case N of
+    { Turn 1: narrate the game as prose and run out of output tokens --
+      no tool call, finish=length. On main the loop returns this as the
+      finished answer and no file lands; the fix must retry instead. }
+    1: Result := TruncatedOf(
+         'Let me build this. ### Player drawing:'#10 +
+         'We draw the ship with rotation. ### Bullets:'#10 +
+         'procedure DrawBullet(X, Y: Integer);'#10 + 'begin'#10 + '  GotoXY(X, Y);');
+    { Turn 2: after the corrective nudge, actually call write_file. }
+    2: Result := RoundOf([OneCall('write_file',
+         ArgsPathContent('game.pas',
+           'program game;'#10 + 'begin'#10 + '  writeln(''ok'');'#10 + 'end.'#10))]);
+  else
+    Result := StopOf('done: wrote game.pas.');
+  end;
+end;
+
+procedure ScenarioTruncationRecovery;
+{ The live Gemini-3.5-Flash failure: a turn that hits the output-token
+  ceiling with no tool call must NOT be treated as a finished answer.
+  On main this scenario fails (loop ends at call 1, no file); with the
+  recovery it nudges toward tool use, retries, and the file lands. }
+var
+  Answer, SP1, SP2: string;
+begin
+  WriteLn;
+  WriteLn('== scenario: truncation-recovery (finish=length + no tool call must not end the turn) ==');
+  if FileExists(GHomeDir + '/workspace/game.pas') then
+    DeleteFile(GHomeDir + '/workspace/game.pas');
+  ResetScenario(H_TruncationRecovery);
+  Answer := Chat('[' + MsgObjJSON('user',
+    'build a small terminal game named game.pas') + ']', 'bench-trunc');
+
+  { Did not terminate on the truncated turn: it retried and delivered. }
+  Check(EnvCount = 3, Format('loop recovered across 3 provider calls (got %d)', [EnvCount]));
+  { Turn 1 is pristine -- no nudge before the truncation happens. }
+  SP1 := EnvSystemPrompt(EnvAt(0));
+  Check(not Has(SP1, 'cut off at the output token limit'),
+    'iteration 1 system prompt carries no truncation nudge yet');
+  { Turn 2 (the retry) carries the corrective nudge steering toward tools. }
+  SP2 := EnvSystemPrompt(EnvAt(1));
+  Check(Has(SP2, 'cut off at the output token limit'),
+    'retry system prompt carries the truncation nudge');
+  Check(Has(SP2, 'write_file') and Has(SP2, 'append_file'),
+    'nudge names the tools to use instead of prose');
+  { The truncated prose blob is dropped, not replayed into the retry. }
+  Check(not Has(SP2, 'DrawBullet'),
+    'the truncated prose is not re-injected into history on retry');
+  { The deliverable actually lands, and the final answer is the stop text,
+    not the half-written ramble. }
+  Check(FileExists(GHomeDir + '/workspace/game.pas'),
+    'deliverable written after recovery');
+  Check(Has(Answer, 'done:') and not Has(Answer, 'DrawBullet'),
+    'final answer is the real result, not the truncated prose');
+  Metric('truncrecovery.provider_calls', EnvCount);
+end;
+
 { ---- gateway lifecycle ---------------------------------------------------- }
 var
   GW: TProcess;
@@ -932,6 +1009,7 @@ begin
     ScenarioRepeatRead;
     ScenarioRealTask;
     ScenarioErrorGuidance;
+    ScenarioTruncationRecovery;
 
     WriteLn;
     WriteLn('== metrics ==');

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -556,7 +556,11 @@ begin
     sLineBreak +
     '1. **ALWAYS use tools** when an action is needed -- call the appropriate ' +
     'tool, do not just say you''ll do it or pretend the work was done. The ' +
-    'user will check.' + sLineBreak +
+    'user will check. In particular, NEVER write a file''s contents (or code ' +
+    'destined for a file) into your reply as prose or a code block: that ' +
+    'creates nothing on disk and risks being cut off at the output-token ' +
+    'limit mid-way. Put file content only inside a write_file / append_file / ' +
+    'apply_patch call.' + sLineBreak +
     sLineBreak +
     '2. **Be precise** -- match the language''s native idioms, name things ' +
     'clearly, do not introduce abstractions the task does not actually need. ' +

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1148,6 +1148,16 @@ begin
     Result := Result + sLineBreak + 'checklist state:' + sLineBreak + L.Checklist;
 end;
 
+function IsTruncatedFinish(const FR: string): Boolean;
+{ Provider-normalised truncation markers for "the model hit the output
+  token ceiling mid-generation". Gemini maps its native MAX_TOKENS to
+  'length' (PasClaw.Providers.Gemini), OpenAI passes 'length' through,
+  and Anthropic surfaces its raw stop_reason 'max_tokens'. Match all,
+  case-insensitively. }
+begin
+  Result := SameText(FR, 'length') or SameText(FR, 'max_tokens');
+end;
+
 function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
@@ -1156,6 +1166,19 @@ const
     around 4-5 to keep a runaway pusher from growing Hist unbounded.
     Drained messages beyond the cap are logged + dropped. }
   MaxSteeringPerTurn = 4;
+  { Truncation-recovery budget. A turn that hits the output ceiling with
+    no tool call gets a corrective nudge and a bounded number of retries
+    before the loop gives up and returns whatever partial text it has. }
+  MaxTruncRetries = 2;
+  TruncationNudgeText =
+    '[your previous reply was cut off at the output token limit and ' +
+    'contained no tool call, so NOTHING was saved]' + sLineBreak +
+    'Do NOT write file contents or code as prose in your reply -- that is ' +
+    'what just failed. To create or change a file you MUST call a tool: ' +
+    'write_file (whole file), append_file (add to the end -- build a large ' +
+    'file across several turns so you never hit the limit), or edit_file / ' +
+    'apply_patch (targeted changes). Emit the tool call now and keep any ' +
+    'prose to one short line.';
 var
   Iter, i, bi, j, fbi, sti: Integer;
   Tools: TToolDefinitionArray;
@@ -1172,6 +1195,8 @@ var
   LedgerBlock: string;
   ReadPaths, ReadHashes: TArray<string>;   { per-turn read-dedup state (C3) }
   Steers: TSteeringMessageArray;
+  TruncRetries: Integer;      { truncation-recovery: retries spent so far }
+  TruncNudgePending: Boolean; { fold the corrective nudge next iteration }
   InContext: string;       { tool output cap (#PR new): in-context
                              body that lands in Hist after the
                              optional StashAndMaybeTruncate pass }
@@ -1236,6 +1261,8 @@ begin
     Ledger.Goal := ExtractLoopGoal(Messages);
   SetLength(ReadPaths, 0);
   SetLength(ReadHashes, 0);
+  TruncRetries := 0;
+  TruncNudgePending := False;
 
   Iter := 0;
   { When progressive disclosure is on (PasClaw.MCP.Disclosure), the
@@ -1301,6 +1328,19 @@ begin
           LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + sLineBreak + sLineBreak;
         LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + LedgerBlock;
       end;
+    end;
+
+    { Truncation-recovery fold. A prior iteration hit the output ceiling
+      with no tool call (see the no-tool-call branch below); fold a
+      corrective nudge into THIS iteration's system prompt, then clear the
+      flag so a later clean turn doesn't carry it. Ephemeral like the
+      ledger -- restored to PersistentSP after the provider call. }
+    if TruncNudgePending then
+    begin
+      if LiveOptions.SystemPrompt <> '' then
+        LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + sLineBreak + sLineBreak;
+      LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + TruncationNudgeText;
+      TruncNudgePending := False;
     end;
 
     { Mid-loop steering: drain any user follow-ups that arrived
@@ -1565,6 +1605,24 @@ begin
 
     if Length(Resp.ToolCalls) = 0 then
     begin
+      { Truncated mid-turn with no tool call: the model hit the output
+        token ceiling (finish_reason length / max_tokens) -- most often
+        while narrating code as prose instead of calling write_file -- so
+        nothing was saved. Do NOT treat this as a finished answer (the old
+        behaviour returned the half-written ramble as Loop.Content and the
+        turn silently produced no file). Fold a corrective nudge and retry,
+        bounded by MaxTruncRetries. The partial content is intentionally
+        dropped (not appended to Hist) so the truncated prose blob doesn't
+        bloat context on the retry. }
+      if IsTruncatedFinish(Resp.FinishReason) and (TruncRetries < MaxTruncRetries) then
+      begin
+        Inc(TruncRetries);
+        TruncNudgePending := True;
+        LogWarn('toolloop: truncated turn (finish=%s) with no tool call; ' +
+                'nudging toward tool use, retry %d/%d',
+                [Resp.FinishReason, TruncRetries, MaxTruncRetries]);
+        Continue;
+      end;
       Loop.Content    := Resp.Content;
       Loop.Iterations := Iter;
       Loop.FinalMessages    := Hist;

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1158,6 +1158,26 @@ begin
   Result := SameText(FR, 'length') or SameText(FR, 'max_tokens');
 end;
 
+function HasWritingTool(const Tools: TToolDefinitionArray): Boolean;
+{ True when at least one file-writing tool is on offer this turn. The
+  truncation nudge steers the model toward write_file/append_file/etc, so
+  it only makes sense when such a tool actually exists. In a no-tools or
+  read-only session (Registry=nil, UseTools=False, plan mode) a truncated
+  no-tool-call turn is just a long text answer -- its content IS the
+  deliverable and must be returned, not retried against absent tools. }
+const
+  Writers: array[0..5] of string = (
+    'write_file', 'append_file', 'edit_file', 'apply_patch',
+    'fs_write', 'fs_edit_hashline');
+var
+  i, j: Integer;
+begin
+  Result := False;
+  for i := 0 to High(Tools) do
+    for j := Low(Writers) to High(Writers) do
+      if SameText(Tools[i].Name, Writers[j]) then Exit(True);
+end;
+
 function RunToolLoop(const Cfg: TToolLoopConfig;
                      var Messages: array of TMessage;
                      out Loop: TToolLoopResult): Boolean;
@@ -1614,7 +1634,13 @@ begin
         bounded by MaxTruncRetries. The partial content is intentionally
         dropped (not appended to Hist) so the truncated prose blob doesn't
         bloat context on the retry. }
-      if IsTruncatedFinish(Resp.FinishReason) and (TruncRetries < MaxTruncRetries) then
+      { Gate on a writing tool actually being available and build mode:
+        the nudge steers toward write_file/append_file, so in a no-tools /
+        read-only / plan session the truncated text is the deliverable and
+        must be returned as-is (with finish=length) rather than dropped and
+        retried against tools that don't exist. }
+      if IsTruncatedFinish(Resp.FinishReason) and (TruncRetries < MaxTruncRetries)
+         and (Cfg.Mode <> pmPlan) and HasWritingTool(Tools) then
       begin
         Inc(TruncRetries);
         TruncNudgePending := True;

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -68,6 +68,7 @@ type
     Prompts: array of string;
     procedure AddToolRound(const Calls: array of TToolCall);
     procedure AddStop(const Text: string);
+    procedure AddTruncated(const Text: string);
     function Chat(const Messages: array of TMessage;
                   const Tools:    array of TToolDefinition;
                   const Model:    string;
@@ -105,6 +106,20 @@ begin
   R := Default(TLLMResponse);
   R.StatusCode := 200;
   R.FinishReason := 'stop';
+  R.Content := Text;
+  SetLength(Script, Length(Script) + 1);
+  Script[High(Script)] := R;
+end;
+
+procedure TScripted.AddTruncated(const Text: string);
+{ A turn that hit the output ceiling: text content, no tool call,
+  finish_reason=length. }
+var
+  R: TLLMResponse;
+begin
+  R := Default(TLLMResponse);
+  R.StatusCode := 200;
+  R.FinishReason := 'length';
   R.Content := Text;
   SetLength(Script, Length(Script) + 1);
   Script[High(Script)] := R;
@@ -392,6 +407,68 @@ begin
   end;
 end;
 
+procedure TestTruncationRecoveryWithTools;
+{ A truncated (finish=length) no-tool-call turn in a tool-enabled build
+  session must NOT end the loop: fold a nudge, retry, and let the write land. }
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+begin
+  if FileExists(FileA) then DeleteFile(FileA);
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    P.AddTruncated('Let me build this. ### Bullets: procedure DrawBullet(X,Y: Integer); begin');
+    P.AddToolRound([MkCall('write_file', '{"path":"' + FileA + '","content":"ok"}')]);
+    P.AddStop('done');
+
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'build a small demo in the workspace');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    AssertTrue(Length(P.Prompts) = 3,
+      'truncated turn retried, then wrote, then stopped (3 calls)');
+    AssertHas(P.Prompts[1], 'cut off at the output token limit',
+      'retry prompt carries the truncation nudge');
+    AssertHas(P.Prompts[1], 'write_file', 'nudge names the writing tool');
+    AssertTrue(FileExists(FileA), 'deliverable landed after recovery');
+    AssertNot(Loop.Content, 'DrawBullet', 'final content is not the truncated prose');
+    WriteLn('  ok: tool-enabled truncated turn recovers, nudges, and delivers');
+  finally
+    Reg.Free;
+  end;
+end;
+
+procedure TestTruncationNoToolsReturnsContent;
+{ Review fix (P2 on #420): with no writing tool available (Registry=nil /
+  UseTools=False / plan mode), a truncated no-tool-call turn is a long TEXT
+  answer -- its content is the deliverable. It must be returned as-is, NOT
+  dropped and retried against tools that don't exist. }
+var
+  P: TScripted;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+begin
+  P := TScripted.Create;
+  Cfg := BaseCfg(P);   { Registry stays nil -> no tools on offer }
+  P.AddTruncated('Here is a long explanation that got cut off at the limit');
+  P.AddStop('SHOULD-NOT-REACH');
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, 'explain this topic at length');
+  AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+  AssertTrue(Length(P.Prompts) = 1,
+    'no-tools truncated turn is returned, not retried (single provider call)');
+  AssertHas(Loop.Content, 'long explanation that got cut off',
+    'the truncated text is returned as the deliverable');
+  WriteLn('  ok: no-tools truncated answer returned as-is, no nudge, no retry');
+end;
+
 var
   Pol: TSandboxPolicy;
 begin
@@ -408,6 +485,8 @@ begin
   TestGoalSkipsMicroTurns;
   TestRepeatReadDedup;
   TestDisableSwitch;
+  TestTruncationRecoveryWithTools;
+  TestTruncationNoToolsReturnsContent;
 
   if FileExists(FileA) then DeleteFile(FileA);
   RemoveDir(WsDir);


### PR DESCRIPTION
## The bug (observed live)

`RunToolLoop` treated **any** response with no tool calls as a finished answer (`Exit(True)`), ignoring `finish_reason`. So when a model hit the output-token ceiling mid-generation — most often while **narrating code as prose** instead of calling `write_file` — the loop returned the half-written ramble as the answer and the turn silently produced no file.

Seen live with **Gemini 3.5 Flash** on a "build Asteroids" prompt: iterations 1–4 went fine (planned, checked `fpc`, wrote+compiled a probe), then on iteration 5 it free-typed the game as a design doc (`"### Bullets drawing: ... procedure DrawCharWrapped..."`), hit `finish=length`, and the loop stopped with nothing on disk.

## The fix

A no-tool-call turn whose `finish_reason` marks truncation — `length` (OpenAI/Gemini; Gemini's native `MAX_TOKENS` is normalized to `length` in the provider) or `max_tokens` (Anthropic's raw `stop_reason`) — now folds a corrective nudge into the next iteration's system prompt and **retries**, bounded by `MaxTruncRetries = 2`, instead of terminating. The nudge steers back to `write_file`/`append_file`/`apply_patch`. The truncated prose is **dropped** (not appended to history) so it can't bloat the retry.

`Rule 1` of the system prompt now also explicitly forbids writing file contents as prose — attacking the root behaviour, not just the symptom.

Scope note: this makes truncation **non-fatal regardless of the output cap.** The separate `max_tokens` output-ceiling change (OpenAI/Gemini already omit when 0; Anthropic requires the field; OpenAI-compatible backends may default low) is delicate and provider-specific, so it's a deliberate follow-up PR rather than bundled here.

## Verified before/after (same bench, one binary each)

New `truncation-recovery` scenario returns `finish=length` + prose + no tool call:

| | `truncrecovery.provider_calls` | file written? |
|---|---|---|
| **main** | **1** (loop ends at the truncated turn) | ❌ no — returns the prose ramble |
| **this branch** | **3** (nudge folded, retried) | ✅ `game.pas` on disk, real answer |

Full 8-scenario agent-loop bench green on-branch; `progress_ledger`, `stream_reliability`, and `smoke` all green. The scenario **fails on main** (5 assertions) and passes here — closing the "bench passes, reality fails" gap for this class of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_