### PR TITLE
Database tools Phase 2: link all engines + wire the config section

### DIFF
--- a/docs/database-tools.md
+++ b/docs/database-tools.md
@@ -8,9 +8,19 @@ to compile on **both** toolchains:
 - **FPC:** sqldb's `TSQLConnector`, connector type picked from config.
 
 The same binary reaches SQLite, PostgreSQL, MySQL/MariaDB, Firebird, MSSQL,
-Oracle and ODBC once the matching driver/connector is linked. **Phase 1 links
-and tests SQLite on both toolchains;** the other engines are recognised by the
-driver mapping but need their connector unit linked (Phase 2).
+Oracle and ODBC. The client library for a given engine (libpq, libmysqlclient,
+libfbclient, FreeTDS, Oracle OCI, unixODBC) is loaded **lazily at connect time**,
+so one portable binary ships every engine and a missing library only fails that
+one connection — it doesn't break the build or the other engines.
+
+- **FPC:** all connector units are linked by default (SQLite, PostgreSQL,
+  MySQL 5.7/8.0, Firebird/Interbase, MSSQL, Oracle, ODBC).
+- **Delphi:** SQLite is linked in every RAD Studio edition. The other FireDAC
+  drivers need Enterprise/Architect — build with `-dPASCLAW_FIREDAC_FULL` to
+  link them, so the default build stays portable across editions.
+
+Canonical `driver` ids: `sqlite`, `postgres`, `mysql` (or `mysql8`, `mariadb`),
+`mssql`, `firebird`, `oracle`, `odbc`.
 
 ## Tools
 
@@ -42,9 +52,12 @@ omit it for the first (default) one.
 - **Secret hygiene.** `db_info` redacts the password; keep credentials out of
   the file with env substitution.
 
-## Configuration (Phase 2 wires this at each entry point)
+## Configuration
 
-The engine reads a `database` array. Each entry:
+Add a `database` array to `config.json`. It's read at every entry point (CLI
+agent, TUI, gateway, serve), kept verbatim across a config save/load, and parsed
+by `PasClaw.Tools.DB.SetDBConfigFromJSON`; until a connection is installed the
+tools are registered but inert.
 
 ```json
 {
@@ -60,15 +73,16 @@ The engine reads a `database` array. Each entry:
 }
 ```
 
-Fields: `name`, `driver` (`sqlite|postgres|mysql|mssql|firebird|oracle|odbc`),
-`database`, `server`, `port`, `user`, `password`, `params`, `mode`, `max_rows`,
-`timeout_ms`. `PasClaw.Tools.DB.SetDBConfigFromJSON` parses this section; until a
-connection is installed the tools are registered but inert.
+Fields: `name`, `driver`, `database`, `server`, `port`, `user`, `password`,
+`params`, `mode`, `max_rows`, `timeout_ms`. Keep credentials out of the file with
+env substitution; `db_info` redacts the password on the way out.
 
 ## Roadmap
 
-- **Phase 2** — link Postgres/MySQL/ODBC connectors + FireDAC driver links; wire
-  the `database` config section at each entry point.
+- **Phase 1 (done)** — engine-agnostic seam + the five tools + safety model,
+  SQLite backend on both toolchains.
+- **Phase 2 (done)** — link all FPC connectors (+ the `PASCLAW_FIREDAC_FULL`
+  define for Delphi); wire the `database` config section at each entry point.
 - **Phase 3** — project the native tools out through PasClaw's MCP server, so
   PasClaw itself is a cross-platform database MCP server.
 - **Phase 4** — a DeepSQL-style "DBA" layer: schema/stat indexing into the KB,

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -41,6 +41,7 @@ uses
   PasClaw.Tools.SessionSearch,
   PasClaw.Tools.PlanWrite,
   PasClaw.Tools.SendMessage,
+  PasClaw.Tools.DB,
   PasClaw.Tools.Cron,
   PasClaw.Tools.WebSearch,
   PasClaw.Search.Factory,
@@ -307,7 +308,8 @@ function NewBuiltinRegistry(UseHashline: Boolean = True;
                             EnableWebFetch: Boolean = False;
                             EnableOutputCache: Boolean = False;
                             EnableCron: Boolean = False;
-                            EnablePlanWrite: Boolean = False): TToolRegistry;
+                            EnablePlanWrite: Boolean = False;
+                            const DBConfigJSON: string = ''): TToolRegistry;
 var
   Skills: TSkillSpecArray;
 begin
