### PR TITLE
memory: make OrtPosix compile under Delphi/Linux

### DIFF
--- a/src/pkg/memory/PasClaw.Memory.OrtPosix.pas
+++ b/src/pkg/memory/PasClaw.Memory.OrtPosix.pas
@@ -31,9 +31,10 @@ implementation
 
 uses
   {$IFDEF FPC}
-  SysUtils, fphttpclient, opensslsockets;
+  SysUtils, Classes, fphttpclient, opensslsockets;
   {$ELSE}
-  System.SysUtils, System.Net.HttpClient, System.Net.URLClient;
+  System.SysUtils, System.Classes, System.Net.HttpClient, System.Net.URLClient
+  {$IFNDEF MSWINDOWS}, Posix.Stdlib{$ENDIF};   { libc system() -- Delphi has no ExecuteProcess }
   {$ENDIF}
 
 const
@@ -103,6 +104,23 @@ end;
 {$ENDIF}
 {$ENDIF}
 
+{$IFNDEF MSWINDOWS}
+{ Run a shell command line via /bin/sh -c; returns the process exit code
+  (0 = success). FPC has SysUtils.ExecuteProcess; Delphi has no equivalent, so
+  on Delphi POSIX we call libc system(), which itself runs the string through
+  /bin/sh -c -- so the caller passes the same command string either way. }
+function RunShell(const ACmd: string): Integer;
+{$IFDEF FPC}
+begin
+  Result := ExecuteProcess('/bin/sh', ['-c', ACmd]);
+end;
+{$ELSE}
+begin
+  Result := Posix.Stdlib.system(PAnsiChar(AnsiString(ACmd)));
+end;
+{$ENDIF}
+{$ENDIF}
+
 function EnsurePosixOrt(const ACacheDir: string; out AMsg: string): Boolean;
 {$IFDEF MSWINDOWS}
 begin
@@ -139,9 +157,9 @@ begin
       Exit(False);
     end;
     { Extract + copy the real (non-symlink) shared lib via system tar. }
-    ExecuteProcess('/bin/sh', ['-c', 'rm -rf "' + Tmp + '" && mkdir -p "' + Tmp +
+    RunShell('rm -rf "' + Tmp + '" && mkdir -p "' + Tmp +
       '" && tar -xzf "' + Tgz + '" -C "' + Tmp + '" && cp "$(find "' + Tmp +
-      '" -name ''' + LibGlob + ''' -type f | head -1)" "' + Dest + '"']);
+      '" -name ''' + LibGlob + ''' -type f | head -1)" "' + Dest + '"');
     Result := FileExists(Dest);
     if Result then AMsg := 'installed at ' + Dest
     else AMsg := 'extract failed (no ' + LibGlob + ' in archive)';
@@ -150,7 +168,7 @@ begin
   end;
   try
     if FileExists(Tgz) then DeleteFile(Tgz);
-    ExecuteProcess('/bin/sh', ['-c', 'rm -rf "' + Tmp + '"']);
+    RunShell('rm -rf "' + Tmp + '"');
   except
     on E: Exception do ;
   end;


### PR DESCRIPTION
## The errors

Delphi/Linux (`dcc` Linux64) rejected `PasClaw.Memory.OrtPosix.pas`:

```
E2003 Undeclared identifier: 'TFileStream'      (line 90)
E2003 Undeclared identifier: 'fmCreate'         (line 94)
E2003 Undeclared identifier: 'ExecuteProcess'   (line 142)
E2010 Incompatible types: 'Integer' and 'string'
F2063 Could not compile used unit 'PasClaw.Memory.OrtPosix.pas'
```

Both are FPC-isms that dcc doesn't accept.

## Fixes

1. **`TFileStream` / `fmCreate`** — the Delphi `uses` clause was missing `System.Classes` (these resolved transitively under FPC, not dcc). Added it (and `Classes` on the FPC side for symmetry).

2. **`ExecuteProcess`** — an FPC `SysUtils` routine with no Delphi equivalent (hence the `Ordinal type required` / `Integer vs string` cascade — dcc parsed it as an undeclared identifier). Wrapped the two `tar`/`rm` shell-outs in a small `RunShell()` helper:
   - **FPC** → `ExecuteProcess('/bin/sh', ['-c', cmd])` (unchanged behavior).
   - **Delphi POSIX** → libc `system()` from `Posix.Stdlib`, which itself runs the string through `/bin/sh -c` — so the exact same command string works either way.

   `Posix.Stdlib` is imported only when **not** `MSWINDOWS`, matching the unit's existing POSIX-only guards, so the Delphi Windows build (which just returns the "windows uses the vendored auto-download" stub) is unaffected.

## Verification

FPC build is clean (`make` compiles `OrtPosix` and links; `pasclaw version` runs). **I can't build the Delphi/Linux path here** (no `dcc`), but the change is the standard `Posix.Stdlib.system` route — please confirm with your Delphi/Linux compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_