### PR TITLE
Database tools Phase 3: PasClaw as a database MCP server

### DIFF
--- a/docs/database-tools.md
+++ b/docs/database-tools.md
@@ -77,14 +77,31 @@ Fields: `name`, `driver`, `database`, `server`, `port`, `user`, `password`,
 `params`, `mode`, `max_rows`, `timeout_ms`. Keep credentials out of the file with
 env substitution; `db_info` redacts the password on the way out.
 
+## PasClaw as a database MCP server
+
+With a `database` section configured, PasClaw projects the db tools out over MCP,
+so any MCP host (Claude Desktop, Cursor, Codex CLI) can query your databases
+through PasClaw:
+
+- **stdio:** `pasclaw mcp stdio` exposes `db_query` / `db_tables` / `db_describe`
+  / `db_info` (read-only). `--allow-write` additionally exposes `db_execute`
+  (still refused on a `readonly` connection). Point a host's MCP config at
+  `pasclaw mcp stdio` as the command.
+- **HTTP:** the gateway's `POST /mcp` route exposes the same tools from its
+  registry.
+
+Two safety layers apply: the MCP server only advertises `tcReadOnly` tools
+unless writes are allowed, and each tool still enforces the connection's mode.
+
 ## Roadmap
 
 - **Phase 1 (done)** — engine-agnostic seam + the five tools + safety model,
   SQLite backend on both toolchains.
 - **Phase 2 (done)** — link all FPC connectors (+ the `PASCLAW_FIREDAC_FULL`
   define for Delphi); wire the `database` config section at each entry point.
-- **Phase 3** — project the native tools out through PasClaw's MCP server, so
-  PasClaw itself is a cross-platform database MCP server.
+- **Phase 3 (done)** — project the native tools out through PasClaw's MCP server
+  (stdio + HTTP `/mcp`), so PasClaw itself is a cross-platform database MCP
+  server.
 - **Phase 4** — a DeepSQL-style "DBA" layer: schema/stat indexing into the KB,
   a plain-English business glossary in memory facts, and a cron+workflow that
   ranks slow queries and proposes indexes.

--- a/src/cmd/PasClaw.Cmd.MCP.pas
+++ b/src/cmd/PasClaw.Cmd.MCP.pas
@@ -24,9 +24,11 @@ uses
   PasClaw.MCP.Hub,
   PasClaw.MCP.OAuth,
   PasClaw.MCP.Server,
+  PasClaw.Logger,
   PasClaw.Tools.Registry,
   PasClaw.Tools.Memory,
   PasClaw.Tools.KB,
+  PasClaw.Tools.DB,
   PasClaw.Tools.SessionSearch;
 
 procedure Help;
@@ -46,11 +48,15 @@ begin
   PrintLn('                            MCP server (opens browser, captures callback)');
   PrintLn('  stdio [--allow-write]     run PasClaw as an MCP server over stdio.');
   PrintLn('                            Exposes memory_search / kb_search /');
-  PrintLn('                            session_search (SCARS lives in workspace/memory)');
-  PrintLn('                            to any host that spawns MCP servers as');
+  PrintLn('                            session_search (SCARS lives in workspace/memory),');
+  PrintLn('                            plus db_query / db_tables / db_describe / db_info');
+  PrintLn('                            when a "database" section is configured -- so');
+  PrintLn('                            PasClaw acts as a database MCP server too.');
+  PrintLn('                            To any host that spawns MCP servers as');
   PrintLn('                            subprocesses (Claude Desktop, Cursor, Codex CLI).');
   PrintLn('                            Read-only by default; --allow-write opts in to');
-  PrintLn('                            mutating tools.');
+  PrintLn('                            mutating tools (incl. db_execute, still refused');
+  PrintLn('                            on a readonly connection).');
 end;
 
 function DoList: Integer;
@@ -547,17 +553,22 @@ function DoStdio(const Argv: array of string): Integer;
   errors) so the host keeps the session alive. Logs go to stderr only --
   stdout MUST stay clean JSON-RPC, otherwise the host's parser bails.
 
