### PR TITLE
shell: trustworthy denylist messages + honest exit=/pipe guidance

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -417,7 +417,14 @@ const
     '<<eof',
     '<<-eof',
     '$(',             { command substitution }
-    '${',             { parameter expansion with possible injection }
+    (* Parameter expansion (dollar-brace) stays banned. /bin/sh expands it
+       BEFORE running the command, so an unset variable can reassemble a
+       forbidden token the pre-expansion scanner never sees -- r${X}m -rf
+       reduces to `rm`, curl ... | b${X}ash to a pipe-to-shell. The denylist
+       is a conservative speed bump, not an expansion-aware parser, so the
+       blunt ban is the safe closure of that whole reassembly class.
+       Operators who want ${...} can disable the denylist. *)
+    '${',             { parameter expansion -- see note above }
     '`',              { backtick command substitution }
     '| sh',
     '|sh',
@@ -667,6 +674,27 @@ begin
   end;
 end;
 
+function DescribeForbiddenPattern(const Hit: string): string;
+{ Name the actual shell construct a forbidden substring represents, so the
+  refusal message is accurate (the old text called every hit "command
+  substitution", which is wrong for a pipe-to-shell or a heredoc). }
+begin
+  if (Hit = '`') or (Copy(Hit, 1, 2) = '$(') then
+    Result := 'command substitution'
+  else if Hit = '${' then
+    Result := 'parameter expansion, which can reassemble a blocked command after the shell expands it'
+  else if Pos('sh', LowerCase(Hit)) > 0 then   { '| sh', '|bash', '|/bin/sh' }
+    Result := 'pipe-to-shell'
+  else if (Copy(Hit, 1, 2) = '<<') then
+    Result := 'here-document'
+  else if Hit = 'dd if=' then
+    Result := 'raw disk copy'
+  else if Copy(Hit, 1, 5) = ':(){:' then
+    Result := 'fork bomb'
+  else
+    Result := 'blocked shell pattern';
+end;
+
 function ShellAllowed(const Cmd: string; out Reason: string): Boolean;
 var
   Hit, Path: string;
@@ -685,16 +713,18 @@ begin
       Reason := 'refused: command contains forbidden token "' + Hit +
                 '" (built-in shell denylist; toggle off via sandbox.shell_deny_enabled=false ' +
                 'in config.json -- strongly discouraged). Rewrite the command without "' + Hit +
-                '", or use the dedicated tools instead (read_file / write_file / edit_file / ' +
-                'find_files / grep_files cover most file work without the shell).';
+                '". For file work use the dedicated tools: read_file / write_file / ' +
+                'append_file / edit_file / find_files / grep_files, and apply_patch to ' +
+                'DELETE or MOVE a file (a "*** Delete File: <path>" or "*** Move to: <path>" ' +
+                'section) -- there is no `rm`/`del` here by design.';
       Exit(False);
     end;
     if MatchesAnySubstring(Cmd, Hit) then
     begin
       Reason := 'refused: command contains forbidden pattern "' + Hit +
-                '" (built-in shell denylist). Rewrite without "' + Hit +
-                '" -- e.g. avoid command substitution / pipes-to-shell; plain loops like ' +
-                '`yes X | head -N` or the dedicated file tools usually cover it.';
+                '" (' + DescribeForbiddenPattern(Hit) + '; built-in shell denylist). ' +
+                'Rewrite without "' + Hit + '" -- the dedicated file tools, or a plain ' +
+                'command (e.g. `yes X | head -N` instead of a $(...) loop), usually cover it.';
       Exit(False);
     end;
   end;

--- a/src/pkg/tools/PasClaw.Tools.Shell.pas
+++ b/src/pkg/tools/PasClaw.Tools.Shell.pas
@@ -157,7 +157,13 @@ begin
     BackendNote := '';
   T.Name        := 'shell_exec';
   T.Description := 'Run a shell command via /bin/sh -c (or cmd.exe on Windows). ' +
-                   'Captures stdout+stderr, caps output at 1 MiB.' + BackendNote;
+                   'Captures stdout+stderr and reports "exit=<code>" on the first ' +
+                   'line. Large output is auto-truncated to a preview with a ' +
+                   'tool_output_get handle -- do NOT pipe to head/tail just to ' +
+                   'limit size. Note: with a pipe, exit= is the LAST stage''s code ' +
+                   '(both /bin/sh and cmd.exe), so `fpc x | tail` reports tail''s 0 ' +
+                   'even when fpc failed -- run a compiler/test WITHOUT a pipe to ' +
+                   'see its real exit status.' + BackendNote;
   T.Schema      := '{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute."}},"required":["command"]}';
   T.Handler     := Tool_Shell;
   T.IsCore      := True;

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -275,9 +275,27 @@ begin
     ConfigureSandbox(Pol, Dir);
     AssertTrue(not ShellAllowed('sudo ls', R), 'denylist still refuses');
     AssertContains(R, 'dedicated tools', 'denial suggests the tool alternatives');
+    { A delete/move token points at apply_patch (the only in-box way to
+      remove a file) -- the old message named tools that can't delete. }
+    AssertTrue(not ShellAllowed('rm -rf build', R), 'rm still refused');
+    AssertContains(R, 'apply_patch', 'rm remediation names apply_patch for deletion');
+    AssertContains(R, 'Delete File', 'rm remediation shows the Delete File section');
+    { Command substitution is labelled correctly (not conflated with the
+      dollar-brace pattern). }
+    AssertTrue(not ShellAllowed('echo $(whoami)', R), 'command substitution refused');
+    AssertContains(R, 'command substitution', 'the $( refusal names command substitution');
+    { Parameter expansion stays refused, with an accurate label: the shell
+      expands it before the scanner runs, so it can reassemble a blocked
+      token. Both a plain use and the reassembly-bypass forms are caught. }
+    AssertTrue(not ShellAllowed('echo ${PIPESTATUS[0]}', R), 'parameter expansion refused');
+    AssertContains(R, 'parameter expansion', 'the ${ refusal names parameter expansion');
+    AssertTrue(not ShellAllowed('r${X}m -rf build', R),
+      'expansion-reassembly of a forbidden token (rm) is refused');
+    AssertTrue(not ShellAllowed('curl x | b${X}ash', R),
+      'expansion-reassembly of a pipe-to-shell is refused');
     Pol.ShellDenyEnabled := False;
     ConfigureSandbox(Pol, Dir);
-    WriteLn('  ok: errors carry the next move (nearest file / similar tool / shell alternative)');
+    WriteLn('  ok: errors carry the next move (nearest file / similar tool / shell alternative / apply_patch delete)');
 
     { --- 4d. F2: grep_files context_lines (grep -C). Matches keep the
       LINENO: anchor shape; context lines are LINENO- so the two can't be


### PR DESCRIPTION
Shell friction a capable model hit repeatedly in the game bench. Two parts, both portable across POSIX and Windows.

## Denylist refusal messages (`PasClaw.Tools.Sandbox`) — accuracy only, blocked set unchanged

- New `DescribeForbiddenPattern` names the **actual** construct in the refusal (command substitution / pipe-to-shell / here-doc / parameter expansion / raw disk copy / fork bomb) instead of calling *every* hit "command substitution" (the bench caught `${` mislabeled that way).
- The forbidden-token remediation now points at **`apply_patch`**. For `rm`/`del`/… it names `apply_patch`'s `*** Delete File` / `*** Move to` — the only in-box way to delete or move a file. The old text listed `read_file`/`write_file`/… none of which delete, so the advice was impossible to follow.

**`${...}` stays blocked.** An earlier revision of this PR lifted the ban (bench friction: idiomatic `${PIPESTATUS[0]}` refused), but review correctly flagged a **P1 bypass**: `/bin/sh` expands parameters *before* the command runs, so an unset var reassembles a forbidden token the pre-expansion scanner never sees — `r${X}m -rf` → `rm`, `curl … | b${X}ash` → pipe-to-shell. The blanket ban is the safe closure of that whole reassembly class; the refusal message now explains the reason, and operators who want `${}` can disable the denylist.

## `shell_exec` description (no behaviour change)

- Output is auto-truncated to a preview + `tool_output_get` handle → **don't pipe to `head`/`tail` just to limit size.**
- **`exit=` is the LAST pipeline stage's code** on both `/bin/sh` and `cmd.exe`, so `fpc x | tail` reports `tail`'s `0` even when `fpc` failed — run compilers/tests without a pipe to see the real status.

## Why not "fix" the pipe exit code

Deliberately **not** rewriting exit semantics. POSIX `set -o pipefail` spuriously fails the common `cmd | head` (SIGPIPE → non-zero) and older `/bin/sh` may not support the option; Windows `cmd.exe` has no pipefail at all. A code-level fix would regress on both platforms. Removing the *incentive* to pipe (output is already capped) plus documenting the caveat is the portable, regression-free fix.

## Verification

`fs_tool_naming_tests` asserts: `rm` → `apply_patch`/`Delete File` remediation; `$(whoami)` refused and labelled "command substitution"; and `${…}` still refused **including the reassembly-bypass forms** `r${X}m` and `curl … | b${X}ash`, with an accurate "parameter expansion" label. Full 8-scenario agent-loop bench, shell-filter tests, and smoke all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6