### PR TITLE
http: honor HTTP(S)_PROXY / NO_PROXY in all builds, not just c2w

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,6 +526,13 @@ test-zip-pack: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/zip_pack_tests.pas -o$(BUILDDIR)/zip_pack_tests
 	@$(BUILDDIR)/zip_pack_tests
 
+# Env-proxy decision: HTTP(S)_PROXY honoured in normal builds; NO_PROXY +
+# loopback bypass (ExtractURLHost / HostBypassesProxy).
+test-http-proxy: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/http_proxy_tests.pas -o$(BUILDDIR)/http_proxy_tests
+	@$(BUILDDIR)/http_proxy_tests
+
 # Stream reliability: empty-turn retry, idle-timeout, tool-call repair.
 # Uses a scripted fake provider; one test sleeps a few seconds to verify
 # the idle-timeout watcher.
@@ -859,4 +866,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -146,6 +146,16 @@ function MakeHeader(const Name, Value: string): THeaderPair;
   var. Safe to call multiple times -- probing happens once and caches. }
 function EnsureOpenSSL(out ErrMsg: string): Boolean;
 
+{ Lowercased host of a URL (scheme, userinfo, port and path stripped;
+  bracketed IPv6 literals unwrapped). Exposed for testing the proxy path. }
+function ExtractURLHost(const URL: string): string;
+
+{ True when Host must bypass the proxy: loopback always, plus any match
+  against the NoProxy list (comma-separated; '*' = all, exact or domain-
+  suffix match, optional leading '.'). NoProxy is passed in (rather than
+  read from the environment) so the matcher is pure and testable. }
+function HostBypassesProxy(const Host, NoProxy: string): Boolean;
+
 implementation
 
 uses
@@ -706,29 +716,98 @@ begin
   if Result then ErrMsg := '' else ErrMsg := OpenSSLHelpMessage;
 end;
 
