### PR TITLE
gateway: guard the /v1/stats response cache against concurrent requests

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -534,13 +534,18 @@ var
     surfacing fresh numbers when the operator hits /stats directly
     after a turn. Reset to (0, '') on first call.
 
-    No lock: the gateway's request handling is single-threaded
-    through OnCommandGet, so reads and writes here are serialised.
-    A future async refactor would need to wrap this in a critical
-    section. }
+    GStatsCacheLock guards these two globals. Indy serves each request
+    on its own worker thread (see RunCheckpointedLoop: turns from
+    different sessions run concurrently), and the web UI auto-refreshes
+    /v1/stats, so two threads can hit HandleStats at once -- reading and
+    writing GStatsCacheBody without a lock is a data race (a torn read of
+    the string, or two writers stomping each other). The lock brackets
+    ONLY the tiny read/write of the pair, never the expensive session
+    walk, so it does not serialise the aggregation itself. }
   GStatsCacheUntil:    TDateTime = 0;
   GStatsCacheBody:     string    = '';
   GStatsCacheTtlSecs:  Integer   = 5;
+  GStatsCacheLock:     TCriticalSection = nil;
 
   { Mutex around the per-endpoint stats sessions
     (_gateway_v1_chat / _gateway_v1_chat_completions /
@@ -2778,6 +2783,9 @@ var
   Cur: Int64;
   Root, ProviderObj, ModelObj: TJsonObject;
   ProviderArr, ModelArr: TJsonArray;
+  CachedBody: string;
+  CacheHit:   Boolean;
+  Body:       string;
 
   procedure BumpMap(M: TStringList; const K: string; Delta: Int64);
   var
@@ -2795,9 +2803,23 @@ var
   end;
 
 begin
-  if Now < GStatsCacheUntil then
+  { Serve a still-fresh cached body. Snapshot under the lock, then write
+    outside it -- WriteJSON must not run while holding the mutex. }
+  CacheHit := False;
+  CachedBody := '';
+  GStatsCacheLock.Enter;
+  try
+    if Now < GStatsCacheUntil then
+    begin
+      CachedBody := GStatsCacheBody;
+      CacheHit   := True;
+    end;
+  finally
+    GStatsCacheLock.Leave;
+  end;
+  if CacheHit then
   begin
-    WriteJSON(AResp, 200, GStatsCacheBody);
+    WriteJSON(AResp, 200, CachedBody);
     Exit;
   end;
 
@@ -2879,9 +2901,15 @@ begin
         ModelArr.Free; raise;
       end;
 
-      GStatsCacheBody  := Root.ToJSON;
-      GStatsCacheUntil := IncSecond(Now, GStatsCacheTtlSecs);
-      WriteJSON(AResp, 200, GStatsCacheBody);
+      Body := Root.ToJSON;
+      GStatsCacheLock.Enter;
+      try
+        GStatsCacheBody  := Body;
+        GStatsCacheUntil := IncSecond(Now, GStatsCacheTtlSecs);
+      finally
+        GStatsCacheLock.Leave;
+      end;
+      WriteJSON(AResp, 200, Body);
     finally
       Root.Free;
     end;
@@ -7644,6 +7672,7 @@ initialization
   GProviderSignatureCacheLock := TCriticalSection.Create;
   GProviderSignatureCache     := TStringList.Create;
   GGatewayStatsLock           := TCriticalSection.Create;
+  GStatsCacheLock             := TCriticalSection.Create;
   { Unsorted on purpose: insertion order doubles as FIFO so the
     eviction in RememberProviderSignature (Delete(0)) actually drops
     the OLDEST entry. A sorted+dupIgnore TStringList would order by
@@ -7658,5 +7687,6 @@ finalization
   GProviderSignatureCache.Free;
   GProviderSignatureCacheLock.Free;
   GGatewayStatsLock.Free;
+  GStatsCacheLock.Free;
 
 end.


### PR DESCRIPTION
## Summary

The process-global `/v1/stats` response cache (`GStatsCacheBody` / `GStatsCacheUntil` in `PasClaw.Gateway.Server.pas`) was read and written **without a lock**, under a stale comment claiming *"the gateway's request handling is single-threaded through OnCommandGet."*

That assumption is false. Indy serves each request on its own worker thread — `RunCheckpointedLoop` is explicitly built around it (*"Indy serves on worker threads, so two requests can run turns at once"*; turns from different sessions run concurrently) — and the web UI **auto-refreshes** `/v1/stats`. So two threads can enter `HandleStats` at the same time, and concurrent access to the cached `string` is a genuine data race: a torn read served to one client, or two writers stomping each other.

## Fix

Add `GStatsCacheLock` (a `TCriticalSection`, mirroring the existing `GGatewayStatsLock` pattern already used for the per-endpoint bucket files) and bracket **only** the tiny read/write of the two globals:

- **Read path:** snapshot the still-fresh body under the lock, then `WriteJSON` *outside* it (never hold the mutex across the response write).
- **Write path:** build the body, store it + the new TTL under the lock, then `WriteJSON` outside it.

The expensive session-directory walk stays **outside** the lock, so aggregation is not serialised and the 5-second cache keeps doing its job — this only closes the race on the cached pair.

## Validation

- Full binary rebuilds clean.
- `gateway_stats_buckets_tests` passes (links the Server unit).
- Live smoke: started a gateway and fired **20 concurrent `/v1/stats` requests** — all returned **200** with valid JSON and no deadlock.

## Context

Found while answering whether two web-UI sessions can run turns simultaneously (they can — per-session turn locks, different sessions overlap). This stale-comment race was the one loose end in that concurrency model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_