### PR TITLE
workflow: fix replicate selectors to real top-level MCP shape + auto-poll raw create_predictions

### DIFF
--- a/src/pkg/workflow/PasClaw.Workflow.pas
+++ b/src/pkg/workflow/PasClaw.Workflow.pas
@@ -806,7 +806,10 @@ begin
     Aw.IntervalMs     := 2000;
     Aw.TimeoutMs      := 300000;
     SetLength(Aw.Success, 1); Aw.Success[0] := 'succeeded';
-    SetLength(Aw.Failure, 2); Aw.Failure[0] := 'failed'; Aw.Failure[1] := 'canceled';
+    { Replicate terminal-failure states: failed, canceled, and aborted (fail
+      fast on any of them rather than polling to the timeout). }
+    SetLength(Aw.Failure, 3);
+    Aw.Failure[0] := 'failed'; Aw.Failure[1] := 'canceled'; Aw.Failure[2] := 'aborted';
   end;
 end;
 

--- a/src/pkg/workflow/PasClaw.Workflow.pas
+++ b/src/pkg/workflow/PasClaw.Workflow.pas
@@ -11,19 +11,24 @@
       "description": "generate then upscale",
       "inputs": [ {"name":"prompt","type":"string","required":true} ],
       "nodes": [
-        {"id":"gen","tool":"replicate__create_prediction",
-         "args":{"input":{"prompt":"{{inputs.prompt}}"}}},
-        {"id":"up","tool":"replicate__create_prediction",
-         "args":{"input":{"image":"{{nodes.gen.structuredContent.output[0]}}"}}}
+        {"id":"gen","tool":"replicate",
+         "args":{"version":"<id>","input":{"prompt":"{{inputs.prompt}}"}}},
+        {"id":"up","tool":"replicate",
+         "args":{"version":"<id>","input":{"image":"{{nodes.gen}}"}}}
       ],
       "edges": [ {"from":"gen","to":"up"} ]
     }
 
+  The "replicate" node is sugar: it creates the prediction, polls until done,
+  and lifts the result URL into the node's output -- so a bare {{nodes.gen}}
+  downstream is the image URL, with no create/get/await/selector wiring.
+
   Templates in a node's args:
     {{inputs.NAME}}            - a workflow input value
+    {{nodes.ID}}               - an upstream node's output (its text/URL)
     {{nodes.ID.SELECTOR}}      - a value pulled from an upstream node's raw
                                  result JSON via a dotted/[i] selector, e.g.
-                                 structuredContent.output[0] or content[0].text
+                                 output[0] or content[0].text
 
   Execution is a topological walk. Dependencies come from BOTH explicit edges
   AND {{nodes.ID..}} references, so ordering is correct even if an edge was
@@ -776,28 +781,32 @@ procedure PlanNode(const Node: TWorkflowNode; out EffTool: string; out Aw: TWork
   selectors. An explicit await on the node overrides the synthesized one. All
   the Replicate names/paths are defaults here -- override per-node if a build
   differs. }
+var
+  T: string;
 begin
   EffTool := Node.Tool;
   Aw := Node.Await;
-  if LowerCase(Trim(Node.Tool)) = 'replicate' then
+  T := LowerCase(Trim(Node.Tool));
+  if T = 'replicate' then EffTool := 'replicate__create_predictions';
+  { Both the "replicate" sugar node AND a raw replicate__create_predictions node
+    kick off an ASYNC prediction that returns immediately with status "starting"
+    and output null. Chaining that pending handle is never what's wanted, so
+    auto-poll to completion unless the author set an explicit await. }
+  if ((T = 'replicate') or (T = 'replicate__create_predictions')) and (not Aw.Enabled) then
   begin
