### PR TITLE
workflow: tolerate stale 'structuredContent.' selector prefix

### DIFF
--- a/src/pkg/workflow/PasClaw.Workflow.Tools.pas
+++ b/src/pkg/workflow/PasClaw.Workflow.Tools.pas
@@ -226,7 +226,9 @@ begin
     'prompt}; output is the reply text. You can also use any raw MCP tool or ' +
     'registered tool as a node. Wire data between nodes with {{inputs.NAME}} ' +
     'and {{nodes.ID}} (the upstream node''s output) or {{nodes.ID.selector}} ' +
-    'for a dotted/[i] path into its JSON.',
+    'for a dotted/[i] path into its JSON. For a raw Replicate model node the ' +
+    'output is the prediction object with fields at the TOP level -- reference ' +
+    'the image/video URL as {{nodes.ID.output[0]}} (NOT structuredContent.output[0]).',
     SAVE_SCHEMA, ToolWorkflowSave, tcMutating);
 
   Reg1(Reg, 'workflow_list',

--- a/src/pkg/workflow/PasClaw.Workflow.pas
+++ b/src/pkg/workflow/PasClaw.Workflow.pas
@@ -442,6 +442,24 @@ begin
     SplitSelector(Selector, Steps);
     if Steps.Count = 0 then Exit;
     Cur := JSON;
+    { Tolerance: agent-authored selectors (and stale examples) often lead with
+      "structuredContent." even though the node output is already the unwrapped
+      top-level payload -- Replicate returns id/status/output at the TOP level
+      (see PlanNode + UnwrapResult), so the wrapper isn't there. If the object
+      has no structuredContent key, drop that leading step and resolve the rest
+      against the top level, so `structuredContent.output[0]` still finds
+      `output[0]`. Only strips when absent, so builds that DO wrap are untouched. }
+    if (Steps.Count >= 1) and (Steps[0] = 'structuredContent') then
+    begin
+      try Obj := TJsonObject.Parse(Cur); except Obj := nil; end;
+      if Obj <> nil then
+      try
+        if not Obj.Has('structuredContent') then Steps.Delete(0);
+      finally
+        Obj.Free;
+      end;
+      if Steps.Count = 0 then Exit;
+    end;
     for i := 0 to Steps.Count - 1 do
     begin
       Step := Steps[i];

--- a/src/tests/workflow_tests.pas
+++ b/src/tests/workflow_tests.pas
@@ -116,6 +116,15 @@ begin
                      'structuredContent.output[0]', V), 'selector: resolves');
   Check(V = 'https://x/a.png', 'selector: correct value (got ' + V + ')');
   Check(not EvalSelector('{"a":{}}', 'a.missing.deep', V), 'selector: missing path fails');
+  { Tolerance: a stale "structuredContent." prefix resolves against the
+    unwrapped top-level payload (agent-authored Replicate selectors). }
+  Check(EvalSelector('{"output":["https://x/b.png"]}',
+                     'structuredContent.output[0]', V), 'selector: tolerates stale structuredContent prefix');
+  Check(V = 'https://x/b.png', 'selector: stale-prefix correct value (got ' + V + ')');
+  { But a real structuredContent wrapper is still honoured (not stripped). }
+  Check(EvalSelector('{"structuredContent":{"output":["https://x/c.png"]}}',
+                     'structuredContent.output[0]', V), 'selector: real wrapper still works');
+  Check(V = 'https://x/c.png', 'selector: real-wrapper value (got ' + V + ')');
 end;
 
 procedure TestRunChains;


### PR DESCRIPTION
## The failure you hit

```
node "animate_image": {{nodes.generate_image.structuredContent.output[0]}}:
selector "structuredContent.output[0]" did not resolve in node "generate_image" output
```

The agent authored the workflow referencing the Replicate node's output as `structuredContent.output[0]`. But the engine **unwraps** each node result to the top-level prediction payload (`id`/`status`/`output` at the top — see `PlanNode` + `UnwrapResult`), so there's no `structuredContent` wrapper to descend into, and the selector fails.

## Fix

**Engine tolerance** (the real fix): `EvalSelector` now drops a leading `structuredContent.` step when the object has no such key, resolving the rest against the top level. So `structuredContent.output[0]` finds `output[0]`. It only strips when the key is **absent**, so an MCP build that genuinely wraps in `structuredContent` is untouched.

→ Your existing `gpt_image_to_p_video` workflow will now run as-is; no re-authoring needed.

**Guidance** (prevents future mis-authoring): the `workflow_save` tool description now tells the agent to reference a Replicate node's URL as `{{nodes.ID.output[0]}}` (NOT `structuredContent.output[0]`).

## Tests
`test-workflow` passes, with added cases: the stale-prefix selector resolves against an unwrapped `{"output":[url]}`, and a real `{"structuredContent":{"output":[...]}}` wrapper still resolves (not stripped).

Pure Pascal (TStringList/TJson), Delphi-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_