### PR TITLE
json: tolerate bare control chars inside strings (lenient parse retry)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -311,6 +311,13 @@ test-json-utf8-roundtrip: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/json_utf8_roundtrip_tests.pas -o$(BUILDDIR)/json_utf8_roundtrip_tests
 	@$(BUILDDIR)/json_utf8_roundtrip_tests
+
+# Lenient parse: bare control chars inside strings (unescaped LLM JSON) are
+# repaired instead of crashing; valid JSON untouched; bad JSON still errors.
+test-json-lenient: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/json_lenient_tests.pas -o$(BUILDDIR)/json_lenient_tests
+	@$(BUILDDIR)/json_lenient_tests
 
 # PasClaw.Providers.Models — /v1/models cache schema round-trip + helpers.
 test-model-discovery: | $(BUILDDIR)
@@ -866,4 +873,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -142,6 +142,71 @@ begin
   end;
 end;
 
+function SanitizeLenientJSON(const S: string): string;
+{ Repair the one lenient-JSON defect LLM providers commonly emit: a raw
+  control character (a bare newline, tab, ...) sitting INSIDE a double-quoted
+  string. Strict RFC-8259 parsers -- notably FPC's jsonscanner -- reject that
+  as an unterminated string ("string exceeds end of line"), which would
+  otherwise take down a whole agent turn on a provider response that wasn't
+  perfectly escaped. Walk the text tracking string/escape state and replace a
+  bare control char INSIDE a string with its JSON escape. Bytes outside
+  strings (structural whitespace) are untouched, so well-formed input
+  round-trips byte-for-byte -- the parse retry that calls this is a no-op for
+  good JSON and only kicks in after a strict parse has already failed. }
+var
+  i: Integer;
+  C: Char;
+  InStr, Esc: Boolean;
+  SB: TStringBuilder;
+begin
+  InStr := False;
+  Esc   := False;
+  SB := TStringBuilder.Create(Length(S) + 16);
+  try
+    for i := 1 to Length(S) do
+    begin
+      C := S[i];
+      if Esc then
+      begin
+        { prior char was a backslash inside a string -- this char completes
+          the escape sequence; pass it through verbatim. }
+        SB.Append(C);
+        Esc := False;
+        Continue;
+      end;
+      if C = '\' then
+      begin
+        SB.Append(C);
+        if InStr then Esc := True;
+        Continue;
+      end;
+      if C = '"' then
+      begin
+        InStr := not InStr;
+        SB.Append(C);
+        Continue;
+      end;
+      if InStr and (Ord(C) < 32) then
+      begin
+        case C of
+          #8:   SB.Append('\b');
+          #9:   SB.Append('\t');
+          #10:  SB.Append('\n');
+          #12:  SB.Append('\f');
+          #13:  SB.Append('\r');
+        else
+          SB.Append(Format('\u%.4x', [Ord(C)]));
+        end;
+        Continue;
+      end;
+      SB.Append(C);
+    end;
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
 {$IFDEF FPC}
 (* ----- FPC backend (fpjson) ----- *)
 
@@ -163,6 +228,55 @@ destructor TJsonObject.Destroy;
 begin
   if FOwnsBacking and (FBacking <> nil) then FBacking.Free;
   inherited Destroy;
+end;
+
+function FPCParseData(const S: string; out ErrMsg: string): TJSONData;
+{ Strict parse of S to a TJSONData, or nil on any scanner/parser error (with
+  the message in ErrMsg). Handles the DefaultSystemCodePage dance documented
+  on TJsonObject.Parse below. Never raises -- callers decide whether to retry
+  leniently (LenientRetry) or surface the error. }
+var
+  Stream: TStringStream;
+  Parser: TJSONParser;
+  PrevCP: TSystemCodePage;
+begin
+  Result := nil;
+  ErrMsg := '';
+  Stream := TStringStream.Create(S);
+  try
+    PrevCP := DefaultSystemCodePage;
+    if PrevCP <> CP_UTF8 then DefaultSystemCodePage := CP_UTF8;
+    try
+      try
+        Parser := TJSONParser.Create(Stream, [joUTF8]);
+        try
+          Result := Parser.Parse;
+        finally
+          Parser.Free;
+        end;
+      except
+        on E: Exception do begin Result := nil; ErrMsg := E.Message; end;
+      end;
+    finally
+      if PrevCP <> CP_UTF8 then DefaultSystemCodePage := PrevCP;
+    end;
+  finally
+    Stream.Free;
+  end;
+end;
+
+function LenientRetry(const S: string): TJSONData;
+{ Second-chance parse: repair bare control chars inside strings (the common
+  LLM / provider defect) and parse the sanitized text. Returns nil when the
+  text needed no repair (SanitizeLenientJSON was a no-op, so the strict parse
+  already failed for a real reason) or is still invalid after repair. }
+var
+  San, Err: string;
+begin
+  Result := nil;
+  San := SanitizeLenientJSON(S);
+  if San <> S then
+    Result := FPCParseData(San, Err);
 end;
 
 class function TJsonObject.Parse(const S: string): TJsonObject;