@@ -372,6 +374,9 @@ begin
   RegisterSendMessageTool(Result);
   Skills := LoadSkillManifests(GetHome);
   RegisterSkills(Result, Skills);
+  { Install the configured db_* connections (inert when the "database" section
+    is absent). Process-global, so one call per surface suffices. }
+  SetDBConfigFromJSON(DBConfigJSON);
 end;
 
 { When the operator declared subagents in config.json, install the
@@ -613,7 +618,8 @@ begin
                                 was selected; auto-includes the dedicated
                                 plan_write tool the `pasclaw plan`
                                 command relies on. }
-                              A.Mode = pmPlan);
+                              A.Mode = pmPlan,
+                              Cfg.DatabaseJSON);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;
@@ -893,7 +899,8 @@ begin
                               (Cfg.ToolOutputCap > 0)
                                 or Cfg.CondenseReversible,
                               Cfg.CronToolEnabled,
-                              A.Mode = pmPlan);
+                              A.Mode = pmPlan,
+                              Cfg.DatabaseJSON);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;
@@ -1341,7 +1348,8 @@ begin
                                 was selected; auto-includes the dedicated
                                 plan_write tool the `pasclaw plan`
                                 command relies on. }
-                              A.Mode = pmPlan);
+                              A.Mode = pmPlan,
+                              Cfg.DatabaseJSON);
     RegisterSkillManageTool(Reg, Cfg);
     RegisterSkillDisclosureTools(Reg, Cfg);
   end;

--- a/src/cmd/PasClaw.Cmd.Gateway.pas
+++ b/src/cmd/PasClaw.Cmd.Gateway.pas
@@ -52,6 +52,7 @@ uses
   PasClaw.Session.Store,    { NewSessionId for the shell session id }
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
+  PasClaw.Tools.DB,
   PasClaw.Skills.Manage,
   PasClaw.Skills.Disclosure,
   PasClaw.Cron.Scheduler,
@@ -287,6 +288,7 @@ begin
       if Cfg.CronToolEnabled then RegisterCronTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
+      SetDBConfigFromJSON(Cfg.DatabaseJSON);   { db_* connections (inert if no "database" section) }
       RegisterSkillManageTool(Reg, Cfg);
       RegisterSkillDisclosureTools(Reg, Cfg);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -74,6 +74,7 @@ uses
   PasClaw.Session.Store,    { NewSessionId for the shell session id }
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
+  PasClaw.Tools.DB,
   PasClaw.Skills.Manage,
   PasClaw.Skills.Disclosure,
   PasClaw.Cron.Scheduler,
@@ -256,6 +257,7 @@ begin
       if Cfg.CronToolEnabled then RegisterCronTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
+      SetDBConfigFromJSON(Cfg.DatabaseJSON);   { db_* connections (inert if no "database" section) }
       RegisterSkillManageTool(Reg, Cfg);
       RegisterSkillDisclosureTools(Reg, Cfg);
       if Length(Skills) > 0 then

--- a/src/cmd/PasClaw.Cmd.TUI.pas
+++ b/src/cmd/PasClaw.Cmd.TUI.pas
@@ -42,6 +42,7 @@ uses
   PasClaw.Shell.Backend.Factory,   { InstallShellBackend }
   PasClaw.MCP.Bridge,
   PasClaw.Skills.Loader,
+  PasClaw.Tools.DB,
   PasClaw.Skills.Manage,
   PasClaw.Skills.Disclosure,
   PasClaw.Agent.Subagent,
@@ -193,6 +194,7 @@ begin
       RegisterSendMessageTool(Reg);
       Skills := LoadSkillManifests(GetHome);
       RegisterSkills(Reg, Skills);
+      SetDBConfigFromJSON(Cfg.DatabaseJSON);   { db_* connections (inert if no "database" section) }
       RegisterSkillManageTool(Reg, Cfg);
       RegisterSkillDisclosureTools(Reg, Cfg);
     end;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -716,11 +716,16 @@ type
       default. The workflow_save/list/run agent tools register alongside skills
       regardless; this flag gates the HTTP surface for locked-down deploys. }
     WorkflowsEnabled:      Boolean;
