### PR TITLE
toolloop: recover from MALFORMED_FUNCTION_CALL turns too, not just length

### DIFF
--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -382,18 +382,18 @@ begin
   end;
 end;
 
-function TruncatedOf(const Text: string): string;
-{ A turn that hit the output ceiling mid-generation: prose content, no
-  tool call, finish_reason=length (the shape Gemini/OpenAI return; the
-  loop also recognises Anthropic's raw 'max_tokens'). Models this as the
-  observed real-world failure -- a model narrating code as prose until it
-  runs out of tokens. }
+function TruncatedOf(const Text, Finish: string): string;
+{ A no-tool-call turn that failed recoverably: prose content, no tool call,
+  finish_reason = 'length' (output ceiling; Gemini/OpenAI) or
+  'MALFORMED_FUNCTION_CALL' (Gemini emitted an unparseable / oversized call
+  alongside narration). Both are the observed real-world Gemini 3.5 Flash
+  failure -- narrating code as prose until it runs out or malforms. }
 var O: TJsonObject;
 begin
   O := TJsonObject.Create;
   try
     O.PutStr('content', Text);
-    O.PutStr('finish_reason', 'length');
+    O.PutStr('finish_reason', Finish);
     Result := O.ToJSON;
   finally
     O.Free;
@@ -839,13 +839,15 @@ end;
 function H_TruncationRecovery(N: Integer; const EnvJSON: string): string;
 begin
   case N of
-    { Turn 1: narrate the game as prose and run out of output tokens --
-      no tool call, finish=length. On main the loop returns this as the
-      finished answer and no file lands; the fix must retry instead. }
+    { Turn 1: narrate the game as prose and emit a malformed function call --
+      finish=MALFORMED_FUNCTION_CALL, no usable tool call. This is the exact
+      live Gemini 3.5 Flash failure. On main the loop returns this narration
+      as the finished answer and no file lands; the fix must retry instead. }
     1: Result := TruncatedOf(
          'Let me build this. ### Player drawing:'#10 +
          'We draw the ship with rotation. ### Bullets:'#10 +
-         'procedure DrawBullet(X, Y: Integer);'#10 + 'begin'#10 + '  GotoXY(X, Y);');
+         'procedure DrawBullet(X, Y: Integer);'#10 + 'begin'#10 + '  GotoXY(X, Y);',
+         'MALFORMED_FUNCTION_CALL');
     { Turn 2: after the corrective nudge, actually call write_file. }
     2: Result := RoundOf([OneCall('write_file',
          ArgsPathContent('game.pas',
@@ -864,23 +866,23 @@ var
   Answer, SP1, SP2: string;
 begin
   WriteLn;
-  WriteLn('== scenario: truncation-recovery (finish=length + no tool call must not end the turn) ==');
+  WriteLn('== scenario: recovery (finish=MALFORMED_FUNCTION_CALL + no tool call must not end the turn) ==');
   if FileExists(GHomeDir + '/workspace/game.pas') then
     DeleteFile(GHomeDir + '/workspace/game.pas');
   ResetScenario(H_TruncationRecovery);
   Answer := Chat('[' + MsgObjJSON('user',
     'build a small terminal game named game.pas') + ']', 'bench-trunc');
 
-  { Did not terminate on the truncated turn: it retried and delivered. }
+  { Did not terminate on the malformed turn: it retried and delivered. }
   Check(EnvCount = 3, Format('loop recovered across 3 provider calls (got %d)', [EnvCount]));
-  { Turn 1 is pristine -- no nudge before the truncation happens. }
+  { Turn 1 is pristine -- no nudge before the failure happens. }
   SP1 := EnvSystemPrompt(EnvAt(0));
-  Check(not Has(SP1, 'cut off at the output token limit'),
-    'iteration 1 system prompt carries no truncation nudge yet');
+  Check(not Has(SP1, 'no usable tool call'),
+    'iteration 1 system prompt carries no recovery nudge yet');
   { Turn 2 (the retry) carries the corrective nudge steering toward tools. }
   SP2 := EnvSystemPrompt(EnvAt(1));
-  Check(Has(SP2, 'cut off at the output token limit'),
-    'retry system prompt carries the truncation nudge');
+  Check(Has(SP2, 'no usable tool call'),
+    'retry system prompt carries the recovery nudge');
   Check(Has(SP2, 'write_file') and Has(SP2, 'append_file'),
     'nudge names the tools to use instead of prose');
   { The truncated prose blob is dropped, not replayed into the retry. }

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1148,14 +1148,23 @@ begin
     Result := Result + sLineBreak + 'checklist state:' + sLineBreak + L.Checklist;
 end;
 
-function IsTruncatedFinish(const FR: string): Boolean;
-{ Provider-normalised truncation markers for "the model hit the output
-  token ceiling mid-generation". Gemini maps its native MAX_TOKENS to
-  'length' (PasClaw.Providers.Gemini), OpenAI passes 'length' through,
-  and Anthropic surfaces its raw stop_reason 'max_tokens'. Match all,
-  case-insensitively. }
+function IsRetryableNoToolFinish(const FR: string): Boolean;
+{ finish_reasons that make a no-tool-call turn a FAILURE to recover from
+  rather than a finished answer. Two shapes, same remedy (retry + a nudge
+  toward a real tool call / chunked writes):
+    - Output-ceiling truncation: 'length' (OpenAI, and Gemini which maps its
+      native MAX_TOKENS here) or 'max_tokens' (Anthropic's raw stop_reason).
+    - Gemini's MALFORMED_FUNCTION_CALL: the model emitted a function call it
+      couldn't serialise -- classically one oversized argument (a whole file
+      crammed into write_file.content). When it ALSO produced narration text
+      (Content<>''), the provider-level empty-turn retry
+      (PasClaw.Stream.Reliability.IsEmptyTurn, which requires Content='')
+      does not fire, so without this the turn exits with the half-narration
+      and nothing on disk (observed live with Gemini 3.5 Flash). }
 begin
-  Result := SameText(FR, 'length') or SameText(FR, 'max_tokens');
+  Result := SameText(FR, 'length')
+         or SameText(FR, 'max_tokens')
+         or SameText(FR, 'MALFORMED_FUNCTION_CALL');
 end;
 
 function HasWritingTool(const Tools: TToolDefinitionArray): Boolean;
@@ -1190,15 +1199,16 @@ const
     no tool call gets a corrective nudge and a bounded number of retries
     before the loop gives up and returns whatever partial text it has. }
   MaxTruncRetries = 2;
-  TruncationNudgeText =
-    '[your previous reply was cut off at the output token limit and ' +
-    'contained no tool call, so NOTHING was saved]' + sLineBreak +
-    'Do NOT write file contents or code as prose in your reply -- that is ' +
-    'what just failed. To create or change a file you MUST call a tool: ' +
-    'write_file (whole file), append_file (add to the end -- build a large ' +
-    'file across several turns so you never hit the limit), or edit_file / ' +
-    'apply_patch (targeted changes). Emit the tool call now and keep any ' +
-    'prose to one short line.';
+  RecoveryNudgeText =
+    '[your previous reply produced no usable tool call -- it was cut off at ' +
+    'the output-token limit, or the function call was too large to parse -- ' +
+    'so NOTHING was saved]' + sLineBreak +
+    'Do NOT write file contents or code as prose in your reply, and do NOT ' +
+    'cram a whole file into one tool call. To create or change a file, call ' +
+    'a tool: write_file (whole file), append_file (add to the end -- build a ' +
+    'large file across several turns so no single call is too big), or ' +
+    'edit_file / apply_patch (targeted changes). Emit ONE tool call now and ' +
+    'keep any prose to one short line.';
 var
   Iter, i, bi, j, fbi, sti: Integer;
   Tools: TToolDefinitionArray;
@@ -1350,16 +1360,17 @@ begin
       end;
     end;
 
-    { Truncation-recovery fold. A prior iteration hit the output ceiling
-      with no tool call (see the no-tool-call branch below); fold a
-      corrective nudge into THIS iteration's system prompt, then clear the
-      flag so a later clean turn doesn't carry it. Ephemeral like the
-      ledger -- restored to PersistentSP after the provider call. }
+    { No-tool-call recovery fold. A prior iteration ended with no usable tool
+      call for a recoverable reason (output-ceiling truncation or a malformed
+      function call -- see the no-tool-call branch below); fold a corrective
+      nudge into THIS iteration's system prompt, then clear the flag so a
+      later clean turn doesn't carry it. Ephemeral like the ledger --
+      restored to PersistentSP after the provider call. }
     if TruncNudgePending then
     begin
       if LiveOptions.SystemPrompt <> '' then
         LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + sLineBreak + sLineBreak;
-      LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + TruncationNudgeText;
+      LiveOptions.SystemPrompt := LiveOptions.SystemPrompt + RecoveryNudgeText;
       TruncNudgePending := False;
     end;
 
@@ -1625,26 +1636,26 @@ begin
 
     if Length(Resp.ToolCalls) = 0 then
     begin
-      { Truncated mid-turn with no tool call: the model hit the output
-        token ceiling (finish_reason length / max_tokens) -- most often
-        while narrating code as prose instead of calling write_file -- so
-        nothing was saved. Do NOT treat this as a finished answer (the old
-        behaviour returned the half-written ramble as Loop.Content and the
-        turn silently produced no file). Fold a corrective nudge and retry,
-        bounded by MaxTruncRetries. The partial content is intentionally
-        dropped (not appended to Hist) so the truncated prose blob doesn't
-        bloat context on the retry. }
-      { Gate on a writing tool actually being available and build mode:
-        the nudge steers toward write_file/append_file, so in a no-tools /
-        read-only / plan session the truncated text is the deliverable and
-        must be returned as-is (with finish=length) rather than dropped and
-        retried against tools that don't exist. }
-      if IsTruncatedFinish(Resp.FinishReason) and (TruncRetries < MaxTruncRetries)
+      { No usable tool call for a recoverable reason: the model hit the
+        output ceiling (finish=length / max_tokens) OR emitted a malformed
+        function call (finish=MALFORMED_FUNCTION_CALL) -- most often while
+        narrating code as prose, or cramming a whole file into one oversized
+        call -- so nothing was saved. Do NOT treat this as a finished answer
+        (the old behaviour returned the half-written ramble as Loop.Content
+        and the turn silently produced no file). Fold a corrective nudge and
+        retry, bounded by MaxTruncRetries. The partial content is dropped
+        (not appended to Hist) so the ramble doesn't bloat the retry.
+
+        Gate on a writing tool being available and build mode: the nudge
+        steers toward write_file/append_file, so in a no-tools / read-only /
+        plan session the text is the deliverable and must be returned as-is
+        rather than dropped and retried against tools that don't exist. }
+      if IsRetryableNoToolFinish(Resp.FinishReason) and (TruncRetries < MaxTruncRetries)
          and (Cfg.Mode <> pmPlan) and HasWritingTool(Tools) then
       begin
         Inc(TruncRetries);
         TruncNudgePending := True;
-        LogWarn('toolloop: truncated turn (finish=%s) with no tool call; ' +
+        LogWarn('toolloop: unrecoverable turn (finish=%s) with no tool call; ' +
                 'nudging toward tool use, retry %d/%d',
                 [Resp.FinishReason, TruncRetries, MaxTruncRetries]);
         Continue;

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -68,7 +68,7 @@ type
     Prompts: array of string;
     procedure AddToolRound(const Calls: array of TToolCall);
     procedure AddStop(const Text: string);
-    procedure AddTruncated(const Text: string);
+    procedure AddTruncated(const Text: string; const Finish: string = 'length');
     function Chat(const Messages: array of TMessage;
                   const Tools:    array of TToolDefinition;
                   const Model:    string;
@@ -111,15 +111,15 @@ begin
   Script[High(Script)] := R;
 end;
 
-procedure TScripted.AddTruncated(const Text: string);
-{ A turn that hit the output ceiling: text content, no tool call,
-  finish_reason=length. }
+procedure TScripted.AddTruncated(const Text: string; const Finish: string);
+{ A no-tool-call turn that failed recoverably: text content, no tool call,
+  finish_reason = length (output ceiling) or MALFORMED_FUNCTION_CALL. }
 var
   R: TLLMResponse;
 begin
   R := Default(TLLMResponse);
   R.StatusCode := 200;
-  R.FinishReason := 'length';
+  R.FinishReason := Finish;
   R.Content := Text;
   SetLength(Script, Length(Script) + 1);
   Script[High(Script)] := R;
@@ -407,8 +407,8 @@ begin
   end;
 end;
 
-procedure TestTruncationRecoveryWithTools;
-{ A truncated (finish=length) no-tool-call turn in a tool-enabled build
+procedure RunRecoveryCase(const Finish: string);
+{ A no-tool-call turn that failed for `Finish` in a tool-enabled build
   session must NOT end the loop: fold a nudge, retry, and let the write land. }
 var
   P: TScripted;
@@ -424,24 +424,30 @@ begin
     P := TScripted.Create;
     Cfg := BaseCfg(P);
     Cfg.Registry := Reg;
-    P.AddTruncated('Let me build this. ### Bullets: procedure DrawBullet(X,Y: Integer); begin');
+    P.AddTruncated('Let me build this. ### Bullets: procedure DrawBullet(X,Y: Integer); begin', Finish);
     P.AddToolRound([MkCall('write_file', '{"path":"' + FileA + '","content":"ok"}')]);
     P.AddStop('done');
 
     SetLength(Msgs, 1);
     Msgs[0] := MakeMessage(mrUser, 'build a small demo in the workspace');
-    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran (' + Finish + ')');
     AssertTrue(Length(P.Prompts) = 3,
-      'truncated turn retried, then wrote, then stopped (3 calls)');
-    AssertHas(P.Prompts[1], 'cut off at the output token limit',
-      'retry prompt carries the truncation nudge');
-    AssertHas(P.Prompts[1], 'write_file', 'nudge names the writing tool');
-    AssertTrue(FileExists(FileA), 'deliverable landed after recovery');
-    AssertNot(Loop.Content, 'DrawBullet', 'final content is not the truncated prose');
-    WriteLn('  ok: tool-enabled truncated turn recovers, nudges, and delivers');
+      Finish + ': failed turn retried, then wrote, then stopped (3 calls)');
+    AssertHas(P.Prompts[1], 'no usable tool call',
+      Finish + ': retry prompt carries the recovery nudge');
+    AssertHas(P.Prompts[1], 'write_file', Finish + ': nudge names the writing tool');
+    AssertTrue(FileExists(FileA), Finish + ': deliverable landed after recovery');
+    AssertNot(Loop.Content, 'DrawBullet', Finish + ': final content is not the ramble');
   finally
     Reg.Free;
   end;
+end;
+
+procedure TestTruncationRecoveryWithTools;
+begin
+  RunRecoveryCase('length');                    { output-ceiling truncation }
+  RunRecoveryCase('MALFORMED_FUNCTION_CALL');   { Gemini malformed call + narration }
+  WriteLn('  ok: tool-enabled length + MALFORMED_FUNCTION_CALL turns recover, nudge, and deliver');
 end;
 
 procedure TestTruncationNoToolsReturnsContent;


### PR DESCRIPTION
Follow-up to #420. That PR made the loop retry a no-tool-call turn that hit the **output ceiling** (`finish=length` / `max_tokens`). But Gemini's *other* big-write failure still slipped through: **`finish=MALFORMED_FUNCTION_CALL`**, where the model emits an unparseable/oversized function call **alongside narration text**.

Why it fell through: the provider-level empty-turn retry (`Stream.Reliability.IsEmptyTurn`) only fires when `Content=''`, and in this case content carries the "I will write the full implementation…" narration. So the turn hit `RunToolLoop`'s clean-stop exit and ended with a half-written ramble and nothing on disk — the exact live Gemini 3.5 Flash trace.

## Change

Fold `MALFORMED_FUNCTION_CALL` into the same recovery path (`IsTruncatedFinish` → `IsRetryableNoToolFinish`). Same gates as #420 (a writing tool is available, not plan mode), same bounded retry (`MaxTruncRetries=2`), same ephemeral nudge — now broadened to also warn against cramming a whole file into one oversized call and to steer toward `append_file` for chunked writes.

No-tools / read-only / plan sessions are unaffected: a `MALFORMED_FUNCTION_CALL` with no writing tool still returns its content as-is rather than retrying against absent tools.

## Verified before/after (same bench binary)

The recovery scenario now returns `finish=MALFORMED_FUNCTION_CALL` + narration + no tool call:

| | `truncrecovery.provider_calls` | file written? |
|---|---|---|
| **main** (has #420) | **1** (ends at the malformed turn) | ❌ returns the narration |
| **this branch** | **3** (nudge, retry, write) | ✅ `game.pas` on disk |

- Unit test (`progress_ledger_tests`) now exercises **both** `length` and `MALFORMED_FUNCTION_CALL` recovery, and the no-tools-returns-content guard still holds.
- Full 8-scenario agent-loop bench, `stream_reliability`, and `smoke` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_