### PR TITLE
cog-build-deploy: make Cloudflare deploy actually fire (nudge + safe scaffold)

### DIFF
--- a/cog-build-deploy/predict.py
+++ b/cog-build-deploy/predict.py
@@ -119,8 +119,13 @@ CLOUDFLARE_DEPLOY_DIRECTIVE = (
 # scaffold fallback ONLY creates a wrangler.toml for one of these dedicated
 # subdirs -- never the workspace root, which also holds sessions/ + memory/
 # (the conversation history); serving that as static assets would publish it.
-_WEB_OUTPUT_DIRS = ("public", "dist", "build", "out", "site", "www", "_site",
-                    "public_html")
+#
+# Order matters: BUILT-output dirs come first (dist / build / out / _site) so a
+# project that has both a source `public/` and a compiled `build/` deploys the
+# compiled artifact, not the uncompiled template. Plain served dirs
+# (public / site / www / public_html) follow for no-build static sites.
+_WEB_OUTPUT_DIRS = ("dist", "build", "out", "_site",
+                    "public", "site", "www", "public_html")
 
 
 def _secret_str(s: Optional[Secret]) -> str:
@@ -963,9 +968,24 @@ class Predictor(BasePredictor):
         ws_root = os.path.join(home_dir, "workspace")
         if not os.path.isdir(ws_root):
             return None
+        ws_real = os.path.realpath(ws_root)
         for name in _WEB_OUTPUT_DIRS:
             cand = os.path.join(ws_root, name)
-            if not os.path.isfile(os.path.join(cand, "index.html")):
+            # Never trust a SYMLINKED asset dir: `public -> .` (or -> anywhere
+            # outside a real dedicated subdir) would let `[assets]` serve the
+            # workspace root and leak sessions/ + memory/. Reject the link
+            # itself, and require the resolved target to be a real directory
+            # STRICTLY inside the workspace (deeper than the root).
+            if os.path.islink(cand):
+                continue
+            cand_real = os.path.realpath(cand)
+            if not os.path.isdir(cand_real):
+                continue
+            if cand_real == ws_real or \
+               not (cand_real + os.sep).startswith(ws_real + os.sep):
+                continue
+            index_html = os.path.join(cand_real, "index.html")
+            if os.path.islink(index_html) or not os.path.isfile(index_html):
                 continue
             toml_path = os.path.join(ws_root, "wrangler.toml")
             if not os.path.exists(toml_path):

--- a/cog-build-deploy/predict.py
+++ b/cog-build-deploy/predict.py
@@ -94,6 +94,35 @@ from cog import BasePredictor, BaseModel, Input, Path, Secret
 WORKSPACE_ZIP_CAP_BYTES = 4 * 1024 * 1024 * 1024
 
 
+# Appended to the build task when deploy_to_cloudflare is on, so the agent
+# knows the deployment contract UP FRONT and produces a deployable Worker
+# project rather than something wrangler can't ship. The deploy step only
+# fires when a wrangler config exists in the workspace; without this nudge a
+# generic "build X" task leaves no wrangler.toml and the deploy silently skips.
+CLOUDFLARE_DEPLOY_DIRECTIVE = (
+    "\n\n---\n"
+    "DEPLOYMENT TARGET (Cloudflare Workers): when you finish, this workspace "
+    "is deployed with `wrangler deploy --temporary`. For that to succeed you "
+    "MUST leave a deployable Cloudflare Worker project in the workspace:\n"
+    "- Write a `wrangler.toml` at the workspace root with `name` (lowercase, "
+    "hyphenated), `compatibility_date = \"2024-11-01\"`, and EITHER "
+    "`main = \"worker.js\"` (a module Worker that `export default`s a `fetch` "
+    "handler) OR an `[assets]` block with `directory = \"./public\"` to serve a "
+    "static site.\n"
+    "- Put a static site's files (index.html, css, js, images) under a "
+    "DEDICATED `public/` (or dist/build/out/site) directory -- do NOT rely on "
+    "serving the workspace root, which also holds internal session data.\n"
+    "Keep the config minimal and standard so `wrangler deploy` accepts it."
+)
+
+# Web-output directory names an agent commonly emits. The deploy-time
+# scaffold fallback ONLY creates a wrangler.toml for one of these dedicated
+# subdirs -- never the workspace root, which also holds sessions/ + memory/
+# (the conversation history); serving that as static assets would publish it.
+_WEB_OUTPUT_DIRS = ("public", "dist", "build", "out", "site", "www", "_site",
+                    "public_html")
+
+
 def _secret_str(s: Optional[Secret]) -> str:
     """Extract the cleartext value from an Optional[Secret] input.
 
@@ -641,6 +670,13 @@ class Predictor(BasePredictor):
             do_build = mode_norm in ("build", "plan build", "plan build goal")
             do_goal  = mode_norm == "plan build goal"
 
+            # Nudge: when we're going to deploy, tell the agent the Cloudflare
+            # contract as part of the task so it emits a wrangler.toml + Worker
+            # (plan mode included, so a chained plan accounts for it too). The
+            # closure below captures `message`, so reassigning it here is enough.
+            if deploy_to_cloudflare and do_build:
+                message = message + CLOUDFLARE_DEPLOY_DIRECTIVE
+
             def invoke_pasclaw(subcmd, extra_args, in_zip_arg, out_zip_arg,
                                 label):
                 """One pasclaw <subcmd> invocation with consistent error
@@ -909,6 +945,45 @@ class Predictor(BasePredictor):
                     best_depth = depth
         return best
 
+    def _scaffold_static_worker(self, home_dir):
+        """Last-resort deploy enabler: if the agent produced a static site in a
+        dedicated web-output subdir but no wrangler config, write a minimal
+        assets-only wrangler.toml at the workspace root pointing at that subdir,
+        and return the workspace root as the project. Returns None when there
+        is nothing safe to scaffold.
+
+        Deliberately conservative -- ONLY a recognised web-output subdir
+        (public/dist/build/out/site/www/...) containing an index.html
+        qualifies. We never point `[assets]` at the workspace root: it also
+        holds sessions/ + memory/ (the conversation history), and serving that
+        as static assets would publish it. If the agent put its site anywhere
+        else, we skip rather than risk a leak -- the nudge is what steers it
+        into a dedicated dir in the first place.
+        """
+        ws_root = os.path.join(home_dir, "workspace")
+        if not os.path.isdir(ws_root):
+            return None
+        for name in _WEB_OUTPUT_DIRS:
+            cand = os.path.join(ws_root, name)
+            if not os.path.isfile(os.path.join(cand, "index.html")):
+                continue
+            toml_path = os.path.join(ws_root, "wrangler.toml")
+            if not os.path.exists(toml_path):
+                with open(toml_path, "w") as f:
+                    f.write(
+                        'name = "pasclaw-deploy"\n'
+                        'compatibility_date = "2024-11-01"\n'
+                        "\n[assets]\n"
+                        f'directory = "./{name}"\n'
+                    )
+                print(
+                    "deploy: no wrangler config found; scaffolded an "
+                    f"assets-only wrangler.toml serving ./{name} "
+                    "(index.html detected)."
+                )
+            return ws_root
+        return None
+
     def _extract_urls(self, blob):
         """Pull every https:// URL out of wrangler's text output.
 
@@ -955,12 +1030,19 @@ class Predictor(BasePredictor):
         """
         proj = self._find_wrangler_project(home_dir, operator_override)
         if proj is None:
+            # No config the agent wrote -- try a safe static-site scaffold
+            # (a dedicated public/dist/... dir with an index.html) before
+            # giving up. Never serves the workspace root. See
+            # _scaffold_static_worker.
+            proj = self._scaffold_static_worker(home_dir)
+        if proj is None:
             print(
-                "deploy: no wrangler config (toml/json/jsonc) under "
+                "deploy: no wrangler config (toml/json/jsonc) and no "
+                "static site (public/dist/... with index.html) under "
                 "$PASCLAW_HOME/workspace/; skipping the deploy step."
             )
-            return ("(no wrangler.toml in workspace -- nothing to deploy)",
-                    "(no wrangler.toml in workspace -- nothing to deploy)")
+            return ("(no deployable Worker in workspace -- nothing to deploy)",
+                    "(no deployable Worker in workspace -- nothing to deploy)")
 
         # Per-prediction HOME so wrangler's cache (and any token it
         # might write) lives inside this prediction's scratch dir.

--- a/cog-build-deploy/test_scaffold.py
+++ b/cog-build-deploy/test_scaffold.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Standalone test for the deploy scaffold's safety contract.
+
+Run: python3 cog-build-deploy/test_scaffold.py   (needs the `cog` runtime;
+`pip install cog`). Exits non-zero on failure.
+
+The one invariant that must never regress: _scaffold_static_worker may only
+point Cloudflare's static-asset serving at a DEDICATED web-output subdir
+(public/dist/build/...). It must NEVER scaffold a config that serves the
+workspace root, which also holds sessions/ + memory/ -- the conversation
+history -- because that would publish it at the deployed URL.
+"""
+
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import predict as P  # noqa: E402
+
+
+def _write(home, rel, body="<h1>site</h1>"):
+    path = os.path.join(home, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(body)
+
+
+def _fail(msg):
+    print("FAIL:", msg)
+    sys.exit(1)
+
+
+def main():
+    pred = P.Predictor.__new__(P.Predictor)  # no setup()
+    ws = "workspace"
+
+    # 1. Dedicated public/ with index.html -> scaffold, serving ./public.
+    h = tempfile.mkdtemp()
+    _write(h, f"{ws}/public/index.html")
+    proj = pred._scaffold_static_worker(h)
+    toml = os.path.join(h, ws, "wrangler.toml")
+    if proj is None or not os.path.isfile(toml):
+        _fail("dedicated public/ should be scaffolded")
+    body = open(toml).read()
+    if 'directory = "./public"' not in body or "[assets]" not in body:
+        _fail("scaffold must be an assets-only config pointing at ./public")
+    print("  ok: dedicated public/ -> assets-only wrangler.toml for ./public")
+
+    # 2. index.html ONLY at the workspace root -> REFUSE (no leak of sessions/).
+    h = tempfile.mkdtemp()
+    _write(h, f"{ws}/index.html")
+    _write(h, f"{ws}/sessions/abc.json", '{"secret":"conversation"}')
+    proj = pred._scaffold_static_worker(h)
+    if proj is not None:
+        _fail("root-only index.html must NOT be scaffolded (would serve sessions/)")
+    if os.path.exists(os.path.join(h, ws, "wrangler.toml")):
+        _fail("no wrangler.toml may be written when only the root has index.html")
+    print("  ok: root-only index.html refused (workspace root never served)")
+
+    # 3. Other recognised web dirs work too (dist/).
+    h = tempfile.mkdtemp()
+    _write(h, f"{ws}/dist/index.html")
+    proj = pred._scaffold_static_worker(h)
+    if proj is None or 'directory = "./dist"' not in open(os.path.join(h, ws, "wrangler.toml")).read():
+        _fail("dist/ should scaffold serving ./dist")
+    print("  ok: dist/ (and other web-output dirs) scaffold correctly")
+
+    # 4. An existing wrangler.toml is never clobbered.
+    h = tempfile.mkdtemp()
+    _write(h, f"{ws}/public/index.html")
+    _write(h, f"{ws}/wrangler.toml", "name = \"already-here\"\n")
+    pred._scaffold_static_worker(h)
+    if "already-here" not in open(os.path.join(h, ws, "wrangler.toml")).read():
+        _fail("an existing wrangler.toml must not be overwritten")
+    print("  ok: existing wrangler.toml left untouched")
+
+    # 5. No web output at all -> nothing to scaffold.
+    h = tempfile.mkdtemp()
+    _write(h, f"{ws}/notes.txt", "just text")
+    if pred._scaffold_static_worker(h) is not None:
+        _fail("no index.html anywhere -> must return None")
+    print("  ok: no static site -> no scaffold")
+
+    print("test_scaffold: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/cog-build-deploy/test_scaffold.py
+++ b/cog-build-deploy/test_scaffold.py
@@ -82,6 +82,32 @@ def main():
         _fail("no index.html anywhere -> must return None")
     print("  ok: no static site -> no scaffold")
 
+    # 6. Built output preferred over source public/ (review P2). A project with
+    #    both public/index.html (source) and build/index.html (compiled) must
+    #    serve the built artifact.
+    h = tempfile.mkdtemp()
+    _write(h, f"{ws}/public/index.html")
+    _write(h, f"{ws}/build/index.html")
+    pred._scaffold_static_worker(h)
+    body = open(os.path.join(h, ws, "wrangler.toml")).read()
+    if 'directory = "./build"' not in body:
+        _fail("with both public/ and build/, must serve ./build (compiled), not ./public")
+    print("  ok: built output (build/) preferred over source public/")
+
+    # 7. Symlinked asset dir is refused (review P1) -- a `public -> .` link
+    #    must NOT let the scaffold serve the workspace root (sessions/).
+    h = tempfile.mkdtemp()
+    os.makedirs(os.path.join(h, ws), exist_ok=True)
+    _write(h, f"{ws}/sessions/abc.json", '{"secret":"x"}')
+    _write(h, f"{ws}/index.html")  # root index (its dir is the root, itself unsafe)
+    os.symlink(os.path.join(h, ws), os.path.join(h, ws, "public"))  # public -> workspace root
+    proj = pred._scaffold_static_worker(h)
+    if proj is not None:
+        _fail("a symlinked asset dir (public -> workspace root) must be refused")
+    if os.path.exists(os.path.join(h, ws, "wrangler.toml")):
+        _fail("no wrangler.toml may be written for a symlinked asset dir")
+    print("  ok: symlinked asset dir refused (no workspace-root exposure)")
+
     print("test_scaffold: OK")
 
 


### PR DESCRIPTION
## What & why

The deploy step only ran when the agent happened to leave a `wrangler` config in the workspace. With a generic build task it didn't, so `_deploy_to_cloudflare` found nothing and skipped — the operator saw `"deploy: no wrangler config ... skipping the deploy step."` and no live URL, even though the build itself succeeded.

I confirmed against the **live image** that the deploy machinery is healthy: `wrangler deploy --temporary` provisions a temp account and returns a `workers.dev` URL + claim URL, and predict.py's URL parser handles that output correctly. The gap was purely that **nothing deployable got produced**.

## Changes

**1. Nudge** — when `deploy_to_cloudflare` is on and we're building, append a Cloudflare deployment directive to the task so the agent produces a deployable Worker project up front (a `wrangler.toml` + a Worker script, or an `[assets]` dir), and is told to put static files in a **dedicated** subdir — never the workspace root.

**2. Safe scaffold fallback** — if the agent still left no wrangler config but emitted a static site in a recognised web-output subdir (`public`/`dist`/`build`/`out`/`site`/`www`/`_site`/`public_html` with an `index.html`), write a minimal assets-only `wrangler.toml` at the workspace root pointing at that subdir, and deploy it.

### Security: the scaffold never serves the workspace root
`[assets]` is only ever pointed at a **dedicated web-output subdir**. It is never pointed at the workspace root, which also holds `sessions/` + `memory/` — the conversation history — since serving that as static assets would publish it at the deployed URL. If the site isn't in a dedicated subdir, we skip rather than risk the leak (the nudge is what steers the agent into a clean dir).

## Verification

- **Live**: an `[assets]` project of exactly the scaffolded shape deploys via `wrangler deploy --temporary` in the published image and returns a `workers.dev` URL + claim URL.
- **`test_scaffold.py`** (runnable: `python3 cog-build-deploy/test_scaffold.py`) pins the safety contract:
  - dedicated `public/`/`dist/` → assets-only config for that dir
  - **root-only `index.html` (with `sessions/` present) → refused, no `wrangler.toml` written**
  - existing `wrangler.toml` never clobbered
  - no static site → no scaffold

`py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_