@@ -195,34 +309,15 @@ class function TJsonObject.Parse(const S: string): TJsonObject;
    all set the same value, so the race is benign; the window is the
    parser pass itself, which is brief and CPU-bound. *)
 var
-  Stream: TStringStream;
-  Parser: TJSONParser;
   Data: TJSONData;
-  PrevCP: TSystemCodePage;
+  Err: string;
 begin
   Result := nil;
   if Trim(S) = '' then Exit;
-  Stream := TStringStream.Create(S);
-  try
-    PrevCP := DefaultSystemCodePage;
-    if PrevCP <> CP_UTF8 then DefaultSystemCodePage := CP_UTF8;
-    try
-      try
-        Parser := TJSONParser.Create(Stream, [joUTF8]);
-        try
-          Data := Parser.Parse;
-        finally
-          Parser.Free;
-        end;
-      except
-        on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
-      end;
-    finally
-      if PrevCP <> CP_UTF8 then DefaultSystemCodePage := PrevCP;
-    end;
-  finally
-    Stream.Free;
-  end;
+  Data := FPCParseData(S, Err);
+  if Data = nil then Data := LenientRetry(S);
+  if Data = nil then
+    raise EPasClawJSON.CreateFmt('JSON parse: %s', [Err]);
   if not (Data is fpjson.TJSONObject) then
   begin
     Data.Free;
@@ -392,36 +487,18 @@ end;
 
 class function TJsonArray.Parse(const S: string): TJsonArray;
 { See TJsonObject.Parse for why we swap DefaultSystemCodePage to
-  CP_UTF8 around the parser run -- same lossy-scanner interaction. }
+  CP_UTF8 around the parser run -- same lossy-scanner interaction. The
+  strict-then-lenient retry (FPCParseData / LenientRetry) is shared too. }
 var
-  Stream: TStringStream;
-  Parser: TJSONParser;
   Data: TJSONData;
-  PrevCP: TSystemCodePage;
+  Err: string;
 begin
   Result := nil;
   if Trim(S) = '' then Exit;
-  Stream := TStringStream.Create(S);
-  try
-    PrevCP := DefaultSystemCodePage;
-    if PrevCP <> CP_UTF8 then DefaultSystemCodePage := CP_UTF8;
-    try
-      try
-        Parser := TJSONParser.Create(Stream, [joUTF8]);
-        try
-          Data := Parser.Parse;
-        finally
-          Parser.Free;
-        end;
-      except
-        on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
-      end;
-    finally
-      if PrevCP <> CP_UTF8 then DefaultSystemCodePage := PrevCP;
-    end;
-  finally
-    Stream.Free;
-  end;
+  Data := FPCParseData(S, Err);
+  if Data = nil then Data := LenientRetry(S);
+  if Data = nil then
+    raise EPasClawJSON.CreateFmt('JSON parse: %s', [Err]);
   if not (Data is fpjson.TJSONArray) then
   begin
     Data.Free;
@@ -589,6 +666,10 @@ begin
   if Trim(S) = '' then Exit;
   try
     V := System.JSON.TJSONObject.ParseJSONValue(S);
+    { Lenient retry: repair bare control chars inside strings (the common
+      LLM / provider defect) and parse again. See SanitizeLenientJSON. }
+    if V = nil then
+      V := System.JSON.TJSONObject.ParseJSONValue(SanitizeLenientJSON(S));
   except
     on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
   end;
@@ -799,6 +880,9 @@ begin
   if Trim(S) = '' then Exit;
   try
     V := System.JSON.TJSONObject.ParseJSONValue(S);
+    { Lenient retry -- see TJsonObject.Parse / SanitizeLenientJSON. }
+    if V = nil then
+      V := System.JSON.TJSONObject.ParseJSONValue(SanitizeLenientJSON(S));
   except
     on E: Exception do raise EPasClawJSON.CreateFmt('JSON parse: %s', [E.Message]);
   end;

