### PR TITLE
shell: rm-refusal names the sanctioned delete path + make clean (B3)

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -712,11 +712,14 @@ begin
     begin
       Reason := 'refused: command contains forbidden token "' + Hit +
                 '" (built-in shell denylist; toggle off via sandbox.shell_deny_enabled=false ' +
-                'in config.json -- strongly discouraged). Rewrite the command without "' + Hit +
-                '". For file work use the dedicated tools: read_file / write_file / ' +
-                'append_file / edit_file / find_files / grep_files, and apply_patch to ' +
-                'DELETE or MOVE a file (a "*** Delete File: <path>" or "*** Move to: <path>" ' +
-                'section) -- there is no `rm`/`del` here by design.';
+                'in config.json -- strongly discouraged). Rewrite without "' + Hit + '". ' +
+                'To DELETE or MOVE a file, call apply_patch with a `patch` argument (note the ' +
+                'arg name) holding a "*** Begin Patch" / "*** Delete File: <path>" (or ' +
+                '"*** Move to: <path>") / "*** End Patch" body -- that is the sanctioned ' +
+                'rm/mv here. To clear BUILD ARTIFACTS (.o files, binaries), run a Makefile ' +
+                'target such as `make clean`: make runs its own rm inside the build, which is ' +
+                'allowed. For other file work use read_file / write_file / append_file / ' +
+                'edit_file / find_files / grep_files.';
       Exit(False);
     end;
     if MatchesAnySubstring(Cmd, Hit) then

--- a/src/pkg/tools/PasClaw.Tools.Sandbox.pas
+++ b/src/pkg/tools/PasClaw.Tools.Sandbox.pas
@@ -718,8 +718,8 @@ begin
                 '"*** Move to: <path>") / "*** End Patch" body -- that is the sanctioned ' +
                 'rm/mv here. To clear BUILD ARTIFACTS (.o files, binaries), run a Makefile ' +
                 'target such as `make clean`: make runs its own rm inside the build, which is ' +
-                'allowed. For other file work use read_file / write_file / append_file / ' +
-                'edit_file / find_files / grep_files.';
+                'allowed. For other file work use the dedicated tools: read_file / ' +
+                'write_file / append_file / edit_file / find_files / grep_files.';
       Exit(False);
     end;
     if MatchesAnySubstring(Cmd, Hit) then


### PR DESCRIPTION
## What & why

Found by running the **coding-agent-benchmark** (multi-language: C/C++/TS) through the relay — the surface SWE-bench (Python-only) never touches. On the C tasks, a model reaching for `rm` (to clear `.o`/binary build artifacts) hit the shell denylist and **burned turns discovering the workaround**: the refusal pointed at `apply_patch`'s `*** Delete File:` section but (a) didn't name `apply_patch`'s **`patch`** argument — the model guessed `input`, one wasted call — and (b) never mentioned that a Makefile `clean` target still works.

## The call I made (and didn't make)

I deliberately **kept the "no `rm`" security control intact.** A scoped relaxation is tempting but not worth the threat surface for a marginal gain, and the actual friction was *discoverability*, not capability (`apply_patch` delete and `make clean` both already work). So this is a **B3 message fix, not a security change** — the refusal is now fully self-documenting:

- names the **`patch`** arg + the full `*** Begin Patch` / `*** Delete File:` / `*** End Patch` envelope
- tells the model that **`make clean`** is the right way to clear build artifacts (make runs its own `rm` inside the build, which is allowed)

No logic change — refusal-message text only. Build + `make smoke` green.

## Provenance
From the compiled-language bench pass (3/3 tasks resolved by their own hidden test suites: C bugfix 8/8, C multifile-segfault 8/8, TS feature 13/13). The build *loop* itself proved strong (tight compile→error→fix, `apply_patch` for multi-file); this was the one recurring friction on that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_