### PR TITLE
webui: expand tool-call details by default (+ collapse toggle)

### DIFF
--- a/src/pkg/gateway/webui.html
+++ b/src/pkg/gateway/webui.html
@@ -614,6 +614,7 @@
       <div class="chat-toolbar">
         <button class="icon-btn" id="sidebar-toggle" title="Collapse / show the session list">☰</button>
         <button class="icon-btn" id="params-toggle" title="Per-chat parameters">⚙ Params</button>
+        <button class="icon-btn" id="tools-toggle" title="Expand or collapse tool-call details (full args + results) in the transcript">🔧 details ▾</button>
         <span id="params-summary" class="params-summary"></span>
         <span id="sandbox-chip" class="sandbox-chip" style="margin-left:auto" hidden></span>
         <button class="icon-btn" id="chat-undo" title="Undo the last turn's file edits (checkpoints)">↶</button>
@@ -2692,7 +2693,7 @@ function toolCard(call, results, detail) {
     isErr = body.indexOf(TV_ERR) >= 0;
     bodyHtml = "<pre>" + (body ? escapeHtml(body) : "(no result)") + "</pre>";
   }
-  return '<details class="tool-card' + (isErr ? " err" : "") + '">'
+  return '<details class="tool-card' + (isErr ? " err" : "") + '"' + (toolsExpanded ? " open" : "") + '>'
        + '<summary><span class="tc-glyph">' + TV_CALL + "</span>"
        + '<span class="tc-call">' + escapeHtml(call) + "</span></summary>"
        + '<div class="tc-body">' + bodyHtml + "</div>"
@@ -2878,6 +2879,32 @@ function initMode() {
     currentMode = (currentMode === "plan") ? "build" : "plan";
     try { localStorage.setItem(MODE_KEY, currentMode); } catch {}
     applyModeUI();
+  });
+}
+
+/* ===== Tool-detail expansion (default ON) =====
+   The tool-call cards already carry the full args + result/error streamed on
+   the `pasclaw-tool` side-channel -- the same context `--debug` prints on the
+   CLI. Default the cards to expanded so the transcript shows what the agent is
+   actually doing without a click; toolCard() reads `toolsExpanded` to emit the
+   `open` attribute. Persisted, so an operator who finds it noisy can collapse
+   every card globally (and new ones stay collapsed). */
+const TOOLS_KEY = "pasclaw.tooldetails.v1";
+let toolsExpanded = true;
+function applyToolsUI() {
+  const b = $("#tools-toggle");
+  if (b) b.textContent = toolsExpanded ? "🔧 details ▾" : "🔧 details ▸";
+  /* Flip already-rendered cards to match; new cards pick it up via toolCard(). */
+  document.querySelectorAll(".tool-card").forEach(d => { d.open = toolsExpanded; });
+}
+function initToolDetails() {
+  try { toolsExpanded = localStorage.getItem(TOOLS_KEY) !== "0"; } catch {}
+  applyToolsUI();
+  const b = $("#tools-toggle");
+  if (b) b.addEventListener("click", () => {
+    toolsExpanded = !toolsExpanded;
+    try { localStorage.setItem(TOOLS_KEY, toolsExpanded ? "1" : "0"); } catch {}
+    applyToolsUI();
   });
 }
 
@@ -4799,6 +4826,7 @@ async function maybeOnboard() {
 /* ===== Boot ===== */
 initTheme();
 initMode();
+initToolDetails();
 loadModels();
 initParams();
 // Restore the tab named in the URL hash (deep link / reload / bookmark).


### PR DESCRIPTION
## Problem

In the web UI the agent looks like it's working silently — you see `⏺ fs_read(...)` but not *what* it read or got back. That context (full args + full result/error) is exactly what `--debug` shows on the CLI.

## Insight

The context is **already in the front end**. The gateway streams a structured `pasclaw-tool` side-channel over SSE with the full args + result/error (capped 8 KB / 16 KB), and `toolCard()` already renders it into `args` / `result` / `error` blocks. The cards were just `<details>` **collapsed by default**, so you had to click each one.

## Change

- **Default the tool-call cards to expanded** — `toolCard()` now emits the `open` attribute from a `toolsExpanded` state, so you see what each tool did inline, no click.
- **Add a persisted `🔧 details` toggle** in the chat toolbar (mirrors the existing theme / mode toggles). Flip it to collapse every card globally; new cards follow the setting. Stored in `localStorage` (`pasclaw.tooldetails.v1`), default ON.
- No flooding: expanded bodies already scroll internally (`max-height` on `.tc-body pre`), so a big `fs_read` result stays a compact scroll box.

Backend untouched — the data was already being streamed.

## Testing

Unit-checked the render/toggle logic in isolation: expanded state emits `<details ... open>`, collapsed omits it, and the persistence semantics (default ON unless stored `"0"`) round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_