### PR TITLE
prompt/toolloop/grep: three Senior-SWE bench findings (AGENTS.md, stale reads, grep hint)

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -397,11 +397,22 @@ end;
 
 function BuildProjectRulesSection: string;
 var
-  Path, Body: string;
+  Path, Body, WorkDir: string;
   Original: Integer;
 begin
   Result := '';
-  Path := FindProjectAgentsMd('');
+  { Read AGENTS.md from the WORKSPACE, not the process launch dir. On a
+    gateway / serve / docker deploy the workspace ($PASCLAW_HOME/workspace,
+    or the configured sandbox.workspace) is a different directory than where
+    the binary was launched -- FindProjectAgentsMd('') walked GetCurrentDir,
+    so an operator's workspace AGENTS.md was silently never injected (the
+    project-rules / conventions mechanism was dead on every server path).
+    CurrentWorkspace is the same dir the Workspace section advertises; fall
+    back to the launch dir when no workspace is configured (the CLI case,
+    where launch dir == project and behaviour is unchanged). }
+  WorkDir := CurrentWorkspace;
+  if Trim(WorkDir) = '' then WorkDir := GetCurrentDir;
+  Path := FindProjectAgentsMd(WorkDir);
   if Path = '' then Exit;
   try
     Body := ReadFileText(Path);

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -596,6 +596,19 @@ begin
   Result := False;
 end;
 
