### PR TITLE
ci: build a Linux arm64 tarball in the release workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -110,7 +110,22 @@ jobs:
   # the Makefile targets (same environment as docker/Dockerfile's builder).
   linux-tarball:
     needs: meta
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86-64: hosted x64 runner.
+          - runner: ubuntu-latest
+            debarch: amd64      # dpkg arch of the OpenSSL .deb
+            tarch: x86_64       # tarball name suffix (uname -m style)
+          # ARM64: hosted arm64 runner (free for public repos). The
+          # debian:bookworm container auto-pulls its arm64 variant, so apt
+          # gives us an arm64 FPC + the arm64 unit tree -- native build, no
+          # cross toolchain.
+          - runner: ubuntu-24.04-arm
+            debarch: arm64
+            tarch: aarch64
+    runs-on: ${{ matrix.runner }}
     container: debian:bookworm
     env:
       # bookworm's lazarus-src installs to /usr/lib/lazarus/2.2.6/, not the
@@ -144,9 +159,9 @@ jobs:
       - name: Assemble the self-contained tarball
         run: |
           set -e
-          out="pasclaw-${{ needs.meta.outputs.version }}-linux-x86_64"
-          # Fetch OpenSSL 1.0.2 so TLS works out of the box (Indy dlopen).
-          url="https://snapshot.debian.org/archive/debian-archive/${OPENSSL_SNAPSHOT}/debian-security/pool/updates/main/o/openssl1.0/libssl1.0.2_${OPENSSL_DEB_VERSION}_amd64.deb"
+          out="pasclaw-${{ needs.meta.outputs.version }}-linux-${{ matrix.tarch }}"
+          # Fetch OpenSSL 1.0.2 (arch-matched) so TLS works out of the box (Indy dlopen).
+          url="https://snapshot.debian.org/archive/debian-archive/${OPENSSL_SNAPSHOT}/debian-security/pool/updates/main/o/openssl1.0/libssl1.0.2_${OPENSSL_DEB_VERSION}_${{ matrix.debarch }}.deb"
           curl -fsSL --retry 3 --max-time 120 "$url" -o /tmp/libssl.deb
           mkdir -p /tmp/ossl
           dpkg-deb -x /tmp/libssl.deb /tmp/ossl
@@ -166,4 +181,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.meta.outputs.tag }}
-          files: pasclaw-*-linux-x86_64.tar.gz
+          files: pasclaw-${{ needs.meta.outputs.version }}-linux-${{ matrix.tarch }}.tar.gz

--- a/installer/README.md
+++ b/installer/README.md
@@ -81,17 +81,27 @@ and CI turns those exes into the two setup installers.
    and uploads `PasClaw-<version>-x64-setup.exe` /
    `PasClaw-<version>-x86-setup.exe` back to the same release.
 
-### Linux tarball (fully in CI)
+### Linux tarballs (fully in CI)
 
 Free Pascal has no license gate, so the hosted runner **compiles the Linux
-binary from source itself** — nothing to upload by hand. The job builds inside
-`debian:bookworm` (the exact apt layout the `Makefile` targets, same as
-`docker/Dockerfile`), then assembles a self-contained
-`pasclaw-<version>-linux-x86_64.tar.gz` containing the `pasclaw` binary,
-bundled OpenSSL 1.0.2 (`libssl`/`libcrypto`, `RPATH=$ORIGIN` — Indy's TLS needs
-1.0.x, which modern distros no longer ship), `LICENSE`, `README.md`, and
-`docs/`. The only runtime dependency left is `libsqlite3` (present on virtually
-every Linux install; `apt install libsqlite3-0` otherwise).
+binaries from source itself** — nothing to upload by hand. A matrix builds both
+architectures on native runners (no cross toolchain):
+
+| Tarball | Runner |
+|---------|--------|
+| `pasclaw-<version>-linux-x86_64.tar.gz`  | `ubuntu-latest` (x64) |
+| `pasclaw-<version>-linux-aarch64.tar.gz` | `ubuntu-24.04-arm` (arm64) |
+
+Each job builds inside `debian:bookworm` (the exact apt layout the `Makefile`
+targets, same as `docker/Dockerfile`; the container auto-pulls the runner's
+arch), then assembles a self-contained tarball containing the `pasclaw` binary,
+arch-matched bundled OpenSSL 1.0.2 (`libssl`/`libcrypto`, `RPATH=$ORIGIN` —
+Indy's TLS needs 1.0.x, which modern distros no longer ship), `LICENSE`,
+`README.md`, and `docs/`. The only runtime dependency left is `libsqlite3`
+(present on virtually every Linux install; `apt install libsqlite3-0`
+otherwise).
+
+> The `ubuntu-24.04-arm` runner is free for public repositories.
 
 To (re-)produce artifacts for an existing release, run the workflow manually
 ("Run workflow") and pass its tag.


### PR DESCRIPTION
## What

Adds a native **Linux arm64** tarball to the release-artifacts workflow, alongside the existing x86_64 one.

The single Linux job becomes a 2-arch matrix:

| Tarball | Runner | Build |
|---|---|---|
| `pasclaw-<ver>-linux-x86_64.tar.gz` | `ubuntu-latest` | existing |
| `pasclaw-<ver>-linux-aarch64.tar.gz` | `ubuntu-24.04-arm` | **new** |

## Why / how

Free Pascal has no license gate, so CI can compile Linux natively (unlike the Delphi/Windows side, which stays hybrid). The arm64 entry runs on the hosted `ubuntu-24.04-arm` runner (free for public repos); `container: debian:bookworm` auto-pulls its arm64 variant, so apt provides a native arm64 FPC + unit tree — **no cross toolchain**, same recipe as x86_64.

Details:
- OpenSSL 1.0.2 bundle is arch-matched via the dpkg arch (`amd64`/`arm64`) so the arm64 tarball is just as self-contained (Indy TLS works out of the box, `RPATH=$ORIGIN`).
- Tarball named with the `uname -m` suffix (`x86_64` / `aarch64`).
- `fail-fast: false` so one arch failing doesn't cancel the other.
- README documents both tarballs and the free-for-public-repos arm64 runner.

## Testing

Reproduced the exact CI arm64 job locally under `qemu-aarch64` emulation (native `debian:bookworm` arm64 container, same apt deps + `make`): the binary builds, reports `aarch64` ELF, and runs (`pasclaw version` / `--help`). Results attached in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_