### PR TITLE
zip: empty dir → valid empty zip; cog surfaces the real build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,6 +519,13 @@ test-subagent-model-arg: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/subagent_model_arg_tests.pas -o$(BUILDDIR)/subagent_model_arg_tests
 	@$(BUILDDIR)/subagent_model_arg_tests
 
+# PackDirToZip: empty dir -> valid (openable) empty zip, not a 0-byte file;
+# non-empty dir round-trips. Pins the cog workspace-handshake artifact fix.
+test-zip-pack: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/zip_pack_tests.pas -o$(BUILDDIR)/zip_pack_tests
+	@$(BUILDDIR)/zip_pack_tests
+
 # Stream reliability: empty-turn retry, idle-timeout, tool-call repair.
 # Uses a scripted fake provider; one test sleeps a few seconds to verify
 # the idle-timeout watcher.
@@ -852,4 +859,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/cog-build-deploy/predict.py
+++ b/cog-build-deploy/predict.py
@@ -727,6 +727,32 @@ class Predictor(BasePredictor):
                     f"(missing flag? out path unwritable?)."
                 )
 
+            # Validate the workspace archive and surface the REAL failure.
+            #
+            # A run that accomplished nothing -- almost always because every
+            # provider call errored (bad key, wrong model id, rate limit,
+            # network) -- leaves an empty PASCLAW_HOME. pasclaw exits 0 and
+            # packs that as an empty zip; historically it was a corrupt 0-byte
+            # file, which Cog then failed to upload with an OPAQUE error that
+            # hid the actual cause. The real cause is in the model's reply
+            # (text_out), e.g. "gemini error 426: ...". Detect the empty /
+            # unreadable archive here and raise WITH that reply, so the
+            # prediction fails legibly instead of shipping a useless artifact.
+            try:
+                with zipfile.ZipFile(out_zip_path) as _zf:
+                    _entries = _zf.namelist()
+            except zipfile.BadZipFile:
+                _entries = None
+            if not _entries:
+                reply_tail = (text_out or "").strip()[-1500:]
+                raise RuntimeError(
+                    f"pasclaw {mode_norm} produced an empty workspace -- the run "
+                    f"accomplished nothing, so there is no artifact to return. "
+                    f"This is almost always a provider/model error. The model's "
+                    f"final output was:\n"
+                    f"{reply_tail or '(no reply text captured)'}"
+                )
+
             # --- persist both outputs outside scratch ---
             #
             # Cog reads the returned Path values AFTER predict() returns,

--- a/cog-build/predict.py
+++ b/cog-build/predict.py
@@ -689,6 +689,32 @@ class Predictor(BasePredictor):
                     f"(missing flag? out path unwritable?)."
                 )
 
+            # Validate the workspace archive and surface the REAL failure.
+            #
+            # A run that accomplished nothing -- almost always because every
+            # provider call errored (bad key, wrong model id, rate limit,
+            # network) -- leaves an empty PASCLAW_HOME. pasclaw exits 0 and
+            # packs that as an empty zip; historically it was a corrupt 0-byte
+            # file, which Cog then failed to upload with an OPAQUE error that
+            # hid the actual cause. The real cause is in the model's reply
+            # (text_out), e.g. "gemini error 426: ...". Detect the empty /
+            # unreadable archive here and raise WITH that reply, so the
+            # prediction fails legibly instead of shipping a useless artifact.
+            try:
+                with zipfile.ZipFile(out_zip_path) as _zf:
+                    _entries = _zf.namelist()
+            except zipfile.BadZipFile:
+                _entries = None
+            if not _entries:
+                reply_tail = (text_out or "").strip()[-1500:]
+                raise RuntimeError(
+                    f"pasclaw {mode_norm} produced an empty workspace -- the run "
+                    f"accomplished nothing, so there is no artifact to return. "
+                    f"This is almost always a provider/model error. The model's "
+                    f"final output was:\n"
+                    f"{reply_tail or '(no reply text captured)'}"
+                )
+
             # --- persist both outputs outside scratch ---
             #
             # Cog reads the returned Path values AFTER predict() returns,

--- a/src/pkg/skills/PasClaw.Skills.Zip.pas
+++ b/src/pkg/skills/PasClaw.Skills.Zip.pas
@@ -346,6 +346,40 @@ begin
   end;
 end;
 
