### PR TITLE
Self-hosted reranking: /v1/rerank, local cross-encoder + LLM backend, wired into retrieval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-rerank test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-rerank test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -325,6 +325,16 @@ test-rerank: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/rerank_tests.pas -o$(BUILDDIR)/rerank_tests
 	@$(BUILDDIR)/rerank_tests
+
+# Retrieval reranking eval (MRR / recall@5, bi-encoder vs cross-encoder).
+# Operator tool: prints a SKIP + exits 0 unless the embedding AND reranker
+# models are provisioned on an ONNX-Runtime host, so it stays green in CI and
+# earns continuous compile coverage. Point PASCLAW_HOME at a provisioned home
+# for real numbers.
+test-rerank-eval: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/rerank_eval.pas -o$(BUILDDIR)/rerank_eval
+	@$(BUILDDIR)/rerank_eval
 
 # PasClaw.Providers.Models — /v1/models cache schema round-trip + helpers.
 test-model-discovery: | $(BUILDDIR)
@@ -880,4 +890,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-rerank test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -318,6 +318,13 @@ test-json-lenient: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/json_lenient_tests.pas -o$(BUILDDIR)/json_lenient_tests
 	@$(BUILDDIR)/json_lenient_tests
+
+# Reranker (cross-encoder) core: model registry + EncodePair pair-packing +
+# token_type_ids segmentation + truncation (ONNX-independent; live scoring needs ORT).
+test-rerank: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/rerank_tests.pas -o$(BUILDDIR)/rerank_tests
+	@$(BUILDDIR)/rerank_tests
 
 # PasClaw.Providers.Models — /v1/models cache schema round-trip + helpers.
 test-model-discovery: | $(BUILDDIR)
@@ -873,4 +880,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-rerank test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip test-json-lenient test-rerank test-sentencepiece test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -325,6 +325,14 @@ test-rerank: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/rerank_tests.pas -o$(BUILDDIR)/rerank_tests
 	@$(BUILDDIR)/rerank_tests
+
+# XLM-R SentencePiece Unigram tokenizer (bge-reranker). Tiny synthetic vocab,
+# no model download -- the byte-exact-vs-HuggingFace proof runs out-of-band on
+# the provisioned tokenizer.json (see the branch's scratch validator).
+test-sentencepiece: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/sentencepiece_tests.pas -o$(BUILDDIR)/sentencepiece_tests
+	@$(BUILDDIR)/sentencepiece_tests
 
 # Retrieval reranking eval (MRR / recall@5, bi-encoder vs cross-encoder).
 # Operator tool: prints a SKIP + exits 0 unless the embedding AND reranker
@@ -890,4 +898,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-sentencepiece test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/src/cmd/PasClaw.Cmd.Memory.pas
+++ b/src/cmd/PasClaw.Cmd.Memory.pas
@@ -68,7 +68,8 @@ uses
   LocalVector.Models,
   LocalVector.OrtProvision,
   LocalVector.VecProvision,
-  LocalVector.Downloader;
+  LocalVector.Downloader,
+  PasClaw.Memory.Rerank;
 
 { Cache directory under PASCLAW_HOME. Built up via nested JoinPath
   calls -- NOT as a single `'cache/localvector'` const -- because on
@@ -89,8 +90,12 @@ begin
   PrintLn('Usage: pasclaw memory <subcommand>');
   PrintLn;
   PrintLn('Subcommands:');
-  PrintLn('  provision   Download sqlite-vec, ONNX Runtime, and the default');
-  PrintLn('              embedding model into $PASCLAW_HOME/cache/localvector/');
+  PrintLn('  provision [--rerank] [--rerank-model KEY]');
+  PrintLn('              Download sqlite-vec, ONNX Runtime, and the default');
+  PrintLn('              embedding model into $PASCLAW_HOME/cache/localvector/.');
+  PrintLn('              --rerank also fetches the cross-encoder reranker');
+  PrintLn('              (default ms-marco-minilm) for /v1/rerank; --rerank-model');
+  PrintLn('              picks one (' + RerankerKeys + ').');
   PrintLn('  status      Show which runtime artifacts are present and which');
   PrintLn('              backend memory_search would pick on the next call');
   PrintLn('  distill [session] [--save]');
@@ -362,7 +367,51 @@ begin
   end;
 end;
 
-function RunProvision: Integer;
+function ProvisionRerankerModel(const AKey: string): Boolean;
+{ Downloads (if missing) the cross-encoder reranker model.onnx + vocab.txt
+  for reranker spec AKey into <cache>/models/<spec.SubDir>/. Same shape as
+  ProvisionEmbeddingModel but backed by the reranker registry. Reuses the
+  ONNX Runtime already provisioned for the embedder -- no extra runtime. }
+var
+  Spec: TModelSpec;
+  Dir:  string;
+  D:    TModelDownloader;
+begin
+  Result := False;
+  if not FindRerankerSpec(AKey, Spec) then
+  begin
+    PrintCheckMark(Ansi.Red, '✗',
+      Format('reranker: unknown model "%s" (known: %s)', [AKey, RerankerKeys]));
+    Exit;
+  end;
+
+  Dir := ModelDir(Spec.SubDir);
+  ForceDirectories(Dir);
+
+  D := TModelDownloader.Create(Spec, Dir, {AVerbose=} True);
+  try
+    try
+      D.EnsureFiles;
+      if FileExists(D.ModelPath) and FileExists(D.VocabPath) then
+      begin
+        PrintCheckMark(Ansi.Green, '✓',
+          Format('reranker model %s (%s) installed at %s',
+                 [Spec.DisplayName, Spec.SizeDesc, Dir]));
+        Result := True;
+      end
+      else
+        PrintCheckMark(Ansi.Red, '✗',
+          'reranker model: download reported success but files missing');
+    except
+      on E: Exception do
+        PrintCheckMark(Ansi.Red, '✗', 'reranker model: ' + E.Message);
+    end;
+  finally
+    D.Free;
+  end;
+end;
+
+function RunProvision(const Argv: array of string): Integer;
 { Drives the three provisioning steps in order, prints a summary at
   the end, returns 0 if all three succeeded, 1 if any failed (the
   hybrid backend needs all three).
@@ -371,9 +420,32 @@ function RunProvision: Integer;
   routines (which assume the dir exists) don't trip on the very first
   fresh-install run. }
 var
-  OkVec, OkOrt, OkModel: Boolean;
-  Cache: string;
+  OkVec, OkOrt, OkModel, OkRerank, WantRerank: Boolean;
+  Cache, RerankKey: string;
+  Cfg: TConfig;
+  i: Integer;
 begin
+  { --rerank            also fetch the default cross-encoder reranker.
+    --rerank-model KEY  fetch a specific reranker (implies --rerank). }
+  WantRerank := False;
+  RerankKey  := DEFAULT_RERANKER;
+  i := 0;
+  while i <= High(Argv) do
+  begin
+    if SameText(Argv[i], '--rerank') then
+      WantRerank := True
+    else if SameText(Argv[i], '--rerank-model') then
+    begin
+      WantRerank := True;
+      if i < High(Argv) then
+      begin
+        RerankKey := Argv[i + 1];
+        Inc(i);
+      end;
+    end;
+    Inc(i);
+  end;
+
   Cache := CacheDir;
   ForceDirectories(Cache);
 
@@ -388,8 +460,40 @@ begin
   OkOrt   := ProvisionOnnxRuntime;
   OkModel := ProvisionEmbeddingModel;
 
+  OkRerank := True;
+  if WantRerank then
+  begin
+    PrintLn;
+    PrintLn(Ansi.Bold + 'Reranker (cross-encoder)' + Ansi.Reset);
+    OkRerank := ProvisionRerankerModel(RerankKey);
+    if OkRerank then
+    begin
+      { Persist which reranker was installed so the /v1/rerank endpoint and
+        the retrieval stage load it. Best-effort -- a save failure shouldn't
+        fail an otherwise-successful download. }
+      try
+        Cfg := LoadConfig;
+        try
+          Cfg.RerankModel := LowerCase(Trim(RerankKey));
+          SaveConfig(Cfg);
+          PrintLn('  ' + Ansi.Dim + 'rerank_model set to "' +
+            Cfg.RerankModel + '" in config.json' + Ansi.Reset);
+        finally
+          Cfg.Free;
+        end;
+      except
+        on E: Exception do
+          PrintLn('  ' + Ansi.Yellow + '·' + Ansi.Reset +
+            ' could not persist rerank_model: ' + E.Message);
+      end;
+      PrintLn('  ' + Ansi.Dim +
+        'enable with rerank_search_enabled: true in config.json ' +
+        '(or serve /v1/rerank now).' + Ansi.Reset);
+    end;
+  end;
+
   PrintLn;
-  if OkVec and OkOrt and OkModel then
+  if OkVec and OkOrt and OkModel and OkRerank then
   begin
     PrintLn(Ansi.Green + '✓' + Ansi.Reset +
       ' hybrid backend ready -- memory_search will use FTS + vector on next call');
@@ -409,10 +513,10 @@ function RunStatus: Integer;
   for diagnostics and as the "did the provision actually work" answer
   separate from running memory_search. }
 var
-  Spec: TModelSpec;
-  ModelP, VocabP: string;
+  Spec, RSpec: TModelSpec;
+  ModelP, VocabP, RModelP, RerankKey: string;
   Cfg: TConfig;
-  Active: string;
+  Active, RerankState: string;
 begin
   Cfg := LoadConfig;
   try
@@ -420,12 +524,19 @@ begin
       Active := 'hybrid (when artifacts present) else FTS-only'
     else
       Active := 'FTS-only (vector_search_enabled is false in config.json)';
+    RerankKey := LowerCase(Trim(Cfg.RerankModel));
+    if RerankKey = '' then RerankKey := DEFAULT_RERANKER;
+    if Cfg.RerankSearchEnabled then
+      RerankState := 'on (rerank_search_enabled) -- model ' + RerankKey
+    else
+      RerankState := 'off (rerank_search_enabled is false) -- model ' + RerankKey;
   finally
     Cfg.Free;
   end;
 
   PrintLn(Ansi.Bold + 'memory_search backend' + Ansi.Reset);
   PrintLn('  config setting: ' + Active);
+  PrintLn('  reranking:      ' + RerankState);
   PrintLn('  cache dir:      ' + CacheDir);
   PrintLn;
   PrintLn(Ansi.Bold + 'Runtime artifacts' + Ansi.Reset);
@@ -449,6 +560,21 @@ begin
       PrintCheckMark(Ansi.Green, '✓', 'vocab at ' + VocabP)
     else
       PrintCheckMark(Ansi.Yellow, '·', 'vocab missing at ' + VocabP);
+  end;
+
+  { Reranker (cross-encoder) -- optional second stage. Reported against the
+    configured key (rerank_model) so `status` reflects what serve / retrieval
+    would actually load; a '·' just means it hasn't been provisioned with
+    `memory provision --rerank`. }
+  if FindRerankerSpec(RerankKey, RSpec) then
+  begin
+    RModelP := JoinPath(ModelDir(RSpec.SubDir), 'model.onnx');
+    if FileExists(RModelP) then
+      PrintCheckMark(Ansi.Green, '✓',
+        'reranker ' + RSpec.DisplayName + ' at ' + RModelP)
+    else
+      PrintCheckMark(Ansi.Yellow, '·',
+        'reranker ' + RSpec.DisplayName + ' not provisioned (memory provision --rerank)');
   end;
 
   { ONNX Runtime -- same gate TVectorMemoryIndex.Open calls before
@@ -935,7 +1061,7 @@ begin
     Help;
     Exit(0);
   end;
-  if Sub = 'provision' then Exit(RunProvision);
+  if Sub = 'provision' then Exit(RunProvision(Argv));
   if Sub = 'status'    then Exit(RunStatus);
   if Sub = 'distill'   then Exit(RunDistill(Argv));
   if Sub = 'facts'     then Exit(RunFacts(Argv));

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -1508,6 +1508,46 @@ begin
   else
     PrintLn('  ' + Ansi.Dim +
       '(deferred -- run `pasclaw memory provision` when ready)' + Ansi.Reset);
+
+  { Optional second stage: cross-encoder reranking. Offered right after
+    vector search because it rescores the SAME candidate pool for sharper
+    ordering. Default NO -- it adds another ~90 MB model download and a
+    per-query scoring pass, so it deserves an explicit opt-in. Reuses the
+    ONNX Runtime the embedder already needs. }
+  PrintLn;
+  PrintLn(Ansi.Bold + 'Memory: cross-encoder reranking (optional)' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'Rescore memory_search / kb_search candidates with a local cross-encoder' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    'for sharper ordering than embeddings alone. Also serves /v1/rerank.' +
+    Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '    reranker model + vocab   (HuggingFace, ~90 MB; reuses ONNX Runtime)' +
+    Ansi.Reset);
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable reranking for retrieval [y/N]: ')));
+  if not ((Choice = 'y') or (Choice = 'yes')) then
+  begin
+    PrintLn('  ' + Ansi.Dim +
+      '(skipped -- enable later with rerank_search_enabled + ' +
+      '`pasclaw memory provision --rerank`)' + Ansi.Reset);
+    Exit;
+  end;
+
+  Cfg.RerankSearchEnabled := True;
+  PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' reranking enabled');
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Download reranker now? [y/N]: ')));
+  if (Choice = 'y') or (Choice = 'yes') then
+  begin
+    PrintLn;
+    Cmd_Memory_Run(['provision', '--rerank']);
+  end
+  else
+    PrintLn('  ' + Ansi.Dim +
+      '(deferred -- run `pasclaw memory provision --rerank` when ready; ' +
+      'until then retrieval keeps the RRF order)' + Ansi.Reset);
 end;
 
 procedure PromptKnowledgebase(Cfg: TConfig);

--- a/src/cmd/PasClaw.Cmd.Onboard.pas
+++ b/src/cmd/PasClaw.Cmd.Onboard.pas
@@ -1438,6 +1438,25 @@ begin
   end;
 end;
 
+function ProviderIsSelfHosted(Cfg: TConfig): Boolean;
+{ True when the configured default provider is a LOCAL / self-hosted model
+  server (ollama / lmstudio / vllm / relay, or any catalog provider whose auth
+  scheme is asNone -- i.e. no cloud API key). Used to pick the reranking
+  default: self-hosted -> a dedicated local cross-encoder (don't burden the
+  local chat model, and it's faster); cloud/frontier -> rerank via the model
+  itself (best quality, no download). }
+var
+  Spec: TProviderSpec;
+  K: string;
+begin
+  K := LowerCase(Trim(Cfg.DefaultProvider));
+  if (K = 'ollama') or (K = 'lmstudio') or (K = 'vllm') or (K = 'relay') then
+    Exit(True);
+  Result := LookupProvider(K, Spec) and (Spec.Auth.Kind = asNone);
+end;
+
+procedure PromptReranking(Cfg: TConfig); forward;
+
 procedure PromptVectorSearch(Cfg: TConfig);
 { Opt-in toggle for hybrid FTS+vector memory_search. Default YES
   because the hybrid index is what picoclaw / nanobot ship and it's
@@ -1509,45 +1528,114 @@ begin
     PrintLn('  ' + Ansi.Dim +
       '(deferred -- run `pasclaw memory provision` when ready)' + Ansi.Reset);
 
-  { Optional second stage: cross-encoder reranking. Offered right after
-    vector search because it rescores the SAME candidate pool for sharper
-    ordering. Default NO -- it adds another ~90 MB model download and a
-    per-query scoring pass, so it deserves an explicit opt-in. Reuses the
-    ONNX Runtime the embedder already needs. }
+  PromptReranking(Cfg);
+end;
+
+procedure PromptReranking(Cfg: TConfig);
+{ Optional second stage: cross-encoder reranking, offered right after vector
+  search because it rescores the SAME candidate pool for sharper ordering.
+  Provider-aware default:
+    * cloud/frontier provider (has an API key) -> rerank with the model itself
+      (best quality, no download); local cross-encoder offered as a faster/free
+      alternative.
+    * self-hosted server (ollama / lmstudio / vllm / relay) -> a dedicated
+      local cross-encoder (bge-reranker-base) is the default -- it doesn't
+      burden the local chat model and is much faster per query.
+  Always opt-in (default NO on the whole feature). }
+var
+  Choice: string;
+  SelfHosted: Boolean;
+begin
+  SelfHosted := ProviderIsSelfHosted(Cfg);
+
   PrintLn;
   PrintLn(Ansi.Bold + 'Memory: cross-encoder reranking (optional)' + Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'Rescore memory_search / kb_search candidates with a local cross-encoder' +
+    'Rescore memory_search / kb_search candidates for sharper ordering than' +
     Ansi.Reset);
   PrintLn(Ansi.Dim +
-    'for sharper ordering than embeddings alone. Also serves /v1/rerank.' +
-    Ansi.Reset);
-  PrintLn(Ansi.Dim +
-    '    reranker model + vocab   (HuggingFace, ~90 MB; reuses ONNX Runtime)' +
-    Ansi.Reset);
+    'embeddings alone. Also serves the /v1/rerank API.' + Ansi.Reset);
   PrintLn;
-  Choice := Trim(LowerCase(ReadLineEcho('  Enable reranking for retrieval [y/N]: ')));
-  if not ((Choice = 'y') or (Choice = 'yes')) then
+
+  if not SelfHosted then
   begin
-    PrintLn('  ' + Ansi.Dim +
-      '(skipped -- enable later with rerank_search_enabled + ' +
-      '`pasclaw memory provision --rerank`)' + Ansi.Reset);
+    { Cloud provider: LLM reranking is the quality path and needs no download. }
+    PrintLn(Ansi.Dim +
+      '  Your provider (' + Cfg.DefaultProvider + ') can rerank with the model' +
+      Ansi.Reset);
+    PrintLn(Ansi.Dim +
+      '  itself (best quality, no download) or a local cross-encoder' + Ansi.Reset);
+    PrintLn(Ansi.Dim +
+      '  (bge-reranker-base, ~280 MB -- faster + free per query).' + Ansi.Reset);
+    PrintLn;
+    Choice := Trim(LowerCase(ReadLineEcho(
+      '  Reranking: [L]LM (default) / [b]ge-local / [s]kip: ')));
+    if (Choice = 's') or (Choice = 'skip') then
+    begin
+      PrintLn('  ' + Ansi.Dim + '(skipped -- enable later via rerank_search_enabled)' + Ansi.Reset);
+      Exit;
+    end;
+    Cfg.RerankSearchEnabled := True;
+    if (Choice = 'b') or (Choice = 'bge') or (Choice = 'local') then
+    begin
+      Cfg.RerankBackend := 'local';
+      Cfg.RerankModel   := 'bge-reranker-base';
+      PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' local reranking (bge-reranker-base)');
+      PrintLn;
+      Choice := Trim(LowerCase(ReadLineEcho('  Download it now (~280 MB)? [y/N]: ')));
+      if (Choice = 'y') or (Choice = 'yes') then
+      begin
+        PrintLn;
+        Cmd_Memory_Run(['provision', '--rerank-model', 'bge-reranker-base']);
+      end
+      else
+        PrintLn('  ' + Ansi.Dim +
+          '(deferred -- `pasclaw memory provision --rerank-model bge-reranker-base`)' + Ansi.Reset);
+    end
+    else
+    begin
+      { default: LLM backend }
+      Cfg.RerankBackend := 'llm';
+      PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset +
+        ' reranking via your provider (rerank_backend=llm)');
+      PrintLn('  ' + Ansi.Dim +
+        'note: retrieval reranking makes one model call per search; switch to ' +
+        'rerank_backend=local (bge) if you prefer speed/cost.' + Ansi.Reset);
+    end;
     Exit;
   end;
 
-  Cfg.RerankSearchEnabled := True;
-  PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' reranking enabled');
+  { Self-hosted: default to a dedicated local cross-encoder. }
+  PrintLn(Ansi.Dim +
+    '  Recommended for self-hosted setups: a dedicated local cross-encoder' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '  (bge-reranker-base, ~280 MB) -- faster than your chat model and it' + Ansi.Reset);
+  PrintLn(Ansi.Dim +
+    '  does not compete with it for the server''s resources.' + Ansi.Reset);
   PrintLn;
-  Choice := Trim(LowerCase(ReadLineEcho('  Download reranker now? [y/N]: ')));
+  Choice := Trim(LowerCase(ReadLineEcho('  Enable local reranking (bge-reranker-base)? [y/N]: ')));
+  if not ((Choice = 'y') or (Choice = 'yes')) then
+  begin
+    PrintLn('  ' + Ansi.Dim +
+      '(skipped -- enable later via rerank_search_enabled + ' +
+      '`pasclaw memory provision --rerank`; or set rerank_backend=llm to use ' +
+      'your local model)' + Ansi.Reset);
+    Exit;
+  end;
+  Cfg.RerankSearchEnabled := True;
+  Cfg.RerankBackend := 'local';
+  Cfg.RerankModel   := 'bge-reranker-base';
+  PrintLn('  ' + Ansi.Green + '✓' + Ansi.Reset + ' local reranking (bge-reranker-base)');
+  PrintLn;
+  Choice := Trim(LowerCase(ReadLineEcho('  Download it now (~280 MB)? [y/N]: ')));
   if (Choice = 'y') or (Choice = 'yes') then
   begin
     PrintLn;
-    Cmd_Memory_Run(['provision', '--rerank']);
+    Cmd_Memory_Run(['provision', '--rerank-model', 'bge-reranker-base']);
   end
   else
     PrintLn('  ' + Ansi.Dim +
-      '(deferred -- run `pasclaw memory provision --rerank` when ready; ' +
-      'until then retrieval keeps the RRF order)' + Ansi.Reset);
+      '(deferred -- `pasclaw memory provision --rerank-model bge-reranker-base`)' + Ansi.Reset);
 end;
 
 procedure PromptKnowledgebase(Cfg: TConfig);

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -642,6 +642,22 @@ type
        300+MB of model weights on disk can flip this in
        config.json or answer 'n' at onboarding. *)
     VectorSearchEnabled: Boolean;
+    (* Second-stage reranking of memory_search / kb_search candidates by a
+       local ONNX cross-encoder (PasClaw.Memory.Rerank). Off by default: it
+       needs the reranker model provisioned (`pasclaw memory provision
+       --rerank`) and adds a per-query scoring pass over the candidate pool.
+       When on, retrieval widens the first-stage (RRF) pool, rescores each
+       (query, candidate) pair with the cross-encoder, and truncates back to
+       K -- more precise ordering than the bi-encoder cosine alone. Falls
+       back silently to the RRF order when the reranker isn't loadable, so
+       flipping this on without provisioning is a no-op, never an error. *)
+    RerankSearchEnabled: Boolean;
+    (* Reranker model id (registry key in PasClaw.Memory.Rerank, e.g.
+       'ms-marco-minilm' or 'bge-reranker-base'). Empty = the built-in
+       default (ms-marco-minilm). Selects which cross-encoder the /v1/rerank
+       endpoint and the RerankSearchEnabled retrieval stage load. Set by
+       `pasclaw memory provision --rerank[-model KEY]`. *)
+    RerankModel:         string;
     (* Render markdown the model emits as ANSI-styled text in the
        terminal (PasClaw.Markdown.Render). On by default -- terminal
        surfaces (pasclaw agent, pasclaw tui) call into it; serve /
@@ -1104,6 +1120,8 @@ begin
   SelfImprovingSkills.Distiller.Model        := '';
   Profile := '';   { PR #291: empty == no persisted profile selection }
   VectorSearchEnabled  := True;  { on by default; onboarding asks (default Y) -- see TConfig comment }
+  RerankSearchEnabled  := False; { opt-in: needs the reranker model provisioned }
+  RerankModel          := '';    { empty == built-in default (ms-marco-minilm) }
   AnthropicServerTools.WebSearch        := False;
   AnthropicServerTools.WebSearchMaxUses := 0;
   AnthropicServerTools.WebFetch         := False;
@@ -1359,6 +1377,12 @@ begin
       across SaveConfig + LoadConfig. }
     if not VectorSearchEnabled then
       Root.PutBool('vector_search_enabled', False);
+    { Reranking: opt-in, so only emit when enabled / customised (keeps the
+      default config.json unchanged for the common case). }
+    if RerankSearchEnabled then
+      Root.PutBool('rerank_search_enabled', True);
+    if RerankModel <> '' then
+      Root.PutStr('rerank_model', RerankModel);
     { Tool output cap: emit only when it differs from the default --
       including an explicit 0 (opt-OUT), which must round-trip or the
       next LoadConfig would silently re-enable the cap. }
@@ -1834,6 +1858,8 @@ begin
                                               MCPProgressiveDisclosure);
     RenderMarkdown      := Root.GetBool('render_markdown',       RenderMarkdown);
     VectorSearchEnabled := Root.GetBool('vector_search_enabled', VectorSearchEnabled);
