### PR TITLE
build(delphi): add pkg\workflow to the dcc64 unit search path

### DIFF
--- a/cog/Makefile
+++ b/cog/Makefile
@@ -105,6 +105,7 @@ UNIT_DIRS = \
 	src/pkg/tokenizer \
 	src/pkg/tools \
 	src/pkg/mcp \
+	src/pkg/workflow \
 	src/pkg/gateway \
 	src/pkg/channels \
 	src/pkg/crypto \

--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;..\pkg\vendor\zpaq;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\workflow;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;..\pkg\vendor\zpaq;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names
@@ -218,12 +218,19 @@
 
         <!-- pkg/mcp -->
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Types.pas"/>
+        <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Result.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.StdioClient.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.HttpClient.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Catalog.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Bridge.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Disclosure.pas"/>
         <DCCReference Include="..\pkg\mcp\PasClaw.MCP.Server.pas"/>
+
+        <!-- pkg/workflow -->
+        <DCCReference Include="..\pkg\workflow\PasClaw.Workflow.pas"/>
+        <DCCReference Include="..\pkg\workflow\PasClaw.Workflow.Store.pas"/>
+        <DCCReference Include="..\pkg\workflow\PasClaw.Workflow.Dispatch.pas"/>
+        <DCCReference Include="..\pkg\workflow\PasClaw.Workflow.Tools.pas"/>
 
         <!-- pkg/gateway -->
         <DCCReference Include="..\pkg\gateway\PasClaw.Gateway.Server.pas"/>


### PR DESCRIPTION
## Summary

Follow-up to #441 (merged). The Delphi build (`dcc64`) fails with:

```
[dcc64 Fatal Error] PasClaw.Skills.Loader.pas(110): F2613 Unit 'PasClaw.Workflow.Tools' not found.
```

because #441 added `src\pkg\workflow` to the FPC `UNIT_DIRS` but not to the Delphi project's unit search path. `RegisterSkills` (compiled into the main app) now `uses PasClaw.Workflow.Tools`, so `dcc64` can't resolve it.

## Fix

- **`src/pasclaw/PasClaw.dproj`** — add `..\pkg\workflow` to `DCC_UnitSearchPath` and `DCCReference` entries for the four workflow units. Also add `PasClaw.MCP.Result` (introduced in #441) to the MCP references, which was likewise missing from the manifest and would be the next `F2613`.
- **`cog/Makefile`** — add `src/pkg/workflow` to its unit dirs (it builds the full app tree, which includes skills → workflow).

Purely a build-config change; mirrors exactly how `pkg\mcp` and every other package dir is already wired.

## Verification

I can't run `dcc64` on Linux, so this is validated by (a) the FPC skills→workflow chain compiling clean, and (b) the dproj edits being exactly parallel to the existing per-package entries. This is the missing piece to make the merged #441 code build under Delphi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_