-    { Raw JSON of the "database" array (a list of named SQL connections for the
-      db_* tools). Stored verbatim -- PasClaw.Tools.DB.SetDBConfigFromJSON parses
-      it at each entry point -- and re-emitted on save so a hand-edited section
-      round-trips. Empty when no "database" key is present. }
+    (* Raw JSON of the "database" array (a list of named SQL connections for the
+       db_* tools). DatabaseJSON is env-EXPANDED (markers resolved) -- it carries
+       live credentials and is what SetDBConfigFromJSON hands the connector; it
+       is NEVER written back to disk. DatabaseRawJSON is the PRE-expansion
+       section (placeholders intact) and is the one ToJSON re-emits, so an env
+       secret marker survives a save/load round-trip instead of leaking the
+       resolved secret into config.json. Both empty when no "database" key is
+       present. *)
     DatabaseJSON:          string;
+    DatabaseRawJSON:       string;
     (* Byte budget for the always-on "durable facts" block injected into
        the system prompt when MemoryDistillEnabled. Facts are tiny, so the
        whole active set usually fits; past the budget the newest/highest-
@@ -1097,6 +1102,7 @@ begin
   MemoryDistillEnabled   := False; { opt-in: ~one extra LLM call per turn. }
   WorkflowsEnabled       := True;  { on: tools are inert until a workflow is saved. }
   DatabaseJSON           := '';    { no db_* connections until a "database" section is added. }
+  DatabaseRawJSON        := '';    { pre-expansion "database" section, for save. }
   MemoryFactsBudget      := 2000;  { ~30 facts injected wholesale when distill on. }
   CheckpointsKeepLast    := 32;    { keep last 32 atomic edit checkpoints. }
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
@@ -1429,9 +1435,13 @@ begin
       locked-down deploy disabling the /v1/workflows surface) round-trips. }
     if not WorkflowsEnabled then
       Root.PutBool('workflows_enabled', False);
-    { Preserve the raw "database" section verbatim so a hand-edited list of
-      connections survives a save/load round-trip. }
-    if Trim(DatabaseJSON) <> '' then
+    { Persist the PRE-expansion "database" section so an env secret marker
+      round-trips as the placeholder, never the resolved value. Fall back to
+      DatabaseJSON only when there is no raw section (e.g. a programmatically
+      set config, which carries no env markers). }
+    if Trim(DatabaseRawJSON) <> '' then
+      Root.PutRaw('database', DatabaseRawJSON)
+    else if Trim(DatabaseJSON) <> '' then
       Root.PutRaw('database', DatabaseJSON);
     { Default OFF -- emit only the explicit-on so an operator opt-in
       (onboarding or hand-edit) sticks across save/load. }
@@ -2235,19 +2245,33 @@ end;
 
 function LoadConfig(const ProfileOverride: string): TConfig;
 var
-  Path, S, ProfileName, PErr, B: string;
+  Path, S, ProfileName, PErr, B, RawDb: string;
   Bodies: TProfileBodyArray;
   i: Integer;
   HasConfigFile: Boolean;
+  RawRoot: TJsonObject;
+  RawArr: TJsonArray;
 begin
   Result := TConfig.Create;
   Path := GetConfigPath;
   S := '';
+  RawDb := '';
   HasConfigFile := FileExists(Path);
   try
     if HasConfigFile then
     begin
       S := ReadFileText(Path);
