### PR TITLE
installer: fix Inno Setup [Code] comment closing early on {app}

### DIFF
--- a/.github/workflows/installer-check.yml
+++ b/.github/workflows/installer-check.yml
@@ -1,0 +1,40 @@
+name: Installer script check
+
+# Compile-checks installer/pasclaw.iss on every change to it, so syntax errors
+# in the Inno Setup script (e.g. a stray "}" inside a { } comment closing it
+# early) are caught at PR time instead of only when a real release runs ISCC.
+#
+# Uses a throwaway dummy exe for SourceExe so no real Delphi build is needed --
+# this validates the script (including the [Code] Pascal), not the payload.
+
+on:
+  push:
+    paths:
+      - 'installer/**'
+      - '.github/workflows/installer-check.yml'
+  pull_request:
+    paths:
+      - 'installer/**'
+      - '.github/workflows/installer-check.yml'
+
+jobs:
+  compile:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup -y --no-progress
+
+      - name: Compile-check both arches (dummy payload)
+        shell: pwsh
+        run: |
+          $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          # ISCC needs the [Files] sources to exist; stand in a dummy for the exe.
+          "dummy" | Out-File -Encoding ascii dummy-pasclaw.exe
+          foreach ($arch in @('x64','x86')) {
+            & $iscc /DArch=$arch /DMyAppVersion=0.0.0 "/DSourceExe=$PWD\dummy-pasclaw.exe" installer\pasclaw.iss
+            if ($LASTEXITCODE -ne 0) { throw "iscc $arch failed to compile installer\pasclaw.iss" }
+          }
+          Write-Host "installer script compiles for x64 and x86"

--- a/installer/pasclaw.iss
+++ b/installer/pasclaw.iss
@@ -175,13 +175,13 @@ var
 begin
   if CurUninstallStep = usUninstall then
   begin
-    { The install added {app} to exactly one hive (HKLM for an admin install,
-      HKCU otherwise), but at uninstall we can't reliably tell which: Inno's
-      IsAdminInstallMode reflects the uninstaller's own elevation token, which
-      an admin deployment tool can flip relative to install time. Rather than
-      persist the mode and second-guess it, clean both hives -- each call
-      no-ops when {app} isn't on that hive's PATH, so the real entry is removed
-      and never orphaned. }
+    { The install added the app dir to exactly one hive (HKLM for an admin
+      install, HKCU otherwise), but at uninstall we can't reliably tell which:
+      Inno's IsAdminInstallMode reflects the uninstaller's own elevation token,
+      which an admin deployment tool can flip relative to install time. Rather
+      than persist the mode and second-guess it, clean both hives -- each call
+      no-ops when the dir isn't on that hive's PATH, so the real entry is
+      removed and never orphaned. }
     Dir := ExpandConstant('{app}');
     RemoveDirFromPathIn(HKEY_LOCAL_MACHINE, EnvHKLMKey, Dir);
     RemoveDirFromPathIn(HKEY_CURRENT_USER, EnvHKCUKey, Dir);


### PR DESCRIPTION
## The failure

The v0.1.3 release's `windows-installers` job failed:

```
Error on line 178 in installer\pasclaw.iss: Column 31: Identifier expected.
Compile aborted.
```

## Cause

The uninstall step's comment contained `{app}`. In Inno Setup's Pascal `[Code]`, `{ }` are **comment delimiters** — so the `}` inside `{app}` closed the comment early, and the text after it (`to exactly one hive…`) was parsed as code → "Identifier expected". ISCC only runs at release time (never in the normal FPC/Delphi builds), so this slipped through PR #449 and only surfaced when v0.1.3 was published.

## Fix

- Reword the comment to avoid literal braces (no `{app}` in `[Code]` comments).
- **Add `.github/workflows/installer-check.yml`**: on any `installer/**` change, compile `pasclaw.iss` with ISCC (both arches, dummy payload) so a script/`[Code]` syntax error is caught at PR time instead of during a release. This PR exercises that check on itself.

## Re-releasing v0.1.3

Once this is merged to `main`, re-run **Release artifacts → Run workflow** with tag `v0.1.3` (the `PasClaw-x64.exe` / `PasClaw-x86.exe` are already attached to the release, so it just repackages). The Linux tarballs from the failed run already uploaded fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_