+function LooksLikeRegexPattern(const P: string): Boolean;
+{ Heuristic: does the query look like the model reached for regex? grep_files
+  is a LITERAL substring search, so a 0-match on an alternation / regex
+  metachar is almost always a wrong mental model, not a genuine absence.
+  Kept narrow (a bare '.' or '*' in a term does NOT trip it) so the hint
+  only fires when it's very likely the real cause. }
+begin
+  Result := (Pos('|', P) > 0)          { alternation -- the dominant case }
+         or (Pos('.*', P) > 0) or (Pos('.+', P) > 0)
+         or (Pos('\d', P) > 0) or (Pos('\w', P) > 0)
+         or (Pos('\s', P) > 0) or (Pos('\b', P) > 0);
+end;
+
 function Tool_FSGrep(const ArgsJSON: string; out ErrMsg: string): string;
 { Recursive line scan returning hashline-formatted matches. Output looks
   like one section per matched file (¶path#hash header + N:line per
@@ -875,7 +888,15 @@ begin
       Exit('');
     end;
     if TotalMatches = 0 then
-      Result := '(no matches)'
+    begin
+      Result := '(no matches)';
+      { B3-style next-move hint: a 0-match regex-shaped pattern is almost
+        always the model expecting regex from a literal-substring tool. }
+      if LooksLikeRegexPattern(Pattern) then
+        Result := Result + ' -- note: grep_files matches a LITERAL substring, ' +
+          'not a regex. Search one plain term (e.g. "to_csv"), or run it once ' +
+          'per alternative.';
+    end
     else
     begin
       Result := Sb.ToString;

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -1345,6 +1345,7 @@ var
   Batch: TToolBatch;
   Workers: array of TToolCallWorker;
   Steering, BatchSteering, HistSystem, LastProviderErrText, BgBlock, PersistentSP: string;
+  Nm: string;   { supersession: the current dispatch's tool name }
   Ledger: TProgressLedger;
   LedgerBlock: string;
   ReadPaths, ReadHashes: TArray<string>;   { per-turn read-dedup state (C3) }
@@ -1825,21 +1826,6 @@ begin
           ElideLargeToolArgs(Hist[High(Hist)].ToolCalls[i].Func.Arguments,
                              ToolArgReplayThreshold);
 
-    { Path-keyed supersession: when this turn writes/edits a file, stub any
-      EARLIER read_file result of the same path -- those bytes are now stale
-      and would otherwise replay on every later turn (a read result made
-      obsolete by a later write was observed persisting whole). Uses the
-      call's `path` arg (write_file / append_file / edit_file str-replace);
-      patch-carrying writers keep their reads (path lives in the patch body,
-      and the model may still want the pre-image). }
-    for i := 0 to High(Resp.ToolCalls) do
-      if (Resp.ToolCalls[i].Func.Name = 'write_file') or
-         (Resp.ToolCalls[i].Func.Name = 'append_file') or
-         (Resp.ToolCalls[i].Func.Name = 'edit_file') or
-         (Resp.ToolCalls[i].Func.Name = 'fs_write') then
-        StubSupersededReads(Hist,
-          LedgerArg(Resp.ToolCalls[i].Func.Arguments, 'path'));
-
     { Partition into batches: read-only calls fan out concurrently
       within a batch when Cfg.Parallel is on; mutating calls each
       get a batch of one and stay serial. Order across batches is
@@ -2038,6 +2024,30 @@ begin
           else
             Hist[High(Hist)] := MakeToolResult(Dispatches[Batch[j]].Call.Id,
                                                 Dispatches[Batch[j]].ResultText);
+
+          { Path-keyed supersession (post-SUCCESS only): a write/edit that
+            actually landed makes any EARLIER read_file result of the same
+            path stale -- stub it so those obsolete bytes don't replay on
+            every later turn. Runs here, in the Err='' branch and only when
+            the call wasn't cancelled, so a denied (plan mode) / hook-
+            cancelled / sandbox-rejected write leaves the last valid read
+            intact (Codex P2 on #426). Patch-carrying writers keep their
+            reads (path lives in the patch body, and the pre-image may still
+            be wanted). }
+          if (Cfg.Mode <> pmPlan) and (not Dispatches[Batch[j]].Cancelled) then
+          begin
+            { We're in the Err='' branch, so the tool didn't error; sandbox /
+              validation failures set Err and never reach here. The one
+              Err=''-but-didn't-land case is a plan-mode refusal (its message
+              lands in ResultText, Err empty -- see DispatchOneToolCall), so
+              gate on pmPlan explicitly. This mirrors the ledger's own
+              "mutating call landed" predicate. }
+            Nm := Dispatches[Batch[j]].Call.Func.Name;
+            if (Nm = 'write_file') or (Nm = 'append_file')
+               or (Nm = 'edit_file') or (Nm = 'fs_write') then
+              StubSupersededReads(Hist,
+                ArgPathField(Dispatches[Batch[j]].Call.Func.Arguments));
+          end;
         end;
       end;
 

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -509,6 +509,67 @@ begin
   end;
 end;
 
+function ArgPathField(const ArgsJSON: string): string;
+{ The `path` string field of a tool-call's JSON args, or '' when absent /
+  unparseable. Self-contained so the supersession helpers below don't depend
+  on LedgerArg (defined later in the unit). }
+var
+  Obj: TJsonObject;
+begin
+  Result := '';
+  Obj := TJsonObject.Parse(ArgsJSON);
+  if Obj = nil then Exit;
+  try Result := Obj.GetStr('path', ''); finally Obj.Free; end;
+end;
+
+function ToolCallNameForId(const Hist: TMessageArray; const CallId: string;
+                           out Path: string): string;
+{ Find the tool_call with Id=CallId across Hist's assistant turns; return its
+  tool name and (out) its `path` argument. '' name when not found. }
+var
+  i, k: Integer;
+begin
+  Result := ''; Path := '';
+  if CallId = '' then Exit;
+  for i := 0 to High(Hist) do
+    if Hist[i].Role = mrAssistant then
+      for k := 0 to High(Hist[i].ToolCalls) do
+        if Hist[i].ToolCalls[k].Id = CallId then
+        begin
+          Result := Hist[i].ToolCalls[k].Func.Name;
+          Path := ArgPathField(Hist[i].ToolCalls[k].Func.Arguments);
+          Exit;
+        end;
+end;
+
+procedure StubSupersededReads(var Hist: TMessageArray; const Path: string);
+{ A write / edit to Path makes any EARLIER read_file result of Path stale --
+  its bytes no longer reflect the file, yet they'd replay on every later
+  turn. Replace those result bodies with a one-line stub. Only touches
+  read_file / fs_read RESULT messages for exactly this path; message
+  structure and tool_call/result pairing are untouched (the model can
+  re-read for the current content, and per-turn read-dedup already covers a
+  repeat read). Idempotent: an already-stubbed result is skipped. }
+const
+  StubMark = '[superseded read_file';
+var
+  i: Integer;
+  Nm, RPath: string;
+begin
+  if Path = '' then Exit;
+  for i := 0 to High(Hist) do
+    if (Hist[i].Role = mrTool) and (Hist[i].ToolCallId <> '')
+       and (Length(Hist[i].Content) > 200)
+       and (Pos(StubMark, Hist[i].Content) = 0) then
+    begin
+      Nm := ToolCallNameForId(Hist, Hist[i].ToolCallId, RPath);
+      if ((Nm = 'read_file') or (Nm = 'fs_read')) and (RPath = Path) then
+        Hist[i].Content := Format('%s %s result -- the file was changed by a ' +
+          'later tool call, so this content is stale; re-read it if you need ' +
+          'the current version]', [StubMark, Path]);
+    end;
+end;
+
 { Run one tool call: PreflightToolCall → Registry.RunTool → fs_edit_hashline
   retry on format errors. Writes ResultText / Err into the dispatch slot.
   Pure with respect to shared state (uses per-call HTTP clients, reads
@@ -1763,6 +1824,21 @@ begin
         Hist[High(Hist)].ToolCalls[i].Func.Arguments :=
           ElideLargeToolArgs(Hist[High(Hist)].ToolCalls[i].Func.Arguments,
                              ToolArgReplayThreshold);
+
+    { Path-keyed supersession: when this turn writes/edits a file, stub any
+      EARLIER read_file result of the same path -- those bytes are now stale
+      and would otherwise replay on every later turn (a read result made
+      obsolete by a later write was observed persisting whole). Uses the
+      call's `path` arg (write_file / append_file / edit_file str-replace);
+      patch-carrying writers keep their reads (path lives in the patch body,
+      and the model may still want the pre-image). }
+    for i := 0 to High(Resp.ToolCalls) do
+      if (Resp.ToolCalls[i].Func.Name = 'write_file') or
+         (Resp.ToolCalls[i].Func.Name = 'append_file') or
+         (Resp.ToolCalls[i].Func.Name = 'edit_file') or
+         (Resp.ToolCalls[i].Func.Name = 'fs_write') then
+        StubSupersededReads(Hist,
+          LedgerArg(Resp.ToolCalls[i].Func.Arguments, 'path'));
 
     { Partition into batches: read-only calls fan out concurrently
       within a batch when Cfg.Parallel is on; mutating calls each

--- a/src/tests/agents_md_tests.pas
+++ b/src/tests/agents_md_tests.pas
@@ -17,6 +17,8 @@ uses
   SysUtils, Classes,
   PasClaw.Agent.Prompt,
   PasClaw.Cmd.Init,
+  PasClaw.Config,          { TSandboxPolicy }
+  PasClaw.Tools.Sandbox,   { ConfigureSandbox -- sets CurrentWorkspace }
   PasClaw.Utils;
 
 procedure Fail_(const Msg: string);
@@ -333,6 +335,35 @@ begin
   end;
 end;
 
+procedure TestBuildSectionFromWorkspaceNotCwd;
+{ The gateway/serve/docker case: AGENTS.md lives in the configured WORKSPACE
+  while the process cwd is elsewhere. BuildProjectRulesSection must read the
+  WORKSPACE copy -- it previously read only the launch cwd, so a workspace
+  AGENTS.md was silently never injected. }
+var
+  WsDir, CwdDir, Saved, Section: string;
+  Pol: TSandboxPolicy;
+begin
+  WsDir := MakeTempDir;
+  CwdDir := MakeTempDir;   { a different dir, with NO AGENTS.md }
+  WriteFile_(JoinPath(WsDir, 'AGENTS.md'),
+    '# WS' + sLineBreak + 'Use the log() helper, never print().' + sLineBreak);
+  Saved := GetCurrentDir;
+  try
+    SetCurrentDir(CwdDir);
+    Pol := Default(TSandboxPolicy);
+    ConfigureSandbox(Pol, WsDir);      { CurrentWorkspace := WsDir }
+    Section := BuildProjectRulesSection;
+    AssertContains(Section, 'Use the log() helper',
+      'workspace AGENTS.md is read even when the process cwd is elsewhere');
+  finally
+    SetCurrentDir(Saved);
+    ConfigureSandbox(Default(TSandboxPolicy), '');   { reset workspace }
+    RemoveTree(WsDir);
+    RemoveTree(CwdDir);
+  end;
+end;
+
 begin
   Randomize;
   TestFindMissing;
@@ -347,5 +378,9 @@ begin
   TestDigestShape;
   TestDigestUtf8;
   TestRunInitArgFailures;
+  { Runs LAST: it configures a real sandbox workspace (module-global
+    CurrentWorkspace), which would otherwise leak into the cwd-reliant
+    section tests above. }
+  TestBuildSectionFromWorkspaceNotCwd;
   Writeln('ok - agents.md ingest + init digest tests passed');
 end.

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -314,7 +314,17 @@ begin
     R := Reg.RunTool('grep_files', '{"path":"' + JEsc(JoinPath(Dir, 'ctx.txt')) +
       '","pattern":"HIT"}', Err);
     AssertTrue(Pos('a2', R) = 0, 'without context_lines the output is matches-only (unchanged)');
-    WriteLn('  ok: grep_files context_lines shows the surroundings inline');
+    { A 0-match regex-shaped pattern (alternation) gets a next-move hint that
+      grep_files is literal-substring, not regex. A plain 0-match does not. }
+    R := Reg.RunTool('grep_files', '{"path":"' + JEsc(JoinPath(Dir, 'ctx.txt')) +
+      '","pattern":"HIT|MISS"}', Err);
+    AssertContains(R, 'no matches', 'alternation pattern finds nothing (literal match)');
+    AssertContains(R, 'LITERAL substring', 'regex-shaped 0-match hints that grep is literal');
+    R := Reg.RunTool('grep_files', '{"path":"' + JEsc(JoinPath(Dir, 'ctx.txt')) +
+      '","pattern":"NOPEPLAIN"}', Err);
+    AssertContains(R, 'no matches', 'plain miss reports no matches');
+    AssertTrue(Pos('LITERAL substring', R) = 0, 'a plain 0-match gets NO regex hint');
+    WriteLn('  ok: grep_files context_lines + regex-shaped 0-match hint');
 
     { --- 5. apply_patch: multi-file (update + add + delete) in one call. --- }
     AssertTrue(DefsHasName(Reg.ToProviderDefs, 'apply_patch'), 'apply_patch advertised');

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -636,6 +636,53 @@ begin
   end;
 end;
 
+procedure TestSupersededReadKeptOnDeniedWrite;
+{ P2 on #426: a write that does NOT land (denied in plan mode) must leave the
+  prior read_file result intact -- the file is unchanged and the read is
+  still the model's only valid view of it. }
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  i: Integer;
+  Err: string;
+  Stubbed, BodyKept: Boolean;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    Reg.RunTool('write_file',
+      '{"path":"' + FileA + '","content":"' + StringOfChar('B', 500) + '"}', Err);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    Cfg.Mode := pmPlan;   { mutating write_file is refused at dispatch }
+    P.AddToolRound([MkCall('read_file', '{"path":"' + FileA + '","plain":true}')]);
+    P.AddToolRound([MkCall('write_file', '{"path":"' + FileA + '","content":"nope"}')]);
+    P.AddStop('done');
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'read then (in plan mode) attempt a write');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+
+    Stubbed := False;
+    BodyKept := False;
+    for i := 0 to High(Loop.FinalMessages) do
+    begin
+      if Pos('superseded read_file', Loop.FinalMessages[i].Content) > 0 then
+        Stubbed := True;
+      if Pos(StringOfChar('B', 300), Loop.FinalMessages[i].Content) > 0 then
+        BodyKept := True;
+    end;
+    AssertTrue(not Stubbed, 'a denied write must NOT stub the prior read');
+    AssertTrue(BodyKept, 'the valid read body is still present after the denied write');
+    WriteLn('  ok: a denied/failed write leaves the prior read result intact');
+  finally
+    Reg.Free;
+  end;
+end;
+
 var
   Pol: TSandboxPolicy;
 begin
@@ -658,6 +705,7 @@ begin
   TestHistoryElidesBigWrite;
   TestSignedToolCallNotElided;
   TestSupersededReadStubbed;
+  TestSupersededReadKeptOnDeniedWrite;
 
   if FileExists(FileA) then DeleteFile(FileA);
   RemoveDir(WsDir);

--- a/src/tests/progress_ledger_tests.pas
+++ b/src/tests/progress_ledger_tests.pas
@@ -588,6 +588,54 @@ begin
   end;
 end;
 
+procedure TestSupersededReadStubbed;
+{ A read_file result made stale by a LATER write of the same path is stubbed
+  in the replayed/persisted history so its obsolete bytes don't ride along. }
+var
+  P: TScripted;
+  Reg: TToolRegistry;
+  Cfg: TToolLoopConfig;
+  Msgs: TMessageArray;
+  Loop: TToolLoopResult;
+  i: Integer;
+  Err: string;
+  Stubbed, StaleBody: Boolean;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+    { Seed FileA with >200 bytes so its read result is worth stubbing. }
+    Reg.RunTool('write_file',
+      '{"path":"' + FileA + '","content":"' + StringOfChar('A', 500) + '"}', Err);
+    P := TScripted.Create;
+    Cfg := BaseCfg(P);
+    Cfg.Registry := Reg;
+    P.AddToolRound([MkCall('read_file', '{"path":"' + FileA + '","plain":true}')]);
+    P.AddToolRound([MkCall('write_file', '{"path":"' + FileA + '","content":"rewritten"}')]);
+    P.AddStop('done');
+    SetLength(Msgs, 1);
+    Msgs[0] := MakeMessage(mrUser, 'read then rewrite the file');
+    AssertTrue(RunToolLoop(Cfg, Msgs, Loop), 'loop ran');
+
+    Stubbed := False;
+    StaleBody := False;
+    for i := 0 to High(Loop.FinalMessages) do
+    begin
+      if (Loop.FinalMessages[i].Role = mrTool) and
+         (Pos('superseded read_file', Loop.FinalMessages[i].Content) > 0) then
+        Stubbed := True;
+      if Pos(StringOfChar('A', 300), Loop.FinalMessages[i].Content) > 0 then
+        StaleBody := True;
+    end;
+    AssertTrue(Stubbed, 'the pre-write read_file result was stubbed as superseded');
+    AssertTrue(not StaleBody, 'the stale 500-byte read body is gone from history');
+    AssertTrue(FileExists(FileA), 'file still exists after rewrite (dispatch unaffected)');
+    WriteLn('  ok: read_file result superseded by a later write is stubbed');
+  finally
+    Reg.Free;
+  end;
+end;
+
 var
   Pol: TSandboxPolicy;
 begin
@@ -609,6 +657,7 @@ begin
   TestElideLargeToolArgsUnit;
   TestHistoryElidesBigWrite;
   TestSignedToolCallNotElided;
+  TestSupersededReadStubbed;
 
   if FileExists(FileA) then DeleteFile(FileA);
   RemoveDir(WsDir);


### PR DESCRIPTION
The three real harness gaps from 5 relay-harness benches modelled on [Senior SWE-Bench](https://senior-swe-bench.snorkel.ai/) dimensions (ambiguous ticket, multi-file feature, behavioral bug, migration, taste). Every task solved at near-minimal step complexity — the harness isn't the bottleneck — and these were the inefficiencies worth fixing.

## 1. [HIGH — verified bug] The gateway ignored the workspace `AGENTS.md`

`BuildProjectRulesSection` called `FindProjectAgentsMd('')`, which reads `GetCurrentDir` — the process **launch** dir. On `serve`/gateway/docker the workspace (`$PASCLAW_HOME/workspace`, or the configured sandbox workspace) is a *different* directory, so an operator's workspace `AGENTS.md` was **silently never injected** — the project-rules / conventions mechanism was dead on every server deploy. (The taste bench caught it: the model had to *discover* the convention by reading the file itself.) Now reads `CurrentWorkspace`, falling back to the launch dir for the CLI case (unchanged). Same launch-cwd bug we fixed for the since-removed facts block, never fixed for the actual rules injector.

## 2. [MODERATE] Stale `read_file` results replayed forever

A `read_file` result made obsolete by a *later write of the same path* persisted whole in history (a read result + its superseding write both shipped every turn — measured in the context-economy bench). New path-keyed supersession: when a turn writes/edits path `P` (`write_file`/`append_file`/`edit_file`), stub any **earlier** `read_file` result of `P`. This complements #425 (which elides oversized write *arguments*) — here it's the stale read *results*. Message structure and tool_call/result pairing are untouched; the model re-reads if it needs the current bytes.

## 3. [MINOR] `grep_files` silent zero on regex-shaped patterns

`grep_files` is literal-substring, but its `pattern` reads regex-shaped, so `to_csv|writerow` returned a **silent** zero-match and wasted a call (orientation bench). A 0-match whose pattern carries regex metachars (`|`, `.*`, `\d`, `\w`, …) now appends a next-move hint that it matches literal substrings — a plain miss gets no hint.

## Verification

- `agents_md_tests`: a workspace `AGENTS.md` is read when the process cwd is elsewhere (new test runs last to avoid leaking the module-global workspace into the cwd-reliant tests).
- `progress_ledger_tests`: a superseded read is stubbed while the file is still rewritten on disk (dispatch unaffected).
- `fs_tool_naming_tests`: the regex-shaped 0-match hint fires; a plain miss does not.
- Full 9-scenario agent-loop bench (elision + truncation scenarios unchanged), smoke, `working_state`, and `session_endpoint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_