### PR TITLE
tools: edit_file accepts old_string/new_string aliases; clarify execute_code

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
+++ b/src/pkg/tools/PasClaw.Tools.ExecuteCode.pas
@@ -578,9 +578,12 @@ begin
   GRunners.Add(Runner);
 
   T.Name        := 'execute_code';
-  T.Description := 'Run a multi-line bash or PowerShell script (loops, heredocs, ' +
-                   'fan-out a single shell_exec can''t express). Returns combined ' +
-                   'stdout+stderr and exit code; same sandbox/denylist as ' +
+  T.Description := 'Run a multi-line SHELL script (bash or PowerShell -- set `lang`). ' +
+                   'The body is shell, not program source: to run Python/Node/etc., ' +
+                   'invoke the interpreter from the script -- e.g. `python3 foo.py`, ' +
+                   'or a heredoc `python3 - <<''EOF''` ... `EOF`. Good for loops, ' +
+                   'heredocs, and fan-out a single shell_exec can''t express. Returns ' +
+                   'combined stdout+stderr and exit code; same sandbox/denylist as ' +
                    'shell_exec. Inside the script, `pasclaw __tool <name> ' +
                    '''<json-args>''` calls back into your own tools.';
   T.Schema      :=

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1826,10 +1826,16 @@ begin
                      'omit new_text to delete. Advanced: a hashline `patch` (read the file ' +
                      'with hashline:true first) does line-anchored multi-hunk edits; format ' +
                      'errors reply with the exact patch syntax.';
+    { old_string/new_string are declared as real properties (see the no-hashline
+      branch below) so schema-guided clients can emit the aliases Claude-family
+      models reach for. This branch has no `required` -- a `patch`-only call is
+      valid -- so alias handling here is purely about declaring the keys. }
     T.Schema      := '{"type":"object","properties":{' +
                      '"path":{"type":"string"},' +
                      '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace). Alias: old_string."},' +
+                     '"old_string":{"type":"string","description":"Alias for old_text."},' +
                      '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text. Alias: new_string."},' +
+                     '"new_string":{"type":"string","description":"Alias for new_text."},' +
                      '"replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring a unique match."},' +
                      '"patch":{"type":"string","description":"Advanced: a hashline-format patch, used INSTEAD of old_text/new_text."}' +
                      '}}';
@@ -1839,12 +1845,21 @@ begin
     T.Description := 'Edit a file by replacing an exact snippet: pass old_text (the existing text, verbatim ' +
                      'including whitespace) and new_text. The match must be unique unless replace_all is set; ' +
                      'omit new_text to delete text.';
+    { The alias keys are declared as real properties (not just mentioned in the
+      canonical field's description) so a schema-validating / grammar-guided
+      client can actually emit them. `required` lists only `path`: the old text
+      may arrive under old_text OR old_string, and JSON Schema can't say "one of
+      these two keys" without anyOf (which some constrained-decoding backends
+      don't support), so the handler enforces "old_text or old_string present"
+      with a precise error instead. }
     T.Schema      := '{"type":"object","properties":{' +
                      '"path":{"type":"string"},' +
                      '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace). Alias: old_string."},' +
+                     '"old_string":{"type":"string","description":"Alias for old_text."},' +
                      '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text. Alias: new_string."},' +
+                     '"new_string":{"type":"string","description":"Alias for new_text."},' +
                      '"replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring a unique match."}' +
-                     '},"required":["path","old_text"]}';
+                     '},"required":["path"]}';
   end;
   T.Handler  := Tool_FSEdit;
   T.IsCore   := True;

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1583,16 +1583,29 @@ begin
     ErrMsg := Reason;
     Exit('');
   end;
-  if not HasJSONKey(ArgsJSON, 'old_text') then
+  { Accept old_string/new_string as aliases for old_text/new_text. Claude-
+    family models reach for old_string/new_string by trained habit (that's
+    Claude Code's own Edit-tool signature) and otherwise eat a rejected first
+    edit; observed across several bench runs. The canonical names win when
+    both are supplied. }
+  if not (HasJSONKey(ArgsJSON, 'old_text') or HasJSONKey(ArgsJSON, 'old_string')) then
   begin
-    ErrMsg := 'missing required argument: old_text. Provide old_text + new_text for a ' +
-              'string replacement, or a `patch` for a hashline edit.';
+    ErrMsg := 'missing required argument: old_text (alias: old_string). Provide ' +
+              'old_text + new_text for a string replacement, or a `patch` for a ' +
+              'hashline edit.';
     Exit('');
   end;
-  ParseStringArg(ArgsJSON, 'old_text', OldText);
-  { new_text may be omitted -> treated as '' (a deletion). }
+  OldText := '';
+  if HasJSONKey(ArgsJSON, 'old_text') then
+    ParseStringArg(ArgsJSON, 'old_text', OldText)
+  else
+    ParseStringArg(ArgsJSON, 'old_string', OldText);
+  { new_text/new_string may be omitted -> treated as '' (a deletion). }
   NewText := '';
-  ParseStringArg(ArgsJSON, 'new_text', NewText);
+  if HasJSONKey(ArgsJSON, 'new_text') then
+    ParseStringArg(ArgsJSON, 'new_text', NewText)
+  else
+    ParseStringArg(ArgsJSON, 'new_string', NewText);
   ReplaceAll := ParseBoolArg(ArgsJSON, 'replace_all', False);
   if OldText = '' then
   begin
@@ -1815,8 +1828,8 @@ begin
                      'errors reply with the exact patch syntax.';
     T.Schema      := '{"type":"object","properties":{' +
                      '"path":{"type":"string"},' +
-                     '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace)."},' +
-                     '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text."},' +
+                     '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace). Alias: old_string."},' +
+                     '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text. Alias: new_string."},' +
                      '"replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring a unique match."},' +
                      '"patch":{"type":"string","description":"Advanced: a hashline-format patch, used INSTEAD of old_text/new_text."}' +
                      '}}';
@@ -1828,8 +1841,8 @@ begin
                      'omit new_text to delete text.';
     T.Schema      := '{"type":"object","properties":{' +
                      '"path":{"type":"string"},' +
-                     '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace)."},' +
-                     '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text."},' +
+                     '"old_text":{"type":"string","description":"Exact existing text to replace (verbatim, including whitespace). Alias: old_string."},' +
+                     '"new_text":{"type":"string","description":"Replacement text. Omit to delete old_text. Alias: new_string."},' +
                      '"replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring a unique match."}' +
                      '},"required":["path","old_text"]}';
   end;

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -236,7 +236,21 @@ begin
     Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"keepDROPkeep"}', Err);
     Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_text":"DROP"}', Err);
     AssertEqStr(ReadBack(Reg, PathA), 'keepkeep', 'edit_file deletes when new_text omitted');
-    WriteLn('  ok: edit_file str-replace (unique / not-found / ambiguous / replace_all / delete)');
+    { old_string/new_string aliases (Claude-family models reach for these). }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"alpha beta gamma"}', Err);
+    R := Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_string":"beta","new_string":"BETA"}', Err);
+    AssertEqStr(Err, '', 'edit_file accepts old_string/new_string aliases');
+    AssertEqStr(ReadBack(Reg, PathA), 'alpha BETA gamma', 'alias replacement applied');
+    { canonical wins when both present }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"pick me"}', Err);
+    Reg.RunTool('edit_file', '{"path":"' + PathA +
+      '","old_text":"me","old_string":"pick","new_text":"YOU"}', Err);
+    AssertEqStr(ReadBack(Reg, PathA), 'pick YOU', 'old_text wins over old_string when both given');
+    { alias-only delete (omit new_*) }
+    Reg.RunTool('write_file', '{"path":"' + PathA + '","content":"keepGONEkeep"}', Err);
+    Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_string":"GONE"}', Err);
+    AssertEqStr(ReadBack(Reg, PathA), 'keepkeep', 'old_string delete works with new_* omitted');
+    WriteLn('  ok: edit_file str-replace + old_string/new_string aliases');
 
     { --- 4b. find_files: glob by NAME (D1). --- }
     AssertTrue(DefsHasName(Reg.ToProviderDefs, 'find_files'), 'find_files advertised');

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -98,7 +98,7 @@ begin
 end;
 
 var
-  Reg: TToolRegistry;
+  Reg, Reg2: TToolRegistry;
   Defs: TToolDefinitionArray;
   Dir, PathA, PathB, PathC, PathN, Patch, R, Err: string;
   T: TTool;
@@ -251,6 +251,30 @@ begin
     Reg.RunTool('edit_file', '{"path":"' + PathA + '","old_string":"GONE"}', Err);
     AssertEqStr(ReadBack(Reg, PathA), 'keepkeep', 'old_string delete works with new_* omitted');
     WriteLn('  ok: edit_file str-replace + old_string/new_string aliases');
+
+    { --- 4a. Schema surfaces the aliases and doesn't over-require them
+      (PR #427 review). A schema-validating / grammar-guided client must be
+      able to emit old_string/new_string and make an alias-only call, so the
+      keys must be declared properties and `required` must not force old_text.
+      The hashline branch declares them; the no-hashline branch (which carried
+      "required":["path","old_text"]) is the one the review flagged. --- }
+    AssertTrue(Reg.Find('edit_file', T), 'edit_file findable for schema check');
+    AssertContains(T.Schema, '"old_string"', 'hashline schema declares old_string alias property');
+    AssertContains(T.Schema, '"new_string"', 'hashline schema declares new_string alias property');
+    Reg2 := TToolRegistry.Create;
+    try
+      RegisterFSTools(Reg2, False);   { --no-hashline mode }
+      AssertTrue(Reg2.Find('edit_file', T), 'no-hashline edit_file findable');
+      AssertContains(T.Schema, '"old_string"', 'no-hashline schema declares old_string alias property');
+      AssertContains(T.Schema, '"new_string"', 'no-hashline schema declares new_string alias property');
+      AssertTrue(Pos('"required":["path","old_text"]', T.Schema) = 0,
+                 'no-hashline schema no longer forces old_text (alias-only calls validate)');
+      AssertContains(T.Schema, '"required":["path"]',
+                 'no-hashline schema still requires path');
+    finally
+      Reg2.Free;
+    end;
+    WriteLn('  ok: edit_file schema declares aliases + does not force old_text');
 
     { --- 4b. find_files: glob by NAME (D1). --- }
     AssertTrue(DefsHasName(Reg.ToProviderDefs, 'find_files'), 'find_files advertised');


### PR DESCRIPTION
The single biggest friction weaker models hit in the Sonnet/Haiku Senior-SWE benches — both fixes are tiny, backed by real runs.

## `edit_file` accepts `old_string`/`new_string` aliases

Claude-family models reach for `old_string`/`new_string` (that's **Claude Code's own Edit-tool signature**) by trained habit, but `edit_file` wanted `old_text`/`new_text`, so the *first* edit was rejected. This showed up in **4 independent runs across Sonnet and Haiku** — Sonnet dodged it by reading the schema first; Haiku ate whole recovery turns (one run even sent a `replacements` array and had to pivot to `sed`). The weaker the model, the more it pays this tax.

Now `old_string`/`new_string` are accepted as aliases (canonical `old_text`/`new_text` win when both are supplied), named in the schema, and mentioned in the missing-arg error.

## `execute_code` description clarified (not restricted)

The body is a **shell** script (bash/PowerShell), but the *name* invites "run any code," so Haiku passed raw Python and it failed. The description now shows that to run another language you invoke its interpreter from the script — `python3 foo.py`, or a `python3 - <<'EOF' … EOF` heredoc — **which works today**; the tool just isn't a Python/JS runner itself. (No behavior change — corrected from an earlier over-strict "bash only, not Python" draft.)

## Verification

`fs_tool_naming` asserts `edit_file` with `old_string`/`new_string` applies the replacement and deletes, and that `old_text` wins when both are given. `execute_code` tests + smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_