--- a/src/tests/json_lenient_tests.pas
+++ b/src/tests/json_lenient_tests.pas
@@ -1,0 +1,84 @@
+program json_lenient_tests;
+(*
+  Pins the lenient-parse retry added to PasClaw.JSON: a raw control char
+  (bare newline / tab) INSIDE a JSON string -- which strict RFC-8259 parsers
+  (FPC's jsonscanner) reject with "string exceeds end of line" -- is repaired
+  and parsed instead of crashing the caller. Reproduces the EPasClawJSON crash
+  seen on a real Gemini build (an agent tool-call/response carrying an
+  unescaped newline).
+
+  Well-formed JSON must be UNAFFECTED (the retry only runs after a strict
+  parse fails, and the sanitizer is a no-op on already-valid input).
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  PasClaw.JSON;
+
+procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+procedure EqS(const Got, Want, Msg: string);
+begin if Got <> Want then Fail_(Msg + ' (got ' + QuotedStr(Got) + ', want ' + QuotedStr(Want) + ')'); end;
+procedure IsTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
+
+var
+  O: TJsonObject;
+  A: TJsonArray;
+  Raised: Boolean;
+const
+  LF = #10;
+  TAB = #9;
+begin
+  { 1. Literal newline inside a string value -> repaired, value preserved. }
+  O := TJsonObject.Parse('{"content":"line1' + LF + 'line2"}');
+  IsTrue(O <> nil, 'object with a bare newline in a string must parse');
+  EqS(O.GetStr('content'), 'line1' + LF + 'line2',
+      'the newline survives as a real newline in the parsed value');
+  O.Free;
+
+  { 2. Literal tab inside a string. }
+  O := TJsonObject.Parse('{"k":"a' + TAB + 'b"}');
+  IsTrue(O <> nil, 'bare tab in a string must parse');
+  EqS(O.GetStr('k'), 'a' + TAB + 'b', 'tab preserved');
+  O.Free;
+
+  { 3. Already-escaped \n is unaffected (well-formed, no retry needed). }
+  O := TJsonObject.Parse('{"a":"b\nc"}');
+  EqS(O.GetStr('a'), 'b' + LF + 'c', 'escaped \n decodes to a newline as usual');
+  O.Free;
+
+  { 4. Pretty-printed JSON (newlines BETWEEN tokens, outside strings) is fine. }
+  O := TJsonObject.Parse('{' + LF + '  "x": "y"' + LF + '}');
+  EqS(O.GetStr('x'), 'y', 'structural whitespace newlines never mangled');
+  O.Free;
+
+  { 5. Structural chars INSIDE a string are not mistaken for structure even
+       when a repair happens elsewhere -- string state machine correctness. }
+  O := TJsonObject.Parse('{"s":"a},{' + LF + '\"q\": b"}');
+  IsTrue(O <> nil, 'braces/commas/escaped-quotes inside a string parse');
+  EqS(O.GetStr('s'), 'a},{' + LF + '"q": b', 'string content with braces + escaped quote intact');
+  O.Free;
+
+  { 6. Array with a bare newline in an element string. }
+  A := TJsonArray.Parse('["ok","x' + LF + 'y"]');
+  IsTrue((A <> nil) and (A.Count = 2), 'array with a bare newline must parse');
+  EqS(A.ItemStr(1), 'x' + LF + 'y', 'array element newline preserved');
+  A.Free;
+
+  { 7. Genuinely invalid JSON (not a control-char issue) still raises. }
+  Raised := False;
+  try
+    O := TJsonObject.Parse('{"a": }');
+    if O <> nil then O.Free;
+  except
+    on EPasClawJSON do Raised := True;
+  end;
+  IsTrue(Raised, 'structurally invalid JSON still raises EPasClawJSON');
+
+  WriteLn('  ok: bare control chars inside strings repaired; valid JSON untouched; bad JSON still errors');
+  WriteLn('json_lenient_tests: OK');
+end.


### PR DESCRIPTION
## What & why

A real Gemini build crashed with an **unhandled** `EPasClawJSON: JSON parse: string exceeds end of line` → non-zero exit → failed prediction. FPC's `jsonscanner` is strict RFC-8259 and rejects a **literal newline/tab inside a JSON string**, which LLM/provider responses intermittently contain (an unescaped newline in a tool-call arg or response field). One bad byte took down the whole agent turn.

This was reproduced **live** — it only became reproducible once the `HTTPS_PROXY` support (#430) let pasclaw actually reach Gemini from the sandbox. pasclaw's own serializer already escapes `\n`, so pasclaw isn't the producer; the defect is in parsing an external blob.

## How

Strict-then-lenient parse: on a scanner failure, `SanitizeLenientJSON` walks the text tracking string/escape state and escapes bare control chars (`\b \t \n \f \r`, else `\uXXXX`) that occur **inside** a string, then retries.

- The sanitizer is a **no-op on well-formed input** and only runs *after* a strict parse has already failed — so valid JSON round-trips byte-for-byte and the happy path pays nothing.
- **Genuinely invalid JSON still raises** the original strict error (structural errors aren't masked).

Factored the FPC parse into `FPCParseData` (non-raising) + `LenientRetry`, shared by `TJsonObject.Parse` and `TJsonArray.Parse`. The Delphi backend gets the same retry (`ParseJSONValue` returns `nil` on failure → `if V = nil then retry`). `SanitizeLenientJSON` is common to both backends.

## Tests

`json_lenient_tests` (`make test-json-lenient`, wired into `make test`):
- bare newline / tab inside a string value → repaired, value preserved
- already-escaped `\n` and pretty-printed structural whitespace → untouched
- braces / commas / escaped-quote **inside** a string → state machine tracks them correctly (no mis-parse)
- array element with a bare newline
- structurally invalid JSON (`{"a": }`) → still raises `EPasClawJSON`

Full build + `make smoke` green.

## Context

This is the last of the chain that started from debugging the `pasclaw-build-deploy` cog. The end-to-end test (proxy binary + deploy nudge in the live image) built and deployed correctly but surfaced this intermittent crash — exactly the class of real-provider failure the relay harness could never reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_