+    RerankSearchEnabled := Root.GetBool('rerank_search_enabled', RerankSearchEnabled);
+    RerankModel         := Root.GetStr('rerank_model', RerankModel);
     ToolOutputCap       := Integer(Root.GetInt('tool_output_cap', ToolOutputCap));
     StatsCollectionEnabled := Root.GetBool('stats_collection_enabled',
                                            StatsCollectionEnabled);

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -981,6 +981,10 @@ uses
                                 see the comment inside LoadConfig }
   PasClaw.Tools.OutputCache,  { LoadConfig propagates condense_reversible
                                 via SetCondenseReversible -- same pattern }
+  PasClaw.Memory.Rerank.Serve, { LoadConfig propagates rerank_model +
+                                rerank_search_enabled -- same pattern. Its
+                                dep cone (LocalVector + onnxruntime) never
+                                imports PasClaw.Config, so no cycle. }
   PasClaw.Otel;               { LoadConfig calls InitOtelFromConfig so
                                 env-var overrides (OTEL_EXPORTER_OTLP_ENDPOINT)
                                 + the diagnostics.otel.* block in config.json
@@ -2285,6 +2289,11 @@ begin
   { Symmetric propagation of the reversible-condensation flag -- OutputCache
     holds the same process-global mirror. }
   SetCondenseReversible(C.CondenseReversible);
+  { Reranker: which cross-encoder to load + whether retrieval reranks. The
+    /v1/rerank endpoint and the memory_search rerank stage both read these
+    process-globals, so this chokepoint keeps them in sync with config.json. }
+  SetLocalRerankModel(C.RerankModel);
+  SetRerankSearchEnabled(C.RerankSearchEnabled);
   { OpenTelemetry traces. No-op when diagnostics.otel.enabled is False AND
     the OTEL_EXPORTER_OTLP_ENDPOINT env var is unset -- so single-shot CLI
     commands like `pasclaw status` pay nothing for the wiring. }

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -658,6 +658,14 @@ type
        endpoint and the RerankSearchEnabled retrieval stage load. Set by
        `pasclaw memory provision --rerank[-model KEY]`. *)
     RerankModel:         string;
+    (* Which reranker backend to use: 'auto' (default) prefers the local ONNX
+       cross-encoder and falls back to asking the configured chat model when
+       no local model is provisioned; 'local' uses only the ONNX model (503 /
+       no-op when absent); 'llm' always asks the chat model; 'off' disables
+       reranking. The LLM backend (PasClaw.Memory.Rerank.LLM) needs no model
+       download -- a frontier model reranks well but costs one provider call
+       per rerank, so it is the fallback, not the retrieval default. *)
+    RerankBackend:       string;
     (* Render markdown the model emits as ANSI-styled text in the
        terminal (PasClaw.Markdown.Render). On by default -- terminal
        surfaces (pasclaw agent, pasclaw tui) call into it; serve /
@@ -1126,6 +1134,7 @@ begin
   VectorSearchEnabled  := True;  { on by default; onboarding asks (default Y) -- see TConfig comment }
   RerankSearchEnabled  := False; { opt-in: needs the reranker model provisioned }
   RerankModel          := '';    { empty == built-in default (ms-marco-minilm) }
+  RerankBackend        := 'auto';{ local if provisioned, else the chat model }
   AnthropicServerTools.WebSearch        := False;
   AnthropicServerTools.WebSearchMaxUses := 0;
   AnthropicServerTools.WebFetch         := False;
@@ -1387,6 +1396,8 @@ begin
       Root.PutBool('rerank_search_enabled', True);
     if RerankModel <> '' then
       Root.PutStr('rerank_model', RerankModel);
+    if (RerankBackend <> '') and (RerankBackend <> 'auto') then
+      Root.PutStr('rerank_backend', RerankBackend);
     { Tool output cap: emit only when it differs from the default --
       including an explicit 0 (opt-OUT), which must round-trip or the
       next LoadConfig would silently re-enable the cap. }
@@ -1864,6 +1875,8 @@ begin
     VectorSearchEnabled := Root.GetBool('vector_search_enabled', VectorSearchEnabled);
     RerankSearchEnabled := Root.GetBool('rerank_search_enabled', RerankSearchEnabled);
     RerankModel         := Root.GetStr('rerank_model', RerankModel);
+    RerankBackend       := LowerCase(Trim(Root.GetStr('rerank_backend', RerankBackend)));
+    if RerankBackend = '' then RerankBackend := 'auto';
     ToolOutputCap       := Integer(Root.GetInt('tool_output_cap', ToolOutputCap));
     StatsCollectionEnabled := Root.GetBool('stats_collection_enabled',
                                            StatsCollectionEnabled);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -491,6 +491,7 @@ uses
   PasClaw.Memory.Distill,       { TFact + NormaliseFact for manual remember }
   PasClaw.Memory.Facts.Embed,   { Phase 4c: semantic fact embedder }
   PasClaw.Memory.Rerank.Serve,  { local ONNX cross-encoder for /v1/rerank }
+  PasClaw.Memory.Rerank.LLM,    { LLM fallback reranker (asks the chat model) }
   PasClaw.Providers.Factory,
   PasClaw.Providers.Catalog,   { TProviderSpec for /v1/models discovery }
   PasClaw.Providers.Models,    { DiscoverModels / cache -- /v1/models roster }
@@ -7166,7 +7167,7 @@ procedure TGatewayServer.HandleRerank(ARequest: TIdHTTPRequestInfo;
   descending, and usage. No outbound call -- the query and documents are
   scored on-host and never leave. }
 var
-  Body, ReqModel, ModelId, OneDoc: string;
+  Body, ReqModel, ModelId, OneDoc, Backend: string;
   Req, Root, Item, DocObj, Usage: TJsonObject;
   DocsArr, ResArr: TJsonArray;
   Docs: array of string;
@@ -7174,7 +7175,7 @@ var
   Scores: TArray<Single>;
   Query: string;
   TopN, i, ApproxTokens, Emitted: Integer;
-  ReturnDocs: Boolean;
+  ReturnDocs, UseLLM: Boolean;
 begin
   Body := ReadRequestBody(ARequest);
   if Trim(Body) = '' then
@@ -7226,23 +7227,59 @@ begin
       Exit;
     end;
 
-    if not LocalRerankAvailable(GetHome) then
+    { Backend selection: 'local' uses only the ONNX model, 'llm' always asks
+      the chat model, 'auto' (default) prefers local and falls back to the LLM
+      when no local model is provisioned. The endpoint is an explicit rerank
+      request, so 'off' behaves like 'auto' here (retrieval, not the API, is
+      what 'off' silences). }
+    Backend := LowerCase(Trim(FCfg.RerankBackend));
+    if Backend = '' then Backend := 'auto';
+    UseLLM := False;
+    if Backend = 'llm' then
+      UseLLM := True
+    else if Backend = 'local' then
+      UseLLM := False
+    else { auto / off / unknown }
+      UseLLM := not LocalRerankAvailable(GetHome);
+
+    if UseLLM then
     begin
-      WriteJSON(AResp, 503,
-        '{"error":{"message":"local reranker not provisioned -- run ' +
-        '`pasclaw memory provision --rerank` to download the ONNX model",' +
-        '"type":"server_error"}}');
-      Exit;
+      if not LLMRerankAvailable(FProvider) then
+      begin
+        WriteJSON(AResp, 503,
+          '{"error":{"message":"no reranker available -- provision a local ' +
+          'model (`pasclaw memory provision --rerank`) or configure a chat ' +
+          'provider for the LLM fallback","type":"server_error"}}');
+        Exit;
+      end;
+      if not LLMRerank(FProvider, '', Query, Docs, 0, 0, Order, Scores) then
+      begin
+        WriteJSON(AResp, 502,
+          '{"error":{"message":"LLM rerank failed (provider error or ' +
+          'unparseable ranking)","type":"server_error"}}');
+        Exit;
+      end;
+      ModelId := 'llm:' + FProvider.GetName;
+    end
+    else
+    begin
+      if not LocalRerankAvailable(GetHome) then
+      begin
+        WriteJSON(AResp, 503,
+          '{"error":{"message":"local reranker not provisioned -- run ' +
+          '`pasclaw memory provision --rerank`, or set rerank_backend to ' +
+          '\"llm\"/\"auto\" to use the chat model","type":"server_error"}}');
+        Exit;
+      end;
+      if not LocalRerank(GetHome, Query, Docs, Order, Scores) then
+      begin
+        WriteJSON(AResp, 500,
+          '{"error":{"message":"rerank failed","type":"server_error"}}');
+        Exit;
+      end;
+      LocalRerankModelInfo(GetHome, ModelId);
     end;
 
-    if not LocalRerank(GetHome, Query, Docs, Order, Scores) then
-    begin
-      WriteJSON(AResp, 500,
-        '{"error":{"message":"rerank failed","type":"server_error"}}');
-      Exit;
-    end;
-
-    LocalRerankModelInfo(GetHome, ModelId);
     ReqModel   := Req.GetStr('model', '');
     ReturnDocs := Req.GetBool('return_documents', False);
     { top_n caps how many ranked results are returned; <=0 or absent = all. }

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -352,6 +352,13 @@ type
       host). 503 when the model isn't provisioned. }
     procedure HandleEmbeddings(ARequest: TIdHTTPRequestInfo;
                                AResp: TIdHTTPResponseInfo);
+    { POST /v1/rerank (aliases /rerank, /v2/rerank) -- cross-encoder reranking
+      computed with PasClaw's local ONNX reranker (no outbound call; the query
+      and documents never leave the host). 503 when the reranker isn't
+      provisioned. Response shape follows the de-facto /v1/rerank contract --
+      a results array of index + relevance_score, sorted descending. }
+    procedure HandleRerank(ARequest: TIdHTTPRequestInfo;
+                           AResp: TIdHTTPResponseInfo);
     { GET /v1/providers/catalog -- the static provider catalog (names, default
       base/model, auth requirement) so the web onboarding wizard can offer a
       provider picker without hardcoding the list client-side. No secrets. }
@@ -483,6 +490,7 @@ uses
   PasClaw.Memory.Facts,         { fact store for the web Memory tab (Phase 5b) }
   PasClaw.Memory.Distill,       { TFact + NormaliseFact for manual remember }
   PasClaw.Memory.Facts.Embed,   { Phase 4c: semantic fact embedder }
+  PasClaw.Memory.Rerank.Serve,  { local ONNX cross-encoder for /v1/rerank }
   PasClaw.Providers.Factory,
   PasClaw.Providers.Catalog,   { TProviderSpec for /v1/models discovery }
   PasClaw.Providers.Models,    { DiscoverModels / cache -- /v1/models roster }
@@ -1269,6 +1277,7 @@ begin
       HandleMCPRequest(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/models')  then HandleModels(AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/embeddings') then HandleEmbeddings(ARequest, AResponse)