-    EffTool := 'replicate__create_predictions';
-    if not Aw.Enabled then
-    begin
-      Aw.Enabled        := True;
-      Aw.PollTool       := 'replicate__get_predictions';
-      { The MCP bridge returns the whole tools/call result object, so an MCP
-        tool's structured fields (id/status/output) live under structuredContent
-        -- NOT at the top level. Select there, or the first poll's self.id and
-        the status/output selectors never resolve against a real MCP result. }
-      Aw.PollArgsJSON   := '{"prediction_id":"{{self.structuredContent.id}}"}';
-      Aw.StatusSelector := 'structuredContent.status';
-      Aw.OutputSelector := 'structuredContent.output[0]';   { image models: output list }
-      Aw.IntervalMs     := 2000;
-      Aw.TimeoutMs      := 300000;
-      SetLength(Aw.Success, 1); Aw.Success[0] := 'succeeded';
-      SetLength(Aw.Failure, 2); Aw.Failure[0] := 'failed'; Aw.Failure[1] := 'canceled';
-    end;
+    Aw.Enabled        := True;
+    Aw.PollTool       := 'replicate__get_predictions';
+    { Confirmed against the live Replicate MCP: create/get return the prediction
+      object with id / status / output at the TOP level of the result JSON (not
+      wrapped in structuredContent). Select there. Override via an explicit
+      await block if a different MCP build wraps the fields. }
+    Aw.PollArgsJSON   := '{"prediction_id":"{{self.id}}"}';
+    Aw.StatusSelector := 'status';
+    Aw.OutputSelector := 'output[0]';   { image models return output: [url] }
+    Aw.IntervalMs     := 2000;
+    Aw.TimeoutMs      := 300000;
+    SetLength(Aw.Success, 1); Aw.Success[0] := 'succeeded';
+    SetLength(Aw.Failure, 2); Aw.Failure[0] := 'failed'; Aw.Failure[1] := 'canceled';
   end;
 end;
 

--- a/src/tests/workflow_tests.pas
+++ b/src/tests/workflow_tests.pas
@@ -203,20 +203,21 @@ function ReplStub(const ToolName, ArgsJSON: string;
   out ResultText, ResultJSON, ErrMsg: string): Boolean;
 begin
   ResultText := ''; ResultJSON := ''; ErrMsg := '';
-  { MCP bridge shape: the tool's fields live under structuredContent, not at
-    the top level (this is what the replicate defaults must select against). }
+  { Real Replicate MCP shape (confirmed via a live run): the prediction object
+    is at the TOP level of the result JSON -- id / status / output, no
+    structuredContent wrapper. }
   if ToolName = 'replicate__create_predictions' then
   begin
     GReplCreateArgs := ArgsJSON;
-    ResultJSON := '{"structuredContent":{"id":"p9","status":"starting"}}';
+    ResultJSON := '{"id":"p9","status":"starting","output":null}';
   end
   else if ToolName = 'replicate__get_predictions' then
   begin
     Inc(GReplPoll);
     if GReplPoll >= 2 then
-      ResultJSON := '{"structuredContent":{"status":"succeeded","output":["https://x/final.png"]}}'
+      ResultJSON := '{"id":"p9","status":"succeeded","output":["https://x/final.png"]}'
     else
-      ResultJSON := '{"structuredContent":{"status":"processing"}}';
+      ResultJSON := '{"id":"p9","status":"processing","output":null}';
   end;
   Result := True;
 end;
@@ -235,6 +236,25 @@ begin
   Check((Length(Res) = 1) and (Res[0].Text = 'https://x/final.png'),
         'replicate: node text is the finished output URL (got "' +
         Res[0].Text + '")');
+end;
+
+procedure TestRawCreateAutoPolls;
+{ A raw replicate__create_predictions node (no await) must auto-poll too --
+  this is the shape the agent built in the field, which returned a pending
+  prediction (status starting / output null) before this fix. }
+var Spec: TWorkflowSpec; Err: string; Res: TWorkflowNodeResultArray;
+begin
+  GReplPoll := 0;
+  Check(ParseWorkflow(
+    '{"name":"raw","inputs":[{"name":"prompt","required":true}],' +
+    '"nodes":[{"id":"gen","tool":"replicate__create_predictions",' +
+      '"args":{"input":{"prompt":"{{inputs.prompt}}"}}}]}', Spec, Err),
+    'raw: parse (' + Err + ')');
+  Check(RunWorkflow(Spec, '{"prompt":"a horse"}', ReplStub, Res, Err),
+        'raw: run succeeds (' + Err + ')');
+  Check(GReplPoll >= 2, 'raw: bare create_predictions auto-polled to completion');
+  Check((Length(Res) = 1) and (Res[0].Text = 'https://x/final.png'),
+        'raw: node text is the finished output (got "' + Res[0].Text + '")');
 end;
 
 procedure TestDispatchRouting;
@@ -283,6 +303,7 @@ begin
   TestRunChains;
   TestAwaitPolling;
   TestReplicateNode;
+  TestRawCreateAutoPolls;
   TestDispatchRouting;
   TestRunMissingInput;
   TestStoreRoundTrip;

--- a/src/tests/workflow_tests.pas
+++ b/src/tests/workflow_tests.pas
@@ -238,6 +238,33 @@ begin
         Res[0].Text + '")');
 end;
 
