### PR TITLE
read_file: accept offset/limit as aliases for start_line/end_line

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -249,7 +249,7 @@ function Tool_FSRead(const ArgsJSON: string; out ErrMsg: string): string;
 var
   Path, Body, Reason: string;
   Hashline: Boolean;
-  StartLn, EndLn, Total, i: Integer;
+  StartLn, EndLn, Total, i, LimitN: Integer;
   Lines: TStringList;
 begin
   ErrMsg := '';
@@ -277,6 +277,22 @@ begin
     must not carry one). }
   StartLn := Integer(ParseInt64Arg(ArgsJSON, 'start_line', 0));
   EndLn   := Integer(ParseInt64Arg(ArgsJSON, 'end_line', 0));
+  { Aliases: models trained on other harnesses reach for offset/limit by habit
+    (offset = 1-based start line, limit = line count). pasclaw's range args are
+    start_line/end_line; without this, an offset/limit call was silently
+    ignored and read the whole (capped) file -- a wasted turn + context bloat
+    on exactly the surgical read the model intended. Map them on when the
+    canonical args are absent. Same spirit as edit_file's old_string alias. }
+  if StartLn = 0 then StartLn := Integer(ParseInt64Arg(ArgsJSON, 'offset', 0));
+  if EndLn = 0 then
+  begin
+    LimitN := Integer(ParseInt64Arg(ArgsJSON, 'limit', 0));
+    if LimitN > 0 then
+    begin
+      if StartLn > 0 then EndLn := StartLn + LimitN - 1
+      else EndLn := LimitN;   { limit without a start -> first `limit` lines }
+    end;
+  end;
   if (StartLn > 0) or (EndLn > 0) then
   begin
     Lines := TStringList.Create;
@@ -1711,16 +1727,20 @@ begin
                      'path#hash header + LINENO:line format used to build an ' +
                      'edit_file `patch` (advanced).';
     T.Schema      := '{"type":"object","properties":{"path":{"type":"string"},' +
-                     '"start_line":{"type":"integer","minimum":1,"description":"First line to return (1-based). Use with end_line to read just the region a grep_files hit pointed at."},' +
+                     '"start_line":{"type":"integer","minimum":1,"description":"First line to return (1-based). Use with end_line to read just the region a grep_files hit pointed at. Alias: offset."},' +
                      '"end_line":{"type":"integer","minimum":1,"description":"Last line to return (inclusive; clamped to the file end)."},' +
+                     '"offset":{"type":"integer","minimum":1,"description":"Alias for start_line (1-based first line)."},' +
+                     '"limit":{"type":"integer","minimum":1,"description":"Number of lines to return from start_line/offset (an alternative to end_line)."},' +
                      '"hashline":{"type":"boolean","description":"Return the hashline #hash+LINENO format for edit_file patch edits, instead of plain text. Ignored when a line range is set."}},"required":["path"]}';
   end
   else
   begin
     T.Description := 'Read the contents of a file from the local filesystem.';
     T.Schema      := '{"type":"object","properties":{"path":{"type":"string","description":"Absolute or relative path to the file."},' +
-                     '"start_line":{"type":"integer","minimum":1,"description":"First line to return (1-based)."},' +
-                     '"end_line":{"type":"integer","minimum":1,"description":"Last line to return (inclusive; clamped)."}},"required":["path"]}';
+                     '"start_line":{"type":"integer","minimum":1,"description":"First line to return (1-based). Alias: offset."},' +
+                     '"end_line":{"type":"integer","minimum":1,"description":"Last line to return (inclusive; clamped)."},' +
+                     '"offset":{"type":"integer","minimum":1,"description":"Alias for start_line (1-based first line)."},' +
+                     '"limit":{"type":"integer","minimum":1,"description":"Number of lines to return from start_line/offset (an alternative to end_line)."}},"required":["path"]}';
   end;
   T.Handler  := Tool_FSRead;
   T.IsCore   := True;

--- a/src/tests/fs_tool_naming_tests.pas
+++ b/src/tests/fs_tool_naming_tests.pas
@@ -165,6 +165,19 @@ begin
     R := Reg.RunTool('read_file', '{"path":"' + PathA + '","start_line":4,"end_line":99}', Err);
     AssertContains(R, '(lines 4-5 of 5', 'end_line clamps to the file end');
     AssertContains(R, '5:r5', 'clamped tail keeps true line numbers');
+    { offset/limit aliases: models trained on other harnesses reach for these;
+      offset->start_line, limit->line count. Must scope the read exactly like
+      start_line/end_line rather than being silently ignored (whole-file read). }
+    R := Reg.RunTool('read_file', '{"path":"' + PathA + '","offset":2,"limit":2}', Err);
+    AssertContains(R, '(lines 2-3 of 5', 'offset/limit scopes the read (offset->start, limit->count)');
+    AssertContains(R, '2:r2', 'offset/limit slice carries true line numbers');
+    AssertTrue(Pos('r4', R) = 0, 'offset/limit excludes lines past offset+limit-1');
+    { canonical args win when both are present }
+    R := Reg.RunTool('read_file', '{"path":"' + PathA + '","start_line":1,"end_line":1,"offset":4,"limit":2}', Err);
+    AssertContains(R, '(lines 1-1 of 5', 'start_line/end_line take precedence over offset/limit');
+    { limit alone -> first `limit` lines }
+    R := Reg.RunTool('read_file', '{"path":"' + PathA + '","limit":2}', Err);
+    AssertContains(R, '(lines 1-2 of 5', 'limit without offset reads the first `limit` lines');
     { Round-trip guard (P2 on #419): ranged output uses the SAME N: format
       write_file's StripHashlinePrefixes consumes, so a copied indented body
       keeps its exact indentation. A "N: " separator would leave a stray


### PR DESCRIPTION
## What & why

Surfaced by a **SWE-bench Verified pilot** (driven through the relay, so it studies harness quality on real, ground-truth-verified tasks): a capable model reached for `read_file {offset, limit}` — its trained habit (Claude Code's `Read` uses `offset`/`limit`). pasclaw's range args are `start_line`/`end_line`, so the unknown args were **silently ignored** and it read the whole (output-capped) file — a **wasted turn** recovering via `sed`, plus **~30 KB** of unwanted content in context, on exactly the surgical read the model intended.

Crucially, large-file navigation is otherwise a **strength**: a 9k-line `xarray` task was solved in 3 turns *when the model used `start_line`/`end_line`*. The parameter-name habit was the *only* barrier — so aliasing it removes the last friction on an otherwise-excellent path. Same class of fix as `edit_file`'s `old_string` alias (#427).

## How

When the canonical args are absent:
- `offset` → `start_line` (1-based first line)
- `limit` → line count: `end_line = start_line + limit − 1`; `limit` alone reads the first `limit` lines
- `start_line`/`end_line` take precedence when both are supplied

`offset`/`limit` are declared as **real schema properties** in both the hashline and no-hashline `read_file` schemas, so grammar-guided/schema-validating clients can emit them (the lesson from #430's review).

## Tests

`fs_tool_naming` gains, alongside the existing `start_line`/`end_line` range tests:
- `offset`/`limit` scopes the read (`offset→start`, `limit→count`), excludes lines past `offset+limit−1`
- `start_line`/`end_line` win over `offset`/`limit` when both present
- `limit` alone reads the first `limit` lines

Build clean; `make smoke` green.

## Provenance

This is the concrete productivity win from running 3 SWE-bench Verified tasks through the relay harness (all 3 resolved, ground-truth-verified). The harness proved strong on the *hard* mechanics — `apply_patch` for multi-file coordination, line-range reads + post-edit echo for large-file navigation — and the remaining friction was entirely at the tool-API affordance layer, of which this `offset`/`limit` habit was the #1, recurring item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_