### PR TITLE
toolloop: elide oversized tool-call args from replayed history

### DIFF
--- a/bench/agentloop/agentloop_bench.pas
+++ b/bench/agentloop/agentloop_bench.pas
@@ -897,6 +897,61 @@ begin
   Metric('truncrecovery.provider_calls', EnvCount);
 end;
 
+function H_HistElide(N: Integer; const EnvJSON: string): string;
+begin
+  case N of
+    { Turn 1: write a big (40 KB) file. Without elision this whole blob is
+      replayed in turn 2's history and every turn after. }
+    1: Result := RoundOf([OneCall('write_file',
+         ArgsPathContent('big.html', StringOfChar('X', 40000)))]);
+    { Turn 2: a trivial call so a second request is built (which replays the
+      turn-1 write in history). }
+    2: Result := RoundOf([OneCall('find_files', '{"pattern":"big.html"}')]);
+  else
+    Result := StopOf('done: wrote big.html.');
+  end;
+end;
+
+procedure ScenarioHistoryElision;
+{ A model's own large write_file content must NOT be re-shipped verbatim on
+  every later turn: the assistant tool-call args are elided to a stub in the
+  replayed history, while the FULL content still lands on disk. }
+var
+  Answer: string;
+  S: TStringList;
+begin
+  WriteLn;
+  WriteLn('== scenario: history-elision (large write args not replayed verbatim) ==');
+  if FileExists(GHomeDir + '/workspace/big.html') then
+    DeleteFile(GHomeDir + '/workspace/big.html');
+  ResetScenario(H_HistElide);
+  Answer := Chat('[' + MsgObjJSON('user',
+    'write a big html file named big.html') + ']', 'bench-elide');
+
+  Check(EnvCount = 3, Format('loop finished in 3 provider calls (got %d)', [EnvCount]));
+  { Turn 2's request (EnvAt(1)) replays turn 1's write in history. The 40 KB
+    of filler must be gone, replaced by the stub. }
+  Check(not Has(EnvAt(1), StringOfChar('X', 5000)),
+    'the 40 KB write content is NOT replayed verbatim in turn 2');
+  Check(Has(EnvAt(1), 'elided'),
+    'the replayed write arg is stubbed with an <elided ...> marker');
+  Check(Length(EnvAt(1)) < 20000,
+    Format('turn 2 request stays small despite the 40 KB write (%d bytes)',
+           [Length(EnvAt(1))]));
+  { The real file still got the full content -- dispatch used the real args. }
+  Check(FileExists(GHomeDir + '/workspace/big.html'), 'big.html exists on disk');
+  S := TStringList.Create;
+  try
+    S.LoadFromFile(GHomeDir + '/workspace/big.html');
+    Check(Length(S.Text) >= 39000,
+      Format('the FULL 40 KB landed on disk (%d bytes) -- dispatch unaffected',
+             [Length(S.Text)]));
+  finally
+    S.Free;
+  end;
+  Metric('histelide.turn2_request_bytes', Length(EnvAt(1)));
+end;
+
 { ---- gateway lifecycle ---------------------------------------------------- }
 var
   GW: TProcess;
@@ -1012,6 +1067,7 @@ begin
     ScenarioRealTask;
     ScenarioErrorGuidance;
     ScenarioTruncationRecovery;
+    ScenarioHistoryElision;
 
     WriteLn;
     WriteLn('== metrics ==');

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1750,11 +1750,19 @@ begin
       turn so a model's own large write content isn't replayed verbatim on
       every subsequent provider call. Dispatches[] already holds the full
       args (copied above), so the live tool run is unaffected -- only what
-      gets re-sent (and persisted into Loop.FinalMessages) is trimmed. }
+      gets re-sent (and persisted into Loop.FinalMessages) is trimmed.
+
+      SKIP calls that carry a ProviderSignature: Gemini 3 signs the
+      functionCall (thoughtSignature) and the Gemini builder echoes that
+      signature back on replay. Mutating the arguments would send a
+      different payload under the old signature, which Gemini rejects as an
+      invalidly-signed turn -- and dropping the signature 400s too (Gemini
+      requires it). Signed calls keep their exact args + signature. }
     for i := 0 to High(Hist[High(Hist)].ToolCalls) do