-  Tool surface: same read-only slice as the HTTP /mcp route --
-  memory_search / memory_get / kb_search / kb_get / session_search.
-  SCARS lives inside workspace/memory/SCARS.md so it's reachable
-  through memory_search; no separate "scars" tool to maintain.
+  Tool surface: the read-only slice of the HTTP /mcp route --
+  memory_search / memory_get / kb_search / kb_get / session_search --
+  plus the db_* tools when a "database" section is configured, which turns
+  PasClaw into a cross-platform database MCP server (db_info / db_tables /
+  db_describe / db_query read-only; db_execute only under --allow-write, and
+  still refused on a readonly connection). SCARS lives inside
+  workspace/memory/SCARS.md so it's reachable through memory_search; no
+  separate "scars" tool to maintain.
   --allow-write also exposes the mutating tools (off by default). }
 var
-  i: Integer;
+  i, NDb: Integer;
   AllowWrite: Boolean;
   Reg: TToolRegistry;
   Srv: TMCPServerCore;
-  Line, Resp: string;
+  Cfg: TConfig;
+  Line, Resp, WriteNote: string;
 begin
   AllowWrite := False;
   for i := 1 to High(Argv) do
@@ -576,6 +587,23 @@ begin
     RegisterMemoryTools(Reg);
     RegisterKBTools(Reg);
     RegisterSessionSearchTool(Reg);
+    { Database tools -- only when the operator configured a "database" section,
+      so a host without one never sees always-erroring db_* tools. Registered
+      here (not via RegisterSkills) to keep the tight, hand-picked surface. The
+      read tools auto-expose (tcReadOnly); db_execute needs --allow-write AND a
+      non-readonly connection. Logs to stderr; stdout stays clean JSON-RPC. }
+    Cfg := LoadConfig;
+    try
+      if Trim(Cfg.DatabaseJSON) <> '' then
+      begin
+        RegisterDBTools(Reg);
+        NDb := SetDBConfigFromJSON(Cfg.DatabaseJSON);
+        if AllowWrite then WriteNote := ' (writes allowed)' else WriteNote := ' (read-only)';
+        LogInfo('mcp stdio: exposing db_* tools for %d connection(s)%s', [NDb, WriteNote]);
+      end;
+    finally
+      Cfg.Free;
+    end;
     Srv := TMCPServerCore.Create(Reg, AllowWrite, '');
     try
       while not Eof(Input) do

--- a/src/pkg/db/PasClaw.DB.pas
+++ b/src/pkg/db/PasClaw.DB.pas
@@ -267,17 +267,38 @@ begin
   end;
 end;
 
-{ Given cleaned SQL that starts with WITH, return the MAIN statement's verb (the
-  statement that follows all CTE definitions). Empty string if the CTE list
-  can't be parsed -- the caller then refuses to certify it as read-only. }
-function ResolveWithVerb(const Clean: string): string;
-var
-  i, save: Integer;
-  w: string;
+{ Danger ordering, so the classifier can pick the WORST kind found across a
+  compound statement (a CTE body + the main statement). Read is safest;
+  anything else disqualifies a statement from db_query. }
+function Severity(K: TSQLKind): Integer;
 begin
-  Result := '';
+  case K of
+    skDDL:   Result := 3;
+    skDML:   Result := 2;
+    skOther: Result := 1;
+  else       Result := 0;   { skReadOnly / skEmpty }
+  end;
+end;
+
+{ Classify a comment/literal-stripped query-expression string. Mutually
+  recursive with ClassifyWithBodies so a CTE body that is itself a WITH is
+  inspected too. FirstWord reports the verb that determined the kind. }
+function ClassifyQueryExpr(const S: string; out FirstWord: string): TSQLKind; forward;
+
+{ A WITH statement is read-only ONLY when every CTE body AND the main statement
+  are reads. PostgreSQL data-modifying CTEs -- "WITH d AS (DELETE FROM t
+  RETURNING *) SELECT * FROM d" -- mutate inside the CTE while the main verb is
+  SELECT, so the body verbs must be classified too. Returns the WORST kind found
+  (skOther on an unparseable CTE list, so it is never certified read-only). }
+function ClassifyWithBodies(const Clean: string; out FirstWord: string): TSQLKind;
+var
+  i, save, bodyStart, bodyLen: Integer;
+  w, subVerb, worstVerb: string;
+  worst, k: TSQLKind;
+begin
+  worst := skReadOnly; worstVerb := 'WITH';
   i := 1;
