### PR TITLE
delphi/posix: restore secret-echo-off + setenv on Delphi/Linux

### DIFF
--- a/src/cmd/PasClaw.Cmd.Build.pas
+++ b/src/cmd/PasClaw.Cmd.Build.pas
@@ -88,6 +88,7 @@ uses
   SysUtils, Classes,
   {$IFDEF MSWINDOWS}Windows,{$ENDIF}
   {$IFNDEF FPC}System.IOUtils,{$ENDIF}
+  {$IF DEFINED(POSIX) AND NOT DEFINED(FPC)}Posix.Base,{$IFEND}   { libc / _PU for setenv }
   PasClaw.CliUI,
   PasClaw.Logger,
   PasClaw.Utils,
@@ -95,20 +96,25 @@ uses
   PasClaw.Cmd.Agent,
   PasClaw.Agent.Prompt;  { ExtractGoalFromPlanFile for --goal flag }
 
-{$IFDEF UNIX}
 { libc setenv is POSIX-portable across glibc / musl / macOS / BSD --
-  FPC's RTL doesn't expose it (only the env-modification helpers in
-  the unitsrc/3.2.2 tree's UnixUtil which aren't packaged on every
-  distro). Declare it directly. }
+  neither FPC's RTL nor (reliably) Delphi's Posix.Stdlib exposes it, so
+  declare it directly against libc. FPC uses `external 'c'`; Delphi POSIX
+  uses the RTL's libc / _PU (Posix.Base), same as the ONNX installer's
+  system() bind. }
+{$IFDEF UNIX}
 function libc_setenv(const Name, Value: PAnsiChar; Overwrite: Integer): Integer;
   cdecl; external 'c' name 'setenv';
 {$ENDIF}
+{$IF DEFINED(POSIX) AND NOT DEFINED(FPC)}
+function libc_setenv(const Name, Value: MarshaledAString; Overwrite: Integer): Integer;
+  cdecl; external libc name _PU + 'setenv';
+{$IFEND}
 
 procedure SetEnv(const Name, Value: string);
 begin
-  {$IFDEF UNIX}
+  {$IF DEFINED(UNIX) OR (DEFINED(POSIX) AND NOT DEFINED(FPC))}
   libc_setenv(PAnsiChar(AnsiString(Name)), PAnsiChar(AnsiString(Value)), 1);
-  {$ENDIF}
+  {$IFEND}
   {$IFDEF MSWINDOWS}
   Windows.SetEnvironmentVariable(PChar(Name), PChar(Value));
   {$ENDIF}

--- a/src/pkg/cliui/PasClaw.CliUI.pas
+++ b/src/pkg/cliui/PasClaw.CliUI.pas
@@ -91,6 +91,9 @@ uses
   {$IFDEF UNIX}
   , BaseUnix, TermIO
   {$ENDIF}
+  {$IF DEFINED(POSIX) AND NOT DEFINED(FPC)}
+  , Posix.Termios   { Delphi/Linux+macOS: tcgetattr/tcsetattr for ECHO control }
+  {$IFEND}
   ;
 
 var
@@ -353,6 +356,30 @@ begin
   if HaveTerm then PrintLn;
 end;
 {$ENDIF}
+{$IF DEFINED(POSIX) AND NOT DEFINED(FPC)}
+{ Delphi on Linux/macOS: same ECHO-off trick via the RTL's Posix.Termios,
+  so a pasted secret isn't echoed to the terminal or its scrollback. }
+var
+  Old, New_: termios;
+  HaveTerm: Boolean;
+begin
+  Print(Prompt);
+  Flush(Output);
+  HaveTerm := tcgetattr(0, Old) = 0;
+  if HaveTerm then
+  begin
+    New_ := Old;
+    New_.c_lflag := New_.c_lflag and not Cardinal(ECHO);
+    tcsetattr(0, TCSANOW, New_);
+  end;
+  try
+    ReadLn(Result);
+  finally
+    if HaveTerm then tcsetattr(0, TCSANOW, Old);
+  end;
+  if HaveTerm then PrintLn;
+end;
+{$IFEND}
 {$IFDEF MSWINDOWS}
 var
   H: THandle;
@@ -376,7 +403,7 @@ begin
   if HaveMode then PrintLn;
 end;
 {$ENDIF}
-{$IF NOT DEFINED(UNIX) AND NOT DEFINED(MSWINDOWS)}
+{$IF NOT DEFINED(UNIX) AND NOT DEFINED(POSIX) AND NOT DEFINED(MSWINDOWS)}
 begin
   { Unknown platform -- fall through to plain echoing read so the
     program still runs. }


### PR DESCRIPTION
Follows the sweep after #458/#459. No compile breakers remained, but two POSIX features were gated on `{$IFDEF UNIX}` — which **FPC defines but Delphi/Linux does not** (Delphi uses `POSIX`). So they compiled fine but silently no-op'd on a Delphi/Linux binary:

## 1. `CliUI.ReadSecretLine` — secret was echoed 🔒
On Delphi/Linux it fell through to a *plain echoing* `ReadLn`, so a pasted API key showed on-screen and in scrollback. Added a Delphi/POSIX branch using the RTL's **`Posix.Termios`** (`tcgetattr`/`tcsetattr`, clear `ECHO`) — a direct mirror of the FPC `BaseUnix`/`TermIO` path. Also excluded `POSIX` from the "unknown platform" fallback so Delphi/Linux takes the real branch.

## 2. `Cmd.Build.SetEnv` — env injection did nothing
`pasclaw build` couldn't push env vars into spawned children. Bound libc `setenv` for Delphi POSIX via **`Posix.Base`** (`libc` / `_PU`) — the exact idiom #459 proved compiles on your Delphi/Linux.

## Safety / verification
- All new code is `{$IF DEFINED(POSIX) AND NOT DEFINED(FPC)}`, so **FPC skips it entirely** — FPC build verified clean, both units compile + link, `pasclaw version` runs.
- Delphi/Windows is untouched (`MSWINDOWS` branches unchanged).
- The Delphi/Linux path I can't build here, but it reuses the **#459-validated** libc-bind pattern, and `Posix.Termios`/`Posix.Base` are standard Delphi POSIX RTL. Please confirm on your `dcc` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_