+    else if (ARequest.Command = 'POST') and ((Doc = '/v1/rerank') or (Doc = '/rerank') or (Doc = '/v2/rerank')) then HandleRerank(ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/providers/catalog') then HandleProvidersCatalog(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/mcp')     then HandleMCPList(AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/cron')    then HandleCronList(AResponse)
@@ -7139,6 +7148,144 @@ begin
       end;
     finally
       DataArr.Free;   { nil after PutArray's ownership transfer -- safe }
+    end;
+  finally
+    Req.Free;
+  end;
+end;
+
+procedure TGatewayServer.HandleRerank(ARequest: TIdHTTPRequestInfo;
+                                      AResp: TIdHTTPResponseInfo);
+{ Cross-encoder reranking over PasClaw's local ONNX model. Accepts the
+  de-facto /v1/rerank body -- query (string), documents (array of strings;
+  the "texts" key is accepted as an alias, as TEI uses), optional model,
+  optional top_n (cap the number of results), optional return_documents
+  (echo each doc's text into the result). Returns a top-level object with
+  model, a results array (each element index + relevance_score, plus a
+  document.text when return_documents is set) sorted by relevance
+  descending, and usage. No outbound call -- the query and documents are
+  scored on-host and never leave. }
+var
+  Body, ReqModel, ModelId, OneDoc: string;
+  Req, Root, Item, DocObj, Usage: TJsonObject;
+  DocsArr, ResArr: TJsonArray;
+  Docs: array of string;
+  Order: TArray<Integer>;
+  Scores: TArray<Single>;
+  Query: string;
+  TopN, i, ApproxTokens, Emitted: Integer;
+  ReturnDocs: Boolean;
+begin
+  Body := ReadRequestBody(ARequest);
+  if Trim(Body) = '' then
+  begin
+    WriteJSON(AResp, 400,
+      '{"error":{"message":"empty body","type":"invalid_request_error"}}');
+    Exit;
+  end;
+
+  Req := nil;
+  try
+    try
+      Req := TJsonObject.Parse(Body);
+    except
+      on E: Exception do
+      begin
+        WriteJSON(AResp, 400,
+          '{"error":{"message":"invalid JSON","type":"invalid_request_error"}}');
+        Exit;
+      end;
+    end;
+
+    Query := Req.GetStr('query', '');
+    if Trim(Query) = '' then
+    begin
+      WriteJSON(AResp, 400,
+        '{"error":{"message":"query is required","type":"invalid_request_error"}}');
+      Exit;
+    end;
+
+    { documents (preferred) or texts (TEI alias): an array of strings. }
+    SetLength(Docs, 0);
+    DocsArr := Req.ChildArray('documents');
+    if DocsArr = nil then
+      DocsArr := Req.ChildArray('texts');
+    if DocsArr <> nil then
+      for i := 0 to DocsArr.Count - 1 do
+      begin
+        OneDoc := DocsArr.ItemStr(i, '');
+        SetLength(Docs, Length(Docs) + 1);
+        Docs[High(Docs)] := OneDoc;
+      end;
+
+    if Length(Docs) = 0 then
+    begin
+      WriteJSON(AResp, 400,
+        '{"error":{"message":"documents is required (an array of strings; ' +
+        '\"texts\" is accepted as an alias)","type":"invalid_request_error"}}');
+      Exit;
+    end;
+
+    if not LocalRerankAvailable(GetHome) then
+    begin
+      WriteJSON(AResp, 503,
+        '{"error":{"message":"local reranker not provisioned -- run ' +
+        '`pasclaw memory provision --rerank` to download the ONNX model",' +
+        '"type":"server_error"}}');
+      Exit;
+    end;
+
+    if not LocalRerank(GetHome, Query, Docs, Order, Scores) then
+    begin
+      WriteJSON(AResp, 500,
+        '{"error":{"message":"rerank failed","type":"server_error"}}');
+      Exit;
+    end;
+
+    LocalRerankModelInfo(GetHome, ModelId);
+    ReqModel   := Req.GetStr('model', '');
+    ReturnDocs := Req.GetBool('return_documents', False);
+    { top_n caps how many ranked results are returned; <=0 or absent = all. }
+    TopN := Req.GetInt('top_n', 0);
+    if TopN <= 0 then TopN := Length(Order);
+
+    ApproxTokens := (Length(Query) + 3) div 4;
+    ResArr := TJsonArray.Create;
+    try
+      Emitted := 0;
+      for i := 0 to High(Order) do
+      begin
+        if Emitted >= TopN then Break;
+        Item := TJsonObject.Create;
+        Item.PutInt('index', Order[i]);
+        Item.PutFloat('relevance_score', Scores[i]);
+        if ReturnDocs then
+        begin
+          DocObj := TJsonObject.Create;
+          DocObj.PutStr('text', Docs[Order[i]]);
+          Item.PutObject('document', DocObj);   { takes ownership }
+        end;
+        ResArr.AddObject(Item);                 { takes ownership; Item := nil }
+        Inc(ApproxTokens, (Length(Docs[Order[i]]) + 3) div 4);
+        Inc(Emitted);
+      end;
+
+      Root := TJsonObject.Create;
+      try
+        if ReqModel <> '' then
+          Root.PutStr('model', ReqModel)         { echo the requested model id }
+        else
+          Root.PutStr('model', 'pasclaw-local-' + ModelId);
+        Root.PutArray('results', ResArr);        { takes ownership; ResArr := nil }
+        Usage := TJsonObject.Create;
+        Usage.PutInt('total_tokens', ApproxTokens);
+        Root.PutObject('usage', Usage);
+        WriteJSON(AResp, 200, Root.ToJSON);
+      finally
+        Root.Free;
+      end;
+    finally
+      ResArr.Free;   { nil after PutArray's ownership transfer -- safe }
     end;
   finally
     Req.Free;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -7167,7 +7167,7 @@ procedure TGatewayServer.HandleRerank(ARequest: TIdHTTPRequestInfo;
   descending, and usage. No outbound call -- the query and documents are
   scored on-host and never leave. }
 var
-  Body, ReqModel, ModelId, OneDoc, Backend: string;
+  Body, ReqModel, ModelId, OneDoc, Backend, RespModel, LLMModel: string;
   Req, Root, Item, DocObj, Usage: TJsonObject;
   DocsArr, ResArr: TJsonArray;
   Docs: array of string;
@@ -7232,6 +7232,14 @@ begin
       when no local model is provisioned. The endpoint is an explicit rerank
       request, so 'off' behaves like 'auto' here (retrieval, not the API, is
       what 'off' silences). }
+    { The request's model is a RERANKER selector for the local backend. Read it
+      up front: it also lets an explicit rerank_backend='llm' caller direct the
+      chat model used for scoring. In 'auto' fallback the value names a reranker
+      (not a chat model), so it is NOT forwarded to the provider there -- that
+      would 404. RespModel is what the response reports: always the model
+      actually used, never a false echo of an unhonored request. }
+    ReqModel := Req.GetStr('model', '');
+
     Backend := LowerCase(Trim(FCfg.RerankBackend));
     if Backend = '' then Backend := 'auto';
     UseLLM := False;
@@ -7242,6 +7250,7 @@ begin
     else { auto / off / unknown }
       UseLLM := not LocalRerankAvailable(GetHome);
 
+    RespModel := '';
     if UseLLM then
     begin
       if not LLMRerankAvailable(FProvider) then
@@ -7252,14 +7261,21 @@ begin
           'provider for the LLM fallback","type":"server_error"}}');
         Exit;
       end;
-      if not LLMRerank(FProvider, '', Query, Docs, 0, 0, Order, Scores) then
+      { Honor an explicit chat-model choice only when the caller explicitly
+        selected the llm backend; auto-fallback's model field is a reranker
+        name, so use the provider default there. }
+      if Backend = 'llm' then LLMModel := ReqModel else LLMModel := '';
+      if not LLMRerank(FProvider, LLMModel, Query, Docs, 0, 0, Order, Scores) then
       begin
         WriteJSON(AResp, 502,
           '{"error":{"message":"LLM rerank failed (provider error or ' +
           'unparseable ranking)","type":"server_error"}}');
         Exit;
       end;
-      ModelId := 'llm:' + FProvider.GetName;
+      if LLMModel <> '' then
+        RespModel := 'llm:' + FProvider.GetName + ':' + LLMModel
+      else
+        RespModel := 'llm:' + FProvider.GetName;
     end
     else
     begin
@@ -7278,9 +7294,12 @@ begin
         Exit;
       end;
       LocalRerankModelInfo(GetHome, ModelId);
+      { Local backend uses the configured model. Echo the caller's requested
+        reranker id when they named one, else the configured model. }
+      if ReqModel <> '' then RespModel := ReqModel
+      else RespModel := 'pasclaw-local-' + ModelId;
     end;
 
-    ReqModel   := Req.GetStr('model', '');
     ReturnDocs := Req.GetBool('return_documents', False);
     { top_n caps how many ranked results are returned; <=0 or absent = all. }
     TopN := Req.GetInt('top_n', 0);
@@ -7309,10 +7328,8 @@ begin
 
       Root := TJsonObject.Create;
       try
-        if ReqModel <> '' then
-          Root.PutStr('model', ReqModel)         { echo the requested model id }
-        else
-          Root.PutStr('model', 'pasclaw-local-' + ModelId);
+        { RespModel is the model actually used (never a false echo). }
+        Root.PutStr('model', RespModel);
         Root.PutArray('results', ResArr);        { takes ownership; ResArr := nil }
         Usage := TJsonObject.Create;
         Usage.PutInt('total_tokens', ApproxTokens);

--- a/src/pkg/kb/PasClaw.KB.Index.pas
+++ b/src/pkg/kb/PasClaw.KB.Index.pas
@@ -150,7 +150,8 @@ uses
   LocalVector.Embedder,
   LocalVector.Tokenizer,
   LocalVector.Models,
-  LocalVector.OrtProvision;
+  LocalVector.OrtProvision,
+  PasClaw.Memory.Rerank.Serve;   { optional cross-encoder rerank stage }
 
 const
   { Extensions indexed by Sync. Lowercase, with dot. Plain-text reads;
@@ -1234,7 +1235,11 @@ begin
   begin
     try
       Emb := EmbedText(Query);
-      VHits := FStore.Search(Query, Emb, smHybrid, K);
+      { Optional cross-encoder rerank: RerankedStoreSearch widens the
+        first-stage pool, rescores (query, chunk) pairs, and truncates back to
+        K when reranking is provisioned/enabled -- otherwise it's a plain
+        hybrid search. Same helper PasClaw.Memory.Vector.Search uses. }
+      VHits := RerankedStoreSearch(GetHome, Query, Emb, FStore, smHybrid, K);
       SetLength(Result, Length(VHits));
       for i := 0 to High(VHits) do
       begin

--- a/src/pkg/memory/PasClaw.Memory.Rerank.LLM.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.LLM.pas
@@ -164,6 +164,16 @@ begin
   Opts := DefaultChatOptions;
   Opts.Temperature := 0;      { deterministic ordering }
   Opts.Stream      := False;
+  { Never let provider grounding/web-search fire for a rerank: we are ordering
+    the passages we were handed, not searching. With Gemini google_search on,
+    the model returns empty text + groundingMetadata for this prompt. }
+  Opts.DisableServerTools := True;
+  { Thinking models (e.g. gemini-2.5-flash) spend output budget reasoning
+    BEFORE emitting the answer; with a small cap the whole budget goes to
+    thinking and the text part comes back empty. The answer here is only a
+    short index array, but give generous headroom so thinking never starves
+    it. Harmless for non-thinking models -- the array is tiny. }
+  Opts.MaxTokens   := 4096;
   Opts.SystemPrompt :=
     'You are a search result reranker. You are given a query and a numbered ' +
     'list of candidate passages. Order the passages from MOST to LEAST ' +

--- a/src/pkg/memory/PasClaw.Memory.Rerank.LLM.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.LLM.pas
@@ -1,0 +1,229 @@
+(*
+  PasClaw.Memory.Rerank.LLM - rerank candidates by asking the configured chat
+  model to order them, the universal fallback when no local ONNX cross-encoder
+  is provisioned (or when the operator prefers an LLM's judgement).
+
+  A frontier chat model is a far stronger reranker than a small local
+  cross-encoder -- it reads the query and every candidate together and reasons
+  about relevance -- at the cost of one provider round-trip per rerank. So this
+  is the natural fallback for the /v1/rerank endpoint: no model download, no
+  tokenizer, works the moment a provider is configured.
+
+  The model is asked for a bare JSON array of candidate indices, most relevant
+  first. The parser is deliberately forgiving: it takes the first bracketed
+  group of integers, dedups, drops out-of-range values, and appends any omitted
+  candidates (in their original order) so the returned Order is always a full
+  permutation -- a sloppy reply degrades gracefully instead of dropping docs.
+*)
+unit PasClaw.Memory.Rerank.LLM;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+uses
+  {$IFDEF FPC}SysUtils,{$ELSE}System.SysUtils,{$ENDIF}
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Types;
+
+{ True when an LLM rerank is possible -- i.e. a real provider is available. }
+function LLMRerankAvailable(const AProvider: ILLMProvider): Boolean;
+
+{ Rank ADocs against AQuery via AProvider. AModel empty -> the provider's
+  default model. Returns Order (doc indices, most relevant first) and matching
+  descending pseudo-scores in (0,1]. ATopN<=0 returns all; ADocCharCap<=0 uses
+  a sane default. False only when the provider errors or returns nothing
+  parseable (caller then keeps the first-stage order). }
+function LLMRerank(const AProvider: ILLMProvider; const AModel, AQuery: string;
+  const ADocs: array of string; ATopN, ADocCharCap: Integer;
+  out Order: TArray<Integer>; out Scores: TArray<Single>): Boolean;
+
+implementation
+
+const
+  DEFAULT_DOC_CHAR_CAP = 600;   { trim each candidate in the prompt to bound tokens }
+
+function LLMRerankAvailable(const AProvider: ILLMProvider): Boolean;
+begin
+  Result := Assigned(AProvider);
+end;
+
+function BuildPrompt(const AQuery: string; const ADocs: array of string;
+  ADocCharCap: Integer): string;
+var
+  I: Integer;
+  Doc: string;
+begin
+  Result := 'Query: ' + AQuery + sLineBreak + sLineBreak +
+            'Candidate passages:' + sLineBreak;
+  for I := 0 to High(ADocs) do
+  begin
+    Doc := ADocs[I];
+    if (ADocCharCap > 0) and (Length(Doc) > ADocCharCap) then
+      Doc := Copy(Doc, 1, ADocCharCap) + ' ...';
+    { collapse newlines so each candidate is one line the model can't confuse
+      with the numbering. }
+    Doc := StringReplace(Doc, sLineBreak, ' ', [rfReplaceAll]);
+    Doc := StringReplace(Doc, #10, ' ', [rfReplaceAll]);
+    Doc := StringReplace(Doc, #13, ' ', [rfReplaceAll]);
+    Result := Result + '[' + IntToStr(I) + '] ' + Doc + sLineBreak;
+  end;
+end;
+
+{ Extract unique in-range indices from ASlice, in order of appearance. }
+function IndicesFrom(const ASlice: string; ACount: Integer): TArray<Integer>;
+var
+  I, V: Integer;
+  Cur: string;
+  Seen: array of Boolean;
+
+  procedure Flush;
+  begin
+    if Cur = '' then Exit;
+    if TryStrToInt(Cur, V) and (V >= 0) and (V < ACount) and (not Seen[V]) then
+    begin
+      Seen[V] := True;
+      SetLength(Result, Length(Result) + 1);
+      Result[High(Result)] := V;
+    end;
+    Cur := '';
+  end;
+
+begin
+  SetLength(Result, 0);
+  SetLength(Seen, ACount);
+  for I := 0 to ACount - 1 do Seen[I] := False;
+  Cur := '';
+  for I := 1 to Length(ASlice) do
+    if (ASlice[I] >= '0') and (ASlice[I] <= '9') then
+      Cur := Cur + ASlice[I]
+    else
+      Flush;
+  Flush;
+end;
+
+{ Recover the ranking array from a possibly-messy model reply. Thinking models
+  (and models that ignore "JSON only") interleave prose and stray brackets like
+  "passage [1] is ..." before the real answer -- so DON'T just take the first
+  bracket. Scan every [ ... ] group, and pick the one yielding the MOST valid
+  unique indices (the real ranking lists them all); on a tie prefer the LAST
+  such group, since the final answer tends to come last. Fall back to a
+  whole-text integer scan when there are no brackets at all. }
+function ParseIndexArray(const AText: string; ACount: Integer): TArray<Integer>;
+var
+  I, GStart: Integer;
+  Cand: TArray<Integer>;
+  Best: TArray<Integer>;
+begin
+  SetLength(Result, 0);
+  if ACount <= 0 then Exit;
+
+  SetLength(Best, 0);
+  GStart := 0;
+  for I := 1 to Length(AText) do
+  begin
+    if AText[I] = '[' then
+      GStart := I
+    else if (AText[I] = ']') and (GStart > 0) then
+    begin
+      Cand := IndicesFrom(Copy(AText, GStart + 1, I - GStart - 1), ACount);
+      { >= so a later group of equal size wins the tie (answer comes last). }
+      if Length(Cand) >= Length(Best) then Best := Cand;
+      GStart := 0;
+    end;
+  end;
+
+  if Length(Best) > 0 then
+    Result := Best
+  else
+    Result := IndicesFrom(AText, ACount);   { no brackets -> scan everything }
+end;
+
+function LLMRerank(const AProvider: ILLMProvider; const AModel, AQuery: string;
+  const ADocs: array of string; ATopN, ADocCharCap: Integer;
+  out Order: TArray<Integer>; out Scores: TArray<Single>): Boolean;
+var
+  Opts: TChatOptions;
+  Msgs: TMessageArray;
+  NoTools: array of TToolDefinition;
+  Resp: TLLMResponse;
+  Model: string;
+  Ranked: TArray<Integer>;
+  InRanked: array of Boolean;
+  I, N, Keep: Integer;
+begin
+  Order  := nil;
+  Scores := nil;
+  Result := False;
+  N := Length(ADocs);
+  if N = 0 then Exit;
+  if not Assigned(AProvider) then Exit;
+  if ADocCharCap <= 0 then ADocCharCap := DEFAULT_DOC_CHAR_CAP;
+
+  Opts := DefaultChatOptions;
+  Opts.Temperature := 0;      { deterministic ordering }
+  Opts.Stream      := False;
+  Opts.SystemPrompt :=
+    'You are a search result reranker. You are given a query and a numbered ' +
+    'list of candidate passages. Order the passages from MOST to LEAST ' +
+    'relevant to the query. Reply with ONLY a JSON array of the passage ' +
+    'numbers in that order, e.g. [3,0,1,2]. Include every number exactly ' +
+    'once and output no other text.';
+
+  SetLength(NoTools, 0);
+  SetLength(Msgs, 1);
+  Msgs[0] := MakeMessage(mrUser, BuildPrompt(AQuery, ADocs, ADocCharCap));
+
+  Model := AModel;
+  if Model = '' then Model := AProvider.GetDefaultModel;
+
+  Resp := Default(TLLMResponse);
+  try
+    Resp := AProvider.Chat(Msgs, NoTools, Model, Opts);
+  except
+    on E: Exception do
+      Exit;   { provider raised -> caller keeps the first-stage order }
+  end;
+
+  { Providers report transport/HTTP failures via StatusCode and stuff the error
+    text into Content rather than raising (e.g. "gemini error: status=-1 msg=TLS
+    ..."). Never parse that as a ranking -- it yields a garbage order. -1 =
+    DNS/TLS/socket, >=400 = HTTP error; 0 = older provider that doesn't set it. }
+  if (Resp.StatusCode = -1) or (Resp.StatusCode >= 400) then Exit;
+
+  Ranked := ParseIndexArray(Resp.Content, N);
+  if Length(Ranked) = 0 then Exit;   { nothing usable }
+
+  { Append any candidates the model omitted, in original order, so Order is a
+    full permutation and no doc is silently dropped. }
+  SetLength(InRanked, N);
+  for I := 0 to N - 1 do InRanked[I] := False;
+  for I := 0 to High(Ranked) do InRanked[Ranked[I]] := True;
+  Order := Copy(Ranked);
+  for I := 0 to N - 1 do
+    if not InRanked[I] then
+    begin
+      SetLength(Order, Length(Order) + 1);
+      Order[High(Order)] := I;
+    end;
+
+  { Descending pseudo-scores in (0,1]: rank 0 -> 1.0, last -> 1/N. }
+  SetLength(Scores, Length(Order));
+  for I := 0 to High(Order) do
+    Scores[I] := (Length(Order) - I) / Length(Order);
+
+  if ATopN > 0 then
+  begin
+    Keep := ATopN;
+    if Keep < Length(Order) then
+    begin
+      SetLength(Order,  Keep);
+      SetLength(Scores, Keep);
+    end;
+  end;
+
+  Result := True;
+end;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.Rerank.Serve.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.Serve.pas
@@ -26,9 +26,9 @@ unit PasClaw.Memory.Rerank.Serve;
 interface
 
 {$IFDEF FPC}
-uses SysUtils;
+uses SysUtils, LocalVector.VectorStore;
 {$ELSE}
-uses System.SysUtils;
+uses System.SysUtils, LocalVector.VectorStore;
 {$ENDIF}
 
 { Choose the reranker model (registry key, e.g. 'ms-marco-minilm' or
@@ -37,12 +37,34 @@ uses System.SysUtils;
   new one loads on the next call. }
 procedure SetLocalRerankModel(const AKey: string);
 
+{ Toggle the retrieval-side rerank stage (config rerank_search_enabled).
+  Propagated from ApplyConfigGlobals, mirroring SetCondenseReversible. This
+  only reflects the operator's intent -- actual reranking still requires the
+  model to be provisioned (RetrievalRerankActive checks both). }
+procedure SetRerankSearchEnabled(AEnabled: Boolean);
+
+{ True when retrieval should rerank: the config toggle is on AND the reranker
+  is loadable for HomeDir. Cheap fast-path (returns False immediately when the
+  toggle is off) so a default install never probes the filesystem. }
+function RetrievalRerankActive(const HomeDir: string): Boolean;
+
 { True when the local ONNX reranker is loadable for HomeDir (model + vocab
   + runtime provisioned). }
 function LocalRerankAvailable(const HomeDir: string): Boolean;
 
 { Active reranker model id (registry key). False when not provisioned. }
 function LocalRerankModelInfo(const HomeDir: string; out ModelId: string): Boolean;
+
+{ Two-stage retrieval helper shared by memory_search and kb_search. When
+  reranking is inactive (toggle off or model not provisioned) this is exactly
+  AStore.Search(Query, AEmbedding, AMode, K). When active it fetches a WIDER
+  first-stage pool (4x K, min 20), rescores each (query, chunk-text) pair with
+  the cross-encoder, and truncates back to K -- promoting the best candidates
+  the bi-encoder RRF ranked lower. Falls back to the RRF order on any rerank
+  failure, and carries the cross-encoder score onto the returned hits. }
+function RerankedStoreSearch(const HomeDir, Query: string;
+  const AEmbedding: TArray<Single>; AStore: IVectorStore;
+  AMode: TSearchMode; K: Integer): TSearchHits;
 
 { Score Documents against Query with the local cross-encoder and return the
   indices ordered by relevance descending, with their 0..1 scores (Order[k]
@@ -67,6 +89,7 @@ var
   GRank:  TReranker = nil;
   GSpec:  TModelSpec;
   GKey:   string = DEFAULT_RERANKER;
+  GSearchEnabled: Boolean = False;   { config rerank_search_enabled mirror }
   GReady: Boolean = False;
   GTried: Boolean = False;
   { True when the latched failure was specifically "artifacts not on disk"
@@ -112,6 +135,19 @@ begin
   finally
     GLock.Release;
   end;
+end;
+
+procedure SetRerankSearchEnabled(AEnabled: Boolean);
+begin
+  { Plain bool write -- read without the lock in the fast path; a torn read is
+    impossible for a Boolean and the worst case is one search using the prior
+    value for a tick after a live config change. }
+  GSearchEnabled := AEnabled;
+end;
+
+function RetrievalRerankActive(const HomeDir: string): Boolean;
+begin
+  Result := GSearchEnabled and LocalRerankAvailable(HomeDir);
 end;
 
 { Load the reranker for HomeDir if not already loaded. Latched. Caller holds
@@ -234,6 +270,53 @@ begin
     Scores[I] := Hits[I].Score;
   end;
   Result := True;
+end;
+
+function RerankedStoreSearch(const HomeDir, Query: string;
+  const AEmbedding: TArray<Single>; AStore: IVectorStore;
+  AMode: TSearchMode; K: Integer): TSearchHits;
+var
+  FetchK, I: Integer;
+  Docs: array of string;
+  Order: TArray<Integer>;
+  Scores: TArray<Single>;
+  Reordered: TSearchHits;
+begin
+  if K <= 0 then
+  begin
+    SetLength(Result, 0);
+    Exit;
+  end;
+
+  if not RetrievalRerankActive(HomeDir) then
+    Exit(AStore.Search(Query, AEmbedding, AMode, K));
+
+  { Widen the first-stage pool so the reranker has candidates to promote. }
+  FetchK := K * 4;
+  if FetchK < 20 then FetchK := 20;
+  Result := AStore.Search(Query, AEmbedding, AMode, FetchK);
+  if Length(Result) > 1 then
+  begin
+    SetLength(Docs, Length(Result));
+    for I := 0 to High(Result) do Docs[I] := Result[I].Text;
+    if LocalRerank(HomeDir, Query, Docs, Order, Scores) then
+    begin
+      SetLength(Reordered, Length(Order));
+      for I := 0 to High(Order) do
+      begin
+        Reordered[I] := Result[Order[I]];
+        { Surface the cross-encoder score so downstream ranking/telemetry
+          reflects the rerank, not the stale RRF score. }
+        Reordered[I].Score := Scores[I];
+      end;
+      Result := Reordered;
+    end;
+    { else: LocalRerank failed -- keep the RRF order untouched. }
+  end;
+
+  { Truncate to the caller's K (the pool was widened only for the reranker). }
+  if Length(Result) > K then
+    SetLength(Result, K);
 end;
 
 initialization

--- a/src/pkg/memory/PasClaw.Memory.Rerank.Serve.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.Serve.pas
@@ -189,7 +189,8 @@ begin
     try
       EnsureOnnxRuntime(Cache, {AAllowDownload=} False, {AVerbose=} False);
       GRank := TReranker.Create(ModelP, VocabP, GSpec.DoLowerCase,
-                                GSpec.NeedsTokenTypeIds);
+                                GSpec.NeedsTokenTypeIds, 512,
+                                RerankerIsSentencePiece(GKey));
       GReady := True;
       LogDebug('rerank-serve: enabled (model=%s)', [GSpec.Key]);
       Result := True;

--- a/src/pkg/memory/PasClaw.Memory.Rerank.Serve.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.Serve.pas
@@ -1,0 +1,246 @@
+(*
+  PasClaw.Memory.Rerank.Serve - process-global loader + gate for the local
+  ONNX cross-encoder reranker, mirroring PasClaw.Memory.Facts.Embed.
+
+  Backs the gateway's /v1/rerank endpoint (and the optional retrieval
+  rerank stage). Everything is best-effort and gated:
+    - LocalRerankAvailable returns False (and the endpoint 503s / the
+      retrieval stage stays off) when the runtime / model / vocab aren't
+      provisioned. A host without `pasclaw memory provision --rerank`
+      simply gets no reranker -- never an error.
+    - The loaded TReranker is process-global and guarded by a critical
+      section: reranks run from concurrent gateway worker threads, and
+      the ORT session is not assumed thread-safe, so calls are serialised.
+    - GTried latches a failed load so we don't re-probe the filesystem /
+      runtime on every request; the artifacts-missing case is cleared once
+      the files appear (same recovery Facts.Embed does for /v1/embeddings).
+
+  The configured model key defaults to DEFAULT_RERANKER and can be
+  overridden via SetLocalRerankModel (called from config apply).
+*)
+unit PasClaw.Memory.Rerank.Serve;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+{$IFDEF FPC}
+uses SysUtils;
+{$ELSE}
+uses System.SysUtils;
+{$ENDIF}
+
+{ Choose the reranker model (registry key, e.g. 'ms-marco-minilm' or
+  'bge-reranker-base'). Empty resets to the default. Takes effect on the
+  next load; if a different model is already loaded it is dropped so the
+  new one loads on the next call. }
+procedure SetLocalRerankModel(const AKey: string);
+
+{ True when the local ONNX reranker is loadable for HomeDir (model + vocab
+  + runtime provisioned). }
+function LocalRerankAvailable(const HomeDir: string): Boolean;
+
+{ Active reranker model id (registry key). False when not provisioned. }
+function LocalRerankModelInfo(const HomeDir: string; out ModelId: string): Boolean;
+
+{ Score Documents against Query with the local cross-encoder and return the
+  indices ordered by relevance descending, with their 0..1 scores (Order[k]
+  is the original document index at rank k; Scores[k] its score). False
+  (graceful) when the reranker isn't provisioned or scoring fails. Serialised
+  internally, so it's safe from concurrent gateway worker threads. }
+function LocalRerank(const HomeDir, Query: string; const Documents: array of string;
+  out Order: TArray<Integer>; out Scores: TArray<Single>): Boolean;
+
+implementation
+
+uses
+  {$IFDEF FPC}SyncObjs,{$ELSE}System.SyncObjs,{$ENDIF}
+  LocalVector.Models,
+  LocalVector.OrtProvision,
+  PasClaw.Utils,
+  PasClaw.Logger,
+  PasClaw.Memory.Rerank;
+
+var
+  GLock:  TCriticalSection;
+  GRank:  TReranker = nil;
+  GSpec:  TModelSpec;
+  GKey:   string = DEFAULT_RERANKER;
+  GReady: Boolean = False;
+  GTried: Boolean = False;
+  { True when the latched failure was specifically "artifacts not on disk"
+    (vs a genuine load failure) -- lets LocalRerankAvailable clear the latch
+    and retry once after provisioning writes the model. }
+  GTriedWithoutArtifacts: Boolean = False;
+
+function RerankModelDir(const HomeDir: string; const Spec: TModelSpec): string;
+begin
+  { Mirror PasClaw.Memory.Facts.Embed's cache layout exactly. }
+  Result := JoinPath(JoinPath(JoinPath(JoinPath(HomeDir, 'cache'),
+                     'localvector'), 'models'), Spec.SubDir);
+end;
+
+function RerankArtifactsExist(const HomeDir: string): Boolean;
+var
+  Spec: TModelSpec;
+  ModelDir: string;
+begin
+  Result := False;
+  if not FindRerankerSpec(GKey, Spec) then Exit;
+  ModelDir := RerankModelDir(HomeDir, Spec);
+  Result := FileExists(JoinPath(ModelDir, 'model.onnx'))
+        and FileExists(JoinPath(ModelDir, 'vocab.txt'));
+end;
+
+procedure SetLocalRerankModel(const AKey: string);
+var
+  NewKey: string;
+begin
+  NewKey := Trim(AKey);
+  if NewKey = '' then NewKey := DEFAULT_RERANKER;
+  GLock.Acquire;
+  try
+    if SameText(NewKey, GKey) then Exit;
+    GKey := NewKey;
+    { Drop any loaded model so the new key loads on next use, and clear the
+      latch so the swap is actually attempted. }
+    FreeAndNil(GRank);
+    GReady := False;
+    GTried := False;
+    GTriedWithoutArtifacts := False;
+  finally
+    GLock.Release;
+  end;
+end;
+
+{ Load the reranker for HomeDir if not already loaded. Latched. Caller holds
+  no lock -- this acquires GLock itself. }
+function EnsureLoaded(const HomeDir: string): Boolean;
+var
+  Cache, ModelDir, ModelP, VocabP: string;
+begin
+  GLock.Acquire;
+  try
+    if GReady then Exit(True);
+    if GTried then Exit(False);
+    GTried := True;
+
+    if not FindRerankerSpec(GKey, GSpec) then
+    begin
+      LogDebug('rerank-serve: unknown reranker model "%s" -- reranker off', [GKey]);
+      Exit(False);
+    end;
+
+    Cache    := JoinPath(JoinPath(HomeDir, 'cache'), 'localvector');
+    ModelDir := RerankModelDir(HomeDir, GSpec);
+    ModelP   := JoinPath(ModelDir, 'model.onnx');
+    VocabP   := JoinPath(ModelDir, 'vocab.txt');
+    if not FileExists(ModelP) then
+    begin
+      LogDebug('rerank-serve: model not found at %s -- reranker off', [ModelP]);
+      GTriedWithoutArtifacts := True;
+      Exit(False);
+    end;
+    if not FileExists(VocabP) then
+    begin
+      LogDebug('rerank-serve: vocab not found at %s -- reranker off', [VocabP]);
+      GTriedWithoutArtifacts := True;
+      Exit(False);
+    end;
+
+    GTriedWithoutArtifacts := False;
+    try
+      EnsureOnnxRuntime(Cache, {AAllowDownload=} False, {AVerbose=} False);
+      GRank := TReranker.Create(ModelP, VocabP, GSpec.DoLowerCase,
+                                GSpec.NeedsTokenTypeIds);
+      GReady := True;
+      LogDebug('rerank-serve: enabled (model=%s)', [GSpec.Key]);
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        LogDebug('rerank-serve: unavailable (%s) -- reranker off', [E.Message]);
+        FreeAndNil(GRank);
+        GReady := False;
+        Result := False;
+      end;
+    end;
+  finally
+    GLock.Release;
+  end;
+end;
+
+function LocalRerankAvailable(const HomeDir: string): Boolean;
+begin
+  Result := EnsureLoaded(HomeDir);
+  if Result then Exit;
+  { If the latched failure was "artifacts missing" AND they now exist, clear
+    the latch and try once more so a gateway started before provisioning
+    recovers in-process (same trick as LocalEmbedAvailable). A genuine load
+    failure is not retried. }
+  GLock.Acquire;
+  try
+    if GReady then Exit(True);
+    if not (GTriedWithoutArtifacts and RerankArtifactsExist(HomeDir)) then
+      Exit(False);
+    GTried := False;
+  finally
+    GLock.Release;
+  end;
+  Result := EnsureLoaded(HomeDir);
+end;
+
+function LocalRerankModelInfo(const HomeDir: string; out ModelId: string): Boolean;
+begin
+  ModelId := '';
+  if not EnsureLoaded(HomeDir) then Exit(False);
+  { GSpec is set once under GLock during load and not mutated after. }
+  ModelId := GSpec.Key;
+  Result  := True;
+end;
+
+function LocalRerank(const HomeDir, Query: string; const Documents: array of string;
+  out Order: TArray<Integer>; out Scores: TArray<Single>): Boolean;
+var
+  Hits: TRerankHits;
+  I: Integer;
+begin
+  Result := False;
+  Order  := nil;
+  Scores := nil;
+  if Length(Documents) = 0 then Exit;
+  if not EnsureLoaded(HomeDir) then Exit;
+  GLock.Acquire;
+  try
+    if not GReady then Exit;
+    try
+      Hits := GRank.Rerank(Query, Documents);
+    except
+      on E: Exception do
+      begin
+        LogWarn('rerank-serve: rerank failed (%s)', [E.Message]);
+        Exit;
+      end;
+    end;
+  finally
+    GLock.Release;
+  end;
+  SetLength(Order,  Length(Hits));
+  SetLength(Scores, Length(Hits));
+  for I := 0 to High(Hits) do
+  begin
+    Order[I]  := Hits[I].Index;
+    Scores[I] := Hits[I].Score;
+  end;
+  Result := True;
+end;
+
+initialization
+  GLock := TCriticalSection.Create;
+
+finalization
+  FreeAndNil(GRank);
+  GLock.Free;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -51,6 +51,7 @@ type
   TReranker = class
   private
     FSession: TORTSession;
+    FOptions: TORTSessionOptions;
     FTok: TBertTokenizer;
     FModelPath, FVocabPath: string;
     FDoLowerCase, FNeedsTokenTypeIds: Boolean;
@@ -159,16 +160,35 @@ begin
 end;
 
 procedure TReranker.EnsureLoaded(AVerbose: Boolean);
+{$IFDEF MSWINDOWS}
+var Path: widestring;
+{$ELSE}
+var Path: ansistring;
+{$ENDIF}
 begin
   if FLoaded then Exit;
   if not FileExists(FModelPath) then
     raise ERerankerError.CreateFmt('Reranker model not found: %s', [FModelPath]);
-  { Same CPU-EP wiring the embedder needs on ONNX Runtime 1.22+ (no implicit
-    CPU provider). See LocalVector.Embedder.Load. }
-  if not Assigned(DefaultSessionOptions.p_) then
-    ThrowOnError(GetApi().CreateSessionOptions(PPOrtSessionOptions(@DefaultSessionOptions.p_)));
-  ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(DefaultSessionOptions.p_, 1));
-  FSession := TORTSession.Create(FModelPath);
+
+  { CPU-EP wiring for ONNX Runtime 1.22+ (no implicit CPU provider). Unlike the
+    embedder, the reranker uses its OWN session-options object rather than the
+    shared DefaultSessionOptions: both the embedder and the reranker load in the
+    same process (memory_search embeds THEN reranks; a gateway serves both
+    /v1/embeddings and /v1/rerank), and appending the CPU EP to the shared
+    options a second time makes ORT 1.22+ fail with "Provider
+    CPUExecutionProvider has already been registered." A dedicated options
+    object keeps the two independent regardless of load order. }
+  EnsureOrtDefaults;   { make sure DefaultEnv exists once the runtime is loaded }
+  if not Assigned(FOptions.p_) then
+    ThrowOnError(GetApi().CreateSessionOptions(PPOrtSessionOptions(@FOptions.p_)));
+  ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(FOptions.p_, 1));
+  {$IFDEF MSWINDOWS}
+  Path := FModelPath;                          { ORTCHAR_T is wchar_t on Windows }
+  FSession := TORTSession.Create(DefaultEnv, PORTCHAR_T(Path), FOptions);
+  {$ELSE}
+  Path := ansistring(FModelPath);              { ORTCHAR_T is char (UTF-8) on POSIX }
+  FSession := TORTSession.Create(DefaultEnv, PORTCHAR_T(PAnsiChar(Path)), FOptions);
+  {$ENDIF}
   FLoaded := True;
 end;
 

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -155,18 +155,22 @@ begin
   { XLM-RoBERTa cross-encoders (SentencePiece tokenizer, no token_type_ids).
     VocabRelURL points at tokenizer.json (the downloader saves it as the
     model's vocab file; TSPUnigram loads it as JSON). int8-quantised ONNX so it
-    is CPU-practical; NeedsTT=False because RoBERTa has no segment embeddings. }
+    is CPU-practical; NeedsTT=False because RoBERTa has no segment embeddings.
+
+    LICENSING (matters for the DEFAULT): bge-reranker-base is MIT, so it is the
+    default -- commercially usable everywhere. jina-reranker-v2 scores higher on
+    BEIR (see rerank_eval) but is CC-BY-NC-4.0 (NON-commercial): offered as a
+    quality opt-in, never the default. (bge-reranker-v2-m3 is Apache-2.0 and
+    would be a great commercial upgrade, but no public ONNX export exists yet,
+    so it is intentionally NOT registered -- would 404 on download.) }
   else if (K = 'bge-reranker-base') or (K = 'bge-rerank') or (K = 'bge-reranker') then
-    ASpec := MakeRSpec('bge-reranker-base', 'bge-reranker-base (int8)', 'bge-reranker-base',
+    ASpec := MakeRSpec('bge-reranker-base', 'bge-reranker-base (int8, MIT)', 'bge-reranker-base',
       'https://huggingface.co/Xenova/bge-reranker-base/resolve/main/',
       'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~280 MB')
-  else if (K = 'bge-reranker-v2-m3') or (K = 'bge-m3') then
-    ASpec := MakeRSpec('bge-reranker-v2-m3', 'bge-reranker-v2-m3 (int8)', 'bge-reranker-v2-m3',
-      'https://huggingface.co/onnx-community/bge-reranker-v2-m3/resolve/main/',
-      'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~570 MB')
   else if (K = 'jina-reranker-v2') or (K = 'jina-rerank')
      or (K = 'jina-reranker-v2-base-multilingual') then
-    ASpec := MakeRSpec('jina-reranker-v2', 'jina-reranker-v2-base-multilingual (int8)',
+    ASpec := MakeRSpec('jina-reranker-v2',
+      'jina-reranker-v2-base-multilingual (int8, CC-BY-NC non-commercial)',
       'jina-reranker-v2-base-multilingual',
       'https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/',
       'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~270 MB')
@@ -176,8 +180,8 @@ end;
 
 function RerankerKeys: string;
 begin
-  Result := 'ms-marco-minilm, ms-marco-minilm-l12, bge-reranker-base, ' +
-            'bge-reranker-v2-m3, jina-reranker-v2';
+  Result := 'ms-marco-minilm, ms-marco-minilm-l12, bge-reranker-base (default), ' +
+            'jina-reranker-v2 (non-commercial)';
 end;
 
 { ----- TReranker ----- }

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -128,7 +128,8 @@ function RerankerIsSentencePiece(const AKey: string): Boolean;
 var K: string;
 begin
   K := LowerCase(Trim(AKey));
-  Result := (Pos('bge-reranker', K) = 1) or (K = 'bge-rerank') or (K = 'bge-m3');
+  Result := (Pos('bge-reranker', K) = 1) or (K = 'bge-rerank') or (K = 'bge-m3')
+         or (Pos('jina-reranker', K) = 1) or (K = 'jina-rerank');
 end;
 
 function FindRerankerSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
@@ -159,13 +160,20 @@ begin
     ASpec := MakeRSpec('bge-reranker-v2-m3', 'bge-reranker-v2-m3 (int8)', 'bge-reranker-v2-m3',
       'https://huggingface.co/onnx-community/bge-reranker-v2-m3/resolve/main/',
       'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~570 MB')
+  else if (K = 'jina-reranker-v2') or (K = 'jina-rerank')
+     or (K = 'jina-reranker-v2-base-multilingual') then
+    ASpec := MakeRSpec('jina-reranker-v2', 'jina-reranker-v2-base-multilingual (int8)',
+      'jina-reranker-v2-base-multilingual',
+      'https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/',
+      'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~270 MB')
   else
     Result := False;
 end;
 
 function RerankerKeys: string;
 begin
-  Result := 'ms-marco-minilm, ms-marco-minilm-l12, bge-reranker-base, bge-reranker-v2-m3';
+  Result := 'ms-marco-minilm, ms-marco-minilm-l12, bge-reranker-base, ' +
+            'bge-reranker-v2-m3, jina-reranker-v2';
 end;
 
 { ----- TReranker ----- }

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -92,7 +92,11 @@ type
   end;
 
 const
-  DEFAULT_RERANKER = 'ms-marco-minilm';
+  { bge-reranker-base is the default local model: on the BEIR/SciFact + the
+    in-repo eval it is the strongest LOCAL cross-encoder (the tiny ms-marco
+    models regress; bge lifts nDCG/recall). ms-marco-minilm stays available as
+    the small (~90 MB) fallback. }
+  DEFAULT_RERANKER = 'bge-reranker-base';
 
 { Registry of the built-in reranker (cross-encoder) models. Mirrors
   LocalVector.Models.FindModelSpec but for rerankers -- reuses TModelSpec so the

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -132,8 +132,7 @@ function RerankerIsSentencePiece(const AKey: string): Boolean;
 var K: string;
 begin
   K := LowerCase(Trim(AKey));
-  Result := (Pos('bge-reranker', K) = 1) or (K = 'bge-rerank') or (K = 'bge-m3')
-         or (Pos('jina-reranker', K) = 1) or (K = 'jina-rerank');
+  Result := (Pos('bge-reranker', K) = 1) or (K = 'bge-rerank') or (K = 'bge-m3');
 end;
 
 function FindRerankerSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
@@ -157,31 +156,32 @@ begin
     model's vocab file; TSPUnigram loads it as JSON). int8-quantised ONNX so it
     is CPU-practical; NeedsTT=False because RoBERTa has no segment embeddings.
 
-    LICENSING (matters for the DEFAULT): bge-reranker-base is MIT, so it is the
-    default -- commercially usable everywhere. jina-reranker-v2 scores higher on
-    BEIR (see rerank_eval) but is CC-BY-NC-4.0 (NON-commercial): offered as a
-    quality opt-in, never the default. (bge-reranker-v2-m3 is Apache-2.0 and
-    would be a great commercial upgrade, but no public ONNX export exists yet,
-    so it is intentionally NOT registered -- would 404 on download.) }
+    LICENSING (matters for the DEFAULT -- an open framework must ship a
+    commercially-usable default): both registered XLM-R rerankers are permissive
+    -- bge-reranker-base is MIT (the light default), bge-reranker-v2-m3 is
+    Apache-2.0 (the stronger, larger quality upgrade). jina-reranker-v2 scores
+    higher on BEIR but is CC-BY-NC-4.0 (non-commercial), so it is deliberately
+    NOT offered -- no non-commercial model ships here. }
   else if (K = 'bge-reranker-base') or (K = 'bge-rerank') or (K = 'bge-reranker') then
     ASpec := MakeRSpec('bge-reranker-base', 'bge-reranker-base (int8, MIT)', 'bge-reranker-base',
       'https://huggingface.co/Xenova/bge-reranker-base/resolve/main/',
       'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~280 MB')
-  else if (K = 'jina-reranker-v2') or (K = 'jina-rerank')
-     or (K = 'jina-reranker-v2-base-multilingual') then
-    ASpec := MakeRSpec('jina-reranker-v2',
-      'jina-reranker-v2-base-multilingual (int8, CC-BY-NC non-commercial)',
-      'jina-reranker-v2-base-multilingual',
-      'https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/',
-      'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~270 MB')
+  else if (K = 'bge-reranker-v2-m3') or (K = 'bge-m3') then
+    { XLM-R-LARGE (568M). Best open commercial quality, but int8-on-CPU is slow
+      (~100 s per 30-doc rerank in testing) -- practical only on GPU / an
+      accelerated server, not for interactive CPU retrieval. }
+    ASpec := MakeRSpec('bge-reranker-v2-m3', 'bge-reranker-v2-m3 (int8, Apache-2.0, GPU-recommended)',
+      'bge-reranker-v2-m3',
+      'https://huggingface.co/onnx-community/bge-reranker-v2-m3-ONNX/resolve/main/',
+      'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~570 MB (large; slow on CPU)')
   else
     Result := False;
 end;
 
 function RerankerKeys: string;
 begin
-  Result := 'ms-marco-minilm, ms-marco-minilm-l12, bge-reranker-base (default), ' +
-            'jina-reranker-v2 (non-commercial)';
+  Result := 'ms-marco-minilm, ms-marco-minilm-l12, ' +
+            'bge-reranker-base (default), bge-reranker-v2-m3';
 end;
 
 { ----- TReranker ----- }

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -36,7 +36,8 @@ uses
   System.SysUtils, System.Math, System.Classes, System.Generics.Collections,
 {$ENDIF}
   onnxruntime_pas_api, onnxruntime,
-  LocalVector.Runtime, LocalVector.Tokenizer, LocalVector.Models;
+  LocalVector.Runtime, LocalVector.Tokenizer, LocalVector.SentencePiece,
+  LocalVector.Models;
 
 type
   ERerankerError = class(Exception);
@@ -52,7 +53,9 @@ type
   private
     FSession: TORTSession;
     FOptions: TORTSessionOptions;
-    FTok: TBertTokenizer;
+    FTok: TBertTokenizer;        { WordPiece (BERT / ms-marco) path }
+    FSP:  TSPUnigram;            { SentencePiece (XLM-R / bge) path }
+    FSentencePiece: Boolean;
     FModelPath, FVocabPath: string;
     FDoLowerCase, FNeedsTokenTypeIds: Boolean;
     FMaxSeq: Integer;
@@ -61,13 +64,19 @@ type
   public
     { AMaxSeq caps the packed pair length -- long candidates are truncated so a
       cross-encoder that pools over one physical batch never rejects the input
-      ("input is too large to process"; cf. LocalAI PR #10104). }
+      ("input is too large to process"; cf. LocalAI PR #10104).
+      ASentencePiece selects the tokenizer: False = BERT WordPiece + [CLS] q
+      [SEP] d [SEP] (ms-marco); True = XLM-R SentencePiece Unigram + <s> q
+      </s></s> d </s> (bge-reranker). AVocabPath is vocab.txt for WordPiece, or
+      a HuggingFace tokenizer.json for SentencePiece. }
     constructor Create(const AModelPath, AVocabPath: string;
-      ADoLowerCase, ANeedsTokenTypeIds: Boolean; AMaxSeq: Integer = 512);
+      ADoLowerCase, ANeedsTokenTypeIds: Boolean; AMaxSeq: Integer = 512;
+      ASentencePiece: Boolean = False);
     destructor Destroy; override;
 
-    { Pack "[CLS] query [SEP] doc [SEP]" into input ids + token_type_ids,
-      truncating doc first (then query) to fit AMaxSeq. Pure -- no ONNX. }
+    { Pack the cross-encoder pair into input ids + token_type_ids, truncating
+      doc first (then query) to fit AMaxSeq. WordPiece: [CLS] q [SEP] d [SEP].
+      SentencePiece: <s> q </s></s> d </s>. Pure -- no ONNX. }
     procedure EncodePair(const AQuery, ADoc: UnicodeString;
       out AIds, ATypeIds: TArray<Int64>);
 
@@ -91,6 +100,9 @@ const
   unused for a cross-encoder. }
 function FindRerankerSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
 function RerankerKeys: string;
+{ True when AKey names an XLM-RoBERTa reranker (bge-*) whose tokenizer is
+  SentencePiece + tokenizer.json, not BERT WordPiece + vocab.txt. }
+function RerankerIsSentencePiece(const AKey: string): Boolean;
 
 implementation
 
@@ -112,6 +124,13 @@ begin
   Result.SizeDesc := ASize;
 end;
 
+function RerankerIsSentencePiece(const AKey: string): Boolean;
+var K: string;
+begin
+  K := LowerCase(Trim(AKey));
+  Result := (Pos('bge-reranker', K) = 1) or (K = 'bge-rerank') or (K = 'bge-m3');
+end;
+
 function FindRerankerSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
 var
   K: string;
@@ -128,42 +147,52 @@ begin
     ASpec := MakeRSpec('ms-marco-minilm-l12', 'ms-marco-MiniLM-L-12-v2', 'ms-marco-MiniLM-L-12-v2',
       'https://huggingface.co/Xenova/ms-marco-MiniLM-L-12-v2/resolve/main/',
       'onnx/model.onnx', 'vocab.txt', True, True, '~130 MB')
+  { XLM-RoBERTa cross-encoders (SentencePiece tokenizer, no token_type_ids).
+    VocabRelURL points at tokenizer.json (the downloader saves it as the
+    model's vocab file; TSPUnigram loads it as JSON). int8-quantised ONNX so it
+    is CPU-practical; NeedsTT=False because RoBERTa has no segment embeddings. }
+  else if (K = 'bge-reranker-base') or (K = 'bge-rerank') or (K = 'bge-reranker') then
+    ASpec := MakeRSpec('bge-reranker-base', 'bge-reranker-base (int8)', 'bge-reranker-base',
+      'https://huggingface.co/Xenova/bge-reranker-base/resolve/main/',
+      'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~280 MB')
+  else if (K = 'bge-reranker-v2-m3') or (K = 'bge-m3') then
+    ASpec := MakeRSpec('bge-reranker-v2-m3', 'bge-reranker-v2-m3 (int8)', 'bge-reranker-v2-m3',
+      'https://huggingface.co/onnx-community/bge-reranker-v2-m3/resolve/main/',
+      'onnx/model_int8.onnx', 'tokenizer.json', False, False, '~570 MB')
   else
     Result := False;
-  { NOTE: the stronger open rerankers -- bge-reranker-base/large,
-    bge-reranker-v2-m3, mxbai-rerank -- are XLM-RoBERTa / DeBERTa models with a
-    SentencePiece tokenizer and no token_type_ids, which this BERT-WordPiece
-    path (TBertTokenizer) cannot produce correctly. They are deliberately NOT
-    registered here: feeding XLM-R text through a WordPiece vocab yields garbage
-    scores. Supporting them needs a SentencePiece tokenizer (future work); until
-    then the LLM rerank backend (PasClaw.Memory.Rerank.LLM) is the high-quality
-    path -- it uses the configured frontier model and needs no local tokenizer. }
 end;
 
 function RerankerKeys: string;
 begin
-  Result := 'ms-marco-minilm, ms-marco-minilm-l12';
+  Result := 'ms-marco-minilm, ms-marco-minilm-l12, bge-reranker-base, bge-reranker-v2-m3';
 end;
 
 { ----- TReranker ----- }
 
 constructor TReranker.Create(const AModelPath, AVocabPath: string;
-  ADoLowerCase, ANeedsTokenTypeIds: Boolean; AMaxSeq: Integer);
+  ADoLowerCase, ANeedsTokenTypeIds: Boolean; AMaxSeq: Integer;
+  ASentencePiece: Boolean);
 begin
   inherited Create;
   FModelPath := AModelPath;
   FVocabPath := AVocabPath;
   FDoLowerCase := ADoLowerCase;
   FNeedsTokenTypeIds := ANeedsTokenTypeIds;
+  FSentencePiece := ASentencePiece;
   if AMaxSeq < 8 then AMaxSeq := 8;
   FMaxSeq := AMaxSeq;
   FLoaded := False;
-  FTok := TBertTokenizer.Create(AVocabPath, ADoLowerCase);
+  if FSentencePiece then
+    FSP := TSPUnigram.Create(AVocabPath)          { AVocabPath is tokenizer.json }
+  else
+    FTok := TBertTokenizer.Create(AVocabPath, ADoLowerCase);
 end;
 
 destructor TReranker.Destroy;
 begin
   FTok.Free;
+  FSP.Free;
   { TORTSession is a managed record; it releases itself. }
   inherited;
 end;
@@ -204,9 +233,12 @@ end;
 procedure TReranker.EncodePair(const AQuery, ADoc: UnicodeString;
   out AIds, ATypeIds: TArray<Int64>);
 begin
-  { The packing lives in the tokenizer (it owns BasicTokenize/WordPiece); this
-    is a thin pass-through carrying the reranker's MaxSeq budget. }
-  FTok.EncodePair(AQuery, ADoc, FMaxSeq, AIds, ATypeIds);
+  { The packing lives in the tokenizer. WordPiece -> [CLS] q [SEP] d [SEP];
+    SentencePiece -> <s> q </s></s> d </s>. Both carry the reranker's MaxSeq. }
+  if FSentencePiece then
+    FSP.EncodePair(AQuery, ADoc, FMaxSeq, AIds, ATypeIds)
+  else
+    FTok.EncodePair(AQuery, ADoc, FMaxSeq, AIds, ATypeIds);
 end;
 
 function TReranker.Score(const AQuery, ADoc: string): Single;

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -123,17 +123,26 @@ begin
     ASpec := MakeRSpec('ms-marco-minilm', 'ms-marco-MiniLM-L-6-v2', 'ms-marco-MiniLM-L-6-v2',
       'https://huggingface.co/Xenova/ms-marco-MiniLM-L-6-v2/resolve/main/',
       'onnx/model.onnx', 'vocab.txt', True, True, '~90 MB')
-  else if (K = 'bge-reranker-base') or (K = 'bge-rerank') or (K = 'bge-reranker') then
-    ASpec := MakeRSpec('bge-reranker-base', 'bge-reranker-base', 'bge-reranker-base',
-      'https://huggingface.co/Xenova/bge-reranker-base/resolve/main/',
-      'onnx/model.onnx', 'vocab.txt', True, True, '~1.1 GB')
+  else if (K = 'ms-marco-minilm-l12') or (K = 'ms-marco-l12')
+     or (K = 'ms-marco-minilm-l-12-v2') then
+    ASpec := MakeRSpec('ms-marco-minilm-l12', 'ms-marco-MiniLM-L-12-v2', 'ms-marco-MiniLM-L-12-v2',
+      'https://huggingface.co/Xenova/ms-marco-MiniLM-L-12-v2/resolve/main/',
+      'onnx/model.onnx', 'vocab.txt', True, True, '~130 MB')
   else
     Result := False;
+  { NOTE: the stronger open rerankers -- bge-reranker-base/large,
+    bge-reranker-v2-m3, mxbai-rerank -- are XLM-RoBERTa / DeBERTa models with a
+    SentencePiece tokenizer and no token_type_ids, which this BERT-WordPiece
+    path (TBertTokenizer) cannot produce correctly. They are deliberately NOT
+    registered here: feeding XLM-R text through a WordPiece vocab yields garbage
+    scores. Supporting them needs a SentencePiece tokenizer (future work); until
+    then the LLM rerank backend (PasClaw.Memory.Rerank.LLM) is the high-quality
+    path -- it uses the configured frontier model and needs no local tokenizer. }
 end;
 
 function RerankerKeys: string;
 begin
-  Result := 'ms-marco-minilm, bge-reranker-base';
+  Result := 'ms-marco-minilm, ms-marco-minilm-l12';
 end;
 
 { ----- TReranker ----- }

--- a/src/pkg/memory/PasClaw.Memory.Rerank.pas
+++ b/src/pkg/memory/PasClaw.Memory.Rerank.pas
@@ -1,0 +1,251 @@
+unit PasClaw.Memory.Rerank;
+
+{ Local ONNX cross-encoder reranker -- the second stage of two-stage retrieval.
+
+  Stage 1 (embeddings + FTS5, fused by RRF) returns a candidate pool cheaply.
+  This reranker RE-SCORES each (query, candidate) PAIR with a cross-encoder and
+  reorders by relevance -- much more precise than the bi-encoder cosine, because
+  the model sees the query and the document TOGETHER.
+
+  Reuses the same ONNX Runtime + BERT/WordPiece tokenizer as the embedder
+  (LocalVector.Embedder / LocalVector.Tokenizer). The only differences from the
+  bi-encoder path:
+    * input is the PAIR "[CLS] query [SEP] doc [SEP]" with token_type_ids
+      segmenting query (0) from doc (1);
+    * the model emits `logits [1, 1]` (a single relevance score), read directly
+      -- no pooling.
+
+  Default model: cross-encoder/ms-marco-MiniLM-L-6-v2 (~90 MB, same BERT
+  WordPiece tokenizer as the MiniLM embedder). bge-reranker-base is a stronger
+  drop-in; bge-reranker-v2-m3 is multilingual.
+
+  NOTE: ONNX inference (Score/Rerank) needs a loadable ONNX Runtime shared
+  library (auto-provisioned on win-x64; installed by the operator elsewhere),
+  exactly like the embedder. The pure tokenization / pair-encoding logic
+  (EncodePair) has no such dependency and is unit-tested on its own. }
+
+{$IFDEF FPC}{$MODE DELPHI}{$H+}{$ENDIF}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Math, Classes, Generics.Collections,
+{$ELSE}
+  System.SysUtils, System.Math, System.Classes, System.Generics.Collections,
+{$ENDIF}
+  onnxruntime_pas_api, onnxruntime,
+  LocalVector.Runtime, LocalVector.Tokenizer, LocalVector.Models;
+
+type
+  ERerankerError = class(Exception);
+
+  { One reranked candidate: its original index in the input list + score. }
+  TRerankHit = record
+    Index: Integer;
+    Score: Single;
+  end;
+  TRerankHits = array of TRerankHit;
+
+  TReranker = class
+  private
+    FSession: TORTSession;
+    FTok: TBertTokenizer;
+    FModelPath, FVocabPath: string;
+    FDoLowerCase, FNeedsTokenTypeIds: Boolean;
+    FMaxSeq: Integer;
+    FLoaded: Boolean;
+    procedure EnsureLoaded(AVerbose: Boolean);
+  public
+    { AMaxSeq caps the packed pair length -- long candidates are truncated so a
+      cross-encoder that pools over one physical batch never rejects the input
+      ("input is too large to process"; cf. LocalAI PR #10104). }
+    constructor Create(const AModelPath, AVocabPath: string;
+      ADoLowerCase, ANeedsTokenTypeIds: Boolean; AMaxSeq: Integer = 512);
+    destructor Destroy; override;
+
+    { Pack "[CLS] query [SEP] doc [SEP]" into input ids + token_type_ids,
+      truncating doc first (then query) to fit AMaxSeq. Pure -- no ONNX. }
+    procedure EncodePair(const AQuery, ADoc: UnicodeString;
+      out AIds, ATypeIds: TArray<Int64>);
+
+    { Relevance score for one pair (sigmoid of the cross-encoder logit -> 0..1).
+      Loads the model on first use. Requires a working ONNX Runtime. }
+    function Score(const AQuery, ADoc: string): Single;
+
+    { Score every candidate against the query and return them ordered by score
+      descending (index = position in ADocs). Requires a working ONNX Runtime. }
+    function Rerank(const AQuery: string; const ADocs: array of string): TRerankHits;
+
+    property ModelPath: string read FModelPath;
+  end;
+
+const
+  DEFAULT_RERANKER = 'ms-marco-minilm';
+
+{ Registry of the built-in reranker (cross-encoder) models. Mirrors
+  LocalVector.Models.FindModelSpec but for rerankers -- reuses TModelSpec so the
+  existing TModelDownloader can fetch model.onnx + vocab.txt. Pooling/Dim are
+  unused for a cross-encoder. }
+function FindRerankerSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
+function RerankerKeys: string;
+
+implementation
+
+{ ----- model registry ----- }
+
+function MakeRSpec(const AKey, ADisplay, ASubDir, ABaseURL, AModelRel, AVocabRel: string;
+  ANeedsTT, ALower: Boolean; const ASize: string): TModelSpec;
+begin
+  Result.Key := AKey;
+  Result.DisplayName := ADisplay;
+  Result.SubDir := ASubDir;
+  Result.BaseURL := ABaseURL;
+  Result.ModelRelURL := AModelRel;
+  Result.VocabRelURL := AVocabRel;
+  Result.Pooling := poCLS;            { unused for a cross-encoder }
+  Result.NeedsTokenTypeIds := ANeedsTT;
+  Result.DoLowerCase := ALower;
+  Result.Dim := 1;                    { single logit }
+  Result.SizeDesc := ASize;
+end;
+
+function FindRerankerSpec(const AKey: string; out ASpec: TModelSpec): Boolean;
+var
+  K: string;
+begin
+  Result := True;
+  K := LowerCase(Trim(AKey));
+  if (K = 'ms-marco-minilm') or (K = 'ms-marco') or (K = 'minilm-rerank')
+     or (K = 'ms-marco-minilm-l-6-v2') then
+    ASpec := MakeRSpec('ms-marco-minilm', 'ms-marco-MiniLM-L-6-v2', 'ms-marco-MiniLM-L-6-v2',
+      'https://huggingface.co/Xenova/ms-marco-MiniLM-L-6-v2/resolve/main/',
+      'onnx/model.onnx', 'vocab.txt', True, True, '~90 MB')
+  else if (K = 'bge-reranker-base') or (K = 'bge-rerank') or (K = 'bge-reranker') then
+    ASpec := MakeRSpec('bge-reranker-base', 'bge-reranker-base', 'bge-reranker-base',
+      'https://huggingface.co/Xenova/bge-reranker-base/resolve/main/',
+      'onnx/model.onnx', 'vocab.txt', True, True, '~1.1 GB')
+  else
+    Result := False;
+end;
+
+function RerankerKeys: string;
+begin
+  Result := 'ms-marco-minilm, bge-reranker-base';
+end;
+
+{ ----- TReranker ----- }
+
+constructor TReranker.Create(const AModelPath, AVocabPath: string;
+  ADoLowerCase, ANeedsTokenTypeIds: Boolean; AMaxSeq: Integer);
+begin
+  inherited Create;
+  FModelPath := AModelPath;
+  FVocabPath := AVocabPath;
+  FDoLowerCase := ADoLowerCase;
+  FNeedsTokenTypeIds := ANeedsTokenTypeIds;
+  if AMaxSeq < 8 then AMaxSeq := 8;
+  FMaxSeq := AMaxSeq;
+  FLoaded := False;
+  FTok := TBertTokenizer.Create(AVocabPath, ADoLowerCase);
+end;
+
+destructor TReranker.Destroy;
+begin
+  FTok.Free;
+  { TORTSession is a managed record; it releases itself. }
+  inherited;
+end;
+
+procedure TReranker.EnsureLoaded(AVerbose: Boolean);
+begin
+  if FLoaded then Exit;
+  if not FileExists(FModelPath) then
+    raise ERerankerError.CreateFmt('Reranker model not found: %s', [FModelPath]);
+  { Same CPU-EP wiring the embedder needs on ONNX Runtime 1.22+ (no implicit
+    CPU provider). See LocalVector.Embedder.Load. }
+  if not Assigned(DefaultSessionOptions.p_) then
+    ThrowOnError(GetApi().CreateSessionOptions(PPOrtSessionOptions(@DefaultSessionOptions.p_)));
+  ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(DefaultSessionOptions.p_, 1));
+  FSession := TORTSession.Create(FModelPath);
+  FLoaded := True;
+end;
+
+procedure TReranker.EncodePair(const AQuery, ADoc: UnicodeString;
+  out AIds, ATypeIds: TArray<Int64>);
+begin
+  { The packing lives in the tokenizer (it owns BasicTokenize/WordPiece); this
+    is a thin pass-through carrying the reranker's MaxSeq budget. }
+  FTok.EncodePair(AQuery, ADoc, FMaxSeq, AIds, ATypeIds);
+end;
+
+function TReranker.Score(const AQuery, ADoc: string): Single;
+var
+  Ids, TypeIds: TArray<Int64>;
+  InputIds, AttnMask, SegIds: TORTTensor<Int64>;
+  OutVal: TORTValue;
+  OutTensor: TORTTensor<Single>;
+  Inputs, Outputs: TORTNameValueList;
+  I, N: Integer;
+begin
+  EnsureLoaded(False);
+  EncodePair(UnicodeString(AQuery), UnicodeString(ADoc), Ids, TypeIds);
+  N := Length(Ids);
+  if N = 0 then Exit(0);
+
+  { TORTTensor.ToValue reverses the declared shape -> declare [N,1] to hand ONNX
+    a [1,N] tensor (matches the embedder). }
+  InputIds := TORTTensor<Int64>.Create([N, 1]);
+  AttnMask := TORTTensor<Int64>.Create([N, 1]);
+  for I := 0 to N - 1 do
+  begin
+    InputIds.Index1[I] := Ids[I];
+    AttnMask.Index1[I] := 1;
+  end;
+  Inputs.Add('input_ids',      InputIds.ToValue);
+  Inputs.Add('attention_mask', AttnMask.ToValue);
+  if FNeedsTokenTypeIds then
+  begin
+    SegIds := TORTTensor<Int64>.Create([N, 1]);
+    for I := 0 to N - 1 do SegIds.Index1[I] := TypeIds[I];
+    Inputs.Add('token_type_ids', SegIds.ToValue);
+  end;
+
+  Outputs := FSession.Run(Inputs);
+  if Outputs.Count = 0 then
+    raise ERerankerError.Create('Reranker returned no outputs.');
+  OutVal := Outputs.Values[0];
+  OutTensor := TORTTensor<Single>.FromValue(OutVal);
+  { logits shape is [1,1] (or [1]) -> the relevance score is element 0. Squash
+    to 0..1 so scores are comparable / interpretable. }
+  Result := 1 / (1 + Exp(-OutTensor.Index1[0]));
+end;
+
+function TReranker.Rerank(const AQuery: string; const ADocs: array of string): TRerankHits;
+var
+  I, J: Integer;
+  Tmp: TRerankHit;
+begin
+  SetLength(Result, Length(ADocs));
+  for I := 0 to High(ADocs) do
+  begin
+    Result[I].Index := I;
+    Result[I].Score := Score(AQuery, ADocs[I]);
+  end;
+  { descending by score -- insertion sort (candidate pools are small, <= a few
+    dozen). }
+  for I := 1 to High(Result) do
+  begin
+    Tmp := Result[I];
+    J := I - 1;
+    while (J >= 0) and (Result[J].Score < Tmp.Score) do
+    begin
+      Result[J + 1] := Result[J];
+      Dec(J);
+    end;
+    Result[J + 1] := Tmp;
+  end;
+end;
+
+end.

--- a/src/pkg/memory/PasClaw.Memory.Vector.pas
+++ b/src/pkg/memory/PasClaw.Memory.Vector.pas
@@ -65,7 +65,8 @@ uses
   LocalVector.OrtProvision,
   PasClaw.Config,
   PasClaw.Utils,
-  PasClaw.Logger;
+  PasClaw.Logger,
+  PasClaw.Memory.Rerank.Serve;   { optional cross-encoder rerank stage }
 
 const
   { Bound the embedder's sequence length so a giant memory file doesn't
@@ -339,7 +340,9 @@ begin
       Exit;
     end;
   end;
-  Hits := FStore.Search(Query, Emb, smHybrid, K);
+  { RerankedStoreSearch is a plain hybrid search when reranking is off, and a
+    widen -> cross-encoder rescore -> truncate-to-K pass when it's on. }
+  Hits := RerankedStoreSearch(GetHome, Query, Emb, FStore, smHybrid, K);
   SetLength(Result, Length(Hits));
   for i := 0 to High(Hits) do
   begin

--- a/src/pkg/memory/localvector/LocalVector.SentencePiece.pas
+++ b/src/pkg/memory/localvector/LocalVector.SentencePiece.pas
@@ -1,0 +1,390 @@
+unit LocalVector.SentencePiece;
+
+{ SentencePiece **Unigram** tokenizer for XLM-RoBERTa-family cross-encoders
+  (bge-reranker-base / -large / -v2-m3). This is a different algorithm from the
+  BERT WordPiece path in LocalVector.Tokenizer:
+
+    * vocabulary is a list of (piece, log-prob score); tokenization is the
+      max-score segmentation found by Viterbi over that unigram language model
+      (not greedy longest-match subword);
+    * whitespace is turned into the meta symbol U+2581 ("lower one eighth
+      block", the SentencePiece space marker) and a leading U+2581 is prepended
+      (HuggingFace Metaspace, prepend_scheme = "always");
+    * the cross-encoder pair input is RoBERTa-style
+      `<s> query </s></s> passage </s>` with token_type_ids all 0 (XLM-R has
+      no segment embeddings), NOT BERT's `[CLS] q [SEP] d [SEP]` with
+      token_type_ids 0/1.
+
+  The vocabulary + specials are loaded from the model's HuggingFace
+  `tokenizer.json` (the `model.vocab` array). A targeted scanner reads just that
+  array rather than building a full 250k-node JSON DOM.
+
+  LIMITATION: XLM-R's `Precompiled` normalizer (an NFKC-ish compiled charmap) is
+  NOT reproduced -- only the trivial "collapse runs of spaces" step is applied.
+  For ASCII / common Latin text (the retrieval / code case) this matches the
+  reference tokenizer exactly; text needing NFKC folding (some CJK width
+  variants, exotic compatibility characters) may tokenize slightly differently.
+  Validated against HuggingFace `tokenizers` on ASCII + accented Latin. }
+
+{$IFDEF FPC}{$MODE DELPHI}{$H+}{$ENDIF}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+interface
+
+uses
+{$IFDEF FPC}
+  SysUtils, Classes, Math, Generics.Collections;
+{$ELSE}
+  System.SysUtils, System.Classes, System.Math, System.Generics.Collections;
+{$ENDIF}
+
+type
+  ESentencePieceError = class(Exception);
+
+  TSPUnigram = class
+  private
+    FPieceToId: TDictionary<UnicodeString, Integer>;
+    FScores:    array of Single;      { score by id }
+    FMinScore:  Single;
+    FMaxLen:    Integer;              { longest piece, in UTF-16 code units }
+    FBosId, FEosId, FPadId, FUnkId: Integer;
+    procedure LoadFromTokenizerJson(const AJsonText: string);
+    function EncodePieceIds(const ANorm: UnicodeString): TArray<Integer>;
+  public
+    { Load the unigram model from a HuggingFace tokenizer.json (or a file whose
+      bytes are that JSON, whatever it is named on disk). }
+    constructor Create(const ATokenizerJsonPath: string);
+    destructor Destroy; override;
+
+    { Normalise + metaspace + Viterbi-encode a single string to piece ids
+      (NO special tokens). Public for testing. }
+    function Encode(const AText: UnicodeString): TArray<Integer>;
+
+    { Cross-encoder pair packing: <s> A </s></s> B </s>, truncated to AMaxLen
+      (query capped at half, passage truncated first), with token_type_ids all
+      0. Mirrors TBertTokenizer.EncodePair's budget logic. }
+    procedure EncodePair(const AQuery, ADoc: UnicodeString; AMaxLen: Integer;
+      out AIds, ATypeIds: TArray<Int64>);
+
+    property BosId: Integer read FBosId;
+    property EosId: Integer read FEosId;
+    property UnkId: Integer read FUnkId;
+    property VocabSize: Integer read FMaxLen;   { not size; see Count below }
+    function Count: Integer;
+  end;
+
+{ JSON-unescape a raw tokenizer.json string token body (already decoded to
+  UTF-16, between the quotes): processes \uXXXX (surrogate halves emitted
+  verbatim so a pair reforms), \n \t \r \" \\ \/ \b \f; literal characters
+  (incl. multi-byte UTF-8 that was decoded to real code points) pass through
+  untouched. Exposed for testing. }
+function JsonUnescape(const ARaw: UnicodeString): UnicodeString;
+
+implementation
+
+{ ----- JSON string unescape ----- }
+
+function HexVal(C: Char): Integer;
+begin
+  case C of
+    '0'..'9': Result := Ord(C) - Ord('0');
+    'a'..'f': Result := Ord(C) - Ord('a') + 10;
+    'A'..'F': Result := Ord(C) - Ord('A') + 10;
+  else Result := 0;
+  end;
+end;
+
+function JsonUnescape(const ARaw: UnicodeString): UnicodeString;
+var
+  i, n: Integer;
+  cp: Integer;
+begin
+  Result := '';
+  i := 1; n := Length(ARaw);
+  while i <= n do
+  begin
+    if (ARaw[i] = '\') and (i < n) then
+    begin
+      case ARaw[i + 1] of
+        'n': begin Result := Result + #10; Inc(i, 2); end;
+        't': begin Result := Result + #9;  Inc(i, 2); end;
+        'r': begin Result := Result + #13; Inc(i, 2); end;
+        'b': begin Result := Result + #8;  Inc(i, 2); end;
+        'f': begin Result := Result + #12; Inc(i, 2); end;
+        '"': begin Result := Result + '"'; Inc(i, 2); end;
+        '\': begin Result := Result + '\'; Inc(i, 2); end;
+        '/': begin Result := Result + '/'; Inc(i, 2); end;
+        'u':
+          begin
+            if i + 5 <= n then
+            begin
+              cp := (HexVal(Char(ARaw[i+2])) shl 12) or (HexVal(Char(ARaw[i+3])) shl 8)
+                 or (HexVal(Char(ARaw[i+4])) shl 4) or HexVal(Char(ARaw[i+5]));
+              Result := Result + WideChar(cp);   { surrogate halves pass through as-is }
+              Inc(i, 6);
+            end
+            else Inc(i, 2);
+          end;
+      else
+        begin Result := Result + ARaw[i + 1]; Inc(i, 2); end;
+      end;
+    end
+    else
+    begin
+      Result := Result + ARaw[i];   { literal (already-decoded) code unit }
+      Inc(i);
+    end;
+  end;
+end;
+
+{ ----- TSPUnigram ----- }
+
+constructor TSPUnigram.Create(const ATokenizerJsonPath: string);
+var
+  SL: TStringList;
+  Txt: string;
+begin
+  inherited Create;
+  FPieceToId := TDictionary<UnicodeString, Integer>.Create;
+  FBosId := 0; FPadId := 1; FEosId := 2; FUnkId := 3;   { XLM-R defaults }
+  FMaxLen := 1; FMinScore := 0;
+  if not FileExists(ATokenizerJsonPath) then
+    raise ESentencePieceError.CreateFmt('tokenizer.json not found: %s', [ATokenizerJsonPath]);
+  SL := TStringList.Create;
+  try
+    SL.LoadFromFile(ATokenizerJsonPath);
+    Txt := SL.Text;
+  finally
+    SL.Free;
+  end;
+  LoadFromTokenizerJson(Txt);
+  if FPieceToId.Count = 0 then
+    raise ESentencePieceError.Create('tokenizer.json has no unigram vocab');
+end;
+
+destructor TSPUnigram.Destroy;
+begin
+  FPieceToId.Free;
+  inherited;
+end;
+
+function TSPUnigram.Count: Integer;
+begin
+  Result := FPieceToId.Count;
+end;
+
+procedure TSPUnigram.LoadFromTokenizerJson(const AJsonText: string);
+{ Scan for "vocab":[ ... ] inside the model object and read each ["piece",score]
+  entry. Bytes in AJsonText are UTF-8 (raw file); JsonUnescape turns the escaped
+  token body into UTF-16, and non-escaped multi-byte UTF-8 is decoded up front. }
+var
+  Uni: UnicodeString;
+  s: string;
+  p, vstart, n, id: Integer;
+  ch: WideChar;
+  piece: UnicodeString;
+  scoreStr: string;
+  sc: Single;
+  fs: TFormatSettings;
+
+  function FindVocabArray(const U: UnicodeString): Integer;
+  var q: Integer;
+  begin
+    { locate the '[' that opens "vocab": [ ... }
+    q := Pos(UnicodeString('"vocab"'), U);
+    Result := 0;
+    if q = 0 then Exit;
+    Inc(q, Length('"vocab"'));
+    while (q <= Length(U)) and (U[q] <> '[') do Inc(q);
+    Result := q;   { position of '[' }
+  end;
+
+begin
+  { Decode the whole file (UTF-8) to UTF-16 once so codepoint handling is
+    uniform. FPC: assigning AnsiString(UTF8) -> UnicodeString decodes via the
+    active code page (UTF8 in this unit). }
+  {$IFDEF FPC}
+  Uni := UTF8Decode(AJsonText);
+  {$ELSE}
+  Uni := UnicodeString(AJsonText);
+  {$ENDIF}
+  s := '';   { silence hint }
+  if s = '' then ;
+
+  fs := {$IFDEF FPC}DefaultFormatSettings{$ELSE}TFormatSettings.Invariant{$ENDIF};
+  fs.DecimalSeparator := '.';
+
+  p := FindVocabArray(Uni);
+  if p = 0 then Exit;
+  n := Length(Uni);
+  id := 0;
+  Inc(p);   { step past '[' }
+
+  while p <= n do
+  begin
+    { skip whitespace / commas }
+    while (p <= n) and ((Uni[p] = ' ') or (Uni[p] = #10) or (Uni[p] = #13)
+          or (Uni[p] = #9) or (Uni[p] = ',')) do Inc(p);
+    if (p > n) or (Uni[p] = ']') then Break;
+    if Uni[p] <> '[' then Break;      { not an entry -> stop }
+    Inc(p);                            { past entry '[' }
+    { expect a quoted string: "piece" }
+    while (p <= n) and (Uni[p] <> '"') do Inc(p);
+    if p > n then Break;
+    Inc(p);                            { past opening quote }
+    vstart := p;
+    while (p <= n) do
+    begin
+      ch := Uni[p];
+      if ch = '\' then Inc(p, 2)       { skip escaped pair }
+      else if ch = '"' then Break
+      else Inc(p);
+    end;
+    piece := JsonUnescape(Copy(Uni, vstart, p - vstart));
+    Inc(p);                            { past closing quote }
+    { comma then score number }
+    while (p <= n) and (Uni[p] <> ',') do Inc(p);
+    Inc(p);
+    while (p <= n) and ((Uni[p] = ' ') or (Uni[p] = #9)) do Inc(p);
+    scoreStr := '';
+    while (p <= n) and (Uni[p] <> ']') do
+    begin
+      scoreStr := scoreStr + Char(Uni[p]);
+      Inc(p);
+    end;
+    Inc(p);                            { past entry ']' }
+
+    sc := StrToFloatDef(Trim(scoreStr), 0, fs);
+    if not FPieceToId.ContainsKey(piece) then
+      FPieceToId.AddOrSetValue(piece, id);
+    if Length(FScores) <= id then SetLength(FScores, id + 1024);
+    FScores[id] := sc;
+    if sc < FMinScore then FMinScore := sc;
+    if Length(piece) > FMaxLen then FMaxLen := Length(piece);
+    Inc(id);
+  end;
+  SetLength(FScores, id);
+end;
+
+function TSPUnigram.EncodePieceIds(const ANorm: UnicodeString): TArray<Integer>;
+{ Viterbi max-score segmentation of ANorm over the unigram vocab. Positions with
+  no vocab piece fall back to a single-codepoint <unk> edge scored just below the
+  worst real piece, so unk is only taken when nothing else fits. }
+var
+  N, i, L, clen: Integer;
+  best: array of Single;
+  backLen: array of Integer;   { length (code units) of the edge landing at i }
+  backId:  array of Integer;   { piece id of that edge }
+  sub: UnicodeString;
+  pid: Integer;
+  cand, unkPenalty: Single;
+  segLen: array of Integer;
+  segId:  array of Integer;
+  cnt, pos: Integer;
+begin
+  Result := nil;
+  N := Length(ANorm);
+  if N = 0 then Exit;
+  SetLength(best, N + 1);
+  SetLength(backLen, N + 1);
+  SetLength(backId, N + 1);
+  for i := 0 to N do begin best[i] := -1e30; backLen[i] := 0; backId[i] := -1; end;
+  best[0] := 0;
+  unkPenalty := FMinScore - 10.0;
+
+  for i := 1 to N do
+  begin
+    { real pieces ending at i, length 1..FMaxLen }
+    for L := 1 to Min(FMaxLen, i) do
+    begin
+      if best[i - L] <= -1e29 then Continue;
+      sub := Copy(ANorm, i - L + 1, L);
+      if FPieceToId.TryGetValue(sub, pid) then
+      begin
+        cand := best[i - L] + FScores[pid];
+        if cand > best[i] then
+        begin best[i] := cand; backLen[i] := L; backId[i] := pid; end;
+      end;
+    end;
+    { unk fallback for one codepoint (2 code units if a surrogate pair) }
+    clen := 1;
+    if (i >= 2) and (Ord(ANorm[i]) >= $DC00) and (Ord(ANorm[i]) <= $DFFF)
+       and (Ord(ANorm[i-1]) >= $D800) and (Ord(ANorm[i-1]) <= $DBFF) then clen := 2;
+    if best[i - clen] > -1e29 then
+    begin
+      cand := best[i - clen] + unkPenalty;
+      if cand > best[i] then
+      begin best[i] := cand; backLen[i] := clen; backId[i] := FUnkId; end;
+    end;
+  end;
+
+  { backtrack }
+  SetLength(segLen, N); SetLength(segId, N); cnt := 0; pos := N;
+  while pos > 0 do
+  begin
+    if backLen[pos] = 0 then begin backLen[pos] := 1; backId[pos] := FUnkId; end;
+    segLen[cnt] := backLen[pos]; segId[cnt] := backId[pos];
+    pos := pos - backLen[pos]; Inc(cnt);
+  end;
+  SetLength(Result, cnt);
+  for i := 0 to cnt - 1 do Result[i] := segId[cnt - 1 - i];   { reverse }
+end;
+
+function TSPUnigram.Encode(const AText: UnicodeString): TArray<Integer>;
+const
+  MARK = WideChar($2581);   { U+2581 lower one eighth block (SentencePiece space) }
+var
+  s: UnicodeString;
+  i: Integer;
+  mspaced: UnicodeString;
+begin
+  { normalise: collapse runs of 2+ ASCII spaces to one (XLM-R's space-run Replace) }
+  s := '';
+  i := 1;
+  while i <= Length(AText) do
+  begin
+    if AText[i] = ' ' then
+    begin
+      s := s + ' ';
+      while (i <= Length(AText)) and (AText[i] = ' ') do Inc(i);
+    end
+    else begin s := s + AText[i]; Inc(i); end;
+  end;
+  { metaspace: prepend U+2581, replace spaces with U+2581 (prepend_scheme=always) }
+  mspaced := MARK;
+  for i := 1 to Length(s) do
+    if s[i] = ' ' then mspaced := mspaced + MARK else mspaced := mspaced + s[i];
+  Result := EncodePieceIds(mspaced);
+end;
+
+procedure TSPUnigram.EncodePair(const AQuery, ADoc: UnicodeString; AMaxLen: Integer;
+  out AIds, ATypeIds: TArray<Int64>);
+var
+  q, d: TArray<Integer>;
+  budget, qcap, i, k: Integer;
+begin
+  q := Encode(AQuery);
+  d := Encode(ADoc);
+  { specials used: <s> ... </s></s> ... </s>  == 4 special slots }
+  if AMaxLen < 5 then AMaxLen := 5;
+  budget := AMaxLen - 4;
+  if budget < 2 then budget := 2;
+  qcap := budget div 2;
+  if Length(q) > qcap then SetLength(q, qcap);
+  if Length(d) > (budget - Length(q)) then SetLength(d, budget - Length(q));
+
+  SetLength(AIds, 0); SetLength(ATypeIds, 0);
+  k := 2 + Length(q) + Length(d) + 2;   { <s> q </s> </s> d </s> }
+  SetLength(AIds, k); SetLength(ATypeIds, k);
+  i := 0;
+  AIds[i] := FBosId; Inc(i);
+  for k := 0 to High(q) do begin AIds[i] := q[k]; Inc(i); end;
+  AIds[i] := FEosId; Inc(i);
+  AIds[i] := FEosId; Inc(i);
+  for k := 0 to High(d) do begin AIds[i] := d[k]; Inc(i); end;
+  AIds[i] := FEosId; Inc(i);
+  { XLM-R: token_type_ids are all 0 }
+  for k := 0 to High(ATypeIds) do ATypeIds[k] := 0;
+end;
+
+end.

--- a/src/pkg/memory/localvector/LocalVector.Tokenizer.pas
+++ b/src/pkg/memory/localvector/LocalVector.Tokenizer.pas
@@ -52,6 +52,13 @@ type
     { Encode text into BERT input ids, including [CLS]/[SEP], truncated so the
       whole sequence is at most AMaxLen tokens. }
     function Encode(const AText: UnicodeString; AMaxLen: Integer = 256): TArray<Int64>;
+    { Encode a (query, doc) PAIR for a cross-encoder: "[CLS] query [SEP] doc
+      [SEP]" as input ids, with token_type_ids segmenting query (0) from doc (1).
+      The doc is truncated first (then the query, capped at half the budget) so
+      the packed pair is at most AMaxLen tokens. Added for PasClaw.Memory.Rerank;
+      the bi-encoder Encode above is unchanged. }
+    procedure EncodePair(const AQuery, ADoc: UnicodeString; AMaxLen: Integer;
+      out AIds, ATypeIds: TArray<Int64>);
     property ClsId: Integer read FClsId;
     property SepId: Integer read FSepId;
     property UnkId: Integer read FUnkId;
@@ -381,6 +388,44 @@ begin
     Result := Ids.ToArray;
   finally
     Ids.Free;
+  end;
+end;
+
+procedure TBertTokenizer.EncodePair(const AQuery, ADoc: UnicodeString;
+  AMaxLen: Integer; out AIds, ATypeIds: TArray<Int64>);
+var
+  Q, D: TList<Int64>;
+  Words: TArray<UnicodeString>;
+  Budget, QCap, I, N: Integer;
+begin
+  Q := TList<Int64>.Create;
+  D := TList<Int64>.Create;
+  try
+    Words := BasicTokenize(AQuery);
+    for I := 0 to High(Words) do WordPiece(Words[I], Q);
+    Words := BasicTokenize(ADoc);
+    for I := 0 to High(Words) do WordPiece(Words[I], D);
+
+    // Room for [CLS] + [SEP] + [SEP]. Cap the query at half the budget so a
+    // pathological query can't crowd out the document, then truncate the doc.
+    Budget := AMaxLen - 3;
+    if Budget < 0 then Budget := 0;
+    QCap := Budget div 2;
+    while Q.Count > QCap do Q.Delete(Q.Count - 1);
+    while (Q.Count + D.Count) > Budget do D.Delete(D.Count - 1);
+
+    N := 1 + Q.Count + 1 + D.Count + 1;
+    SetLength(AIds, N);
+    SetLength(ATypeIds, N);
+    AIds[0] := FClsId; ATypeIds[0] := 0;
+    N := 1;
+    for I := 0 to Q.Count - 1 do begin AIds[N] := Q[I]; ATypeIds[N] := 0; Inc(N); end;
+    AIds[N] := FSepId; ATypeIds[N] := 0; Inc(N);   // first [SEP] -> segment A
+    for I := 0 to D.Count - 1 do begin AIds[N] := D[I]; ATypeIds[N] := 1; Inc(N); end;
+    AIds[N] := FSepId; ATypeIds[N] := 1;           // closing [SEP] -> segment B
+  finally
+    Q.Free;
+    D.Free;
   end;
 end;
 

--- a/src/pkg/providers/PasClaw.Providers.Anthropic.pas
+++ b/src/pkg/providers/PasClaw.Providers.Anthropic.pas
@@ -594,7 +594,12 @@ var
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1/messages';
-  Body := BuildRequest(Messages, Tools, UseModel, Options, FServerTools);
+  { A caller can force server tools off for one call (the reranker sets this so
+    a rank-these-docs prompt never triggers provider-side web search / fetch). }
+  if Options.DisableServerTools then
+    Body := BuildRequest(Messages, Tools, UseModel, Options, NoAnthropicServerTools)
+  else
+    Body := BuildRequest(Messages, Tools, UseModel, Options, FServerTools);
 
   {$IFDEF PASCLAW_C2W}
   SetLength(Headers, 3);
@@ -833,7 +838,10 @@ begin
   { Force stream:true in the request body. }
   Opts := Options;
   Opts.Stream := True;
-  Body := BuildRequest(Messages, Tools, UseModel, Opts, FServerTools);
+  if Opts.DisableServerTools then
+    Body := BuildRequest(Messages, Tools, UseModel, Opts, NoAnthropicServerTools)
+  else
+    Body := BuildRequest(Messages, Tools, UseModel, Opts, FServerTools);
   Root := TJsonObject.Parse(Body);
   if Root = nil then
   begin

--- a/src/pkg/providers/PasClaw.Providers.Gemini.pas
+++ b/src/pkg/providers/PasClaw.Providers.Gemini.pas
@@ -830,7 +830,13 @@ var
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + '/v1beta/models/' + UseModel + ':generateContent';
-  Body := BuildRequest(Messages, Tools, UseModel, Options, FServerTools);
+  { A caller can force server tools off for one call (e.g. the reranker, which
+    must not trigger google_search grounding -- grounding returns empty text
+    for a rank-these-passages prompt). }
+  if Options.DisableServerTools then
+    Body := BuildRequest(Messages, Tools, UseModel, Options, NoGeminiServerTools)
+  else
+    Body := BuildRequest(Messages, Tools, UseModel, Options, FServerTools);
 
   SetLength(Headers, 1);
   Headers[0] := MakeHeader('x-goog-api-key', FAPIKey);

--- a/src/pkg/providers/PasClaw.Providers.OpenAI.pas
+++ b/src/pkg/providers/PasClaw.Providers.OpenAI.pas
@@ -409,7 +409,12 @@ var
 begin
   if Model <> '' then UseModel := Model else UseModel := FDefaultModel;
   URL  := FAPIBase + FChatPath;
-  Body := BuildOAIRequest(Messages, Tools, UseModel, Options, FServerTools);
+  { A caller can force server tools off for one call (the reranker sets this so
+    a rank-these-docs prompt never triggers provider-side web search). }
+  if Options.DisableServerTools then
+    Body := BuildOAIRequest(Messages, Tools, UseModel, Options, NoOpenAIServerTools)
+  else
+    Body := BuildOAIRequest(Messages, Tools, UseModel, Options, FServerTools);
 
   Headers := BuildAuthHeaders;
 

--- a/src/pkg/providers/PasClaw.Providers.Types.pas
+++ b/src/pkg/providers/PasClaw.Providers.Types.pas
@@ -122,6 +122,13 @@ type
     CacheEnabled:  Boolean;
     CacheTTL:      string;
     CacheKey:      string;
+    (* Suppress provider-side "server tools" (e.g. Gemini google_search
+       grounding) for THIS call, regardless of the provider's configured
+       defaults. Set by callers whose task must not trigger web grounding --
+       notably the LLM reranker, where grounding makes Gemini return empty
+       text (parts:[{text:""}] + groundingMetadata) for a rank-these-passages
+       prompt. Off by default; providers without server tools ignore it. *)
+    DisableServerTools: Boolean;
     Extra:         string;   { provider-specific JSON object }
   end;
 

--- a/src/tests/loop_shaping_defaults_tests.pas
+++ b/src/tests/loop_shaping_defaults_tests.pas
@@ -47,6 +47,8 @@ begin
     AssertTrue(C.ToolOutputCap = DefaultToolOutputCap,
                'ToolOutputCap defaults to DefaultToolOutputCap (24576)');
     AssertTrue(not C.OrientTaskAware,   'OrientTaskAware stays False');
+    AssertTrue(not C.RerankSearchEnabled, 'RerankSearchEnabled defaults to False');
+    AssertTrue(C.RerankModel = '',      'RerankModel defaults to empty (built-in default)');
     AssertTrue(not C.SelfImprovingSkills.SelfManage,
                'SelfImprovingSkills.SelfManage stays False');
   finally
@@ -73,6 +75,8 @@ begin
     AssertTrue(Pos('render_markdown',     S) = 0, 'fresh ToJSON omits render_markdown');
     AssertTrue(Pos('tool_output_cap',     S) = 0, 'fresh ToJSON omits tool_output_cap');
     AssertTrue(Pos('orient_task_aware',   S) = 0, 'fresh ToJSON omits orient_task_aware');
+    AssertTrue(Pos('rerank_search_enabled', S) = 0, 'fresh ToJSON omits rerank_search_enabled');
+    AssertTrue(Pos('rerank_model',        S) = 0, 'fresh ToJSON omits rerank_model');
   finally
     C.Free;
   end;
@@ -96,6 +100,8 @@ begin
     C.CondenseReversible := True;
     C.OrientTaskAware    := True;
     C.ToolOutputCap      := 0;      { default 24576 -> explicit opt-OUT }
+    C.RerankSearchEnabled := True;  { default False -> opt-in }
+    C.RerankModel        := 'bge-reranker-base';  { default '' -> custom }
     S := C.ToJSON;
     { Each non-default field must be present in the serialised form,
       otherwise LoadConfig would silently fall back to the default. }
@@ -107,6 +113,8 @@ begin
     AssertTrue(Pos('"condense_reversible"',   S) > 0, 'opt-in condense_reversible emitted');
     AssertTrue(Pos('"orient_task_aware"',     S) > 0, 'opt-in orient_task_aware emitted');
     AssertTrue(Pos('"tool_output_cap"',       S) > 0, 'opt-out tool_output_cap emitted');
+    AssertTrue(Pos('"rerank_search_enabled"', S) > 0, 'opt-in rerank_search_enabled emitted');
+    AssertTrue(Pos('"rerank_model"',          S) > 0, 'custom rerank_model emitted');
   finally
     C.Free;
   end;
@@ -122,6 +130,8 @@ begin
     AssertTrue(C2.CondenseReversible,       'CondenseReversible round-trips True');
     AssertTrue(C2.OrientTaskAware,          'OrientTaskAware round-trips True');
     AssertTrue(C2.ToolOutputCap = 0,        'ToolOutputCap round-trips the explicit 0 opt-out');
+    AssertTrue(C2.RerankSearchEnabled,      'RerankSearchEnabled round-trips True');
+    AssertTrue(C2.RerankModel = 'bge-reranker-base', 'RerankModel round-trips the custom key');
   finally
     C2.Free;
   end;

--- a/src/tests/loop_shaping_defaults_tests.pas
+++ b/src/tests/loop_shaping_defaults_tests.pas
@@ -49,6 +49,7 @@ begin
     AssertTrue(not C.OrientTaskAware,   'OrientTaskAware stays False');
     AssertTrue(not C.RerankSearchEnabled, 'RerankSearchEnabled defaults to False');
     AssertTrue(C.RerankModel = '',      'RerankModel defaults to empty (built-in default)');
+    AssertTrue(C.RerankBackend = 'auto','RerankBackend defaults to auto (local, else LLM)');
     AssertTrue(not C.SelfImprovingSkills.SelfManage,
                'SelfImprovingSkills.SelfManage stays False');
   finally
@@ -77,6 +78,7 @@ begin
     AssertTrue(Pos('orient_task_aware',   S) = 0, 'fresh ToJSON omits orient_task_aware');
     AssertTrue(Pos('rerank_search_enabled', S) = 0, 'fresh ToJSON omits rerank_search_enabled');
     AssertTrue(Pos('rerank_model',        S) = 0, 'fresh ToJSON omits rerank_model');
+    AssertTrue(Pos('rerank_backend',      S) = 0, 'fresh ToJSON omits rerank_backend (default auto)');
   finally
     C.Free;
   end;
@@ -101,7 +103,8 @@ begin
     C.OrientTaskAware    := True;
     C.ToolOutputCap      := 0;      { default 24576 -> explicit opt-OUT }
     C.RerankSearchEnabled := True;  { default False -> opt-in }
-    C.RerankModel        := 'bge-reranker-base';  { default '' -> custom }
+    C.RerankModel        := 'ms-marco-minilm-l12';  { default '' -> custom }
+    C.RerankBackend      := 'llm';  { default 'auto' -> custom }
     S := C.ToJSON;
     { Each non-default field must be present in the serialised form,
       otherwise LoadConfig would silently fall back to the default. }
@@ -115,6 +118,7 @@ begin
     AssertTrue(Pos('"tool_output_cap"',       S) > 0, 'opt-out tool_output_cap emitted');
     AssertTrue(Pos('"rerank_search_enabled"', S) > 0, 'opt-in rerank_search_enabled emitted');
     AssertTrue(Pos('"rerank_model"',          S) > 0, 'custom rerank_model emitted');
+    AssertTrue(Pos('"rerank_backend"',        S) > 0, 'custom rerank_backend emitted');
   finally
     C.Free;
   end;
@@ -131,7 +135,8 @@ begin
     AssertTrue(C2.OrientTaskAware,          'OrientTaskAware round-trips True');
     AssertTrue(C2.ToolOutputCap = 0,        'ToolOutputCap round-trips the explicit 0 opt-out');
     AssertTrue(C2.RerankSearchEnabled,      'RerankSearchEnabled round-trips True');
-    AssertTrue(C2.RerankModel = 'bge-reranker-base', 'RerankModel round-trips the custom key');
+    AssertTrue(C2.RerankModel = 'ms-marco-minilm-l12', 'RerankModel round-trips the custom key');
+    AssertTrue(C2.RerankBackend = 'llm',    'RerankBackend round-trips the custom value');
   finally
     C2.Free;
   end;

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -67,6 +67,7 @@ begin
       ms-marco-MiniLM-L-6  (local ONNX)   MRR 0.639   recall@5 0.417   (regresses)
       ms-marco-MiniLM-L-12 (local ONNX)   MRR 0.611   recall@5 0.417   (regresses)
       bge-reranker-base    (int8, local)  MRR 0.778   recall@5 0.917   (best local)
+      jina-reranker-v2     (int8, local)  MRR 0.722   recall@5 0.833   (competitive)
       LLM backend (Gemini 2.5 Flash)      MRR 1.000   recall@5 1.000   (perfect)
     Takeaway: the small ms-marco cross-encoders REWARD query/passage lexical
     overlap, so on these deliberately lexical-vs-semantic cases they rank a
@@ -74,11 +75,15 @@ begin
     bi-encoder -- a bigger L-12 does not fix it. The XLM-RoBERTa bge-reranker
     (SentencePiece tokenizer, LocalVector.SentencePiece) is the strongest LOCAL
     option -- it doesn't regress MRR and lifts recall@5 -- and int8 is
-    CPU-practical. The LLM backend (PasClaw.Memory.Rerank.LLM) still tops it by
-    reading query+passages together and reasoning. So: 'llm'/'auto' for the
-    best quality; bge-reranker-base/-v2-m3 as the strong offline model;
-    ms-marco as the tiny no-frills fallback. Relevant indices below are the
-    docs that, to a human, answer the query. }
+    CPU-practical. jina-reranker-v2-base-multilingual (same SentencePiece path)
+    is competitive but edged out bge at int8 here -- on a 6-case set that is
+    within noise, and jina rates higher on public benchmarks, so it is offered
+    as a peer local option (notably multilingual). The LLM backend
+    (PasClaw.Memory.Rerank.LLM) still tops them all by reading query+passages
+    together and reasoning. So: 'llm'/'auto' for the best quality;
+    bge-reranker / jina-reranker-v2 as the strong offline models; ms-marco as
+    the tiny no-frills fallback. Relevant indices below are the docs that, to a
+    human, answer the query. }
   Result := TArray<TEvalCase>.Create(
     C('how do I stop being billed every month',
       ['Your subscription renews automatically every month on the billing date.',   { lexical decoy: "billed/month" }

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -1,0 +1,247 @@
+program rerank_eval;
+(*
+  Retrieval reranking eval -- quantifies the lift the local cross-encoder gives
+  over the bi-encoder (embedding cosine) ordering, in MRR and recall@5.
+
+  For each labeled case (a query + candidate docs + which candidates are
+  relevant) it produces two rankings of the SAME candidates:
+    * baseline  -- sort by embedding cosine (what stage 1 / RRF's vector half
+                   effectively does);
+    * reranked  -- the cross-encoder's (query, doc) relevance order.
+  and reports MRR (mean reciprocal rank of the first relevant hit) and mean
+  recall@5 for each, plus the delta. A positive delta is the reranker earning
+  its keep.
+
+  This is an OPERATOR tool, not a CI unit test: meaningful numbers need the
+  embedding model AND the reranker model provisioned (`pasclaw memory provision
+  --rerank`) on a host with a loadable ONNX Runtime. Without them it prints a
+  SKIP line and exits 0, so `make test-rerank-eval` stays green everywhere and
+  gives the program continuous compile coverage.
+
+  Usage:
+    PASCLAW_HOME=/path/to/provisioned/home  rerank_eval
+  The built-in dataset is a small, deliberately adversarial set where keyword
+  overlap and semantic relevance disagree -- exactly where a cross-encoder is
+  supposed to help. Point it at a real corpus by editing BuildCases (or wiring
+  a JSONL loader) for a domain-specific read.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Math,
+  PasClaw.Config,
+  PasClaw.Memory.Facts.Embed,
+  PasClaw.Memory.Rerank.Serve;
+
+type
+  TEvalCase = record
+    Query: string;
+    Docs:  TArray<string>;
+    Rel:   TArray<Integer>;   { indices into Docs that are relevant }
+  end;
+
+function C(const AQuery: string; const ADocs: array of string;
+  const ARel: array of Integer): TEvalCase;
+var i: Integer;
+begin
+  Result.Query := AQuery;
+  SetLength(Result.Docs, Length(ADocs));
+  for i := 0 to High(ADocs) do Result.Docs[i] := ADocs[i];
+  SetLength(Result.Rel, Length(ARel));
+  for i := 0 to High(ARel) do Result.Rel[i] := ARel[i];
+end;
+
+function BuildCases: TArray<TEvalCase>;
+begin
+  Result := TArray<TEvalCase>.Create(
+    C('how do I cancel my subscription',
+      ['To end your plan, open Settings > Billing and choose Cancel plan.',
+       'Subscriptions renew automatically each month on your billing date.',
+       'Cancel culture has nothing to do with software billing.',
+       'Our cancellation policy: you keep access until the period ends.',
+       'Upgrade your subscription to unlock more seats.'],
+      [0, 3]),
+
+    C('why is my build failing with a linker error',
+      ['A linker error usually means a symbol was declared but never defined.',
+       'Builds run nightly on the CI server at 2am UTC.',
+       'To fix "undefined reference", check you linked the library (-l flag).',
+       'The building has three floors and a rooftop garden.',
+       'Compiler warnings are not the same as linker errors.'],
+      [0, 2]),
+
+    C('reset a forgotten password',
+      ['Click "Forgot password" on the sign-in page to get a reset link.',
+       'Passwords must be at least 12 characters with a symbol.',
+       'We hash passwords with bcrypt and never store them in plaintext.',
+       'If you did not request a reset, ignore the email.',
+       'Reset the device by holding the power button for 10 seconds.'],
+      [0]),
+
+    C('what is the return policy for opened items',
+      ['Opened items can be returned within 14 days for store credit.',
+       'Return the favor by leaving us a review.',
+       'Unopened items get a full refund within 30 days.',
+       'Items marked final sale cannot be returned once opened.',
+       'Shipping is free on orders over fifty dollars.'],
+      [0, 3])
+  );
+end;
+
+function Dot(const A, B: TArray<Single>): Single;
+var i: Integer;
+begin
+  Result := 0;
+  for i := 0 to Min(High(A), High(B)) do
+    Result := Result + A[i] * B[i];
+end;
+
+{ Baseline ranking: candidate indices ordered by embedding cosine descending.
+  LocalEmbed returns unit-normalised vectors, so dot product == cosine. }
+function BaselineOrder(const HomeDir: string; const ACase: TEvalCase;
+  out AOk: Boolean): TArray<Integer>;
+var
+  QVec, DVec: TArray<Single>;
+  Scores: TArray<Single>;
+  i, j, ti: Integer;
+  tf: Single;
+begin
+  AOk := False;
+  SetLength(Result, Length(ACase.Docs));
+  SetLength(Scores, Length(ACase.Docs));
+  if not LocalEmbed(HomeDir, ACase.Query, QVec) then Exit;
+  for i := 0 to High(ACase.Docs) do
+  begin
+    if not LocalEmbed(HomeDir, ACase.Docs[i], DVec) then Exit;
+    Result[i] := i;
+    Scores[i] := Dot(QVec, DVec);
+  end;
+  { insertion sort by score desc (candidate lists are tiny) }
+  for i := 1 to High(Result) do
+  begin
+    j := i - 1; ti := Result[i]; tf := Scores[i];
+    while (j >= 0) and (Scores[j] < tf) do
+    begin
+      Scores[j + 1] := Scores[j];
+      Result[j + 1] := Result[j];
+      Dec(j);
+    end;
+    Scores[j + 1] := tf;
+    Result[j + 1] := ti;
+  end;
+  AOk := True;
+end;
+
+function IsRel(const ACase: TEvalCase; AIdx: Integer): Boolean;
+var r: Integer;
+begin
+  Result := False;
+  for r in ACase.Rel do
+    if r = AIdx then Exit(True);
+end;
+
+{ Reciprocal rank of the first relevant hit in the ordered candidate list. }
+function RR(const ACase: TEvalCase; const AOrder: TArray<Integer>): Double;
+var rank: Integer;
+begin
+  Result := 0;
+  for rank := 0 to High(AOrder) do
+    if IsRel(ACase, AOrder[rank]) then
+      Exit(1.0 / (rank + 1));
+end;
+
+{ Fraction of this case's relevant docs that land in the top 5. }
+function Recall5(const ACase: TEvalCase; const AOrder: TArray<Integer>): Double;
+var rank, hit, top: Integer;
+begin
+  if Length(ACase.Rel) = 0 then Exit(0);
+  hit := 0;
+  top := Min(5, Length(AOrder));
+  for rank := 0 to top - 1 do
+    if IsRel(ACase, AOrder[rank]) then Inc(hit);
+  Result := hit / Length(ACase.Rel);
+end;
+
+var
+  Home: string;
+  Cases: TArray<TEvalCase>;
+  Ci: Integer;
+  BaseOrder, RerankOrder: TArray<Integer>;
+  RerankScores: TArray<Single>;
+  Ok: Boolean;
+  MrrBase, MrrRerank, Rec5Base, Rec5Rerank: Double;
+  N: Integer;
+begin
+  Home := GetHome;
+
+  if not LocalEmbedAvailable(Home) then
+  begin
+    WriteLn('SKIP: embedding model not provisioned -- run `pasclaw memory provision`.');
+    WriteLn('rerank_eval: SKIPPED');
+    Halt(0);
+  end;
+  { The eval uses LocalRerank (raw reranker API); it does not depend on the
+    rerank_search_enabled toggle, only on the model being provisioned. }
+  if not LocalRerankAvailable(Home) then
+  begin
+    WriteLn('SKIP: reranker model not provisioned -- run `pasclaw memory provision --rerank`.');
+    WriteLn('rerank_eval: SKIPPED');
+    Halt(0);
+  end;
+
+  Cases := BuildCases;
+  N := 0;
+  MrrBase := 0; MrrRerank := 0; Rec5Base := 0; Rec5Rerank := 0;
+
+  WriteLn('Retrieval reranking eval (', Length(Cases), ' cases)');
+  WriteLn('  home: ', Home);
+  WriteLn;
+  WriteLn(Format('  %-40s  %8s  %8s', ['query', 'RR base', 'RR rrk']));
+
+  for Ci := 0 to High(Cases) do
+  begin
+    BaseOrder := BaselineOrder(Home, Cases[Ci], Ok);
+    if not Ok then
+    begin
+      WriteLn('  (embed failed for a doc -- skipping case)');
+      Continue;
+    end;
+    if not LocalRerank(Home, Cases[Ci].Query, Cases[Ci].Docs,
+                       RerankOrder, RerankScores) then
+    begin
+      WriteLn('  (rerank failed -- skipping case)');
+      Continue;
+    end;
+
+    Inc(N);
+    MrrBase    := MrrBase    + RR(Cases[Ci], BaseOrder);
+    MrrRerank  := MrrRerank  + RR(Cases[Ci], RerankOrder);
+    Rec5Base   := Rec5Base   + Recall5(Cases[Ci], BaseOrder);
+    Rec5Rerank := Rec5Rerank + Recall5(Cases[Ci], RerankOrder);
+
+    WriteLn(Format('  %-40s  %8.3f  %8.3f',
+      [Copy(Cases[Ci].Query, 1, 40),
+       RR(Cases[Ci], BaseOrder), RR(Cases[Ci], RerankOrder)]));
+  end;
+
+  if N = 0 then
+  begin
+    WriteLn('rerank_eval: no cases scored');
+    Halt(1);
+  end;
+
+  WriteLn;
+  WriteLn(Format('  MRR         base=%.3f  rerank=%.3f  delta=%+.3f',
+    [MrrBase / N, MrrRerank / N, (MrrRerank - MrrBase) / N]));
+  WriteLn(Format('  recall@5    base=%.3f  rerank=%.3f  delta=%+.3f',
+    [Rec5Base / N, Rec5Rerank / N, (Rec5Rerank - Rec5Base) / N]));
+  WriteLn;
+  if MrrRerank >= MrrBase then
+    WriteLn('rerank_eval: OK (reranker did not regress MRR)')
+  else
+    WriteLn('rerank_eval: WARN (reranker regressed MRR on this set)');
+end.

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -62,27 +62,25 @@ begin
     relevant doc that is semantically right but shares few surface words --
     the regime where surface overlap and true relevance disagree.
 
-    MEASURED (2026-07, these 6 cases, ONNX Runtime provisioned):
-      bi-encoder (MiniLM) baseline        MRR 0.778   recall@5 0.833
-      ms-marco-MiniLM-L-6  (local ONNX)   MRR 0.639   recall@5 0.417   (regresses)
-      ms-marco-MiniLM-L-12 (local ONNX)   MRR 0.611   recall@5 0.417   (regresses)
-      bge-reranker-base    (int8, local)  MRR 0.778   recall@5 0.917   (best local)
-      jina-reranker-v2     (int8, local)  MRR 0.722   recall@5 0.833   (competitive)
-      LLM backend (Gemini 2.5 Flash)      MRR 1.000   recall@5 1.000   (perfect)
-    Takeaway: the small ms-marco cross-encoders REWARD query/passage lexical
-    overlap, so on these deliberately lexical-vs-semantic cases they rank a
-    topical-but-wrong passage above a correctly-phrased answer and lose to the
-    bi-encoder -- a bigger L-12 does not fix it. The XLM-RoBERTa bge-reranker
-    (SentencePiece tokenizer, LocalVector.SentencePiece) is the strongest LOCAL
-    option -- it doesn't regress MRR and lifts recall@5 -- and int8 is
-    CPU-practical. jina-reranker-v2-base-multilingual (same SentencePiece path)
-    is competitive but edged out bge at int8 here -- on a 6-case set that is
-    within noise, and jina rates higher on public benchmarks, so it is offered
-    as a peer local option (notably multilingual). The LLM backend
-    (PasClaw.Memory.Rerank.LLM) still tops them all by reading query+passages
-    together and reasoning. So: 'llm'/'auto' for the best quality;
-    bge-reranker / jina-reranker-v2 as the strong offline models; ms-marco as
-    the tiny no-frills fallback. Relevant indices below are the docs that, to a
+    AUTHORITATIVE result -- BEIR/SciFact, 300 queries, human qrels, rerank of
+    the BM25 top-30 (int8 ONNX on CPU), nDCG@10 / MRR@10 / Recall@10:
+      BM25 (first stage)     0.657 / 0.618 / 0.788
+      ms-marco-minilm        0.677 / 0.640 / 0.803   (+0.020 nDCG, MIT)
+      bge-reranker-base      0.683 / 0.646 / 0.811   (+0.025 nDCG, MIT -- DEFAULT)
+      jina-reranker-v2       0.729 / 0.700 / 0.827   (+0.071 nDCG, CC-BY-NC!)
+    On real qrels EVERY cross-encoder beats BM25 (SciFact's candidates are
+    genuinely on-topic, so reranking helps -- unlike the adversarial 6-case set
+    below, where the tiny ms-marco models regressed on lexical traps).
+    jina-reranker-v2 is the clear quality winner, BUT it is CC-BY-NC-4.0
+    (non-commercial), so bge-reranker-base (MIT) is the default and jina is a
+    quality opt-in. The LLM backend (PasClaw.Memory.Rerank.LLM) tops all local
+    models by reading query+passages together. So: 'llm'/'auto' for best
+    quality; bge-reranker-base (MIT) as the default offline model; jina-
+    reranker-v2 for the strongest offline result where a non-commercial license
+    is acceptable; ms-marco as the tiny fallback.
+
+    The cases below are an illustrative in-repo smoke set (no dataset needed).
+    Relevant indices are the docs that, to a
     human, answer the query. }
   Result := TArray<TEvalCase>.Create(
     C('how do I stop being billed every month',

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -62,16 +62,22 @@ begin
     relevant doc that is semantically right but shares few surface words --
     the regime where surface overlap and true relevance disagree.
 
-    NOTE (measured 2026-07): on this small hand-labeled set the ms-marco-MiniLM
-    cross-encoder did NOT beat the MiniLM bi-encoder -- it regressed MRR,
-    because it rewards query/passage lexical+topical overlap and so ranks a
-    topical-but-wrong passage above a correct answer phrased differently (the
-    same trap the bi-encoder falls into). Two lessons: (a) reranker value is
-    corpus- and model-dependent, not automatic; (b) hand-labeled relevance on
-    ambiguous cases is itself noisy. Treat these numbers as ILLUSTRATIVE, not a
-    verdict -- a trustworthy answer needs a real labeled IR set (BEIR / MS
-    MARCO qrels). Relevant indices below are the docs that, to a human, answer
-    the query. }
+    MEASURED (2026-07, these 6 cases, ONNX Runtime provisioned):
+      bi-encoder (MiniLM) baseline        MRR 0.778   recall@5 0.833
+      ms-marco-MiniLM-L-6  (local ONNX)   MRR 0.639   recall@5 0.417   (regresses)
+      ms-marco-MiniLM-L-12 (local ONNX)   MRR 0.611   recall@5 0.417   (regresses)
+      LLM backend (Gemini 2.5 Flash)      MRR 1.000   recall@5 1.000   (perfect)
+    Takeaway: the small ms-marco cross-encoders REWARD query/passage lexical
+    overlap, so on these deliberately lexical-vs-semantic cases they rank a
+    topical-but-wrong passage above a correctly-phrased answer and lose to the
+    bi-encoder -- a bigger L-12 does not fix it. The LLM backend
+    (PasClaw.Memory.Rerank.LLM), which reads query+passages together and
+    reasons, ranks every case perfectly. This is why 'llm' / 'auto' is the
+    recommended rerank_backend and the local ms-marco models are a
+    no-dependency fallback, not the quality tier. (The stronger local rerankers
+    -- bge-reranker-v2-m3 etc. -- would likely match the LLM but need a
+    SentencePiece tokenizer this WordPiece path lacks; see Rerank.pas.)
+    Relevant indices below are the docs that, to a human, answer the query. }
   Result := TArray<TEvalCase>.Create(
     C('how do I stop being billed every month',
       ['Your subscription renews automatically every month on the billing date.',   { lexical decoy: "billed/month" }
@@ -218,7 +224,8 @@ begin
 end;
 
 var
-  Home: string;
+  Home, RerankModelId: string;
+  Cfg: TConfig;
   Cases: TArray<TEvalCase>;
   Ci: Integer;
   BaseOrder, RerankOrder: TArray<Integer>;
@@ -228,6 +235,12 @@ var
   N: Integer;
 begin
   Home := GetHome;
+
+  { Apply config so the configured rerank_model (SetLocalRerankModel, via
+    ApplyConfigGlobals) is honoured -- lets operators A/B different rerankers
+    just by changing rerank_model in config.json. }
+  Cfg := LoadConfig;
+  Cfg.Free;
 
   if not LocalEmbedAvailable(Home) then
   begin
@@ -248,8 +261,11 @@ begin
   N := 0;
   MrrBase := 0; MrrRerank := 0; Rec5Base := 0; Rec5Rerank := 0;
 
+  RerankModelId := '';
+  LocalRerankModelInfo(Home, RerankModelId);
   WriteLn('Retrieval reranking eval (', Length(Cases), ' cases)');
-  WriteLn('  home: ', Home);
+  WriteLn('  home:     ', Home);
+  WriteLn('  reranker: ', RerankModelId);
   WriteLn;
   WriteLn(Format('  %-40s  %8s  %8s', ['query', 'RR base', 'RR rrk']));
 

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -66,18 +66,19 @@ begin
       bi-encoder (MiniLM) baseline        MRR 0.778   recall@5 0.833
       ms-marco-MiniLM-L-6  (local ONNX)   MRR 0.639   recall@5 0.417   (regresses)
       ms-marco-MiniLM-L-12 (local ONNX)   MRR 0.611   recall@5 0.417   (regresses)
+      bge-reranker-base    (int8, local)  MRR 0.778   recall@5 0.917   (best local)
       LLM backend (Gemini 2.5 Flash)      MRR 1.000   recall@5 1.000   (perfect)
     Takeaway: the small ms-marco cross-encoders REWARD query/passage lexical
     overlap, so on these deliberately lexical-vs-semantic cases they rank a
     topical-but-wrong passage above a correctly-phrased answer and lose to the
-    bi-encoder -- a bigger L-12 does not fix it. The LLM backend
-    (PasClaw.Memory.Rerank.LLM), which reads query+passages together and
-    reasons, ranks every case perfectly. This is why 'llm' / 'auto' is the
-    recommended rerank_backend and the local ms-marco models are a
-    no-dependency fallback, not the quality tier. (The stronger local rerankers
-    -- bge-reranker-v2-m3 etc. -- would likely match the LLM but need a
-    SentencePiece tokenizer this WordPiece path lacks; see Rerank.pas.)
-    Relevant indices below are the docs that, to a human, answer the query. }
+    bi-encoder -- a bigger L-12 does not fix it. The XLM-RoBERTa bge-reranker
+    (SentencePiece tokenizer, LocalVector.SentencePiece) is the strongest LOCAL
+    option -- it doesn't regress MRR and lifts recall@5 -- and int8 is
+    CPU-practical. The LLM backend (PasClaw.Memory.Rerank.LLM) still tops it by
+    reading query+passages together and reasoning. So: 'llm'/'auto' for the
+    best quality; bge-reranker-base/-v2-m3 as the strong offline model;
+    ms-marco as the tiny no-frills fallback. Relevant indices below are the
+    docs that, to a human, answer the query. }
   Result := TArray<TEvalCase>.Create(
     C('how do I stop being billed every month',
       ['Your subscription renews automatically every month on the billing date.',   { lexical decoy: "billed/month" }

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -57,38 +57,83 @@ end;
 
 function BuildCases: TArray<TEvalCase>;
 begin
+  { Deliberately hard cases: each query has strong LEXICAL distractors (docs
+    that share the query's keywords but answer a different question) and a
+    relevant doc that is semantically right but shares few surface words --
+    the regime where surface overlap and true relevance disagree.
+
+    NOTE (measured 2026-07): on this small hand-labeled set the ms-marco-MiniLM
+    cross-encoder did NOT beat the MiniLM bi-encoder -- it regressed MRR,
+    because it rewards query/passage lexical+topical overlap and so ranks a
+    topical-but-wrong passage above a correct answer phrased differently (the
+    same trap the bi-encoder falls into). Two lessons: (a) reranker value is
+    corpus- and model-dependent, not automatic; (b) hand-labeled relevance on
+    ambiguous cases is itself noisy. Treat these numbers as ILLUSTRATIVE, not a
+    verdict -- a trustworthy answer needs a real labeled IR set (BEIR / MS
+    MARCO qrels). Relevant indices below are the docs that, to a human, answer
+    the query. }
   Result := TArray<TEvalCase>.Create(
-    C('how do I cancel my subscription',
-      ['To end your plan, open Settings > Billing and choose Cancel plan.',
-       'Subscriptions renew automatically each month on your billing date.',
-       'Cancel culture has nothing to do with software billing.',
-       'Our cancellation policy: you keep access until the period ends.',
-       'Upgrade your subscription to unlock more seats.'],
+    C('how do I stop being billed every month',
+      ['Your subscription renews automatically every month on the billing date.',   { lexical decoy: "billed/month" }
+       'We accept every major card for monthly billing and annual billing.',        { lexical decoy }
+       'Open Settings, choose your plan, and select End plan to halt renewals.',     { relevant, low overlap }
+       'Monthly usage reports are emailed on the first of every month.',             { decoy }
+       'Billing history shows each monthly charge for the past two years.',          { decoy }
+       'To avoid further charges, turn off auto-renew before the next cycle.',        { relevant, low overlap }
+       'Our monthly newsletter covers billing tips and product news.'],              { decoy }
+      [2, 5]),
+
+    C('the app is slow to start up',
+      ['Startup speed depends on how many extensions load at launch.',              { relevant-ish but generic }
+       'The app store rating improved after our latest update.',                    { decoy: "app" }
+       'Cold launches are slow because the on-disk cache is rebuilt each time; ' +
+         'clear stale plugins to speed the first frame.',                           { relevant, low overlap }
+       'Slow-motion video capture starts at 120 frames per second.',               { decoy: "slow/start" }
+       'Start your free trial today -- no card required.',                          { decoy: "start" }
+       'Disable auto-loading of large workspaces to cut launch time.',             { relevant, low overlap }
+       'The startup company raised a slow but steady seed round.'],                 { decoy: "startup/slow" }
+      [2, 5]),
+
+    C('I never got the confirmation email',
+      ['Check your spam folder -- delivery filters sometimes divert our mail.',      { relevant, low overlap }
+       'Confirmation emails are sent within five minutes of signup.',               { lexical decoy }
+       'You can change the email address on your confirmed account anytime.',        { decoy }
+       'If it still has not arrived, resend it from the account page.',              { relevant, low overlap }
+       'We confirmed your email preferences: newsletters are on.',                  { decoy }
+       'The confirmation number is printed at the top of every email receipt.',      { decoy }
+       'Marketing emails can be turned off without affecting confirmations.'],       { decoy }
       [0, 3]),
 
-    C('why is my build failing with a linker error',
-      ['A linker error usually means a symbol was declared but never defined.',
-       'Builds run nightly on the CI server at 2am UTC.',
-       'To fix "undefined reference", check you linked the library (-l flag).',
-       'The building has three floors and a rooftop garden.',
-       'Compiler warnings are not the same as linker errors.'],
-      [0, 2]),
-
     C('reset a forgotten password',
-      ['Click "Forgot password" on the sign-in page to get a reset link.',
-       'Passwords must be at least 12 characters with a symbol.',
-       'We hash passwords with bcrypt and never store them in plaintext.',
-       'If you did not request a reset, ignore the email.',
-       'Reset the device by holding the power button for 10 seconds.'],
-      [0]),
+      ['Passwords must be at least 12 characters and include a symbol.',            { lexical decoy }
+       'Use the "Forgot password" link on sign-in to receive a recovery link.',      { relevant }
+       'We store passwords hashed with bcrypt, never in plaintext.',                { decoy }
+       'Hold the power button ten seconds to reset the device to factory state.',    { decoy: "reset" }
+       'If you did not request a reset, you can safely ignore that email.',          { decoy: "reset" }
+       'An admin can send you a one-time recovery link from the console.',           { relevant, low overlap }
+       'Reset your usage limits by upgrading to the pro tier.'],                     { decoy: "reset" }
+      [1, 5]),
 
-    C('what is the return policy for opened items',
-      ['Opened items can be returned within 14 days for store credit.',
-       'Return the favor by leaving us a review.',
-       'Unopened items get a full refund within 30 days.',
-       'Items marked final sale cannot be returned once opened.',
-       'Shipping is free on orders over fifty dollars.'],
-      [0, 3])
+    C('why does the build fail to link',
+      ['A build fails to link when a referenced symbol is declared but never ' +
+         'defined -- add the object or library that provides it.',                  { relevant }
+       'Nightly builds run on the CI server at 2am UTC.',                           { decoy: "build" }
+       'The new office building has a rooftop garden and a link bridge.',            { decoy: "building/link" }
+       'Pass the correct -l flags so the linker can find each dependency.',          { relevant, low overlap }
+       'Link your account to GitHub to enable build status badges.',                { decoy: "link/build" }
+       'Compiler warnings are unrelated to linker errors.',                         { decoy }
+       'Faster builds come from caching, not from changing linker flags.'],          { decoy }
+      [0, 3]),
+
+    C('can I get a refund for something I already opened',
+      ['Unopened items qualify for a full refund within 30 days.',                  { lexical decoy: "refund" }
+       'Opened products are eligible only for store credit, not a cash refund.',     { relevant }
+       'Refunds are processed to the original card in five business days.',          { decoy }
+       'Once a sealed item is opened it can be exchanged but not fully refunded.',   { relevant, low overlap }
+       'We opened three new stores this year.',                                     { decoy: "opened" }
+       'Gift receipts let the recipient get store credit for any return.',           { decoy }
+       'Final-sale items are never refundable, opened or not.'],                    { decoy }
+      [1, 3])
   );
 end;
 
@@ -134,6 +179,12 @@ begin
     Result[j + 1] := ti;
   end;
   AOk := True;
+end;
+
+function SignedDelta(V: Double): string;
+begin
+  if V >= 0 then Result := '+' + Format('%.3f', [V])
+  else           Result := Format('%.3f', [V]);
 end;
 
 function IsRel(const ACase: TEvalCase; AIdx: Integer): Boolean;
@@ -235,10 +286,11 @@ begin
   end;
 
   WriteLn;
-  WriteLn(Format('  MRR         base=%.3f  rerank=%.3f  delta=%+.3f',
-    [MrrBase / N, MrrRerank / N, (MrrRerank - MrrBase) / N]));
-  WriteLn(Format('  recall@5    base=%.3f  rerank=%.3f  delta=%+.3f',
-    [Rec5Base / N, Rec5Rerank / N, (Rec5Rerank - Rec5Base) / N]));
+  { FPC's Format has no '+' flag, so sign the delta by hand. }
+  WriteLn(Format('  MRR         base=%.3f  rerank=%.3f  delta=%s',
+    [MrrBase / N, MrrRerank / N, SignedDelta((MrrRerank - MrrBase) / N)]));
+  WriteLn(Format('  recall@5    base=%.3f  rerank=%.3f  delta=%s',
+    [Rec5Base / N, Rec5Rerank / N, SignedDelta((Rec5Rerank - Rec5Base) / N)]));
   WriteLn;
   if MrrRerank >= MrrBase then
     WriteLn('rerank_eval: OK (reranker did not regress MRR)')

--- a/src/tests/rerank_eval.pas
+++ b/src/tests/rerank_eval.pas
@@ -71,13 +71,15 @@ begin
     On real qrels EVERY cross-encoder beats BM25 (SciFact's candidates are
     genuinely on-topic, so reranking helps -- unlike the adversarial 6-case set
     below, where the tiny ms-marco models regressed on lexical traps).
-    jina-reranker-v2 is the clear quality winner, BUT it is CC-BY-NC-4.0
-    (non-commercial), so bge-reranker-base (MIT) is the default and jina is a
-    quality opt-in. The LLM backend (PasClaw.Memory.Rerank.LLM) tops all local
-    models by reading query+passages together. So: 'llm'/'auto' for best
-    quality; bge-reranker-base (MIT) as the default offline model; jina-
-    reranker-v2 for the strongest offline result where a non-commercial license
-    is acceptable; ms-marco as the tiny fallback.
+    jina-reranker-v2 scored highest but is CC-BY-NC-4.0 (non-commercial) and is
+    therefore NOT shipped. Among the offered (permissive) models bge-reranker-
+    base (MIT) is the default; bge-reranker-v2-m3 (Apache-2.0, XLM-R-large) is
+    the stronger commercial upgrade but int8-on-CPU is ~100 s per 30-doc rerank
+    -- GPU/server only, so not run at full scale here. The LLM backend
+    (PasClaw.Memory.Rerank.LLM) tops all local models by reading query+passages
+    together. So: 'llm'/'auto' for best quality; bge-reranker-base (MIT) as the
+    default CPU-practical offline model; bge-reranker-v2-m3 on a GPU box;
+    ms-marco as the tiny fallback.
 
     The cases below are an illustrative in-repo smoke set (no dataset needed).
     Relevant indices are the docs that, to a

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -151,7 +151,9 @@ var
   QsegLen, DsegLen: Integer;
 begin
   { --- registry --- }
-  IsTrue(FindRerankerSpec('ms-marco-minilm', Spec), 'default reranker resolves');
+  IsTrue(SameText(DEFAULT_RERANKER, 'bge-reranker-base'), 'default reranker is bge-reranker-base');
+  IsTrue(FindRerankerSpec(DEFAULT_RERANKER, Spec), 'DEFAULT_RERANKER resolves');
+  IsTrue(FindRerankerSpec('ms-marco-minilm', Spec), 'ms-marco-minilm resolves (small fallback)');
   IsTrue(Spec.NeedsTokenTypeIds, 'ms-marco cross-encoder needs token_type_ids');
   IsTrue(Pos('ms-marco', LowerCase(Spec.DisplayName)) > 0, 'display name');
   IsTrue(FindRerankerSpec('ms-marco-l12', Spec), 'ms-marco L-12 alias resolves');

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -156,9 +156,16 @@ begin
   IsTrue(Pos('ms-marco', LowerCase(Spec.DisplayName)) > 0, 'display name');
   IsTrue(FindRerankerSpec('ms-marco-l12', Spec), 'ms-marco L-12 alias resolves');
   IsTrue(Pos('L-12', Spec.DisplayName) > 0, 'L-12 alias maps to the L-12 model');
-  IsTrue(not FindRerankerSpec('bge-reranker', Spec), 'bge (SentencePiece) is NOT registered');
+  IsTrue(not RerankerIsSentencePiece('ms-marco-minilm'), 'ms-marco is WordPiece (not SP)');
+  { bge-reranker: XLM-R, SentencePiece tokenizer, no token_type_ids }
+  IsTrue(FindRerankerSpec('bge-reranker-base', Spec), 'bge-reranker-base resolves');
+  IsTrue(not Spec.NeedsTokenTypeIds, 'bge (XLM-R) needs no token_type_ids');
+  IsTrue(Pos('tokenizer.json', Spec.VocabRelURL) > 0, 'bge vocab is tokenizer.json');
+  IsTrue(RerankerIsSentencePiece('bge-reranker-base'), 'bge-reranker-base is SentencePiece');
+  IsTrue(RerankerIsSentencePiece('bge-reranker-v2-m3'), 'bge-reranker-v2-m3 is SentencePiece');
+  IsTrue(FindRerankerSpec('bge-reranker-v2-m3', Spec), 'bge-reranker-v2-m3 resolves');
   IsTrue(not FindRerankerSpec('nope', Spec), 'unknown key -> false');
-  WriteLn('  ok: reranker registry (ms-marco L-6 default + L-12, SentencePiece models rejected)');
+  WriteLn('  ok: reranker registry (ms-marco WordPiece + bge SentencePiece)');
 
   Vocab := WriteVocab;
   { model path unused until Score(); EncodePair only needs the tokenizer/vocab. }

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -1,0 +1,101 @@
+program rerank_tests;
+(*
+  Unit tests for the ONNX-INDEPENDENT parts of PasClaw.Memory.Rerank:
+    * the reranker model registry (FindRerankerSpec);
+    * EncodePair -- the "[CLS] query [SEP] doc [SEP]" packing + token_type_ids
+      segmentation + truncation-to-fit.
+
+  Live cross-encoder scoring (Score/Rerank) needs a loadable ONNX Runtime and a
+  real model, so it is NOT exercised here -- it is validated on an ORT-equipped
+  machine. EncodePair is the tricky pure logic and is fully covered.
+
+  Uses a tiny hand-built vocab so no model download / ONNX runtime is required.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  LocalVector.Models,
+  PasClaw.Memory.Rerank;
+
+procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
+procedure IsTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
+procedure EqI(Got, Want: Integer; const Msg: string);
+begin if Got <> Want then Fail_(Msg + Format(' (got %d want %d)', [Got, Want])); end;
+
+function WriteVocab: string;
+var S: TStringList;
+begin
+  { id = line index (0-based): [PAD]=0 [UNK]=1 [CLS]=2 [SEP]=3 ... }
+  Result := IncludeTrailingPathDelimiter(GetTempDir) + 'rerank_vocab_' + IntToStr(GetProcessID) + '.txt';
+  S := TStringList.Create;
+  try
+    S.Add('[PAD]'); S.Add('[UNK]'); S.Add('[CLS]'); S.Add('[SEP]');
+    S.Add('cancel'); S.Add('subscription'); S.Add('the'); S.Add('cat');
+    S.Add('a'); S.Add('b'); S.Add('c'); S.Add('d'); S.Add('e');
+    S.WriteBOM := False;
+    S.SaveToFile(Result);
+  finally S.Free; end;
+end;
+
+var
+  Spec: TModelSpec;
+  Rk: TReranker;
+  Vocab: string;
+  Ids, Types: TArray<Int64>;
+  i: Integer;
+  QsegLen, DsegLen: Integer;
+begin
+  { --- registry --- }
+  IsTrue(FindRerankerSpec('ms-marco-minilm', Spec), 'default reranker resolves');
+  IsTrue(Spec.NeedsTokenTypeIds, 'ms-marco cross-encoder needs token_type_ids');
+  IsTrue(Pos('ms-marco', LowerCase(Spec.DisplayName)) > 0, 'display name');
+  IsTrue(FindRerankerSpec('bge-reranker', Spec), 'bge-reranker alias resolves');
+  IsTrue(not FindRerankerSpec('nope', Spec), 'unknown key -> false');
+  WriteLn('  ok: reranker registry (ms-marco default + bge alias, unknown rejected)');
+
+  Vocab := WriteVocab;
+  { model path unused until Score(); EncodePair only needs the tokenizer/vocab. }
+  Rk := TReranker.Create('/nonexistent/model.onnx', Vocab, True, True, 512);
+  try
+    { --- pair packing: "[CLS] cancel subscription [SEP] the cat [SEP]" --- }
+    Rk.EncodePair('cancel subscription', 'the cat', Ids, Types);
+    EqI(Length(Ids), 7, 'pair length = CLS + 2 query + SEP + 2 doc + SEP');
+    EqI(Integer(Ids[0]), 2, 'starts with [CLS]');
+    EqI(Integer(Ids[1]), 4, 'query token 1 = cancel');
+    EqI(Integer(Ids[2]), 5, 'query token 2 = subscription');
+    EqI(Integer(Ids[3]), 3, 'first [SEP] after query');
+    EqI(Integer(Ids[4]), 6, 'doc token 1 = the');
+    EqI(Integer(Ids[5]), 7, 'doc token 2 = cat');
+    EqI(Integer(Ids[6]), 3, 'closing [SEP]');
+    { token_type_ids: 0 for [CLS]+query+first[SEP], 1 for doc+closing[SEP] }
+    for i := 0 to 3 do EqI(Integer(Types[i]), 0, 'segment A id = 0 at ' + IntToStr(i));
+    for i := 4 to 6 do EqI(Integer(Types[i]), 1, 'segment B id = 1 at ' + IntToStr(i));
+    WriteLn('  ok: EncodePair packs [CLS] q [SEP] d [SEP] with correct segment ids');
+
+    { --- truncation: a long doc is truncated to fit MaxSeq (=12 here) --- }
+    Rk.Free;
+    Rk := TReranker.Create('/nonexistent/model.onnx', Vocab, True, True, 12);
+    Rk.EncodePair('a b', 'c d e a b c d e', Ids, Types);
+    EqI(Length(Ids), 12, 'packed pair is capped at MaxSeq');
+    EqI(Integer(Ids[0]), 2, 'still starts with [CLS] after truncation');
+    EqI(Integer(Ids[High(Ids)]), 3, 'still ends with [SEP] after truncation');
+    { last token type must be segment B (doc side) }
+    EqI(Integer(Types[High(Types)]), 1, 'closing [SEP] stays in segment B');
+    { count segment lengths are sane (query capped at budget/2) }
+    QsegLen := 0; DsegLen := 0;
+    for i := 0 to High(Types) do
+      if Types[i] = 0 then Inc(QsegLen) else Inc(DsegLen);
+    IsTrue((QsegLen >= 1) and (DsegLen >= 1), 'both segments non-empty after truncation');
+    WriteLn('  ok: EncodePair truncates the doc to fit MaxSeq, keeps CLS/SEP structure');
+  finally
+    Rk.Free;
+    DeleteFile(Vocab);
+  end;
+
+  WriteLn('rerank_tests: OK');
+end.

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -20,13 +20,112 @@ uses
   {$IFDEF UNIX}cthreads,{$ENDIF}
   SysUtils, Classes,
   LocalVector.Models,
+  PasClaw.Providers.Intf,
+  PasClaw.Providers.Types,
   PasClaw.Memory.Rerank,
-  PasClaw.Memory.Rerank.Serve;
+  PasClaw.Memory.Rerank.Serve,
+  PasClaw.Memory.Rerank.LLM;
 
 procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
 procedure IsTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
 procedure EqI(Got, Want: Integer; const Msg: string);
 begin if Got <> Want then Fail_(Msg + Format(' (got %d want %d)', [Got, Want])); end;
+
+type
+  { Canned-response provider so LLMRerank can be exercised without a network
+    call: it echoes a fixed Content + StatusCode, the way a real provider
+    returns a ranking (or an error string) from Chat. }
+  TFakeProvider = class(TInterfacedObject, ILLMProvider)
+  private
+    FContent: string;
+    FStatus:  Integer;
+  public
+    constructor Create(const AContent: string; AStatus: Integer);
+    function Chat(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+      const Model: string; const Options: TChatOptions): TLLMResponse;
+    function GetDefaultModel: string;
+    function GetName: string;
+    function SupportsThinking: Boolean;
+    function SupportsNativeSearch: Boolean;
+    function SupportsStreaming: Boolean;
+    function ChatStream(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+      const Model: string; const Options: TChatOptions; OnChunk: TStreamCallback): TLLMResponse;
+  end;
+
+constructor TFakeProvider.Create(const AContent: string; AStatus: Integer);
+begin inherited Create; FContent := AContent; FStatus := AStatus; end;
+
+function TFakeProvider.Chat(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+  const Model: string; const Options: TChatOptions): TLLMResponse;
+begin
+  Result := Default(TLLMResponse);
+  Result.Content := FContent;
+  Result.StatusCode := FStatus;
+end;
+
+function TFakeProvider.GetDefaultModel: string; begin Result := 'fake-model'; end;
+function TFakeProvider.GetName: string; begin Result := 'fake'; end;
+function TFakeProvider.SupportsThinking: Boolean; begin Result := False; end;
+function TFakeProvider.SupportsNativeSearch: Boolean; begin Result := False; end;
+function TFakeProvider.SupportsStreaming: Boolean; begin Result := False; end;
+function TFakeProvider.ChatStream(const Messages: array of TMessage; const Tools: array of TToolDefinition;
+  const Model: string; const Options: TChatOptions; OnChunk: TStreamCallback): TLLMResponse;
+begin Result := Chat(Messages, Tools, Model, Options); end;
+
+function Fake(const C: string; St: Integer): ILLMProvider;
+begin Result := TFakeProvider.Create(C, St); end;
+
+procedure TestLLMRerank;
+var
+  Order: TArray<Integer>;
+  Scores: TArray<Single>;
+  Docs: array of string;
+begin
+  SetLength(Docs, 3);
+  Docs[0] := 'doc zero'; Docs[1] := 'doc one'; Docs[2] := 'doc two';
+
+  { clean array }
+  IsTrue(LLMRerank(Fake('[2, 0, 1]', 200), '', 'q', Docs, 0, 0, Order, Scores),
+    'clean array parses');
+  EqI(Length(Order), 3, 'clean: full permutation');
+  EqI(Order[0], 2, 'clean: best is 2'); EqI(Order[1], 0, 'clean: then 0'); EqI(Order[2], 1, 'clean: then 1');
+  IsTrue((Scores[0] > Scores[1]) and (Scores[1] > Scores[2]), 'clean: scores strictly descending');
+
+  { thinking/prose with a stray early bracket -- pick the group with the MOST
+    indices, not the first one (this is the [1,0,2] bug from the live run). }
+  IsTrue(LLMRerank(Fake('Passage [1] looks off-topic. Final ranking: [2, 0, 1]', 200),
+    '', 'q', Docs, 0, 0, Order, Scores), 'messy prose parses');
+  EqI(Order[0], 2, 'messy: real array wins over stray [1]');
+  EqI(Order[1], 0, 'messy: second is 0');
+
+  { model omits a doc -> it is appended so Order stays a full permutation }
+  IsTrue(LLMRerank(Fake('[2, 0]', 200), '', 'q', Docs, 0, 0, Order, Scores), 'partial parses');
+  EqI(Length(Order), 3, 'partial: omitted doc appended');
+  EqI(Order[2], 1, 'partial: the missing index (1) lands last');
+
+  { top_n truncates }
+  IsTrue(LLMRerank(Fake('[2, 0, 1]', 200), '', 'q', Docs, 2, 0, Order, Scores), 'topN parses');
+  EqI(Length(Order), 2, 'topN=2 keeps two');
+
+  { provider transport error (status=-1, error text in Content) must NOT be
+    parsed as a ranking -- the exact live failure (garbage "1" from status=-1) }
+  IsTrue(not LLMRerank(Fake('gemini error: status=-1 msg=TLS could not load', -1),
+    '', 'q', Docs, 0, 0, Order, Scores), 'transport error -> False, not a bogus order');
+  IsTrue(Length(Order) = 0, 'transport error yields no order');
+
+  { HTTP error status likewise rejected }
+  IsTrue(not LLMRerank(Fake('{"error":"rate limited"}', 429), '', 'q', Docs, 0, 0, Order, Scores),
+    'HTTP 429 -> False');
+
+  { success status but no parseable indices -> False (caller keeps RRF order) }
+  IsTrue(not LLMRerank(Fake('I cannot help with that.', 200), '', 'q', Docs, 0, 0, Order, Scores),
+    'no integers -> False');
+
+  { no provider -> False }
+  IsTrue(not LLMRerank(nil, '', 'q', Docs, 0, 0, Order, Scores), 'nil provider -> False');
+
+  WriteLn('  ok: LLM reranker parses rankings, completes permutations, and rejects error responses');
+end;
 
 function WriteVocab: string;
 var S: TStringList;
@@ -55,9 +154,11 @@ begin
   IsTrue(FindRerankerSpec('ms-marco-minilm', Spec), 'default reranker resolves');
   IsTrue(Spec.NeedsTokenTypeIds, 'ms-marco cross-encoder needs token_type_ids');
   IsTrue(Pos('ms-marco', LowerCase(Spec.DisplayName)) > 0, 'display name');
-  IsTrue(FindRerankerSpec('bge-reranker', Spec), 'bge-reranker alias resolves');
+  IsTrue(FindRerankerSpec('ms-marco-l12', Spec), 'ms-marco L-12 alias resolves');
+  IsTrue(Pos('L-12', Spec.DisplayName) > 0, 'L-12 alias maps to the L-12 model');
+  IsTrue(not FindRerankerSpec('bge-reranker', Spec), 'bge (SentencePiece) is NOT registered');
   IsTrue(not FindRerankerSpec('nope', Spec), 'unknown key -> false');
-  WriteLn('  ok: reranker registry (ms-marco default + bge alias, unknown rejected)');
+  WriteLn('  ok: reranker registry (ms-marco L-6 default + L-12, SentencePiece models rejected)');
 
   Vocab := WriteVocab;
   { model path unused until Score(); EncodePair only needs the tokenizer/vocab. }
@@ -112,6 +213,8 @@ begin
     'reranker reports unavailable when the model is not on disk');
   SetRerankSearchEnabled(False);   { restore }
   WriteLn('  ok: retrieval rerank gate needs BOTH the toggle and a provisioned model');
+
+  TestLLMRerank;
 
   WriteLn('rerank_tests: OK');
 end.

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -164,8 +164,7 @@ begin
   IsTrue(not Spec.NeedsTokenTypeIds, 'bge (XLM-R) needs no token_type_ids');
   IsTrue(Pos('tokenizer.json', Spec.VocabRelURL) > 0, 'bge vocab is tokenizer.json');
   IsTrue(RerankerIsSentencePiece('bge-reranker-base'), 'bge-reranker-base is SentencePiece');
-  IsTrue(RerankerIsSentencePiece('bge-reranker-v2-m3'), 'bge-reranker-v2-m3 is SentencePiece');
-  IsTrue(FindRerankerSpec('bge-reranker-v2-m3', Spec), 'bge-reranker-v2-m3 resolves');
+  IsTrue(SameText(DEFAULT_RERANKER, 'bge-reranker-base'), 'default is bge-reranker-base (MIT)');
   { jina-reranker-v2: same XLM-R SentencePiece path, input_ids+attention_mask only }
   IsTrue(FindRerankerSpec('jina-reranker-v2', Spec), 'jina-reranker-v2 resolves');
   IsTrue(not Spec.NeedsTokenTypeIds, 'jina (XLM-R) needs no token_type_ids');

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -20,7 +20,8 @@ uses
   {$IFDEF UNIX}cthreads,{$ENDIF}
   SysUtils, Classes,
   LocalVector.Models,
-  PasClaw.Memory.Rerank;
+  PasClaw.Memory.Rerank,
+  PasClaw.Memory.Rerank.Serve;
 
 procedure Fail_(const Msg: string); begin WriteLn('FAIL: ' + Msg); Halt(1); end;
 procedure IsTrue(Cond: Boolean; const Msg: string); begin if not Cond then Fail_(Msg); end;
@@ -96,6 +97,21 @@ begin
     Rk.Free;
     DeleteFile(Vocab);
   end;
+
+  { --- retrieval gate composition (ONNX-free): the config toggle AND
+        provisioning must both hold before retrieval reranks. In this test
+        env no reranker model is on disk, so "available" is always false --
+        which is exactly the graceful-no-op property we want to guarantee. --- }
+  SetRerankSearchEnabled(False);
+  IsTrue(not RetrievalRerankActive(GetTempDir),
+    'gate off -> retrieval does not rerank (fast path, no fs probe)');
+  SetRerankSearchEnabled(True);
+  IsTrue(not RetrievalRerankActive(GetTempDir),
+    'gate on but model unprovisioned -> still no rerank (graceful no-op)');
+  IsTrue(not LocalRerankAvailable(GetTempDir),
+    'reranker reports unavailable when the model is not on disk');
+  SetRerankSearchEnabled(False);   { restore }
+  WriteLn('  ok: retrieval rerank gate needs BOTH the toggle and a provisioned model');
 
   WriteLn('rerank_tests: OK');
 end.

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -164,6 +164,11 @@ begin
   IsTrue(RerankerIsSentencePiece('bge-reranker-base'), 'bge-reranker-base is SentencePiece');
   IsTrue(RerankerIsSentencePiece('bge-reranker-v2-m3'), 'bge-reranker-v2-m3 is SentencePiece');
   IsTrue(FindRerankerSpec('bge-reranker-v2-m3', Spec), 'bge-reranker-v2-m3 resolves');
+  { jina-reranker-v2: same XLM-R SentencePiece path, input_ids+attention_mask only }
+  IsTrue(FindRerankerSpec('jina-reranker-v2', Spec), 'jina-reranker-v2 resolves');
+  IsTrue(not Spec.NeedsTokenTypeIds, 'jina (XLM-R) needs no token_type_ids');
+  IsTrue(RerankerIsSentencePiece('jina-reranker-v2'), 'jina-reranker-v2 is SentencePiece');
+  IsTrue(Pos('tokenizer.json', Spec.VocabRelURL) > 0, 'jina vocab is tokenizer.json');
   IsTrue(not FindRerankerSpec('nope', Spec), 'unknown key -> false');
   WriteLn('  ok: reranker registry (ms-marco WordPiece + bge SentencePiece)');
 

--- a/src/tests/rerank_tests.pas
+++ b/src/tests/rerank_tests.pas
@@ -165,13 +165,16 @@ begin
   IsTrue(Pos('tokenizer.json', Spec.VocabRelURL) > 0, 'bge vocab is tokenizer.json');
   IsTrue(RerankerIsSentencePiece('bge-reranker-base'), 'bge-reranker-base is SentencePiece');
   IsTrue(SameText(DEFAULT_RERANKER, 'bge-reranker-base'), 'default is bge-reranker-base (MIT)');
-  { jina-reranker-v2: same XLM-R SentencePiece path, input_ids+attention_mask only }
-  IsTrue(FindRerankerSpec('jina-reranker-v2', Spec), 'jina-reranker-v2 resolves');
-  IsTrue(not Spec.NeedsTokenTypeIds, 'jina (XLM-R) needs no token_type_ids');
-  IsTrue(RerankerIsSentencePiece('jina-reranker-v2'), 'jina-reranker-v2 is SentencePiece');
-  IsTrue(Pos('tokenizer.json', Spec.VocabRelURL) > 0, 'jina vocab is tokenizer.json');
+  { bge-reranker-v2-m3: Apache-2.0 quality upgrade, same XLM-R SentencePiece path }
+  IsTrue(FindRerankerSpec('bge-reranker-v2-m3', Spec), 'bge-reranker-v2-m3 resolves');
+  IsTrue(not Spec.NeedsTokenTypeIds, 'bge-v2-m3 (XLM-R) needs no token_type_ids');
+  IsTrue(RerankerIsSentencePiece('bge-reranker-v2-m3'), 'bge-reranker-v2-m3 is SentencePiece');
+  IsTrue(Pos('tokenizer.json', Spec.VocabRelURL) > 0, 'bge-v2-m3 vocab is tokenizer.json');
+  IsTrue(Pos('Apache', Spec.DisplayName) > 0, 'bge-v2-m3 labeled Apache-2.0');
+  { jina-reranker-v2 is CC-BY-NC (non-commercial) -- deliberately NOT offered }
+  IsTrue(not FindRerankerSpec('jina-reranker-v2', Spec), 'jina (non-commercial) is NOT registered');
   IsTrue(not FindRerankerSpec('nope', Spec), 'unknown key -> false');
-  WriteLn('  ok: reranker registry (ms-marco WordPiece + bge SentencePiece)');
+  WriteLn('  ok: reranker registry (MIT/Apache SentencePiece models; jina dropped)');
 
   Vocab := WriteVocab;
   { model path unused until Score(); EncodePair only needs the tokenizer/vocab. }

--- a/src/tests/sentencepiece_tests.pas
+++ b/src/tests/sentencepiece_tests.pas
@@ -1,0 +1,103 @@
+program sentencepiece_tests;
+(*
+  Unit tests for LocalVector.SentencePiece (XLM-R SentencePiece Unigram
+  tokenizer) using a TINY hand-built tokenizer.json -- no 90 MB model / 250k
+  vocab needed, so this runs in CI. Covers:
+    * JSON string unescape (\uXXXX + the escape set);
+    * metaspace + Viterbi max-score segmentation over a small unigram model;
+    * RoBERTa pair packing <s> A </s></s> B </s> with token_type_ids all 0.
+
+  The FULL correctness proof -- byte-identical output vs HuggingFace tokenizers
+  on the real bge-reranker vocab (ASCII, accented Latin, code) -- is done
+  out-of-band with the provisioned tokenizer.json (see the branch's scratch
+  validator); it can't run in CI because the vocab file is 8 MB.
+*)
+{$IFDEF FPC}{$MODE DELPHI}{$H+}{$ENDIF}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils, Classes,
+  LocalVector.SentencePiece;
+
+procedure Fail_(const M: string); begin WriteLn('FAIL: ' + M); Halt(1); end;
+procedure IsTrue(C: Boolean; const M: string); begin if not C then Fail_(M); end;
+procedure EqI(G, W: Integer; const M: string);
+begin if G <> W then Fail_(M + Format(' (got %d want %d)', [G, W])); end;
+
+function WriteTinyTokenizer: string;
+{ ids: <s>=0 <pad>=1 </s>=2 <unk>=3 then pieces. Scores chosen so the
+  intended segmentation wins the Viterbi. U+2581 written as ▁. }
+var S: TStringList;
+begin
+  Result := IncludeTrailingPathDelimiter(GetTempDir) + 'sp_tiny_' + IntToStr(GetProcessID) + '.json';
+  S := TStringList.Create;
+  try
+    S.Text :=
+      '{"model":{"type":"Unigram","unk_id":3,"vocab":[' +
+      '["<s>",0.0],["<pad>",0.0],["</s>",0.0],["<unk>",0.0],' +
+      '["▁",-3.0],' +               { id 4: lone marker }
+      '["▁hello",-2.0],' +          { id 5 }
+      '["hello",-5.0],' +                { id 6 }
+      '["▁world",-2.0],' +          { id 7 }
+      '["▁wor",-6.0],' +            { id 8 }
+      '["ld",-6.0],' +                   { id 9 }
+      '["▁a",-4.0]' +               { id 10 }
+      ']}}';
+    S.WriteBOM := False;
+    S.SaveToFile(Result);
+  finally S.Free; end;
+end;
+
+var
+  Tok: TSPUnigram;
+  Path: string;
+  ids: TArray<Integer>;
+  pids, ptt: TArray<Int64>;
+  u: UnicodeString;
+begin
+  { --- JsonUnescape --- }
+  u := JsonUnescape('a▁b');
+  IsTrue((Length(u) = 3) and (u[1] = 'a') and (Ord(u[2]) = $2581) and (u[3] = 'b'),
+    'JsonUnescape decodes \\u2581 to U+2581');
+  u := JsonUnescape('tab\tquote\"slash\\done');
+  IsTrue(Pos(UnicodeString(#9), u) > 0, 'JsonUnescape handles \\t');
+  WriteLn('  ok: JsonUnescape');
+
+  Path := WriteTinyTokenizer;
+  Tok := TSPUnigram.Create(Path);
+  try
+    EqI(Tok.Count, 11, 'tiny vocab loaded');
+    EqI(Tok.BosId, 0, 'bos=0'); EqI(Tok.EosId, 2, 'eos=2'); EqI(Tok.UnkId, 3, 'unk=3');
+
+    { "hello world" -> "▁hello▁world": [_hello](-2)+[_world](-2) = -4
+      beats [_](-3)+[hello](-5)=-8 and [_wor..](-6)... so ids [5,7]. }
+    ids := Tok.Encode('hello world');
+    EqI(Length(ids), 2, 'hello world -> 2 pieces');
+    EqI(ids[0], 5, 'first piece = _hello (id 5)');
+    EqI(ids[1], 7, 'second piece = _world (id 7)');
+    WriteLn('  ok: Viterbi picks the max-score segmentation');
+
+    { an unknown char (no piece, no single-char match) -> <unk> }
+    ids := Tok.Encode('z');
+    IsTrue((Length(ids) >= 1) and (ids[High(ids)] = 3), 'unknown char -> <unk>');
+    WriteLn('  ok: unknown codepoint falls back to <unk>');
+
+    { pair packing: <s> hello </s></s> world </s> = [0,5,2,2,7,2], type_ids 0 }
+    Tok.EncodePair('hello', 'world', 512, pids, ptt);
+    EqI(Length(pids), 6, 'pair length = <s> q </s></s> d </s>');
+    EqI(Integer(pids[0]), 0, 'starts <s>');
+    EqI(Integer(pids[1]), 5, 'query piece');
+    EqI(Integer(pids[2]), 2, 'first </s>');
+    EqI(Integer(pids[3]), 2, 'second </s> (RoBERTa double-sep)');
+    EqI(Integer(pids[4]), 7, 'doc piece');
+    EqI(Integer(pids[5]), 2, 'closing </s>');
+    IsTrue((ptt[0] = 0) and (ptt[5] = 0), 'XLM-R token_type_ids are all 0');
+    WriteLn('  ok: EncodePair packs <s> q </s></s> d </s> (type_ids all 0)');
+  finally
+    Tok.Free;
+    DeleteFile(Path);
+  end;
+
+  WriteLn('sentencepiece_tests: OK');
+end.


### PR DESCRIPTION
## What & why

Two-stage retrieval: after the bi-encoder + FTS RRF fusion returns a candidate pool, re-score the top candidates with a cross-encoder for sharper ordering. This adds a **self-hosted `/v1/rerank`** endpoint (the de-facto shape other providers expose), **local ONNX cross-encoders** (ms-marco WordPiece **and** bge XLM-R SentencePiece), and an **LLM fallback** — all off by default, gated on provisioning/config.

Built in phases, then hardened by actually running it end-to-end (which surfaced several real bugs invisible to a build-only check).

## What's in it

- **Local ONNX cross-encoders** (`PasClaw.Memory.Rerank`):
  - ms-marco-MiniLM **L-6** (default) / **L-12** — BERT WordPiece.
  - **bge-reranker-base / -v2-m3** — XLM-RoBERTa, via a new **SentencePiece Unigram tokenizer** (`LocalVector.SentencePiece`): Metaspace + Viterbi max-score segmentation + `<s> q </s></s> d </s>` packing. Validated **byte-exact vs HuggingFace `tokenizers`** on the real 250k-piece vocab.
- **`/v1/rerank`** (+ `/rerank`, `/v2/rerank`) in the gateway, mirroring `/v1/embeddings`.
- **LLM rerank backend** (`PasClaw.Memory.Rerank.LLM`): ranks candidates by asking the configured chat model — no model download. `rerank_backend` = `auto` (local→LLM) | `local` | `llm`.
- **Provisioning + onboarding + config**: `memory provision [--rerank] [--rerank-model KEY]`, an onboarding prompt, `memory status`, and `rerank_search_enabled` / `rerank_model` / `rerank_backend` (opt-in, round-tripped, tested).
- **Retrieval wiring**: `memory_search` + `kb_search` share `RerankedStoreSearch` (widen → rescore → truncate), gated on config **and** provisioning, graceful RRF fallback.
- **Eval harness** (`make test-rerank-eval`) + **SentencePiece unit tests** (`make test-sentencepiece`).

## Does it help? (measured, real ONNX Runtime)

| Reranker | MRR | recall@5 |
|---|---|---|
| bi-encoder (MiniLM) baseline | 0.778 | 0.833 |
| ms-marco-MiniLM-L-6 / L-12 (local) | 0.64 / 0.61 | 0.417 *(regress)* |
| **bge-reranker-base (int8, local)** | **0.778** | **0.917** *(best local)* |
| **LLM (Gemini 2.5 Flash)** | **1.000** | **1.000** |

The tiny ms-marco cross-encoders reward lexical overlap and *regress* on lexical-vs-semantic cases. **bge is the only local model that doesn't regress** (same MRR, +0.083 recall@5) — the strong offline tier. The LLM backend tops everything. So: `llm`/`auto` for best quality; bge-reranker for strong offline; ms-marco as the tiny fallback.

## Bugs found by running it (not by building it)

- **CPU-EP double-registration**: reranker appended the CPU EP to the *shared* session-options the embedder also configures → ORT 1.22+ rejected it, breaking every embed-then-rerank sequence. Fixed with a dedicated options object.
- **StatusCode garbage-parse**: providers return transport errors as `Content` (`"...status=-1..."`); the parser scraped a bogus ranking out of it. Now rejects failed responses.
- **Gemini grounding empties rerank replies**: `google_search` grounding makes the model answer a rank-these-passages prompt with empty text — added `TChatOptions.DisableServerTools`, set by the reranker.

Validated live end-to-end through the gateway (ONNX Runtime + a real provider over Indy TLS). Unit tests cover the pure logic: WordPiece + SentencePiece packing/truncation, Viterbi, registry, the retrieval gate, and LLM parse/permutation/error-handling with a fake provider.

## Test plan

- `make test-rerank`, `make test-sentencepiece`, `make test-loop-shaping-defaults`, `make test-rerank-eval` (skips), plus `test-kb-index` / `test-memory-facts` / gemini/anthropic/openai server-tools + tool-choice suites — all pass.
- Full `make all` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6