-  if ReadWord(Clean, i) <> 'WITH' then Exit;
+  if ReadWord(Clean, i) <> 'WITH' then begin FirstWord := 'WITH'; Exit(skOther); end;
   save := i;
   if ReadWord(Clean, i) <> 'RECURSIVE' then i := save;   { optional }
   while True do
@@ -285,88 +306,98 @@ begin
     ReadWord(Clean, i);                 { CTE name }
     SkipWS(Clean, i);
     if (i <= Length(Clean)) and (Clean[i] = '(') then    { optional (col,...) }
-      if not SkipParenGroup(Clean, i) then Exit;
-    if ReadWord(Clean, i) <> 'AS' then Exit;             { malformed }
+      if not SkipParenGroup(Clean, i) then begin FirstWord := 'WITH'; Exit(skOther); end;
+    if ReadWord(Clean, i) <> 'AS' then begin FirstWord := 'WITH'; Exit(skOther); end;
     save := i;                                           { optional [NOT] MATERIALIZED }
     w := ReadWord(Clean, i);
     if w = 'NOT' then ReadWord(Clean, i)
     else if w <> 'MATERIALIZED' then i := save;
     SkipWS(Clean, i);
-    if (i > Length(Clean)) or (Clean[i] <> '(') then Exit;
-    if not SkipParenGroup(Clean, i) then Exit;           { the CTE body }
+    if (i > Length(Clean)) or (Clean[i] <> '(') then begin FirstWord := 'WITH'; Exit(skOther); end;
+    { classify the CTE body's own statement before skipping past it }
+    bodyStart := i + 1;
+    if not SkipParenGroup(Clean, i) then begin FirstWord := 'WITH'; Exit(skOther); end;
+    bodyLen := (i - 1) - bodyStart;     { inside the parens, excluding ')' }
+    k := ClassifyQueryExpr(Copy(Clean, bodyStart, bodyLen), subVerb);
+    if Severity(k) > Severity(worst) then begin worst := k; worstVerb := subVerb; end;
     SkipWS(Clean, i);
     if (i <= Length(Clean)) and (Clean[i] = ',') then    { another CTE follows }
     begin Inc(i); Continue; end;
     Break;
   end;
-  Result := ReadWord(Clean, i);          { the main statement's verb }
+  { the main statement after the CTE list }
+  k := ClassifyQueryExpr(Copy(Clean, i, MaxInt), w);
+  if Severity(k) >= Severity(worst) then begin worst := k; worstVerb := w; end;
+  FirstWord := worstVerb;
+  Result := worst;
 end;
 
-{ EXPLAIN by itself only plans and is read-only. But "EXPLAIN ANALYZE <stmt>"
-  (PostgreSQL) actually EXECUTES the statement, so its safety is the inner
-  statement's. Return the effective verb: EXPLAIN when it's a plain plan, else
-  the executed inner verb. }
-function ResolveExplainVerb(const Clean: string): string;
+function ClassifyQueryExpr(const S: string; out FirstWord: string): TSQLKind;
+var Clean: string;
+begin
+  Clean := Trim(S);
+  FirstWord := LeadingWord(Clean);
+  if FirstWord = '' then Exit(skEmpty);
+  if FirstWord = 'WITH' then Exit(ClassifyWithBodies(Clean, FirstWord));
+  if FirstWord = 'PRAGMA' then
+  begin
+    if Pos('=', Clean) > 0 then Exit(skOther) else Exit(skReadOnly);
+  end;
+  Result := KindOfVerb(FirstWord);
+end;
+
+{ EXPLAIN by itself only plans (read-only). "EXPLAIN ANALYZE <stmt>" /
+  "EXPLAIN (ANALYZE) <stmt>" actually EXECUTE on PostgreSQL. Returns True (with
+  InnerStart at the executed statement) when ANALYZE is present. }
+function ExplainAnalyzeInner(const Clean: string; out InnerStart: Integer): Boolean;
 var
   i, save: Integer;
   w: string;
-  Analyze: Boolean;
 begin
+  Result := False;
+  InnerStart := 0;
   i := 1;
-  if ReadWord(Clean, i) <> 'EXPLAIN' then Exit('EXPLAIN');
-  Analyze := False;
-  { consume EXPLAIN options: ANALYZE, VERBOSE, QUERY PLAN, or a (...) option list }
+  if ReadWord(Clean, i) <> 'EXPLAIN' then Exit;
   while True do
   begin
     SkipWS(Clean, i);
     if (i <= Length(Clean)) and (Clean[i] = '(') then
     begin
-      { "EXPLAIN (ANALYZE, ...) stmt" -- ANALYZE inside the option list counts }
       save := i;
       if not SkipParenGroup(Clean, i) then Break;
-      if Pos('ANALYZE', UpperCase(Copy(Clean, save, i - save))) > 0 then Analyze := True;
+      if Pos('ANALYZE', UpperCase(Copy(Clean, save, i - save))) > 0 then Result := True;
       Continue;
     end;
     save := i;
     w := ReadWord(Clean, i);
-    if w = 'ANALYZE' then begin Analyze := True; Continue; end;
+    if w = 'ANALYZE' then begin Result := True; Continue; end;
     if (w = 'VERBOSE') or (w = 'QUERY') or (w = 'PLAN') then Continue;
-    i := save; Break;   { not an option keyword -> the inner statement starts }
+    i := save; Break;   { the inner statement starts here }
   end;
-  if not Analyze then Exit('EXPLAIN');   { plain plan -> read-only }
-  w := ReadWord(Clean, i);               { inner statement verb executes }
-  if w = 'WITH' then w := ResolveWithVerb(Copy(Clean, i - Length(w), MaxInt));
-  if w = '' then Exit('');               { unparseable -> caller refuses }
-  Result := w;
+  InnerStart := i;
 end;
 
 function ClassifySQL(const SQL: string; out FirstWord: string): TSQLKind;
 var
-  Clean, Verb: string;
+  Clean: string;
+  InnerStart: Integer;
 begin
   Clean := Trim(StripSQLNoise(SQL));
   FirstWord := LeadingWord(Clean);
   if FirstWord = '' then Exit(skEmpty);
 
-  { A WITH (CTE) statement is read-only only if its MAIN statement is a read:
-    "WITH c AS (SELECT 1) DELETE FROM t RETURNING *" is a WRITE. Resolve the
-    verb the CTE actually runs; an unparseable CTE is not certified read-only. }
+  { WITH: read-only only if every CTE body AND the main statement read. }
   if FirstWord = 'WITH' then
-  begin
-    Verb := ResolveWithVerb(Clean);
-    if Verb = '' then begin FirstWord := 'WITH'; Exit(skOther); end;
-    FirstWord := Verb;
-    Exit(KindOfVerb(Verb));
-  end;
+    Exit(ClassifyWithBodies(Clean, FirstWord));
 
-  { EXPLAIN plans (read-only) unless it's EXPLAIN ANALYZE, which executes. }
+  { EXPLAIN plans (read-only) unless EXPLAIN ANALYZE, which executes the inner
+    statement -- classify by that (incl. its CTE bodies). }
   if FirstWord = 'EXPLAIN' then
   begin
-    Verb := ResolveExplainVerb(Clean);
-    if Verb = '' then begin FirstWord := 'EXPLAIN'; Exit(skOther); end;
-    if Verb = 'EXPLAIN' then Exit(skReadOnly);
-    FirstWord := Verb;
-    Exit(KindOfVerb(Verb));
+    if not ExplainAnalyzeInner(Clean, InnerStart) then Exit(skReadOnly);
+    Result := ClassifyQueryExpr(Copy(Clean, InnerStart, MaxInt), FirstWord);
+    if Result = skEmpty then begin FirstWord := 'EXPLAIN'; Result := skReadOnly; end;
+    Exit;
   end;
 
   { PRAGMA is read-only only in its "PRAGMA name;" form; "PRAGMA name = value"

--- a/src/tests/db_tools_tests.pas
+++ b/src/tests/db_tools_tests.pas
@@ -85,6 +85,17 @@ begin
   Check(ClassifySQL('WITH a AS (SELECT 1), b AS (SELECT 2) UPDATE t SET x=1', w) = skDML,
     'classify: multi-CTE ..UPDATE is write');
   Check(ClassifySQL('WITH c AS (SELECT 1) UPDATE t SET x=1', w) <> skReadOnly, 'classify: WITH..UPDATE not read');
+  { data-modifying CTE bodies: the mutation is INSIDE the CTE, main verb is SELECT }
+  Check(ClassifySQL('WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d', w) = skDML,
+    'classify: data-modifying CTE (DELETE body) is a write');
+  Check(ClassifySQL('WITH d AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM d', w) = skDML,
+    'classify: data-modifying CTE (INSERT body) is a write');
+  Check(ClassifySQL('WITH a AS (SELECT 1), b AS (UPDATE t SET x=1 RETURNING *) SELECT * FROM b', w) = skDML,
+    'classify: data-modifying CTE among reads is a write');
+  Check(ClassifySQL('WITH d AS (SELECT 1) SELECT * FROM d', w) = skReadOnly,
+    'classify: all-read CTE stays read');
+  Check(ClassifySQL('EXPLAIN ANALYZE WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d', w) = skDML,
+    'classify: EXPLAIN ANALYZE + data-modifying CTE is a write');
   { EXPLAIN plans (read); EXPLAIN ANALYZE executes -> classify by inner stmt. }
   Check(ClassifySQL('EXPLAIN SELECT 1', w) = skReadOnly, 'classify: EXPLAIN plan is read');
   Check(ClassifySQL('EXPLAIN ANALYZE DELETE FROM t', w) = skDML, 'classify: EXPLAIN ANALYZE DELETE is write');
@@ -167,9 +178,12 @@ begin
     { db_query refuses a writable CTE (the readonly-bypass this hardening fixes) }
     Res := Reg.RunTool('db_query', '{"sql":"WITH c AS (SELECT 1) DELETE FROM t"}', Err);
     Check(Err <> '', 'query: refuses writable CTE (WITH..DELETE)');
-    { and the rows are still there afterwards }
+    { and a data-modifying CTE whose MAIN verb is SELECT is refused too }
+    Res := Reg.RunTool('db_query', '{"sql":"WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d"}', Err);
+    Check(Err <> '', 'query: refuses data-modifying CTE (DELETE body, SELECT main)');
+    { rows must still be there -- neither refused statement ran }
     Res := Reg.RunTool('db_query', '{"sql":"SELECT COUNT(*) AS n FROM t"}', Err);
-    Check(HasSub(Res, '"n":2'), 'query: writable CTE did not delete rows (got ' + Res + ')');
+    Check(HasSub(Res, '"n":2'), 'query: refused CTEs did not delete rows (got ' + Res + ')');
 
     { db_tables + db_describe }
     Res := Reg.RunTool('db_tables', '{}', Err);

--- a/src/tests/mcp_server_tests.pas
+++ b/src/tests/mcp_server_tests.pas
@@ -39,6 +39,7 @@ uses
   PasClaw.JSON,
   PasClaw.Tools.Types,
   PasClaw.Tools.Registry,
+  PasClaw.Tools.DB,        { Phase 3: db_* tools projected over MCP }
   PasClaw.MCP.Server;
 
 procedure Fail_(const Msg: string);
@@ -491,6 +492,65 @@ begin
   end;
 end;
 
+(* Phase 3: PasClaw as a database MCP server. With a "database" connection
+   configured, the db_* read tools project through the server core (tcReadOnly
+   auto-exposed), db_execute stays hidden until --allow-write, and a tools/call
+   into db_query returns real rows -- the whole point of the projection. *)
+procedure TestDatabaseToolsProjected;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp, Err, DbPath: string;
+begin
+  DbPath := IncludeTrailingPathDelimiter(GetTempDir(False)) + 'pasclaw_mcp_db_test.db';
+  if FileExists(DbPath) then DeleteFile(DbPath);
+  { full-mode SQLite connection so we can seed; path JSON-escaped for Windows }
+  SetDBConfigFromJSON('[{"name":"main","driver":"sqlite","database":"' +
+    StringReplace(DbPath, '\', '\\', [rfReplaceAll]) + '","mode":"full"}]');
+  Reg := TToolRegistry.Create;
+  try
+    RegisterDBTools(Reg);
+    { seed a table + row directly through the registry (not via MCP) }
+    Reg.RunTool('db_execute', '{"sql":"CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"}', Err);
+    AssertEqStr(Err, '', 'seed: create table');
+    Reg.RunTool('db_execute', '{"sql":"INSERT INTO t (id,name) VALUES (1,''alice'')"}', Err);
+    AssertEqStr(Err, '', 'seed: insert row');
+
+    { read-only server (default): db read tools exposed, db_execute hidden }
+    Srv := TMCPServerCore.Create(Reg, False, '');
+    try
+      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+      AssertContains(Resp, '"name":"db_query"',    'db_query projected over MCP');
+      AssertContains(Resp, '"name":"db_tables"',   'db_tables projected');
+      AssertContains(Resp, '"name":"db_describe"', 'db_describe projected');
+      AssertContains(Resp, '"name":"db_info"',     'db_info projected');
+      AssertNotContains(Resp, '"name":"db_execute"',
+                        'db_execute hidden without --allow-write');
+
+      { a tools/call into db_query returns the real row }
+      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":2,"method":"tools/call",' +
+        '"params":{"name":"db_query","arguments":{"sql":"SELECT name FROM t WHERE id=1"}}}');
+      AssertContains(Resp, 'alice', 'db_query over MCP returns the row');
+      AssertNotContains(Resp, '"isError":true', 'db_query happy path is not an error');
+    finally
+      Srv.Free;
+    end;
+
+    { --allow-write: db_execute now exposed (still mode-gated inside the tool) }
+    Srv := TMCPServerCore.Create(Reg, True, '');
+    try
+      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":3,"method":"tools/list"}');
+      AssertContains(Resp, '"name":"db_execute"', 'db_execute exposed under --allow-write');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+    SetDBConfigFromJSON('');   { reset the process-global connection set }
+    if FileExists(DbPath) then DeleteFile(DbPath);
+  end;
+end;
+
 begin
   TestInitializeRoundTrip;                  WriteLn('  ok: initialize');
   TestInitializedNotificationHasNoResponse; WriteLn('  ok: initialized notification (no response)');
@@ -505,5 +565,6 @@ begin
   TestAllowListNarrowsSurface;              WriteLn('  ok: allowlist narrows surface');
   TestIdNestedInParamsDoesNotConfuseEcho;   WriteLn('  ok: id-in-params does not leak into echo');
   TestPingRoundTrip;                        WriteLn('  ok: ping round-trip');
+  TestDatabaseToolsProjected;               WriteLn('  ok: db_* tools projected over MCP');
   WriteLn('PASS');
 end.


### PR DESCRIPTION
Phase 3 projects the db tools (from #468/#469) out over MCP, so any MCP host — Claude Desktop, Cursor, Codex CLI — can query your databases through PasClaw. This is the TMS product shape, but cross-platform (our Linux x64/ARM64 tarballs) and driven by the same config.

## What changed

The pleasant surprise: `TMCPServerCore` already auto-exposes any `tcReadOnly` tool in its registry, so most of this was already latent — the work was configuring connections at the MCP entry point and scoping the surface.

- **stdio (`pasclaw mcp stdio`)** — `DoStdio` now loads config and, **only when a `database` section is configured**, registers the db tools and installs the connections. So a host without a database never sees always-erroring `db_*` tools. Exposure:
  - `db_query` / `db_tables` / `db_describe` / `db_info` — read-only, exposed by default.
  - `db_execute` — needs `--allow-write` **and** is still refused on a `readonly` connection.
- **HTTP (`POST /mcp`)** — serves from the same registry Phase 2 already registered + configured, so it exposes the db tools for free (no new code).

**Two safety layers** stack: the MCP server advertises only `tcReadOnly` tools unless writes are allowed, and each tool still enforces the per-connection mode. So even `--allow-write` against a `readonly` connection can't mutate.

Point a host's MCP config at `pasclaw mcp stdio` as the command and you have a database MCP server.

## Tests

`mcp_server_tests` gains `TestDatabaseToolsProjected`: seeds a real SQLite table, then asserts the read tools list over MCP, `db_execute` is **hidden** without `--allow-write` (and shown with it), and a `tools/call` into `db_query` returns the actual row. → `ok: db_* tools projected over MCP`.

## Verification
- `make all` links clean.
- `make test-mcp-server` → all pass incl. the new case; `make test-db-tools` → OK.

## Notes
- No Delphi-specific code here — this is all in the shared MCP/command layer, so no `dcc` caveat this time.
- The stdio server runs without a chat provider (it just exposes corpora + databases), so it's a lightweight always-available surface.

That leaves **Phase 4** — the DeepSQL-style "DBA" layer (schema/stat indexing into the KB, a plain-English business glossary in memory facts, and a cron+workflow that ranks slow queries and proposes indexes) — per `docs/database-tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_