+      { Capture the "database" section from the RAW file, BEFORE env expansion,
+        so env-marker placeholders (not the resolved secrets) are what round-
+        trips back to disk on the next SaveConfig. }
+      try RawRoot := TJsonObject.Parse(S); except RawRoot := nil; end;
+      if RawRoot <> nil then
+      try
+        RawArr := RawRoot.ChildArray('database');
+        if RawArr <> nil then RawDb := RawArr.ToJSON;
+      finally
+        RawRoot.Free;
+      end;
       (* Resolve ${VAR_NAME} markers BEFORE FromJSON parses. Lets
          operators keep API keys / bearer tokens / webhook URLs in
          the environment and reference them by name from config.json
@@ -2307,6 +2331,8 @@ begin
           ;
       end;
     end;
+    { The operator file's pre-expansion database section is the one we persist. }
+    Result.DatabaseRawJSON := RawDb;
   finally
     { Propagate config-derived process globals. Centralised in
       ApplyConfigGlobals so code-driven embedders (no LoadConfig) can run

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -716,6 +716,11 @@ type
       default. The workflow_save/list/run agent tools register alongside skills
       regardless; this flag gates the HTTP surface for locked-down deploys. }
     WorkflowsEnabled:      Boolean;
+    { Raw JSON of the "database" array (a list of named SQL connections for the
+      db_* tools). Stored verbatim -- PasClaw.Tools.DB.SetDBConfigFromJSON parses
+      it at each entry point -- and re-emitted on save so a hand-edited section
+      round-trips. Empty when no "database" key is present. }
+    DatabaseJSON:          string;
     (* Byte budget for the always-on "durable facts" block injected into
        the system prompt when MemoryDistillEnabled. Facts are tiny, so the
        whole active set usually fits; past the budget the newest/highest-
@@ -1091,6 +1096,7 @@ begin
   CheckpointsEnabled     := True;  { on by default -- zero prompt cost, prevents lost work on multi-edit sessions. }
   MemoryDistillEnabled   := False; { opt-in: ~one extra LLM call per turn. }
   WorkflowsEnabled       := True;  { on: tools are inert until a workflow is saved. }
+  DatabaseJSON           := '';    { no db_* connections until a "database" section is added. }
   MemoryFactsBudget      := 2000;  { ~30 facts injected wholesale when distill on. }
   CheckpointsKeepLast    := 32;    { keep last 32 atomic edit checkpoints. }
   PromptwareEnabled      := True;  { on by default -- substring scan, effectively free. }
@@ -1423,6 +1429,10 @@ begin
       locked-down deploy disabling the /v1/workflows surface) round-trips. }
     if not WorkflowsEnabled then
       Root.PutBool('workflows_enabled', False);
+    { Preserve the raw "database" section verbatim so a hand-edited list of
+      connections survives a save/load round-trip. }
+    if Trim(DatabaseJSON) <> '' then
+      Root.PutRaw('database', DatabaseJSON);
     { Default OFF -- emit only the explicit-on so an operator opt-in
       (onboarding or hand-edit) sticks across save/load. }
     if MemoryDistillEnabled then
@@ -1892,6 +1902,9 @@ begin
     CheckpointsEnabled  := Root.GetBool('checkpoints_enabled', CheckpointsEnabled);
     MemoryDistillEnabled := Root.GetBool('memory_distill_enabled', MemoryDistillEnabled);
     WorkflowsEnabled := Root.GetBool('workflows_enabled', WorkflowsEnabled);
+    { Keep the "database" array verbatim; PasClaw.Tools.DB parses it. }
+    Arr := Root.ChildArray('database');
+    if Arr <> nil then DatabaseJSON := Arr.ToJSON;
     MemoryFactsBudget    := Root.GetInt('memory_facts_budget', MemoryFactsBudget);
     CheckpointsKeepLast := Integer(Root.GetInt('checkpoints_keep_last',
                                                 CheckpointsKeepLast));

--- a/src/pkg/db/PasClaw.DB.pas
+++ b/src/pkg/db/PasClaw.DB.pas
@@ -114,11 +114,25 @@ implementation
 uses
   SysUtils, Classes, TypInfo,
   {$IFDEF FPC}
-  DB, sqldb, sqlite3conn, fpjson,
+  DB, sqldb, fpjson,
+  { Each connector unit self-registers its TSQLConnector type. Linking them all
+    keeps one binary multi-engine; the client library (libpq / libmysqlclient /
+    libfb / FreeTDS / Oracle OCI / unixODBC) is loaded lazily at connect time,
+    so a missing lib only fails that connection -- it doesn't break the build or
+    other engines. }
+  sqlite3conn, pqconnection, mysql57conn, mysql80conn,
+  ibconnection, mssqlconn, odbcconn, oracleconnection,
   {$ELSE}
   Data.DB, System.JSON,
   FireDAC.Comp.Client, FireDAC.Stan.Def, FireDAC.Stan.Async,
   FireDAC.Stan.Param, FireDAC.DApt, FireDAC.Phys.SQLite,
+  { Extra FireDAC drivers need RAD Studio Enterprise/Architect. Build with
+    -dPASCLAW_FIREDAC_FULL to link them; the SQLite driver above is in every
+    edition, so the default build stays portable. }
+  {$IFDEF PASCLAW_FIREDAC_FULL}
+  FireDAC.Phys.PG, FireDAC.Phys.MySQL, FireDAC.Phys.MSSQL,
+  FireDAC.Phys.Oracle, FireDAC.Phys.IB, FireDAC.Phys.ODBCBase, FireDAC.Phys.ODBC,
+  {$ENDIF}
   {$ENDIF}
   PasClaw.JSON,
   PasClaw.Logger;
@@ -454,7 +468,8 @@ begin
   D := LowerCase(Trim(Driver));
   if (D = 'sqlite') or (D = 'sqlite3') then Result := 'SQLite3'
   else if (D = 'postgres') or (D = 'postgresql') or (D = 'pg') then Result := 'PostgreSQL'
-  else if D = 'mysql' then Result := 'MySQL 5.7'
+  else if (D = 'mysql') or (D = 'mysql5') or (D = 'mariadb') then Result := 'MySQL 5.7'
+  else if (D = 'mysql8') then Result := 'MySQL 8.0'
   else if (D = 'firebird') or (D = 'interbase') then Result := 'Firebird'
   else if (D = 'mssql') or (D = 'sqlserver') then Result := 'MSSQLServer'
   else if D = 'oracle' then Result := 'Oracle'

--- a/src/pkg/db/PasClaw.DB.pas
+++ b/src/pkg/db/PasClaw.DB.pas
@@ -483,7 +483,7 @@ begin
   D := LowerCase(Trim(Driver));
   if (D = 'sqlite') or (D = 'sqlite3') then Result := 'SQLite'
   else if (D = 'postgres') or (D = 'postgresql') or (D = 'pg') then Result := 'PG'
-  else if D = 'mysql' then Result := 'MySQL'
+  else if (D = 'mysql') or (D = 'mysql5') or (D = 'mysql8') or (D = 'mariadb') then Result := 'MySQL'
   else if (D = 'firebird') then Result := 'FB'
   else if (D = 'interbase') then Result := 'IB'
   else if (D = 'mssql') or (D = 'sqlserver') then Result := 'MSSQL'

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -512,6 +512,37 @@ begin
   finally
     C.Free;
   end;
+
+  { Case 4: an env-expanded secret must NOT be materialized into config.json on
+    save. SaveConfig/ToJSON persists the PRE-expansion section (DatabaseRawJSON,
+    with the env-marker placeholder), never the runtime DatabaseJSON (with the
+    resolved secret). Tested in-memory so it doesn't depend on the parent
+    process having an env var set. }
+  WriteFileText(CfgPath, '{}');
+  C := LoadConfig('');
+  try
+    C.DatabaseJSON    := '[{"name":"app","driver":"postgres","password":"REAL-SECRET"}]';
+    C.DatabaseRawJSON := '[{"name":"app","driver":"postgres","password":"${DB_PW}"}]';
+    SaveConfig(C);
+  finally
+    C.Free;
+  end;
+  AssertTrue(Pos('REAL-SECRET', ReadFileText(CfgPath)) = 0,
+             'expanded secret is NOT written to config.json');
+  AssertTrue(Pos('${DB_PW}', ReadFileText(CfgPath)) > 0,
+             'placeholder IS preserved in config.json');
+
+  { Case 5: LoadConfig captures the raw section verbatim, incl. an (unset) env
+    marker -- so the placeholder is what would persist. }
+  WriteFileText(CfgPath,
+    '{"database":[{"name":"app","driver":"postgres","password":"${PASCLAW_UNSET_DB_PW}"}]}');
+  C := LoadConfig('');
+  try
+    AssertTrue(Pos('${PASCLAW_UNSET_DB_PW}', C.DatabaseRawJSON) > 0,
+               'raw section keeps the placeholder');
+  finally
+    C.Free;
+  end;
 end;
 
 begin

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -465,6 +465,55 @@ begin
   end;
 end;
 
+(* Phase 2 db tools: the config.json "database" array is kept verbatim in
+   TConfig.DatabaseJSON and re-emitted on save, so a hand-edited list of
+   connections survives a mutating command's save/load round-trip. *)
+procedure TestDatabaseSection;
+var
+  CfgPath: string;
+  C: TConfig;
+begin
+  CfgPath := JoinPath(Home, 'config.json');
+
+  { Case 1: a "database" section loads into DatabaseJSON. }
+  WriteFileText(CfgPath,
+    '{"database":[{"name":"app","driver":"sqlite","database":"app.db","mode":"readonly"}]}');
+  C := LoadConfig('');
+  try
+    AssertTrue(Pos('"app"', C.DatabaseJSON) > 0, 'database section loaded into DatabaseJSON');
+    AssertTrue(Pos('sqlite', C.DatabaseJSON) > 0, 'driver present in DatabaseJSON');
+  finally
+    C.Free;
+  end;
+
+  { Case 2: absent section -> empty DatabaseJSON. }
+  WriteFileText(CfgPath, '{}');
+  C := LoadConfig('');
+  try
+    AssertEqS(C.DatabaseJSON, '', 'no database section -> empty');
+  finally
+    C.Free;
+  end;
+
+  { Case 3: round-trip -- a mutating SaveConfig must not drop the section. }
+  WriteFileText(CfgPath,
+    '{"database":[{"name":"reports","driver":"postgres","database":"rpt","mode":"readwrite"}]}');
+  C := LoadConfig('');
+  try
+    C.DefaultModel := 'claude-opus-4-8';   { an unrelated mutation }
+    SaveConfig(C);
+  finally
+    C.Free;
+  end;
+  C := LoadConfig('');
+  try
+    AssertTrue(Pos('"reports"', C.DatabaseJSON) > 0, 'database section survives save/load');
+    AssertTrue(Pos('postgres', C.DatabaseJSON) > 0, 'driver survives save/load');
+  finally
+    C.Free;
+  end;
+end;
+
 begin
   { PASCLAW_HOME is set by the Makefile target before launching --
     fpc doesn't ship fpSetenv on every supported version and setting
@@ -493,6 +542,7 @@ begin
     TestOptOutsPersistAcrossRoundTrip;
     TestSelfShadowInherit;
     TestDiffMaterial;
+    TestDatabaseSection;
     WriteLn('ok - config profile tests passed');
   finally
     try RemoveDir(JoinPath(Home, 'profiles')); except end;


### PR DESCRIPTION
Phase 2 makes the database tools (from #468) functional end-to-end: every engine is linked, and the `database` config section is read at each entry point.

## Engines

- **FPC** — link every sqldb connector: SQLite, PostgreSQL, MySQL 5.7/8.0, Firebird/Interbase, MSSQL, Oracle, ODBC. Each self-registers its `TSQLConnector` type, and the client library (libpq / libmysqlclient / libfbclient / FreeTDS / OCI / unixODBC) loads **lazily at connect time** — so one portable binary ships all engines and a missing lib only fails that one connection. Driver map gains `mysql8` / `mysql5` / `mariadb` aliases.
- **Delphi** — SQLite stays linked in every RAD Studio edition; the other FireDAC drivers are behind `-dPASCLAW_FIREDAC_FULL` (they require Enterprise/Architect), so the default build stays portable across editions.

## Config wiring

- `TConfig` gains `DatabaseJSON` — the raw `database` array kept verbatim on load and re-emitted on save (`PutRaw`), so a hand-edited connection list survives a mutating command's save/load round-trip (same pattern as the persisted `profile` field).
- Each chat surface installs the connections: `NewBuiltinRegistry` (CLI agent) takes an optional trailing `DBConfigJSON` and its three callers pass `Cfg.DatabaseJSON`; TUI / Gateway / Serve call `SetDBConfigFromJSON(Cfg.DatabaseJSON)` right after `RegisterSkills`. `SetDBConfig` is process-global, so one call per surface suffices.

Example `config.json`:
```json
{
  "database": [
    { "name": "app", "driver": "sqlite", "database": "workspace/app.db", "mode": "readonly", "max_rows": 500 }
  ]
}
```

## Tests

`config_profile_tests` gains `TestDatabaseSection`: the section loads into `DatabaseJSON`, is empty when absent, and **survives a `SaveConfig` round-trip** (an unrelated mutation must not drop it). `db_tools_tests` (from #468) still passes with all connectors linked.

## Verification
- `make all` links clean with every FPC connector linked.
- `make test-db-tools` → OK, `make test-config-profile` → OK.

## Notes
- **Delphi** compilation of the FireDAC branch (and `-dPASCLAW_FIREDAC_FULL`) needs a `dcc` build to confirm — I can only compile the FPC half here.
- Non-SQLite engines are wired but untested against a live server here (no Postgres/MySQL in the CI image); the lazy-load design means they activate when the client lib + server are present. Phase 3 (MCP-server projection) and Phase 4 (DeepSQL-style DBA layer) remain per `docs/database-tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_