### PR TITLE
memory: bind libc system() directly for OrtPosix (Delphi)

### DIFF
--- a/src/pkg/memory/PasClaw.Memory.OrtPosix.pas
+++ b/src/pkg/memory/PasClaw.Memory.OrtPosix.pas
@@ -34,7 +34,7 @@ uses
   SysUtils, Classes, fphttpclient, opensslsockets;
   {$ELSE}
   System.SysUtils, System.Classes, System.Net.HttpClient, System.Net.URLClient
-  {$IFNDEF MSWINDOWS}, Posix.Stdlib{$ENDIF};   { libc system() -- Delphi has no ExecuteProcess }
+  {$IFNDEF MSWINDOWS}, Posix.Base{$ENDIF};   { libc / _PU for the system() bind below }
   {$ENDIF}
 
 const
@@ -105,6 +105,13 @@ end;
 {$ENDIF}
 
 {$IFNDEF MSWINDOWS}
+{$IFNDEF FPC}
+{ Bind libc system() directly. Posix.Stdlib doesn't expose `system` on all
+  Delphi versions (E2003 on Linux), so declare it against libc ourselves. }
+function PosixSystem(command: MarshaledAString): Integer; cdecl;
+  external libc name _PU + 'system';
+{$ENDIF}
+
 { Run a shell command line via /bin/sh -c; returns the process exit code
   (0 = success). FPC has SysUtils.ExecuteProcess; Delphi has no equivalent, so
   on Delphi POSIX we call libc system(), which itself runs the string through
@@ -116,7 +123,7 @@ begin
 end;
 {$ELSE}
 begin
-  Result := Posix.Stdlib.system(PAnsiChar(AnsiString(ACmd)));
+  Result := PosixSystem(PAnsiChar(AnsiString(ACmd)));
 end;
 {$ENDIF}
 {$ENDIF}


### PR DESCRIPTION
## The error

Follow-up to #458:

```
[DCC Error] PasClaw.Memory.OrtPosix.pas(119): E2003 Undeclared identifier: 'system'
```

My #458 fix called `Posix.Stdlib.system(...)`, but **`Posix.Stdlib` doesn't export `system` on your Delphi version** — it varies across releases (and it's arguably an "unsafe" API some versions omit).

## Fix

Stop relying on the RTL exporting it — **declare `system()` against libc ourselves** using the standard Delphi POSIX external idiom:

```pascal
function PosixSystem(command: MarshaledAString): Integer; cdecl;
  external libc name _PU + 'system';
```

`libc` and `_PU` come from **`Posix.Base`** (swapped in for `Posix.Stdlib` in the `uses`). The `RunShell` FPC branch (`ExecuteProcess`) is untouched. This is the same mechanism the RTL itself uses to bind `getenv`, `setenv`, etc., so it doesn't depend on which libc wrappers a given Delphi ships.

## Verification

FPC build is clean (all changes are in Delphi-only branches). **I can't build the Delphi/Linux path here** (no `dcc`) — please confirm on your compile. If `dcc` flags `libc`/`_PU` (Posix.Base symbol names differ across Delphi versions, though this is the documented idiom), send the message and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_