-{$IFDEF PASCLAW_C2W}
-procedure ApplyBrowserProxy(Http: TIdHTTP; HTTPS: Boolean);
-(* container2wasm in-browser deployment only (compiled with -dPASCLAW_C2W).
+function ExtractURLHost(const URL: string): string;
+{ Lowercased host of a URL, stripped of scheme, userinfo, port and path.
+  Handles bracketed IPv6 literals ([::1]:8000 -> ::1). }
+var
+  S: string;
+  P: Integer;
+begin
+  S := URL;
+  P := Pos('://', S);
+  if P > 0 then S := Copy(S, P + 3, MaxInt);
+  P := Pos('@', S);               { strip userinfo }
+  if P > 0 then S := Copy(S, P + 1, MaxInt);
+  P := Pos('/', S);               { strip path }
+  if P > 0 then S := Copy(S, 1, P - 1);
+  if (S <> '') and (S[1] = '[') then
+  begin
+    P := Pos(']', S);             { IPv6 literal -- take what's inside brackets }
+    if P > 0 then S := Copy(S, 2, P - 2);
+  end
+  else
+  begin
+    P := Pos(':', S);             { strip :port }
+    if P > 0 then S := Copy(S, 1, P - 1);
+  end;
+  Result := LowerCase(Trim(S));
+end;
 
-   When PasClaw runs inside a c2w guest with the serverless `c2w-net-proxy`
-   network stack, that proxy injects HTTP_PROXY / HTTPS_PROXY (e.g.
-   http://192.168.127.253:80) into the environment, TLS-terminates HTTPS with
-   its own CA, and re-issues each request through the browser's Fetch API.
-   Indy's TIdHTTP does NOT read those env vars on its own, so without this it
-   would try a direct socket -- which has no egress in the browser. Route the
-   client through the proxy here.
+function HostBypassesProxy(const Host, NoProxy: string): Boolean;
+{ Loopback always bypasses so local providers (ollama / lmstudio / vllm) and
+  127.0.0.1 callbacks never route through an external proxy. Then honour the
+  NoProxy list, matching the semantics curl / wget / Go use: '*' bypasses
+  everything; an entry matches Host exactly or as a domain suffix (a leading
+  '.' is optional, so both "example.com" and ".example.com" match
+  "api.example.com"). }
+var
+  Raw, Entry: string;
+  Start, i, L: Integer;
+begin
+  Result := True;
+  if (Host = 'localhost') or (Host = '127.0.0.1') or (Host = '::1')
+     or (Copy(Host, 1, 4) = '127.') then Exit;
 
-   No CA wiring is needed: Indy does not verify the server certificate by
-   default, so the proxy's MITM cert is accepted. (If a future change turns on
-   peer verification, load /.wasmenv/proxy.crt -- c2w sets SSL_CERT_FILE.)
+  if NoProxy <> '' then
+  begin
+    Raw := LowerCase(NoProxy);
+    Start := 1;
+    L := Length(Raw);
+    for i := 1 to L + 1 do
+      if (i > L) or (Raw[i] = ',') then
+      begin
+        Entry := Trim(Copy(Raw, Start, i - Start));
+        Start := i + 1;
+        if Entry = '' then Continue;
+        if Entry = '*' then Exit;
+        while (Entry <> '') and (Entry[1] = '.') do Delete(Entry, 1, 1);
+        if Entry = '' then Continue;
+        if (Host = Entry) or
+           ((Length(Host) > Length(Entry)) and
+            (Copy(Host, Length(Host) - Length(Entry), Length(Entry) + 1)
+             = '.' + Entry)) then Exit;
+      end;
+  end;
+  Result := False;
+end;
 
-   Off by default: this whole procedure is excluded from normal builds, which
-   keep going direct to the provider. *)
+function EnvNoProxy: string;
+begin
+  Result := GetEnvironmentVariable('NO_PROXY');
+  if Result = '' then Result := GetEnvironmentVariable('no_proxy');
+end;
+
+procedure ApplyEnvProxy(Http: TIdHTTP; const URL: string);
+(* Route the client through an HTTP(S)_PROXY from the environment, the way
+   curl / wget / git / npm / wrangler all do. Indy's TIdHTTP does NOT read
+   these env vars on its own -- without this it opens a direct socket, which
+   fails wherever egress is only available through a proxy (corporate
+   networks, the c2w in-browser guest, sandboxed CI). For an https:// target
+   Indy issues a CONNECT tunnel through the proxy, so the TLS session is still
+   end-to-end to the provider.
+
+   HTTPS_PROXY governs https targets, HTTP_PROXY governs http; NO_PROXY (and
+   loopback, always) opts a host out -- see HostBypassesProxy. The proxy URL
+   itself is parsed down to host[:port] (default port 80).
+
+   No CA wiring is needed for a TLS-terminating (MITM) proxy: Indy does not
+   verify the server certificate by default, so the proxy's re-signed cert is
+   accepted. This generalises the former c2w-only ApplyBrowserProxy. *)
 var
   Raw, Host: string;
   P, Port: Integer;
 begin
-  if HTTPS then
+  if MakeHTTPS(URL) then
   begin
     Raw := GetEnvironmentVariable('HTTPS_PROXY');
     if Raw = '' then Raw := GetEnvironmentVariable('https_proxy');
@@ -739,9 +818,10 @@ begin
     if Raw = '' then Raw := GetEnvironmentVariable('http_proxy');
   end;
   if Raw = '' then Exit;
+  if HostBypassesProxy(ExtractURLHost(URL), EnvNoProxy) then Exit;
 
   { Strip scheme://, any userinfo@, and trailing /path so only host[:port]
-    remains. The proxy URL c2w injects is a plain http://host:port. }
+    remains (proxy URLs are typically a plain http://host:port). }
   P := Pos('://', Raw);
   if P > 0 then Raw := Copy(Raw, P + 3, MaxInt);
   P := Pos('/', Raw);
@@ -765,9 +845,8 @@ begin
   Http.ProxyParams.ProxyServer := Host;
   Http.ProxyParams.ProxyPort   := Port;
 end;
-{$ENDIF}
 
-function NewClient(TimeoutSeconds: Integer; HTTPS: Boolean;
+function NewClient(TimeoutSeconds: Integer; const URL: string;
                    out ErrMsg: string): TIdHTTP;
 var
   SSL: TIdSSLIOHandlerSocketOpenSSL;
@@ -778,10 +857,10 @@ begin
   Result.ReadTimeout    := TimeoutSeconds * 1000;
   Result.HandleRedirects := True;
   Result.Request.UserAgent := 'PasClaw/0.1 (+https://github.com/FMXExpress/PasClaw)';
-  {$IFDEF PASCLAW_C2W}
-  ApplyBrowserProxy(Result, HTTPS);
-  {$ENDIF}
-  if HTTPS then
+  { Honour HTTP(S)_PROXY / NO_PROXY from the environment (all builds, not just
+    c2w) so pasclaw reaches providers through a proxy like every other CLI. }
+  ApplyEnvProxy(Result, URL);
+  if MakeHTTPS(URL) then
   begin
     if not EnsureOpenSSL(ErrMsg) then Exit;
     SSL := TIdSSLIOHandlerSocketOpenSSL.Create(Result);
@@ -799,7 +878,7 @@ var
   Req: TStringStream;
   SSLErr: string;
 begin
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode := -1;
@@ -830,7 +909,7 @@ var
   Req, Resp: TStringStream;
   SSLErr: string;
 begin
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode := -1;
@@ -883,7 +962,7 @@ var
   Http: TIdHTTP;
   SSLErr: string;
 begin
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode := -1;
@@ -949,7 +1028,7 @@ var
   SSLErr: string;
   Adapter: TRedirectAdapter;
 begin
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode  := -1;
@@ -987,7 +1066,7 @@ var
   Req: TStringStream;
   SSLErr: string;
 begin
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode  := -1;
@@ -1027,7 +1106,7 @@ begin
   Result := False;
   StatusCode := 0;
   ErrMsg := '';
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     StatusCode := -1;
@@ -1076,7 +1155,7 @@ begin
   Result.Body        := '';
   Result.ContentType := '';
   Result.ErrorMsg    := '';
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode := -1;
@@ -1123,7 +1202,7 @@ begin
   Result.Body        := '';
   Result.ContentType := '';
   Result.ErrorMsg    := '';
-  Http := NewClient(TimeoutSeconds, MakeHTTPS(URL), SSLErr);
+  Http := NewClient(TimeoutSeconds, URL, SSLErr);
   if SSLErr <> '' then
   begin
     Result.StatusCode := -1;

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -178,6 +178,81 @@ begin
   Result := (Length(URL) >= 8) and SameText(Copy(URL, 1, 8), 'https://');
 end;
 
+(* The proxy-decision helpers live in the common section (not the Indy backend
+   branch) so a PASCLAW_NETHTTP Delphi build -- which compiles the other
+   backend branch -- still has their implementations for the interface
+   declarations. They are pure string logic with no backend dependency. *)
+
+function ExtractURLHost(const URL: string): string;
+{ Lowercased host of a URL, stripped of scheme, userinfo, port and path.
+  Handles bracketed IPv6 literals ([::1]:8000 -> ::1). }
+var
+  S: string;
+  P: Integer;
+begin
+  S := URL;
+  P := Pos('://', S);
+  if P > 0 then S := Copy(S, P + 3, MaxInt);
+  { Reduce to the authority FIRST (strip the path), then the userinfo. Doing
+    it in this order matters: a path can legitimately contain '@'
+    (e.g. https://api.example.com/users/@me) -- stripping userinfo before the
+    path would otherwise mistake the path '@' for the authority delimiter and
+    return the wrong host, breaking loopback / NO_PROXY matching. }
+  P := Pos('/', S);                { strip path -> authority only }
+  if P > 0 then S := Copy(S, 1, P - 1);
+  P := Pos('@', S);               { strip userinfo (now safely within authority) }
+  if P > 0 then S := Copy(S, P + 1, MaxInt);
+  if (S <> '') and (S[1] = '[') then
+  begin
+    P := Pos(']', S);             { IPv6 literal -- take what's inside brackets }
+    if P > 0 then S := Copy(S, 2, P - 2);
+  end
+  else
+  begin
+    P := Pos(':', S);             { strip :port }
+    if P > 0 then S := Copy(S, 1, P - 1);
+  end;
+  Result := LowerCase(Trim(S));
+end;
+
+function HostBypassesProxy(const Host, NoProxy: string): Boolean;
+{ Loopback always bypasses so local providers (ollama / lmstudio / vllm) and
+  127.0.0.1 callbacks never route through an external proxy. Then honour the
+  NoProxy list, matching the semantics curl / wget / Go use: '*' bypasses
+  everything; an entry matches Host exactly or as a domain suffix (a leading
+  '.' is optional, so both "example.com" and ".example.com" match
+  "api.example.com"). }
+var
+  Raw, Entry: string;
+  Start, i, L: Integer;
+begin
+  Result := True;
+  if (Host = 'localhost') or (Host = '127.0.0.1') or (Host = '::1')
+     or (Copy(Host, 1, 4) = '127.') then Exit;
+
+  if NoProxy <> '' then
+  begin
+    Raw := LowerCase(NoProxy);
+    Start := 1;
+    L := Length(Raw);
+    for i := 1 to L + 1 do
+      if (i > L) or (Raw[i] = ',') then
+      begin
+        Entry := Trim(Copy(Raw, Start, i - Start));
+        Start := i + 1;
+        if Entry = '' then Continue;
+        if Entry = '*' then Exit;
+        while (Entry <> '') and (Entry[1] = '.') do Delete(Entry, 1, 1);
+        if Entry = '' then Continue;
+        if (Host = Entry) or
+           ((Length(Host) > Length(Entry)) and
+            (Copy(Host, Length(Host) - Length(Entry), Length(Entry) + 1)
+             = '.' + Entry)) then Exit;
+      end;
+  end;
+  Result := False;
+end;
+
 {$IF Defined(PASCLAW_NETHTTP) and not Defined(FPC)}
 (* ============================================================
    TNetHTTPClient backend -- Delphi only, opt-in via -DPASCLAW_NETHTTP.
@@ -714,71 +789,6 @@ begin
   ProbeOpenSSL;
   Result := GSSLAvailable;
   if Result then ErrMsg := '' else ErrMsg := OpenSSLHelpMessage;
-end;
-
-function ExtractURLHost(const URL: string): string;
-{ Lowercased host of a URL, stripped of scheme, userinfo, port and path.
-  Handles bracketed IPv6 literals ([::1]:8000 -> ::1). }
-var
-  S: string;
-  P: Integer;
-begin
-  S := URL;
-  P := Pos('://', S);
-  if P > 0 then S := Copy(S, P + 3, MaxInt);
-  P := Pos('@', S);               { strip userinfo }
-  if P > 0 then S := Copy(S, P + 1, MaxInt);
-  P := Pos('/', S);               { strip path }
-  if P > 0 then S := Copy(S, 1, P - 1);
-  if (S <> '') and (S[1] = '[') then
-  begin
-    P := Pos(']', S);             { IPv6 literal -- take what's inside brackets }
-    if P > 0 then S := Copy(S, 2, P - 2);
-  end
-  else
-  begin
-    P := Pos(':', S);             { strip :port }
-    if P > 0 then S := Copy(S, 1, P - 1);
-  end;
-  Result := LowerCase(Trim(S));
-end;
-
-function HostBypassesProxy(const Host, NoProxy: string): Boolean;
-{ Loopback always bypasses so local providers (ollama / lmstudio / vllm) and
-  127.0.0.1 callbacks never route through an external proxy. Then honour the
-  NoProxy list, matching the semantics curl / wget / Go use: '*' bypasses
-  everything; an entry matches Host exactly or as a domain suffix (a leading
-  '.' is optional, so both "example.com" and ".example.com" match
-  "api.example.com"). }
-var
-  Raw, Entry: string;
-  Start, i, L: Integer;
-begin
-  Result := True;
-  if (Host = 'localhost') or (Host = '127.0.0.1') or (Host = '::1')
-     or (Copy(Host, 1, 4) = '127.') then Exit;
-
-  if NoProxy <> '' then
-  begin
-    Raw := LowerCase(NoProxy);
-    Start := 1;
-    L := Length(Raw);
-    for i := 1 to L + 1 do
-      if (i > L) or (Raw[i] = ',') then
-      begin
-        Entry := Trim(Copy(Raw, Start, i - Start));
-        Start := i + 1;
-        if Entry = '' then Continue;
-        if Entry = '*' then Exit;
-        while (Entry <> '') and (Entry[1] = '.') do Delete(Entry, 1, 1);
-        if Entry = '' then Continue;
-        if (Host = Entry) or
-           ((Length(Host) > Length(Entry)) and
-            (Copy(Host, Length(Host) - Length(Entry), Length(Entry) + 1)
-             = '.' + Entry)) then Exit;
-      end;
-  end;
-  Result := False;
 end;
 
 function EnvNoProxy: string;

--- a/src/tests/http_proxy_tests.pas
+++ b/src/tests/http_proxy_tests.pas
@@ -1,0 +1,64 @@
+program http_proxy_tests;
+(*
+  Pins the environment-proxy decision logic added so normal (non-c2w)
+  pasclaw builds honour HTTP(S)_PROXY / NO_PROXY like curl / git / npm:
+
+    * ExtractURLHost -- host out of a URL (scheme, userinfo, port, path
+      stripped; IPv6 literal unwrapped; lowercased).
+    * HostBypassesProxy -- loopback always bypasses (so local ollama /
+      lmstudio / vllm providers never get proxied), plus NO_PROXY list
+      matching (exact, domain-suffix, leading-dot, '*').
+
+  Pure functions -- no network, no env mutation.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  PasClaw.Providers.HTTP;
+
+procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+
+procedure EqS(const Got, Want, Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got "' + Got + '", want "' + Want + '")'); end;
+
+procedure IsTrue(Cond: Boolean; const Msg: string);
+begin if not Cond then Fail_(Msg); end;
+
+procedure IsFalse(Cond: Boolean; const Msg: string);
+begin if Cond then Fail_(Msg); end;
+
+begin
+  { --- ExtractURLHost --- }
+  EqS(ExtractURLHost('https://api.openai.com/v1/chat'), 'api.openai.com', 'basic https host');
+  EqS(ExtractURLHost('http://host:8080/path'), 'host', 'strips port + path');
+  EqS(ExtractURLHost('https://user:pass@host.example.com:443/x'), 'host.example.com', 'strips userinfo + port');
+  EqS(ExtractURLHost('http://[::1]:8000/'), '::1', 'unwraps IPv6 literal, strips port');
+  EqS(ExtractURLHost('https://API.Example.COM'), 'api.example.com', 'lowercased, no path');
+  WriteLn('  ok: ExtractURLHost parses scheme/userinfo/port/path/IPv6');
+
+  { --- HostBypassesProxy: loopback always bypasses (empty NO_PROXY) --- }
+  IsTrue(HostBypassesProxy('localhost', ''),   'localhost bypasses');
+  IsTrue(HostBypassesProxy('127.0.0.1', ''),   '127.0.0.1 bypasses');
+  IsTrue(HostBypassesProxy('127.0.0.5', ''),   '127.0.0.0/8 bypasses');
+  IsTrue(HostBypassesProxy('::1', ''),         'IPv6 loopback bypasses');
+  WriteLn('  ok: loopback always bypasses the proxy (local providers safe)');
+
+  { --- HostBypassesProxy: NO_PROXY matching --- }
+  IsFalse(HostBypassesProxy('api.openai.com', ''),                 'no NO_PROXY -> proxied');
+  IsTrue (HostBypassesProxy('api.openai.com', '*'),                '* bypasses everything');
+  IsTrue (HostBypassesProxy('api.openai.com', 'openai.com'),       'domain-suffix match');
+  IsTrue (HostBypassesProxy('api.openai.com', '.openai.com'),      'leading-dot suffix match');
+  IsTrue (HostBypassesProxy('openai.com',     'openai.com'),       'exact match');
+  IsTrue (HostBypassesProxy('api.openai.com', 'example.com,openai.com'), 'matches a later list entry');
+  IsTrue (HostBypassesProxy('api.openai.com', 'OPENAI.COM'),       'NO_PROXY match is case-insensitive');
+  IsFalse(HostBypassesProxy('notopenai.com',  'openai.com'),       'suffix must be on a dot boundary (no false positive)');
+  IsFalse(HostBypassesProxy('api.openai.com', 'anthropic.com'),    'non-matching entry -> proxied');
+  WriteLn('  ok: NO_PROXY exact / suffix / leading-dot / wildcard / boundary');
+
+  WriteLn('http_proxy_tests: OK');
+end.

--- a/src/tests/http_proxy_tests.pas
+++ b/src/tests/http_proxy_tests.pas
@@ -39,7 +39,15 @@ begin
   EqS(ExtractURLHost('https://user:pass@host.example.com:443/x'), 'host.example.com', 'strips userinfo + port');
   EqS(ExtractURLHost('http://[::1]:8000/'), '::1', 'unwraps IPv6 literal, strips port');
   EqS(ExtractURLHost('https://API.Example.COM'), 'api.example.com', 'lowercased, no path');
-  WriteLn('  ok: ExtractURLHost parses scheme/userinfo/port/path/IPv6');
+  { Path may legitimately contain '@' -- the authority must be isolated BEFORE
+    userinfo stripping or the host comes out wrong (review P2 on #430). }
+  EqS(ExtractURLHost('http://localhost/@health'), 'localhost',
+      '@ in path does not corrupt the host (loopback still matches)');
+  EqS(ExtractURLHost('https://api.example.com/users/@me'), 'api.example.com',
+      '@ in path does not corrupt the host');
+  EqS(ExtractURLHost('https://user:pass@host.example.com/p/@x'), 'host.example.com',
+      'real userinfo stripped even when the path also has an @');
+  WriteLn('  ok: ExtractURLHost parses scheme/userinfo/port/path/IPv6 (+ @ in path)');
 
   { --- HostBypassesProxy: loopback always bypasses (empty NO_PROXY) --- }
   IsTrue(HostBypassesProxy('localhost', ''),   'localhost bypasses');


### PR DESCRIPTION
## What & why

pasclaw's HTTP client only routed through a proxy when built with `-dPASCLAW_C2W` — `ApplyBrowserProxy` lived inside that ifdef. Every **normal** build (CLI, gateway, the cog image) opened a **direct socket** to the provider and ignored `HTTPS_PROXY`, so pasclaw couldn't reach providers from behind a corporate / CI / agent proxy the way `curl`, `git`, `npm`, and `wrangler` all do.

Concretely: in a proxied sandbox, pasclaw's direct socket got intercepted and every model call failed with `gemini error 426: Upgrade Required`, while `curl` to the same host succeeded — because curl used the proxy and pasclaw didn't.

## How

Generalised the c2w-only `ApplyBrowserProxy` into `ApplyEnvProxy`, compiled in **all** builds and applied unconditionally in `NewClient`:

- `HTTPS_PROXY` governs https targets, `HTTP_PROXY` governs http.
- **`NO_PROXY` honored** with curl/Go semantics: `*` bypasses everything; an entry matches a host exactly or as a domain suffix (leading `.` optional).
- **Loopback always bypasses** (`localhost` / `127.0.0.0/8` / `::1`) — so the local-server providers (`ollama` / `lmstudio` / `vllm`) and 127.0.0.1 callbacks never get routed through an external proxy.
- For https targets Indy issues a `CONNECT` tunnel, so TLS stays end-to-end to the provider. A TLS-terminating (MITM) proxy needs no CA wiring since Indy doesn't verify the peer cert by default (unchanged posture).

`NewClient` now takes the target `URL` (it already received `MakeHTTPS(URL)` at every call site) so it can check `NO_PROXY` against the real host. The proxy-decision helpers (`ExtractURLHost`, `HostBypassesProxy`) are pure and exposed for testing.

## Verified end-to-end

Swapped this binary into the published cog image with `HTTPS_PROXY` set: a `pasclaw build` **reached Gemini through the proxy and produced a real workspace** (created the requested file, valid non-empty zip) — where the stock binary's direct socket had failed with `gemini error 426`.

## Tests

`http_proxy_tests` (`make test-http-proxy`, wired into `make test`):
- URL host extraction — scheme / userinfo / port / path / IPv6 literal
- `NO_PROXY` matcher — exact / domain-suffix / leading-dot / `*` wildcard / dot-boundary (no false positive on `notopenai.com` vs `openai.com`) / loopback bypass

`make smoke` green; binary builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_