### PR TITLE
prompt: teach the skill-authoring format (+ workflows design doc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,6 +497,15 @@ test-config-profile: | $(BUILDDIR)
 
 # Active Plan section -- pins BuildActivePlanSection's gating cases
 # (NoPlan / pmPlan / missing) and the happy-path PLAN.md injection.
+# Skill-authoring primer in the system prompt: the "## Skills" section must
+# teach the SKILL.md format even when zero skills are installed (so "build me
+# a skill" works), and keep teaching it when a catalog is present.
+test-skills-prompt: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/skills_prompt_tests.pas -o$(BUILDDIR)/skills_prompt_tests
+	@rm -rf $(BUILDDIR)/skills-prompt-home
+	@PASCLAW_HOME=$(BUILDDIR)/skills-prompt-home $(BUILDDIR)/skills_prompt_tests
+
 test-active-plan-section: | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/active_plan_section_tests.pas -o$(BUILDDIR)/active_plan_section_tests
@@ -906,4 +915,4 @@ test-fs-grep-tier5-6: | $(BUILDDIR)
 	$(FPC) $(FPCFLAGS) src/tests/fs_grep_tier5_6_tests.pas -o$(BUILDDIR)/fs_grep_tier5_6_tests
 	@$(BUILDDIR)/fs_grep_tier5_6_tests
 
-test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-sentencepiece test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-guardfall test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build
+test: smoke test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-gemini-schema-strip test-markdown-render test-json-utf8-roundtrip test-json-lenient test-rerank test-sentencepiece test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-ansi-width test-shell-filters test-learn test-export test-execute-code test-session-stats test-auto-router test-gateway-stats-buckets test-session-list-filter test-session-endpoints test-config-secret-merge test-skills-install test-self-improving-skills test-loop-shaping-defaults test-max-iter-notice test-max-iter-notice test-plan-build-mode test-config-profile test-tool-rpc test-session-search test-subagent-bg test-subagent-default test-subagent-model-arg test-zip-pack test-http-proxy test-stream-reliability test-mcp-server test-mcp-hub-projection test-checkpoints test-condense-json test-goals-runner test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-promptware test-orient test-condense-reversible test-heartbeat test-shell-backend test-env-inject test-run-timeout test-shell-output-decode test-fs-grep-tier1-4 test-fs-grep-tier5-6 test-fs-tool-naming test-workspace-paths test-guardfall test-skills-prompt test-progress-ledger test-otel test-logger-level-quiet test-gateway-token test-fs-secret-gate test-config-env-subst test-delphi-build

--- a/docs/workflows-design.md
+++ b/docs/workflows-design.md
@@ -1,0 +1,198 @@
+# Design: agent-built + manual workflows (Replicate MCP chaining)
+
+Status: **proposal** (Phase 0/1 specced here; Phase 2/3 sketched). Nothing in
+this doc is wired yet except the skill-authoring primer shipped alongside it.
+
+## Goal
+
+Let an operator chain tool calls — starting with the Replicate MCP (e.g.
+`generate → upscale`) — two ways:
+
+1. **Manually**, via a drag-and-drop node editor in the web UI ("Workflow" tab).
+2. **By asking the agent** ("build me a generate→upscale workflow"), which
+   authors a saved workflow the operator can inspect, run, and edit.
+
+A saved workflow is a persisted artifact that can be run headless (no LLM turn),
+from the UI, from the agent, or from cron.
+
+## The one hard constraint (why Phase 0 exists)
+
+MCP tool results are **flattened to a text string** before anything above the
+client sees them. `TMCPHttpClient.CallTool` / `TMCPStdioClient.CallTool` keep
+only `content[]` blocks of `type:"text"`, concatenate their `.text`, and free
+the JSON-RPC envelope in place (`src/pkg/mcp/PasClaw.MCP.HttpClient.pas:416`,
+`PasClaw.MCP.StdioClient.pas:393`). `structuredContent`, `type:"image"`,
+`type:"resource"` blocks, and the raw `result` object are all discarded.
+
+Consequences for chaining:
+
+- A `generate` step's image URL usually arrives *inside* a text block, so it is
+  technically reachable — but only by string-scraping a URL out of prose, which
+  is brittle.
+- If a tool returns its output only in `structuredContent` or a non-text block,
+  it is **lost entirely** — there is no structured path today.
+
+So typed edge data flow (upstream output field → downstream input field) is not
+possible without extending the one MCP choke point. That extension is Phase 0.
+
+## Architecture
+
+```
+Workflow artifact  →  $PASCLAW_HOME/workspace/workflows/<id>.json   (nodes[] + edges[])
+        │ registered as
+        ▼
+Callable tool      →  workflow_<name>            (agent + cron can invoke, like skill_<name>)
+        │ executed by
+        ▼
+Engine (in-process)→  topo-sort nodes; each node = Registry.RunTool('replicate__x', argsJSON)
+        │ edges map
+        ▼
+Data flow          →  upstream ResultJSON → selector → downstream arg    (needs Phase 0)
+        │ observed via
+        ▼
+SSE                →  GET /v1/workflows/<id>/run   (reuse gwSseUrl pattern)
+```
+
+Key existing seams this reuses (no new plumbing):
+
+- **Single-tool call, no LLM:** `TToolRegistry.RunTool(Name, ArgsJSON, out Err)`
+  (`src/pkg/tools/PasClaw.Tools.Registry.pas:400`). MCP tools are named
+  `replicate__<tool>` (double underscore; `PasClaw.MCP.Bridge.pas:303`) and
+  carry their `inputSchema` verbatim on `TTool.Schema`.
+- **JSON-file-per-item store:** mirror the sessions store
+  (`$PASCLAW_HOME/workspace/sessions/*.json`; CRUD in `HandleSessionItem`,
+  `PasClaw.Gateway.Server.pas:3052`). Whole `workspace/` rides the export zip
+  automatically (`Server.pas:196`).
+- **"Saved thing becomes a callable tool":** shell/prompt skills register as
+  `skill_<name>` in `PasClaw.Skills.Loader`; workflows register as
+  `workflow_<name>` the same way.
+- **Agent-authored + operator-approved staging:** the skills `.pending/`
+  approve/reject pipeline (`PasClaw.Skills.Pending.pas`) is reused verbatim for
+  agent-authored workflows.
+- **UI tab contract:** nav button + `#tab-workflow` pane + `tabLoaders.workflow`
+  in `src/pkg/gateway/webui.html` (rebuild `.res` via `make` after editing).
+
+## Workflow JSON schema (v1)
+
+```jsonc
+{
+  "id": "gen-upscale",               // stable id == filename stem
+  "name": "gen_upscale",             // -> registers workflow_gen_upscale
+  "description": "Generate an image then upscale it 4x",
+  "inputs": [                        // workflow-level params (fill at run time)
+    { "name": "prompt", "type": "string", "required": true }
+  ],
+  "nodes": [
+    { "id": "gen",  "tool": "replicate__create_prediction",
+      "args": { "model": "black-forest-labs/flux-schnell",
+                "input": { "prompt": "{{inputs.prompt}}" } } },
+    { "id": "up",   "tool": "replicate__create_prediction",
+      "args": { "model": "nightmareai/real-esrgan",
+                "input": { "image": "{{nodes.gen.output.url}}", "scale": 4 } } }
+  ],
+  "edges": [
+    { "from": "gen", "to": "up" }    // ordering + data dependency
+  ]
+}
+```
+
+- `{{inputs.X}}` — a workflow input.
+- `{{nodes.<id>.<selector>}}` — a value pulled from an upstream node's result.
+  `<selector>` is a small dotted/JSONPath-lite path evaluated against that
+  node's **structured** result (Phase 0). `output.url`, `output[0]`,
+  `content[?type=image].url` are the target shapes.
+- Missing/ambiguous selector → the run fails that node with a clear error
+  (fail-fast; no silent empty-string substitution).
+
+## Phase 0 — structured MCP output (prerequisite, ~1 day, own PR)
+
+Extend the MCP client contract so callers can opt into the raw result:
+
+- `PasClaw.MCP.Types.pas:51` — add `out ResultJSON: string` to the `CallTool`
+  signature (the full `result` object as JSON; `''` if absent).
+- `PasClaw.MCP.HttpClient.pas` / `StdioClient.pas` — capture `result` verbatim
+  before freeing the envelope; keep the existing text flattening unchanged.
+- `PasClaw.MCP.Bridge.pas` `TMCPServerState.CallTool` — thread `ResultJSON`
+  through.
+- Existing callers pass/ignore the new out-param → **zero behavior change**;
+  add a test asserting `structuredContent` and an image block survive.
+
+This is independently useful (any future structured-output consumer benefits)
+and is the gate for typed edges.
+
+## Phase 1 — engine + store + headless run (~3–4 days, own PR)
+
+New unit `PasClaw.Workflow.pas`:
+
+- **Schema + parse/serialize** (`TWorkflowSpec`): nodes, edges, inputs.
+- **Validator:** DAG (no cycles), every `tool` exists in the registry, every
+  `{{nodes.X…}}` references a declared upstream node, required inputs present.
+- **Executor:** topological order; per node resolve `args` templates
+  (`{{inputs.*}}`, `{{nodes.*.*}}`) against prior results, then
+  `Registry.RunTool(node.tool, resolvedArgs)`; store each node's structured
+  result for downstream selectors. Fail-fast with the offending node id.
+- **Selector:** minimal dotted path + `[i]` index + a single
+  `[?key=value]` filter over the structured result (Phase 0). No full JSONPath.
+
+Store + registration:
+
+- `$PASCLAW_HOME/workspace/workflows/<id>.json`, CRUD mirroring the sessions
+  store.
+- Register each saved workflow as a `workflow_<name>` tool (mirror
+  `RegisterSkills`), so the agent/cron can invoke a whole chain by name.
+
+Gateway endpoints (mirror the sessions route block, `Server.pas:1328-1330`):
+
+- `GET  /v1/workflows` — list.
+- `POST /v1/workflows` — create/validate; `422` with node-level errors on
+  invalid graphs.
+- `GET/PUT/DELETE /v1/workflows/<id>` — read/replace/delete.
+- `GET  /v1/workflows/<id>/run` — SSE stream of per-node status
+  (`started` / `result` / `error` / `done`), reusing the existing `gwSseUrl`
+  token-in-query pattern.
+
+**Phase 1 deliverable:** a hand-written `gen_upscale.json` runs end-to-end
+headless and produces the upscaled image URL — proving the chain before any UI.
+
+## Phase 2 — Workflow tab + node editor (~4–6 days, sketch)
+
+- Three edits add the tab (nav button, `#tab-workflow` pane,
+  `tabLoaders.workflow`).
+- The node editor is **vanilla SVG, hand-rolled** — `webui.html` ships as a
+  single self-contained file with no external scripts and no existing
+  canvas/graph code, so no React-Flow/LiteGraph. Nodes = draggable SVG groups;
+  edges = SVG paths; a node's input fields are generated from the MCP tool's
+  `inputSchema`.
+- Node palette is populated from the MCP tool list. (Note: there is **no**
+  existing endpoint that enumerates outbound MCP tools — a small
+  `GET /v1/mcp/tools` returning `{name, description, schema}` is needed here.)
+- Save → `PUT /v1/workflows/<id>`; Run → the SSE endpoint with live per-node
+  status painted on the canvas.
+
+## Phase 3 — agent authoring (~2–3 days, sketch)
+
+- `workflows_manage` tool (create/edit/validate) with a schema-teaching
+  description, plus a "Workflow authoring" system-prompt section that lists the
+  available MCP tools + schemas (the same idea as the skill-authoring primer
+  shipped in this PR).
+- Agent-authored workflows land in `workspace/workflows/.pending/` and surface
+  in the Workflow tab with Approve/Reject — reusing the skills `.pending`
+  machinery.
+
+## Build order / recommendation
+
+Ship **Phase 0 then Phase 1** first: that yields a working, saveable
+generate→upscale chain driven by JSON, de-risking the MCP-chaining unknown in
+~1 week before committing to the multi-week node editor. Phase 2 (UI) and
+Phase 3 (agent authoring) follow independently.
+
+## Open questions
+
+1. Selector language: is dotted + `[i]` + one `[?k=v]` filter enough for
+   Replicate's output shapes, or is full JSONPath worth a dependency?
+2. Long-running predictions: Replicate `create_prediction` may return a
+   pending id needing polling. Does the engine need a per-node
+   poll-until-complete step, or does the Replicate MCP block until done?
+   (Determines whether nodes need a `poll` sub-kind.)
+3. Should `workflow_<name>` tools be default-on for the agent, or opt-in like
+   `skills_manage`?

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -447,6 +447,31 @@ begin
     Body;
 end;
 
+function SkillAuthoringPrimer: string;
+{ Compact, always-present "what a skill is + how to make one" block. Without
+  it the agent has NO in-context notion of the skill format: the catalog below
+  only lists skills that already exist, and docs/skills.md is never injected --
+  so "build me a skill" sends the model grepping the codebase for a framework
+  that does not exist. Kept short (it renders on every tool-loaded prompt) and
+  deliberately names write_file, which needs no skills_manage tool (off by
+  default) -- a SKILL.md is just a file the loader picks up on the next run. }
+var
+  Dir: string;
+begin
+  Dir := JoinPath(GetHome, 'workspace/skills');
+  Result :=
+    '### Authoring a skill' + sLineBreak +
+    'A skill is a directory `' + Dir + '/<name>/SKILL.md`: YAML frontmatter ' +
+    '(`name`, `description`, optional `kind: shell|prompt` with a matching ' +
+    '`shell:`/`prompt:` line and single-line JSON `schema`) followed by a ' +
+    'markdown body. Omit `kind` for a knowledge-only skill (a doc you read on ' +
+    'demand); `kind: shell` or `kind: prompt` registers a callable ' +
+    '`skill_<name>` tool. To create one, write that SKILL.md with `write_file` ' +
+    '-- it loads on the next run. You do not need a special tool or to search ' +
+    'the codebase for a "skill" framework; this is the entire format. Full ' +
+    'reference: `docs/skills.md`.';
+end;
+
 function BuildSkillsSection(ProgressiveDisclosure: Boolean): string;
 var
   Skills: TSkillSpecArray;
@@ -459,9 +484,20 @@ begin
   try
     Skills := LoadSkillManifests(GetHome);
   except
+    { Even if manifest loading fails, still teach the format so "build me a
+      skill" works on a clean install. }
+    Result := '## Skills' + sLineBreak + sLineBreak + SkillAuthoringPrimer;
     Exit;
   end;
-  if Length(Skills) = 0 then Exit;
+  if Length(Skills) = 0 then
+  begin
+    { The gap this fixes: a default install has no skills, so the section used
+      to be empty and the agent never learned skills exist or how to author one. }
+    Result := '## Skills' + sLineBreak + sLineBreak +
+      'No skills are installed yet.' + sLineBreak + sLineBreak +
+      SkillAuthoringPrimer;
+    Exit;
+  end;
 
   { Progressive disclosure (Cfg.SelfImprovingSkills.ProgressiveDisclosure):
     don't inline the catalog. Point the model at skills_list / skill_view
@@ -474,7 +510,8 @@ begin
       Format('You have %d skill(s) available. Call `skills_list` to see ' +
              'their names + descriptions, then `skill_view(name)` to load ' +
              'the full instructions for the one that fits the task. Do this ' +
-             'before reinventing a procedure from scratch.', [Length(Skills)]);
+             'before reinventing a procedure from scratch.', [Length(Skills)]) +
+      sLineBreak + sLineBreak + SkillAuthoringPrimer;
     Exit;
   end;
 
@@ -522,6 +559,8 @@ begin
           Lines.Add('- **' + Skills[i].Name + '** -- ' + Desc + '. Read `' + Skills[i].Source + '` for the full instructions.');
       end;
     end;
+    Lines.Add('');
+    Lines.Add(SkillAuthoringPrimer);
     Result := Lines.Text;
     { Strip trailing newline TStringList.Text adds, so the SectionSep
       below doesn't end up with an extra blank line. }

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -452,13 +452,33 @@ function SkillAuthoringPrimer: string;
   it the agent has NO in-context notion of the skill format: the catalog below
   only lists skills that already exist, and docs/skills.md is never injected --
   so "build me a skill" sends the model grepping the codebase for a framework
-  that does not exist. Kept short (it renders on every tool-loaded prompt) and
-  deliberately names write_file, which needs no skills_manage tool (off by
-  default) -- a SKILL.md is just a file the loader picks up on the next run. }
+  that does not exist. Kept short (it renders on every tool-loaded prompt).
+
+  The "how to create" line is sandbox-aware. Skills load ONLY from
+  $PASCLAW_HOME/workspace/skills, and that dir is normally writable (the
+  sandbox is off by default; under `pasclaw serve` it sits inside the
+  workspace), so plain write_file works and needs no skills_manage tool (off by
+  default). But when restrict_to_workspace pins writes to a project dir that
+  the skills dir is outside of, write_file there is REFUSED -- so advertising it
+  unconditionally would hand the model a path that fails. Probe CanWritePath and
+  switch the advice to skills_manage / an allow_write_paths request in that case
+  (do NOT tell it to write elsewhere -- the loader would never see the file). }
 var
-  Dir: string;
+  Dir, HowTo, Reason: string;
 begin
   Dir := JoinPath(GetHome, 'workspace/skills');
+  if CanWritePath(JoinPath(Dir, 'SKILL.md'), Reason) then
+    HowTo :=
+      'To create one, write that SKILL.md with `write_file` -- it loads on the ' +
+      'next run. You do not need a special tool or to search the codebase for a ' +
+      '"skill" framework; this is the entire format.'
+  else
+    HowTo :=
+      'That directory is outside the active write sandbox, so `write_file` there ' +
+      'is refused. Create the skill with the `skills_manage` tool (it writes to ' +
+      'the skills dir directly), or ask the operator to add `' + Dir + '` to ' +
+      'sandbox.allow_write_paths. Skills load only from that directory, so ' +
+      'writing the file anywhere else will not register it.';
   Result :=
     '### Authoring a skill' + sLineBreak +
     'A skill is a directory `' + Dir + '/<name>/SKILL.md`: YAML frontmatter ' +
@@ -466,10 +486,7 @@ begin
     '`shell:`/`prompt:` line and single-line JSON `schema`) followed by a ' +
     'markdown body. Omit `kind` for a knowledge-only skill (a doc you read on ' +
     'demand); `kind: shell` or `kind: prompt` registers a callable ' +
-    '`skill_<name>` tool. To create one, write that SKILL.md with `write_file` ' +
-    '-- it loads on the next run. You do not need a special tool or to search ' +
-    'the codebase for a "skill" framework; this is the entire format. Full ' +
-    'reference: `docs/skills.md`.';
+    '`skill_<name>` tool. ' + HowTo + ' Full reference: `docs/skills.md`.';
 end;
 
 function BuildSkillsSection(ProgressiveDisclosure: Boolean): string;

--- a/src/tests/skills_prompt_tests.pas
+++ b/src/tests/skills_prompt_tests.pas
@@ -1,0 +1,107 @@
+program skills_prompt_tests;
+(*
+  Pins the skill-authoring primer in the system prompt's Skills section.
+
+  The bug this guards: on a default install (NO skills), BuildSkillsSection
+  used to emit nothing, so the agent had zero in-context notion of what a
+  skill is or how to author one -- "build me a skill" sent it grepping the
+  codebase. The primer must render in BOTH states:
+    - zero skills   -> a "## Skills / No skills are installed yet / how to
+                       author" block, so the format is always teachable;
+    - skills present -> the catalog PLUS the primer appended, so "create
+                       another one" still has the format in context.
+
+  Both cases build a real prompt via BuildSystemPrompt against a clean,
+  isolated PASCLAW_HOME.
+*)
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+{$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
+
+uses
+  SysUtils, Classes,
+  PasClaw.Config,
+  PasClaw.Utils,
+  PasClaw.Agent.Prompt;
+
+var
+  Failures: Integer = 0;
+
+procedure WriteFileText(const Path, Content: string);
+var S: TStringList;
+begin
+  S := TStringList.Create;
+  try
+    S.Text := Content;
+    S.SaveToFile(Path);
+  finally
+    S.Free;
+  end;
+end;
+
+procedure Contains(const Hay, Needle, Why: string);
+begin
+  if Pos(Needle, Hay) <= 0 then
+  begin
+    WriteLn('FAIL [', Why, ']: missing "', Needle, '"');
+    Inc(Failures);
+  end;
+end;
+
+function PromptNow: string;
+var Cfg: TConfig;
+begin
+  Cfg := LoadConfig;
+  try
+    Result := BuildSystemPrompt(Cfg, '', {ToolsEnabled=} True, '');
+  finally
+    Cfg.Free;
+  end;
+end;
+
+procedure TestZeroSkillsTeachesFormat;
+var P: string;
+begin
+  P := PromptNow;
+  Contains(P, '## Skills',                              'zero: section header present');
+  Contains(P, 'No skills are installed yet.',           'zero: honest empty state');
+  Contains(P, 'Authoring a skill',                      'zero: authoring primer present');
+  Contains(P, 'SKILL.md',                               'zero: names the file format');
+  Contains(P, 'write_file',                             'zero: points at write_file, not skills_manage');
+  Contains(P, 'docs/skills.md',                         'zero: points at the full reference');
+end;
+
+procedure TestSkillPresentStillTeachesFormat(const Home: string);
+var P, Dir: string;
+begin
+  { Drop one knowledge-only skill and confirm the catalog AND the primer render. }
+  Dir := JoinPath(JoinPath(JoinPath(Home, 'workspace'), 'skills'), 'demo_skill');
+  ForceDirectories(Dir);
+  WriteFileText(JoinPath(Dir, 'SKILL.md'),
+    '---'#10'name: demo_skill'#10'description: a demo skill for the prompt test'#10'---'#10#10'# Demo'#10'body'#10);
+
+  P := PromptNow;
+  Contains(P, 'demo_skill',        'present: catalog lists the installed skill');
+  Contains(P, 'Authoring a skill', 'present: primer still appended alongside the catalog');
+end;
+
+var
+  Home: string;
+begin
+  { PASCLAW_HOME is set to a clean, per-run temp dir by the make target, so no
+    ambient skills leak into the zero-skills assertion. }
+  Home := GetHome;
+  ForceDirectories(JoinPath(Home, 'workspace'));
+
+  TestZeroSkillsTeachesFormat;
+  TestSkillPresentStillTeachesFormat(Home);
+
+  if Failures = 0 then
+    WriteLn('skills_prompt_tests: OK')
+  else
+  begin
+    WriteLn('skills_prompt_tests: ', Failures, ' failure(s)');
+    Halt(1);
+  end;
+end.

--- a/src/tests/skills_prompt_tests.pas
+++ b/src/tests/skills_prompt_tests.pas
@@ -23,6 +23,7 @@ uses
   SysUtils, Classes,
   PasClaw.Config,
   PasClaw.Utils,
+  PasClaw.Tools.Sandbox,
   PasClaw.Agent.Prompt;
 
 var
@@ -45,6 +46,15 @@ begin
   if Pos(Needle, Hay) <= 0 then
   begin
     WriteLn('FAIL [', Why, ']: missing "', Needle, '"');
+    Inc(Failures);
+  end;
+end;
+
+procedure NotContains(const Hay, Needle, Why: string);
+begin
+  if Pos(Needle, Hay) > 0 then
+  begin
+    WriteLn('FAIL [', Why, ']: unexpected "', Needle, '"');
     Inc(Failures);
   end;
 end;
@@ -86,6 +96,36 @@ begin
   Contains(P, 'Authoring a skill', 'present: primer still appended alongside the catalog');
 end;
 
+procedure TestRestrictedSandboxSwitchesAdvice(const Home: string);
+{ Codex #440 P2: when restrict_to_workspace pins writes to a project dir that
+  the skills dir is outside of, write_file to the skills dir is refused -- so
+  the primer must NOT advertise it. Point at skills_manage / allow_write_paths
+  instead. Runs LAST because it mutates the process-global sandbox policy. }
+var
+  Cfg: TConfig;
+  Pol: TSandboxPolicy;
+  Elsewhere, P: string;
+begin
+  Elsewhere := JoinPath(GetTempDir, 'pasclaw-restrict-' + IntToStr(GetProcessID));
+  ForceDirectories(Elsewhere);
+  Cfg := LoadConfig;
+  try
+    Pol := Cfg.Sandbox;
+    Pol.RestrictToWorkspace := True;              { pin writes... }
+    ConfigureSandbox(Pol, Elsewhere);             { ...to a dir the skills dir is NOT under }
+  finally
+    Cfg.Free;
+  end;
+
+  P := PromptNow;
+  Contains(P, 'skills_manage',                    'restricted: routes to skills_manage');
+  Contains(P, 'allow_write_paths',                'restricted: offers the allowlist path');
+  Contains(P, 'refused',                          'restricted: warns write_file is refused');
+  { The writable-branch-only phrasing must be gone so the model is not told to
+    just write_file into a dir where that call fails. }
+  NotContains(P, 'this is the entire format',     'restricted: drops the plain write_file advice');
+end;
+
 var
   Home: string;
 begin
@@ -96,6 +136,7 @@ begin
 
   TestZeroSkillsTeachesFormat;
   TestSkillPresentStillTeachesFormat(Home);
+  TestRestrictedSandboxSwitchesAdvice(Home);
 
   if Failures = 0 then
     WriteLn('skills_prompt_tests: OK')


### PR DESCRIPTION
## Summary

Fixes the "**I asked the agent to build a skill and it didn't know what a skill was**" problem, and lands the design doc for the larger agent-built/manual **workflows** feature this is the first step toward.

### The bug

On a default install the agent had **zero in-context notion of what a skill is**:
- `BuildSkillsSection` emitted **nothing** when no skills were installed (`if Length(Skills) = 0 then Exit`).
- The `## Skills` section only ever listed skills that *already* exist — never the format or how to create one.
- `docs/skills.md` fully explains it but is never injected.

So "build me a skill" sent the model grepping the codebase for a framework that doesn't exist — exactly the reported behavior.

### The fix

Add `SkillAuthoringPrimer` — a compact "what a skill is + how to author one" block — rendered in **all three** states of the Skills section:
- **zero skills** → `## Skills / No skills are installed yet.` + primer (was an empty section);
- **progressive disclosure** → count + `skills_list` pointer + primer;
- **full catalog** → the skill list + primer appended.

The primer deliberately names **`write_file`** — a `SKILL.md` is just a file the loader picks up on the next run — so authoring needs no `skills_manage` tool (which is off by default). Kept short since it renders on every tool-loaded prompt.

### Tests

`src/tests/skills_prompt_tests.pas` (`make test-skills-prompt`, wired into `test:`): asserts the primer renders **with zero skills** *and* **alongside a populated catalog**, both built through the real `BuildSystemPrompt` against an isolated `PASCLAW_HOME`. Verified end-to-end that a fresh-install prompt now contains the format.

### Design doc

`docs/workflows-design.md` — the **Phase 0/1 spec** for agent-built + manual Replicate-MCP workflows (generate→upscale):
- **Phase 0 (prerequisite):** MCP results are currently flattened to text — `structuredContent`/image blocks are discarded (`HttpClient.pas:416`), so typed edge data flow is impossible without extending the one `CallTool` choke point.
- **Phase 1:** workflow artifact (`workspace/workflows/<id>.json`) + validator + topo executor over `Registry.RunTool` + gateway endpoints, reusing the sessions store, the `skill_<name>`→`workflow_<name>` callable-tool trick, and the skills `.pending` approval pipeline.
- Phase 2 (node editor) / Phase 3 (agent authoring) sketched. Recommends shipping Phase 0+1 first to de-risk MCP chaining before the multi-week UI.

## Validation

- `make test-skills-prompt`, `test-self-improving-skills`, `test-active-plan-section` all green; main binary rebuilds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_