-      Hist[High(Hist)].ToolCalls[i].Func.Arguments :=
-        ElideLargeToolArgs(Hist[High(Hist)].ToolCalls[i].Func.Arguments,
-                           ToolArgReplayThreshold);
+      if Hist[High(Hist)].ToolCalls[i].ProviderSignature = '' then
+        Hist[High(Hist)].ToolCalls[i].Func.Arguments :=
+          ElideLargeToolArgs(Hist[High(Hist)].ToolCalls[i].Func.Arguments,
+                             ToolArgReplayThreshold);
 
     { Partition into batches: read-only calls fan out concurrently
       within a batch when Cfg.Parallel is on; mutating calls each

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -256,6 +256,17 @@ function LoopResultText(const Loop: TToolLoopResult): string;
 function FormatMaxIterNotice(const Loop: TToolLoopResult; MaxIter: Integer;
                             const HowToRaise: string; Resumable: Boolean): string;
 
+{ Shrink a tool-call's JSON arguments for REPLAY in history: any top-level
+  string value longer than Threshold bytes is replaced with a short "<elided
+  N bytes ...>" stub, keeping small fields (path, flags) intact. Used to stop
+  a model's own large write_file/apply_patch content from being re-shipped
+  verbatim on every subsequent turn (measured: a 24 KB index.html write
+  ballooned each later request by ~27 KB). Returns the input unchanged when
+  it is already small, unparseable, or has no oversized string field. The
+  live tool DISPATCH always uses the original arguments -- only the copy kept
+  in message history is shrunk. Exposed for tests. }
+function ElideLargeToolArgs(const ArgsJSON: string; Threshold: Integer): string;
+
 type
   (* Late-bound hook so PasClaw.Tools.ToolLoop doesn't have to
      `uses` PasClaw.Agent.SubagentBg (which itself calls
@@ -449,6 +460,53 @@ function MakeToolResult(const ToolCallId, Content: string): TMessage;
 begin
   Result := MakeMessage(mrTool, Content);
   Result.ToolCallId := ToolCallId;
+end;
+
+function ElideLargeToolArgs(const ArgsJSON: string; Threshold: Integer): string;
+var
+  Obj: TJsonObject;
+  Keys: TStringList;
+  i: Integer;
+  K, V: string;
+  Changed: Boolean;
+begin
+  Result := ArgsJSON;
+  { Cheap-out: if the whole arg blob is under the threshold, no single
+    string field can exceed it either. }
+  if Length(ArgsJSON) <= Threshold then Exit;
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj = nil then Exit;   { not an object / malformed -- leave verbatim }
+  try
+    Changed := False;
+    Keys := Obj.Keys;
+    try
+      for i := 0 to Keys.Count - 1 do
+      begin
+        K := Keys[i];
+        { NEVER elide fields a post-dispatch consumer parses back out of the
+          replayed/persisted history: `patch` (Session.Store working-state +
+          the web UI's apply_patch file list read the envelope from it) and
+          `command` (working-state's LastShell). They're normally small; the
+          bloat we're targeting is the `content` blob of a big write_file. }
+        if SameText(K, 'patch') or SameText(K, 'command') then Continue;
+        { GetStr returns '' for non-string values (numbers, bools, nested
+          objects), so only large STRING fields -- content / new_text / code
+          -- are ever elided; path and flags survive. }
+        V := Obj.GetStr(K, '');
+        if Length(V) > Threshold then
+        begin
+          Obj.PutStr(K, Format('<elided: %d bytes; call read_file to get the current content>',
+                               [Length(V)]));
+          Changed := True;
+        end;
+      end;
+    finally
+      Keys.Free;
+    end;
+    if Changed then Result := Obj.ToJSON;
+  finally
+    Obj.Free;
+  end;
 end;
 
 { Run one tool call: PreflightToolCall → Registry.RunTool → fs_edit_hashline
@@ -1209,6 +1267,11 @@ const
     'large file across several turns so no single call is too big), or ' +
     'edit_file / apply_patch (targeted changes). Emit ONE tool call now and ' +
     'keep any prose to one short line.';
+  { A tool-call argument string bigger than this is elided from the history
+    kept for REPLAY (the live dispatch always uses the full args). Keeps a
+    model's own 24 KB write_file/apply_patch content from being re-shipped
+    verbatim on every later turn -- it can read_file if it needs it back. }
+  ToolArgReplayThreshold = 2048;
 var
   Iter, i, bi, j, fbi, sti: Integer;
   Tools: TToolDefinitionArray;
@@ -1682,6 +1745,16 @@ begin
       Dispatches[i].Err        := '';
       Dispatches[i].Cancelled  := False;
     end;
+
+    { Shrink oversized argument blobs in the HISTORY copy of the assistant
+      turn so a model's own large write content isn't replayed verbatim on
+      every subsequent provider call. Dispatches[] already holds the full
+      args (copied above), so the live tool run is unaffected -- only what
+      gets re-sent (and persisted into Loop.FinalMessages) is trimmed. }
+    for i := 0 to High(Hist[High(Hist)].ToolCalls) do
+      Hist[High(Hist)].ToolCalls[i].Func.Arguments :=
+        ElideLargeToolArgs(Hist[High(Hist)].ToolCalls[i].Func.Arguments,
+                           ToolArgReplayThreshold);
 
     { Partition into batches: read-only calls fan out concurrently
       within a batch when Cfg.Parallel is on; mutating calls each

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -475,6 +475,74 @@ begin
   WriteLn('  ok: no-tools truncated answer returned as-is, no nudge, no retry');
 end;
 
+procedure TestElideLargeToolArgsUnit;
+{ Direct: a big string field is stubbed, small fields survive, and small
+  args are returned verbatim. }
+var
+  Big, Small, Outp: string;
+begin
+  Big := '{"path":"index.html","content":"' + StringOfChar('x', 5000) + '"}';
+  Outp := ElideLargeToolArgs(Big, 2048);
+  AssertHas(Outp, 'index.html', 'path survives elision');
+  AssertHas(Outp, 'elided', 'oversized content is elided');
+  AssertTrue(Pos(StringOfChar('x', 3000), Outp) = 0, 'the 5000-char blob is gone');
+  AssertTrue(Length(Outp) < 300, 'elided args are compact (got ' + IntToStr(Length(Outp)) + ')');
+
+  Small := '{"path":"a.txt","content":"hello","plain":true}';
+  AssertTrue(ElideLargeToolArgs(Small, 2048) = Small, 'small args returned verbatim');
+
+  { A large `patch` is NEVER elided -- Session.Store working-state and the
+    web UI parse the envelope's file paths back out of it. }
+  Big := '{"patch":"*** Begin Patch\n' + StringOfChar('p', 5000) + '\n*** End Patch"}';
+  AssertTrue(ElideLargeToolArgs(Big, 2048) = Big, 'a large patch field is preserved');
+  WriteLn('  ok: ElideLargeToolArgs stubs big content, keeps small + structural (patch) fields');
+end;
+
+procedure TestHistoryElidesBigWrite;
+{ End-to-end: a big write_file lands FULL content on disk (dispatch uses
+  the real args) but the assistant turn kept in Loop.FinalMessages carries
+  the elided stub, so it won't be re-shipped verbatim next turn. }
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  i, k: Integer;
+  Elided: Boolean;
+  Disk, Err: string;
+begin
+  if FileExists(FileA) then DeleteFile(FileA);
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    P.AddToolRound([MkCall('write_file',
+      '{"path":"' + FileA + '","content":"' + StringOfChar('Z', 5000) + '"}')]);
+    P.AddStop('done');
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'write a big file');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+
+    Elided := False;
+    for i := 0 to High(Loop.FinalMessages) do
+      for k := 0 to High(Loop.FinalMessages[i].ToolCalls) do
+        if Pos('elided', Loop.FinalMessages[i].ToolCalls[k].Func.Arguments) > 0 then
+          Elided := True;
+    AssertTrue(Elided, 'big write_file args are elided in the persisted history');
+
+    Disk := Reg.RunTool('read_file', '{"path":"' + FileA + '","plain":true}', Err);
+    AssertTrue(Length(Disk) >= 5000,
+      'file on disk got the FULL content -- dispatch used the real args (got ' +
+      IntToStr(Length(Disk)) + ')');
+    WriteLn('  ok: big write elided in history, full content still written to disk');
+  finally
+    Reg.Free;
+  end;
+end;
+
 var
   Pol: TSandboxPolicy;
 begin
@@ -493,6 +561,8 @@ begin
   TestDisableSwitch;
   TestTruncationRecoveryWithTools;
   TestTruncationNoToolsReturnsContent;
+  TestElideLargeToolArgsUnit;
+  TestHistoryElidesBigWrite;
 
   if FileExists(FileA) then DeleteFile(FileA);
   RemoveDir(WsDir);

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -543,6 +543,51 @@ begin
   end;
 end;
 
+procedure TestSignedToolCallNotElided;
+{ Gemini 3 signs its tool calls (ProviderSignature). Mutating the args
+  would invalidate the echoed signature, so a signed call's big content is
+  left intact even above the threshold. }
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  Call: TToolCall;
+  i, k: Integer;
+  FullKept: Boolean;
+begin
+  if FileExists(FileA) then DeleteFile(FileA);
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    Call := MkCall('write_file',
+      '{"path":"' + FileA + '","content":"' + StringOfChar('S', 5000) + '"}');
+    Call.ProviderSignature := 'gemini-thought-sig';
+    P.AddToolRound([Call]);
+    P.AddStop('done');
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'write a big signed file');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+
+    FullKept := False;
+    for i := 0 to High(Loop.FinalMessages) do
+      for k := 0 to High(Loop.FinalMessages[i].ToolCalls) do
+        if (Loop.FinalMessages[i].ToolCalls[k].ProviderSignature <> '') and
+           (Pos(StringOfChar('S', 4000),
+                Loop.FinalMessages[i].ToolCalls[k].Func.Arguments) > 0) then
+          FullKept := True;
+    AssertTrue(FullKept,
+      'a signed tool call keeps its full args so the thoughtSignature stays valid');
+    WriteLn('  ok: signed (Gemini 3) tool call args are NOT elided');
+  finally
+    Reg.Free;
+  end;
+end;
+
 var
   Pol: TSandboxPolicy;
 begin
@@ -563,6 +608,7 @@ begin
   TestTruncationNoToolsReturnsContent;
   TestElideLargeToolArgsUnit;
   TestHistoryElidesBigWrite;
+  TestSignedToolCallNotElided;
 
   if FileExists(FileA) then DeleteFile(FileA);
   RemoveDir(WsDir);


### PR DESCRIPTION
The one real inefficiency the pasclaw.dev build bench surfaced (verified against the raw transcript, not the agent's word).

## The problem

A model's own large `write_file` content is re-shipped verbatim in the assistant turn on **every subsequent provider call**. In the pasclaw.dev build the envelope jumped **19,665 → 46,743 bytes** the moment a 24 KB `index.html` write landed in history — and `msg[1]` was 26 KB, of which **24,260 B was the write_file `content` argument** (the tool *result* was only 196 B). On an iterative edit loop this compounds every turn.

## The fix

After a tool call is dispatched, shrink oversized string arguments in the **history copy** of the assistant turn: any top-level string field over 2 KB becomes `<elided: N bytes; call read_file to get the current content>`. The live dispatch always uses the original args (copied into `Dispatches` first), so **files are written in full** — only what gets replayed to the provider and persisted is trimmed. The model can `read_file` if it needs the content back (and per-turn read-dedup already covers repeat reads).

**`patch` and `command` are never elided** — `Session.Store` working-state and the web UI parse file paths / the last command back out of the persisted history, so eliding them would break #422's `apply_patch` tracking and the file dropdown on reload. `path` and flags are small and always survive.

## Verified before/after (same bench binary)

New `history-elision` scenario writes a 40 KB file then takes another turn:

| | `histelide.turn2_request_bytes` | 40 KB on disk? |
|---|---|---|
| **main** | **58,885** (write replayed verbatim) | ✅ |
| **this branch** | **18,949** (write is a stub) | ✅ 40,001 B full |

- Unit tests: oversized `content` elided, `path` + small fields + a large `patch` preserved, disk content full, and end-to-end that `Loop.FinalMessages` carries the stub while the file got the real bytes.
- `working_state_tests`, `session_endpoint_tests`, full 8-scenario bench, and smoke all green.

This was the last item on the effectiveness plan — the pasclaw.dev prompt that opened this whole effort (the ~100-call failure) now builds a clean 23 KB landing page in 3 turns, and this removes the remaining per-turn bloat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_