### PR TITLE
ci: ship the raw exe as a portable download, drop the CI input name

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -67,11 +67,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          $tag = '${{ needs.meta.outputs.tag }}'
+          $ver = '${{ needs.meta.outputs.version }}'
           New-Item -ItemType Directory -Force bin | Out-Null
-          foreach ($a in @('PasClaw-x64.exe','PasClaw-x86.exe')) {
-            gh release download '${{ needs.meta.outputs.tag }}' -p $a -D bin
-            if (Test-Path "bin/$a") { Write-Host "got $a" }
-            else { Write-Host "::warning::$a is not attached to the release -- skipping that arch" }
+          # For each arch: prefer the raw upload name you attach (PasClaw-x64.exe),
+          # but fall back to a previously-published portable asset so a re-run
+          # still works after this job renamed the raw input away.
+          foreach ($arch in @('x64','x86')) {
+            $input    = "PasClaw-$arch.exe"
+            $portable = "PasClaw-$ver-$arch-portable.exe"
+            $local    = "bin/PasClaw-$arch.exe"
+            gh release download $tag -p $input -D bin 2>$null
+            if (-not (Test-Path $local)) {
+              gh release download $tag -p $portable -D bin 2>$null
+              if (Test-Path "bin/$portable") { Move-Item "bin/$portable" $local }
+            }
+            if (Test-Path $local) { Write-Host "got $arch" }
+            else { Write-Host "::warning::no $arch binary attached (PasClaw-$arch.exe) -- skipping that arch" }
           }
           if (-not (Test-Path bin\PasClaw-x64.exe) -and -not (Test-Path bin\PasClaw-x86.exe)) {
             throw "neither PasClaw-x64.exe nor PasClaw-x86.exe was attached to the release"
@@ -104,6 +116,28 @@ jobs:
           $files = Get-ChildItem installer\Output\*.exe | ForEach-Object { $_.FullName }
           if ($files) { gh release upload '${{ needs.meta.outputs.tag }}' @files --clobber }
           else { throw "no installers were produced" }
+
+      - name: Publish the self-contained exe as a portable download
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The Delphi build is self-contained, so the raw exe is a working
+          # no-installer PasClaw. Re-publish it under a clear, versioned name and
+          # remove the raw upload name so the release lists intentional downloads
+          # (setup + portable) rather than the CI input.
+          $tag = '${{ needs.meta.outputs.tag }}'
+          $ver = '${{ needs.meta.outputs.version }}'
+          foreach ($arch in @('x64','x86')) {
+            $local    = "bin/PasClaw-$arch.exe"
+            $portable = "PasClaw-$ver-$arch-portable.exe"
+            if (Test-Path $local) {
+              Copy-Item $local $portable -Force
+              gh release upload $tag $portable --clobber
+              # Drop the raw input name (ignore if it wasn't attached, e.g. a re-run).
+              gh release delete-asset $tag "PasClaw-$arch.exe" --yes 2>$null
+            }
+          }
 
   # --- Linux: compile with FPC and ship a self-contained tarball ------------
   # Runs inside debian:bookworm because that is the exact apt package layout

--- a/installer/README.md
+++ b/installer/README.md
@@ -80,6 +80,13 @@ and CI turns those exes into the two setup installers.
    Inno Setup via Chocolatey, runs `iscc` with the matching `/DArch` + version,
    and uploads `PasClaw-<version>-x64-setup.exe` /
    `PasClaw-<version>-x86-setup.exe` back to the same release.
+4. Because the Delphi build is self-contained, the same exe is also a working
+   no-installer binary. The job re-publishes it as
+   `PasClaw-<version>-x64-portable.exe` (and `-x86-`) and **removes the raw
+   `PasClaw-x64.exe` / `PasClaw-x86.exe` upload name**, so the finished release
+   lists intentional downloads (setup + portable) instead of the CI input. A
+   re-run can still find the binary — it falls back to the portable asset when
+   the raw name is gone.
 
 ### Linux tarballs (fully in CI)
 


### PR DESCRIPTION
## Why

Right now a finished release lists the two raw `PasClaw-x64.exe` / `PasClaw-x86.exe` (the binaries you attach for CI to package) *next to* the installers — redundant and confusing. But since the Delphi build is self-contained, each raw exe is a genuinely useful **no-installer / portable** PasClaw.

## What

After the installers are built, the `windows-installers` job now:

- Re-publishes each exe as **`PasClaw-<version>-x64-portable.exe`** (and `-x86-`).
- **Deletes the raw `PasClaw-x64.exe` / `PasClaw-x86.exe`** upload name.

So a finished release lists intentional downloads only:

```
PasClaw-<ver>-x64-setup.exe
PasClaw-<ver>-x86-setup.exe
PasClaw-<ver>-x64-portable.exe
PasClaw-<ver>-x86-portable.exe
pasclaw-<ver>-linux-x86_64.tar.gz
pasclaw-<ver>-linux-aarch64.tar.gz
```

## Re-run safety

The download step now prefers the raw upload name but **falls back to the portable asset** if it's gone, so re-running the packaging workflow still works after the rename (no need to re-attach the exe).

## Applying to v0.1.3

The current v0.1.3 release still shows the raw exes. Once this merges, re-run **Release artifacts → Run workflow → tag `v0.1.3`** and it'll rename them to `-portable` and clean up retroactively. I'll also add a "Portable (no installer)" row to the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_