+function AbortStub(const ToolName, ArgsJSON: string;
+  out ResultText, ResultJSON, ErrMsg: string): Boolean;
+begin
+  ResultText := ''; ResultJSON := ''; ErrMsg := '';
+  if ToolName = 'replicate__create_predictions' then
+    ResultJSON := '{"id":"p9","status":"starting","output":null}'
+  else if ToolName = 'replicate__get_predictions' then
+  begin
+    Inc(GReplPoll);
+    { Replicate can abort before the model starts -- a terminal state. }
+    ResultJSON := '{"id":"p9","status":"aborted","output":null}';
+  end;
+  Result := True;
+end;
+
+procedure TestReplicateAbortedFailsFast;
+var Spec: TWorkflowSpec; Err: string; Res: TWorkflowNodeResultArray;
+begin
+  GReplPoll := 0;
+  ParseWorkflow('{"name":"ab","nodes":[{"id":"gen","tool":"replicate",' +
+    '"args":{"input":{}}}]}', Spec, Err);
+  Check(not RunWorkflow(Spec, '{}', AbortStub, Res, Err),
+        'aborted: run fails');
+  Check(GReplPoll <= 2, 'aborted: terminal status fails fast (no timeout spin), polls=' + IntToStr(GReplPoll));
+  Check(Pos('aborted', Err) > 0, 'aborted: error names the terminal status');
+end;
+
 procedure TestRawCreateAutoPolls;
 { A raw replicate__create_predictions node (no await) must auto-poll too --
   this is the shape the agent built in the field, which returned a pending
@@ -303,6 +330,7 @@ begin
   TestRunChains;
   TestAwaitPolling;
   TestReplicateNode;
+  TestReplicateAbortedFailsFast;
   TestRawCreateAutoPolls;
   TestDispatchRouting;
   TestRunMissingInput;


### PR DESCRIPTION
## What the live run revealed

A real Replicate MCP run (thanks for the paste) gave us the ground truth we'd been guessing at:

```json
{ "id": "re03…", "status": "starting", "output": null, "urls": {…}, … }
```

The prediction object comes back at the **top level** of the result JSON — **not** under `structuredContent` (the level a #443 review assumed and shipped). So the `replicate` node's synthesized poll never resolved `{{self.id}}`, and its `status`/`output` selectors missed. Two fixes:

## 1. Correct the selectors to top-level

`replicate` node defaults are now `{{self.id}}` / `status` / `output[0]` (was `structuredContent.*`), confirmed against the live shape. Overridable via an explicit `await` block for an MCP build that wraps fields.

## 2. Auto-poll a raw `create_predictions` node too

The failing workflow used **raw `replicate__create_predictions` nodes** (not the `replicate` sugar), so nothing polled — `generate_image` returned a *pending* prediction (`status:"starting"`, `output:null`) and the downstream selector failed on null. `PlanNode` now auto-polls a bare `replicate__create_predictions` node to completion (unless it has an explicit `await`) — chaining a pending handle is never intended.

## Docs

The header example + guidance now use the `replicate` sugar node so a bare `{{nodes.gen}}` downstream is the finished image URL — steering authors away from hand-wiring `create_predictions` + selectors.

## Tests

Updated the stub to the **real top-level shape**; the replicate-node test and a new raw-`create_predictions` test both assert the node auto-polls and yields the finished `output[0]` URL. Workflow/skills/gateway tests green; binary links.

---

### Your failing workflow — the fix + one manual gotcha

With this, **rebuild it with `replicate` nodes** and it works cleanly:
```json
{"id":"generate_image","tool":"replicate","args":{"version":"<flux-id>","input":{"prompt":"{{inputs.prompt}}"}}}
{"id":"upscale_image","tool":"replicate","args":{"version":"<esrgan-id>","input":{"image":"{{nodes.generate_image}}"}}}
```
`generate_image` now auto-polls and `{{nodes.generate_image}}` resolves to the finished URL.

Note: your current workflow also hand-wrote the selector `{{nodes.generate_image.structuredContent.output[0]}}` — that path was wrong (my earlier docs' fault) and should be `output[0]`, or just `{{nodes.generate_image}}` with the sugar node.

### One remaining unknown (overridable default)

The poll uses `replicate__get_predictions` with arg `prediction_id` and `{{self.id}}`. The tool name is from your log; the **arg name `prediction_id` is a reasonable default I couldn't verify** against the live MCP. If the poll errors on the argument, it's a one-line override in an explicit `await` block — and if you can tell me the exact `get_predictions` arg name, I'll bake it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_