+function WriteEmptyZip(const ZipPath: string; out ErrMsg: string): Boolean;
+{ Emit the canonical 22-byte End-Of-Central-Directory record -- a valid zip
+  that expands to nothing. FPC's TZipper.ZipAllFiles leaves a 0-BYTE file
+  when handed an empty entry set (verified against the cog workspace
+  handshake: an empty PASCLAW_HOME produced a 0-byte "workspace.zip" that
+  is not a valid archive, so `zipfile.is_zipfile` fails and every consumer
+  -- the cog handshake, the gateway export download, a checkpoint restore
+  -- chokes on it). Writing the EOCD ourselves guarantees an
+  empty-but-valid archive instead of a corrupt zero-length one. }
+const
+  { PK\005\006 followed by 18 zero bytes: disk numbers, entry counts, central-
+    directory size/offset, and comment length all zero. }
+  EOCD: array[0..21] of Byte =
+    ($50, $4B, $05, $06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+var
+  FS: TFileStream;
+begin
+  Result := False;
+  ErrMsg := '';
+  try
+    if ExtractFilePath(ZipPath) <> '' then
+      ForceDirectories(ExtractFilePath(ZipPath));
+    FS := TFileStream.Create(ZipPath, fmCreate);
+    try
+      FS.WriteBuffer(EOCD, SizeOf(EOCD));
+    finally
+      FS.Free;
+    end;
+    Result := True;
+  except
+    on E: Exception do ErrMsg := 'empty-zip write failed: ' + E.Message;
+  end;
+end;
+
 function PackDirToZip(const SrcDir, ZipPath: string;
                       const ExcludeNames: array of string;
                       out ErrMsg: string;
@@ -381,6 +415,13 @@ begin
   try
     try
       CollectFiles(Src, '', ExcludeNames, Files);
+      { Empty directory: TZipper would leave a corrupt 0-byte file, so write
+        a valid empty archive directly instead. See WriteEmptyZip. }
+      if Files.Count = 0 then
+      begin
+        Result := WriteEmptyZip(ZipPath, ErrMsg);
+        Exit;
+      end;
       for i := 0 to Files.Count - 1 do
       begin
         OnDisk := Src + PathDelim + StringReplace(Files[i], '/', PathDelim,
@@ -424,6 +465,13 @@ begin
   try
     try
       CollectFiles(Src, '', ExcludeNames, Files);
+      { Empty directory: emit a valid empty archive directly rather than
+        risk a consumer-hostile output. Parallels the FPC branch. }
+      if Files.Count = 0 then
+      begin
+        Result := WriteEmptyZip(ZipPath, ErrMsg);
+        Exit;
+      end;
       Z.Open(ZipPath, zmWrite);
       for i := 0 to Files.Count - 1 do
       begin

--- a/src/tests/zip_pack_tests.pas
+++ b/src/tests/zip_pack_tests.pas
@@ -1,0 +1,90 @@
+program zip_pack_tests;
+(*
+  Pins PackDirToZip's archive validity, in particular the empty-directory
+  case that broke the cog workspace handshake:
+
+    * An EMPTY source directory must yield a VALID (openable) empty zip --
+      not a 0-byte file. FPC's TZipper.ZipAllFiles writes a zero-length
+      file for an empty entry set; that is not a valid archive, so the cog
+      predictor (which returns the zip as a Cog Path output) shipped a
+      corrupt artifact that failed to upload with an opaque error. The fix
+      writes the 22-byte End-Of-Central-Directory record instead.
+
+    * A NON-empty directory round-trips: pack then extract recovers the
+      file and its contents.
+
+  Drives PackDirToZip / ExtractZipToDir against temp dirs. No model.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  PasClaw.Skills.Zip;
+
+procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+procedure AssertTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
+
+function ReadAll(const Path: string): string;
+var S: TStringList;
+begin
+  S := TStringList.Create;
+  try S.LoadFromFile(Path); Result := S.Text; finally S.Free; end;
+end;
+
+var
+  Base, EmptyDir, FullDir, EmptyZip, FullZip, OutDir, Err: string;
+  F: TextFile;
+  Sz: Int64;
+  FS: TFileStream;
+  Sig: array[0..3] of Byte;
+
+begin
+  Base := IncludeTrailingPathDelimiter(GetTempDir) + 'pcziptest_' + IntToStr(GetProcessID);
+  EmptyDir := Base + PathDelim + 'empty';
+  FullDir  := Base + PathDelim + 'full';
+  EmptyZip := Base + PathDelim + 'empty.zip';
+  FullZip  := Base + PathDelim + 'full.zip';
+  OutDir   := Base + PathDelim + 'out';
+  ForceDirectories(EmptyDir);
+  ForceDirectories(FullDir);
+
+  { --- 1. Empty directory -> valid, openable empty zip (not 0 bytes). --- }
+  AssertTrue(PackDirToZip(EmptyDir, EmptyZip, [], Err),
+             'PackDirToZip(empty) should succeed: ' + Err);
+  AssertTrue(FileExists(EmptyZip), 'empty zip file created');
+  FS := TFileStream.Create(EmptyZip, fmOpenRead or fmShareDenyNone);
+  try
+    Sz := FS.Size;
+    FS.ReadBuffer(Sig, 4);
+  finally FS.Free; end;
+  AssertTrue(Sz >= 22, 'empty zip is a real archive, not a 0-byte file (got '
+                       + IntToStr(Sz) + ' bytes)');
+  { Must carry the End-Of-Central-Directory signature (PK\005\006) -- exactly
+    what zipfile.is_zipfile scans for on the cog side, i.e. the check the
+    corrupt 0-byte file failed. }
+  AssertTrue((Sig[0] = $50) and (Sig[1] = $4B) and (Sig[2] = $05) and (Sig[3] = $06),
+             'empty zip starts with the EOCD signature (valid empty archive)');
+  WriteLn('  ok: empty directory -> valid empty zip with EOCD signature (not 0 bytes)');
+
+  { --- 2. Non-empty directory round-trips. --- }
+  AssignFile(F, FullDir + PathDelim + 'hello.txt'); Rewrite(F);
+  Write(F, 'hi there'); CloseFile(F);
+  AssertTrue(PackDirToZip(FullDir, FullZip, [], Err),
+             'PackDirToZip(full) should succeed: ' + Err);
+  FS := TFileStream.Create(FullZip, fmOpenRead or fmShareDenyNone);
+  try Sz := FS.Size; finally FS.Free; end;
+  AssertTrue(Sz > 22, 'non-empty zip larger than a bare EOCD');
+  AssertTrue(ExtractZipToDir(FullZip, OutDir, Err),
+             'full zip extracts: ' + Err);
+  AssertTrue(FileExists(OutDir + PathDelim + 'hello.txt'),
+             'round-tripped file present after extract');
+  AssertTrue(Pos('hi there', ReadAll(OutDir + PathDelim + 'hello.txt')) > 0,
+             'round-tripped file content preserved');
+  WriteLn('  ok: non-empty directory packs + round-trips through extract');
+
+  WriteLn('zip_pack_tests: OK');
+end.


### PR DESCRIPTION
## What & why

Reproduced against the **live Replicate image** (`r8.im/fmxexpress/pasclaw-build-deploy@sha256:3b75917…`): when a `pasclaw build` run accomplishes nothing — almost always because every provider call errored — `PASCLAW_HOME` is left empty and `PackDirToZip` emitted a **0-byte file**. FPC's `TZipper.ZipAllFiles` writes nothing for an empty entry set yet returns success, so pasclaw exited 0 with a corrupt `workspace.zip`. The cog predictor checked only `os.path.exists` (never validity), handed the 0-byte file to Cog as a `Path` output, and Cog failed to upload it with an **opaque error that hid the actual cause** — which was sitting in `reply.txt` (e.g. `"gemini error 426: Upgrade Required"`).

Confirmed in the running image: `output[0]` = 0 bytes / invalid zip, real error buried in `output[1]`. (Also verified the operator's key + `gemini-3.5-flash` + the exact `v1beta/models/…:generateContent` endpoint all return HTTP 200 — the provider path itself is fine.)

## Fixes (defense in depth)

- **A — `PackDirToZip` (`Skills.Zip.pas`)**: an empty source dir now writes the canonical **22-byte End-Of-Central-Directory** record via a shared `WriteEmptyZip` helper — a valid, openable empty archive instead of a 0-byte file. Applied to **both** the FPC and Delphi branches, so every caller (cog handshake, gateway workspace export, checkpoint restore) stops shipping corrupt zips.
- **B + C — `cog-build` & `cog-build-deploy` `predict.py`**: after the build, validate the output archive (`zipfile` + non-empty `namelist`). An empty/unreadable workspace means the run produced no artifact, so raise a `RuntimeError` **carrying the model's reply** — the prediction now fails **legibly** with `"gemini error 426: …"` instead of an opaque Cog upload failure.

## Tests

`zip_pack_tests` (`make test-zip-pack`, wired into `make test`):
- empty dir → ≥22-byte archive carrying the EOCD signature (what `zipfile.is_zipfile` scans for)
- non-empty dir round-trips through pack → extract

Also verified out-of-band: the predict.py detection raises on both the new empty-valid zip and the legacy 0-byte zip, and passes a normal non-empty one. `make smoke` green; binary builds clean.

## Note

This makes any "build produced nothing" failure legible; it does **not** itself diagnose the operator's specific 4-minute Replicate error (their provider path tested healthy from here, and this sandbox can't reproduce a *successful* build — pasclaw's normal build has no `HTTPS_PROXY` support, so it can't egress through the environment's proxy). The real cause of that run will now appear directly in the prediction error once this ships. The reply text from a failing run (or the Replicate prediction logs) will still be the fastest confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_