### PR TITLE
Database tools Phase 4: DBA layer (db_schema + db_explain index advisor)

### DIFF
--- a/docs/database-tools.md
+++ b/docs/database-tools.md
@@ -31,6 +31,8 @@ Canonical `driver` ids: `sqlite`, `postgres`, `mysql` (or `mysql8`, `mariadb`),
 | `db_describe` | read-only | columns of a table: name, type, size, nullable |
 | `db_query` | read-only | run ONE read statement (`SELECT`/`WITH`/`EXPLAIN`) with `:name` params |
 | `db_execute` | mutating | run ONE write (`INSERT`/`UPDATE`/`DELETE`; DDL in `full` mode) |
+| `db_schema` | read-only | schema digest: every table with columns + row counts (grounding for NL→SQL) |
+| `db_explain` | read-only | plan a query (without running it) + flag full table scans + index hint |
 
 All tools take an optional `connection` argument to select a named connection;
 omit it for the first (default) one.
@@ -93,6 +95,46 @@ through PasClaw:
 Two safety layers apply: the MCP server only advertises `tcReadOnly` tools
 unless writes are allowed, and each tool still enforces the connection's mode.
 
+## DBA layer
+
+The `db_schema` / `db_explain` tools plus PasClaw's existing memory, KB, workflow
+and cron machinery compose into a lightweight "always-on DBA" — the DeepSQL idea,
+built from parts you already have:
+
+- **Ground NL→SQL in the real schema.** `db_schema` returns each table's columns
+  and row counts. Read it before writing queries; the agent can also persist the
+  digest into the knowledgebase (`workspace/kb`) so `kb_search` recalls it.
+- **Teach business rules in plain English.** Store definitions with the memory
+  tools — "MRR = sum(amount) where status='active'", "a hotel is *active* when
+  `deleted_at is null`" — and they persist across sessions and surface via
+  `memory_search`, so later queries use your vocabulary.
+- **Optimize slow queries.** `db_explain` plans a query without running it,
+  flags full table scans in `full_scans`, and hints at an index. Apply the index
+  (with `db_execute` on a `full`-mode connection), then re-run `db_explain` to
+  confirm the plan switched to `SEARCH … USING INDEX`.
+- **Automate it.** Wrap the loop in a saved workflow and put it on a cron: pull
+  slow statements (e.g. Postgres `pg_stat_statements`) with `db_query`, run each
+  through `db_explain`, and post the ranked findings + proposed indexes to a
+  channel. For example:
+
+  ```json
+  {
+    "name": "slow_query_audit",
+    "inputs": [{ "name": "min_ms", "type": "number" }],
+    "nodes": [
+      { "id": "slow", "tool": "db_query", "args": {
+          "sql": "SELECT query, mean_exec_time FROM pg_stat_statements WHERE mean_exec_time > :ms ORDER BY mean_exec_time DESC LIMIT 10",
+          "params": { "ms": "{{inputs.min_ms}}" } } },
+      { "id": "advise", "tool": "llm", "args": {
+          "provider": "anthropic",
+          "prompt": "For each slow query below, call db_explain and propose an index. {{nodes.slow}}" } }
+    ]
+  }
+  ```
+
+`db_schema` and `db_explain` are read-only, so they project over MCP too — an
+external host gets schema grounding and query-plan analysis for free.
+
 ## Roadmap
 
 - **Phase 1 (done)** — engine-agnostic seam + the five tools + safety model,
@@ -102,6 +144,6 @@ unless writes are allowed, and each tool still enforces the connection's mode.
 - **Phase 3 (done)** — project the native tools out through PasClaw's MCP server
   (stdio + HTTP `/mcp`), so PasClaw itself is a cross-platform database MCP
   server.
-- **Phase 4** — a DeepSQL-style "DBA" layer: schema/stat indexing into the KB,
-  a plain-English business glossary in memory facts, and a cron+workflow that
-  ranks slow queries and proposes indexes.
+- **Phase 4 (done)** — the DBA layer: `db_schema` (schema/stat digest) and
+  `db_explain` (query-plan + full-scan/index advisor), composing with memory
+  facts (business glossary) and workflow+cron (slow-query audit) as above.

--- a/src/pkg/tools/PasClaw.Tools.DB.pas
+++ b/src/pkg/tools/PasClaw.Tools.DB.pas
@@ -53,7 +53,7 @@ procedure RegisterDBTools(Reg: TToolRegistry);
 implementation
 
 uses
-  SysUtils,
+  SysUtils, Classes,
   PasClaw.JSON,
   PasClaw.Tools.Types;
 
@@ -342,6 +342,224 @@ begin
   end;
 end;
 
+{ ---- Phase 4: DBA layer (schema digest + query-plan / index advisor) ---- }
+
+{ SELECT COUNT(*) for a table via the read path; -1 on any error (view without
+  count support, permission, etc.). Table is identifier-validated by the caller. }
+function CountRows(Conn: IDBConnection; const Table: string): Int64;
+var
+  RowsJSON, Err: string;
+  RC: Integer;
+  Trunc: Boolean;
+  Arr: TJsonArray;
+  O: TJsonObject;
+begin
+  Result := -1;
+  if not Conn.Query('SELECT COUNT(*) AS n FROM ' + Table, '', 1, RowsJSON, RC, Trunc, Err) then Exit;
+  try Arr := TJsonArray.Parse(RowsJSON); except Arr := nil; end;
+  if Arr = nil then Exit;
+  try
+    if Arr.Count > 0 then
+    begin
+      O := Arr.ItemObject(0);
+      if O <> nil then try Result := O.GetInt('n', -1); finally O.Free; end;
+    end;
+  finally
+    Arr.Free;
+  end;
+end;
+
+{ SQLite plans read-only via "EXPLAIN QUERY PLAN"; other engines use "EXPLAIN". }
+function ExplainPrefix(const Driver: string): string;
+var D: string;
+begin
+  D := LowerCase(Trim(Driver));
+  if (D = 'sqlite') or (D = 'sqlite3') then Result := 'EXPLAIN QUERY PLAN '
+  else Result := 'EXPLAIN ';
+end;
+
+{ Pull table names from a SQLite EXPLAIN QUERY PLAN "detail" that is a full table
+  SCAN (no index). "SCAN t" => full scan; "SEARCH t USING INDEX" and
+  "SCAN t USING COVERING INDEX" are indexed and ignored. Appends to Scans. }
+procedure CollectFullScan(const Detail: string; Scans: TStringList);
+
+  { read the identifier at position i (letters/digits/underscore), advancing i }
+  function WordAt(var i: Integer): string;
+  begin
+    Result := '';
+    while (i <= Length(Detail)) and (Detail[i] = ' ') do Inc(i);
+    while (i <= Length(Detail)) and
+          (((Detail[i] >= 'A') and (Detail[i] <= 'Z')) or
+           ((Detail[i] >= 'a') and (Detail[i] <= 'z')) or
+           ((Detail[i] >= '0') and (Detail[i] <= '9')) or (Detail[i] = '_')) do
+    begin Result := Result + Detail[i]; Inc(i); end;
+  end;
+
+var U, Tbl: string; p, i: Integer;
+begin
+  U := UpperCase(Detail);
+  p := Pos('SCAN ', U);
+  if p = 0 then Exit;
+  if Pos('USING', U) > 0 then Exit;   { covering/secondary index -- not a full scan }
+  i := p + 5;
+  Tbl := WordAt(i);
+  { older SQLite says "SCAN TABLE t", newer just "SCAN t" -- skip the keyword }
+  if UpperCase(Tbl) = 'TABLE' then Tbl := WordAt(i);
+  if (Tbl <> '') and (Scans.IndexOf(Tbl) < 0) then Scans.Add(Tbl);
+end;
+
+function ToolDBSchema(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Cfg: TDBConn;
+  ConnName, OneTable, Err, ListJSON, ColsJSON: string;
+  WithCounts: Boolean;
+  Conn: IDBConnection;
+  Root, TblObj: TJsonObject;
+  Tables: TJsonArray;
+  Names: TStringList;
+  ListArr: TJsonArray;
+  i, Cap: Integer;
+  RC: Int64;
+begin
+  ErrMsg := '';
+  ConnName   := JsonReadStr(ArgsJSON, 'connection', '');
+  OneTable   := JsonReadStr(ArgsJSON, 'table', '');
+  WithCounts := JsonReadBool(ArgsJSON, 'with_row_counts', True);
+  if not PickConn(ConnName, Cfg, ErrMsg) then Exit('');
+
+  Conn := NewDBConnection;
+  if not Conn.Open(Cfg, Err) then begin ErrMsg := 'db_schema: ' + Err; Exit(''); end;
+  Names := TStringList.Create;
+  try
+    if Trim(OneTable) <> '' then
+      Names.Add(OneTable)
+    else
+    begin
+      if not Conn.ListTables(ListJSON, Err) then
+      begin ErrMsg := 'db_schema: ' + Err; Exit(''); end;
+      try ListArr := TJsonArray.Parse(ListJSON); except ListArr := nil; end;
+      if ListArr <> nil then
+      try
+        for i := 0 to ListArr.Count - 1 do Names.Add(ListArr.ItemStr(i, ''));
+      finally
+        ListArr.Free;
+      end;
+    end;
+
+    Root := TJsonObject.Create;
+    try
+      Root.PutStr('database', Cfg.Name);
+      Root.PutStr('driver', Cfg.Driver);
+      Tables := TJsonArray.Create;
+      Cap := 200;   { keep the digest bounded for large schemas }
+      for i := 0 to Names.Count - 1 do
+      begin
+        if i >= Cap then Break;
+        if Trim(Names[i]) = '' then Continue;
+        TblObj := TJsonObject.Create;
+        TblObj.PutStr('name', Names[i]);
+        if Conn.DescribeTable(Names[i], ColsJSON, Err) then
+          TblObj.PutRaw('columns', ColsJSON)
+        else
+          TblObj.PutRaw('columns', '[]');
+        if WithCounts and IsSafeIdentifier(Names[i]) then
+        begin
+          RC := CountRows(Conn, Names[i]);
+          if RC >= 0 then TblObj.PutInt('row_count', RC);
+        end;
+        Tables.AddObject(TblObj);
+      end;
+      Root.PutArray('tables', Tables);
+      if Names.Count > Cap then
+        Root.PutStr('note', Format('showing first %d of %d tables', [Cap, Names.Count]));
+      Result := Root.ToJSON;
+    finally
+      Root.Free;
+    end;
+  finally
+    Names.Free;
+    Conn.Close;
+  end;
+end;
+
+function ToolDBExplain(const ArgsJSON: string; out ErrMsg: string): string;
+var
+  Cfg: TDBConn;
+  ConnName, SQL, ParamsJSON, Err, PlanJSON: string;
+  Conn: IDBConnection;
+  Root, O: TJsonObject;
+  Plan: TJsonArray;
+  Scans: TStringList;
+  ScanArr: TJsonArray;
+  RC, i, k: Integer;
+  Trunc: Boolean;
+  Keys: TStringList;
+begin
+  ErrMsg := '';
+  ParseCommon(ArgsJSON, ConnName, SQL, ParamsJSON);
+  if Trim(SQL) = '' then begin ErrMsg := 'db_explain: "sql" is required'; Exit(''); end;
+  if not PickConn(ConnName, Cfg, ErrMsg) then Exit('');
+  if SQLHasMultipleStatements(SQL) then
+  begin ErrMsg := 'db_explain: one statement per call'; Exit(''); end;
+
+  Conn := NewDBConnection;
+  if not Conn.Open(Cfg, Err) then begin ErrMsg := 'db_explain: ' + Err; Exit(''); end;
+  Scans := TStringList.Create;
+  try
+    { EXPLAIN / EXPLAIN QUERY PLAN only PLANS -- it never executes the statement,
+      so this is read-only regardless of the query's verb. }
+    if not Conn.Query(ExplainPrefix(Cfg.Driver) + SQL, ParamsJSON, 500,
+                      PlanJSON, RC, Trunc, Err) then
+    begin ErrMsg := 'db_explain: ' + Err; Exit(''); end;
+
+    { Heuristic full-scan detection (SQLite plan "detail" strings). Scan every
+      string field of every plan row so it's tolerant of column-name shape. }
+    try Plan := TJsonArray.Parse(PlanJSON); except Plan := nil; end;
+    if Plan <> nil then
+    try
+      for i := 0 to Plan.Count - 1 do
+      begin
+        O := Plan.ItemObject(i);
+        if O = nil then Continue;
+        try
+          Keys := O.Keys;
+          try
+            for k := 0 to Keys.Count - 1 do
+              CollectFullScan(O.GetStr(Keys[k], ''), Scans);
+          finally
+            Keys.Free;
+          end;
+        finally
+          O.Free;
+        end;
+      end;
+    finally
+      Plan.Free;
+    end;
+
+    Root := TJsonObject.Create;
+    try
+      Root.PutBool('ok', True);
+      Root.PutRaw('plan', PlanJSON);
+      ScanArr := TJsonArray.Create;
+      for i := 0 to Scans.Count - 1 do ScanArr.AddStr(Scans[i]);
+      Root.PutArray('full_scans', ScanArr);
+      if Scans.Count > 0 then
+        Root.PutStr('hint',
+          'full table scan on: ' + Scans.CommaText +
+          ' -- consider an index on the WHERE / JOIN / ORDER BY columns for ' +
+          'those tables, then re-run db_explain to confirm the plan switches to ' +
+          'a SEARCH ... USING INDEX.');
+      Result := Root.ToJSON;
+    finally
+      Root.Free;
+    end;
+  finally
+    Scans.Free;
+    Conn.Close;
+  end;
+end;
+
 const
   CONN_ARG =
     '"connection":{"type":"string","description":"configured connection name; ' +
@@ -366,6 +584,16 @@ const
     '{"type":"object","properties":{' + CONN_ARG + ',' +
     '"sql":{"type":"string","description":"a single write statement (INSERT/UPDATE/DELETE); ' +
       'DDL requires a full-mode connection. Use :name placeholders + params."},' +
+    '"params":{"type":"object","description":"values for :name placeholders"}' +
+    '},"required":["sql"]}';
+  SCHEMA_SCHEMA =
+    '{"type":"object","properties":{' + CONN_ARG + ',' +
+    '"table":{"type":"string","description":"limit to one table (optionally schema.table); omit for the whole schema"},' +
+    '"with_row_counts":{"type":"boolean","description":"include per-table row counts (default true)"}' +
+    '}}';
+  EXPLAIN_SCHEMA =
+    '{"type":"object","properties":{' + CONN_ARG + ',' +
+    '"sql":{"type":"string","description":"the query to analyze. It is PLANNED, not run."},' +
     '"params":{"type":"object","description":"values for :name placeholders"}' +
     '},"required":["sql"]}';
 
@@ -416,6 +644,21 @@ begin
     'connection) and return the affected row count. Refused on a readonly ' +
     'connection. Bind values with :name placeholders + "params".',
     EXECUTE_SCHEMA, ToolDBExecute, tcMutating);
+
+  Reg1(Reg, 'db_schema',
+    'Digest the schema for grounding SQL: every table (or one named table) with ' +
+    'its columns (name/type/nullable) and, by default, its row count. Read this ' +
+    'before writing queries against an unfamiliar database, and store durable ' +
+    'business rules ("MRR = ...", "active = status IN (...)") with the memory ' +
+    'tools so they persist across sessions.',
+    SCHEMA_SCHEMA, ToolDBSchema, tcReadOnly);
+
+  Reg1(Reg, 'db_explain',
+    'Analyze a query WITHOUT running it: returns the engine query plan plus ' +
+    '"full_scans" (tables read without an index) and an index hint. Use it to ' +
+    'diagnose slow queries and validate that a proposed index is actually used ' +
+    '(re-run and confirm the plan switches to SEARCH ... USING INDEX).',
+    EXPLAIN_SCHEMA, ToolDBExplain, tcReadOnly);
 end;
 
 end.

--- a/src/pkg/tools/PasClaw.Tools.DB.pas
+++ b/src/pkg/tools/PasClaw.Tools.DB.pas
@@ -494,6 +494,7 @@ var
   RC, i, k: Integer;
   Trunc: Boolean;
   Keys: TStringList;
+  Stmt, FirstWord: string;
 begin
   ErrMsg := '';
   ParseCommon(ArgsJSON, ConnName, SQL, ParamsJSON);
@@ -502,14 +503,28 @@ begin
   if SQLHasMultipleStatements(SQL) then
   begin ErrMsg := 'db_explain: one statement per call'; Exit(''); end;
 
+  { Classify the CONSTRUCTED statement, not the raw sql. Prepending EXPLAIN keeps
+    a plain query read-only (EXPLAIN plans, doesn't run), but if the caller
+    smuggles ANALYZE into sql -- "ANALYZE DELETE ..." / "(ANALYZE) UPDATE ..." --
+    the result is "EXPLAIN ANALYZE <write>", which PostgreSQL EXECUTES. Require
+    the whole thing to classify read-only before running it; the classifier
+    already resolves EXPLAIN ANALYZE to its inner (executed) verb. }
+  Stmt := ExplainPrefix(Cfg.Driver) + SQL;
+  if ClassifySQL(Stmt, FirstWord) <> skReadOnly then
+  begin
+    ErrMsg := Format('db_explain: refusing "%s" -- EXPLAIN ANALYZE (and similar) ' +
+                     'executes the statement. Pass a plain query to analyze; its ' +
+                     'plan is computed without running it.', [FirstWord]);
+    Exit('');
+  end;
+
   Conn := NewDBConnection;
   if not Conn.Open(Cfg, Err) then begin ErrMsg := 'db_explain: ' + Err; Exit(''); end;
   Scans := TStringList.Create;
   try
-    { EXPLAIN / EXPLAIN QUERY PLAN only PLANS -- it never executes the statement,
-      so this is read-only regardless of the query's verb. }
-    if not Conn.Query(ExplainPrefix(Cfg.Driver) + SQL, ParamsJSON, 500,
-                      PlanJSON, RC, Trunc, Err) then
+    { Stmt is EXPLAIN [QUERY PLAN] <query> and classified read-only above, so it
+      only PLANS -- it never executes the statement. }
+    if not Conn.Query(Stmt, ParamsJSON, 500, PlanJSON, RC, Trunc, Err) then
     begin ErrMsg := 'db_explain: ' + Err; Exit(''); end;
 
     { Heuristic full-scan detection (SQLite plan "detail" strings). Scan every

--- a/src/tests/db_tools_tests.pas
+++ b/src/tests/db_tools_tests.pas
@@ -254,6 +254,16 @@ begin
     Check(Res = CountBefore, 'explain: planning a DELETE did not run it (before=' +
           CountBefore + ' after=' + Res + ')');
 
+    { db_explain must reject a smuggled ANALYZE (would become EXPLAIN ANALYZE
+      <write>, which executes on PostgreSQL) -- and must not mutate. }
+    CountBefore := Reg.RunTool('db_query', '{"sql":"SELECT COUNT(*) AS n FROM t"}', Err);
+    Res := Reg.RunTool('db_explain', '{"sql":"ANALYZE DELETE FROM t WHERE id=1"}', Err);
+    Check(Err <> '', 'explain: refuses a smuggled ANALYZE <write>');
+    Res := Reg.RunTool('db_explain', '{"sql":"(ANALYZE) UPDATE t SET name=''z'' WHERE id=2"}', Err);
+    Check(Err <> '', 'explain: refuses (ANALYZE) <write>');
+    Res := Reg.RunTool('db_query', '{"sql":"SELECT COUNT(*) AS n FROM t"}', Err);
+    Check(Res = CountBefore, 'explain: refused ANALYZE attempts did not mutate');
+
     { no connection configured => clear guidance, not a crash }
     SetDBConfig([]);
     Res := Reg.RunTool('db_query', '{"sql":"SELECT 1"}', Err);

--- a/src/tests/db_tools_tests.pas
+++ b/src/tests/db_tools_tests.pas
@@ -130,7 +130,7 @@ end;
 procedure TestToolsLive;
 var
   Reg: TToolRegistry;
-  Err, Res: string;
+  Err, Res, CountBefore: string;
   RW: TDBConn;
 begin
   { fresh db }
@@ -222,6 +222,37 @@ begin
     Res := Reg.RunTool('db_execute', '{"sql":"DROP TABLE t"}', Err);
     Check(Err <> '', 'gating: readwrite refuses DROP (needs full)');
     Check(Pos('full', Err) > 0, 'gating: DDL refusal names full mode');
+
+    { ---- Phase 4 DBA tools ---- }
+    SetDBConfig([RW]);   { back to the seeded full-mode db }
+
+    { db_schema: lists the table + its columns + a row count }
+    Res := Reg.RunTool('db_schema', '{}', Err);
+    Check(Err = '', 'schema: ran (' + Err + ')');
+    Check(HasSub(Res, '"name":"t"'), 'schema: lists table t (got ' + Res + ')');
+    Check(HasSub(Res, '"name":"id"') and HasSub(Res, '"name":"name"'), 'schema: lists columns');
+    Check(Pos('row_count', Res) > 0, 'schema: includes row_count');
+
+    { db_explain: a WHERE on an unindexed column is a full SCAN -> flagged }
+    Res := Reg.RunTool('db_explain', '{"sql":"SELECT * FROM t WHERE name = ''alice''"}', Err);
+    Check(Err = '', 'explain: ran (' + Err + ')');
+    Check(Pos('"plan"', Res) > 0, 'explain: returns a plan');
+    Check(HasSub(Res, '"full_scans":["t"]') or (Pos('"t"', Res) > 0), 'explain: flags the full scan on t (got ' + Res + ')');
+    Check(Pos('hint', Res) > 0, 'explain: gives an index hint');
+
+    { after indexing name, the same query no longer full-scans }
+    Reg.RunTool('db_execute', '{"sql":"CREATE INDEX idx_t_name ON t(name)"}', Err);
+    Check(Err = '', 'explain: create index (' + Err + ')');
+    Res := Reg.RunTool('db_explain', '{"sql":"SELECT * FROM t WHERE name = ''alice''"}', Err);
+    Check(Pos('"full_scans":[]', StringReplace(Res, ' ', '', [rfReplaceAll])) > 0,
+          'explain: indexed query no longer flagged as full scan (got ' + Res + ')');
+
+    { db_explain plans without executing -- an explained DELETE must not delete }
+    CountBefore := Reg.RunTool('db_query', '{"sql":"SELECT COUNT(*) AS n FROM t"}', Err);
+    Reg.RunTool('db_explain', '{"sql":"DELETE FROM t WHERE id=1"}', Err);
+    Res := Reg.RunTool('db_query', '{"sql":"SELECT COUNT(*) AS n FROM t"}', Err);
+    Check(Res = CountBefore, 'explain: planning a DELETE did not run it (before=' +
+          CountBefore + ' after=' + Res + ')');
 
     { no connection configured => clear guidance, not a crash }
     SetDBConfig([]);


### PR DESCRIPTION
Phase 4 — the DeepSQL-style "DBA layer", built from parts PasClaw already has. Two new **read-only** tools plus a composition pattern over memory/KB/workflow/cron.

## New tools

- **`db_schema`** — a schema digest: every table (or one named table) with its columns and, by default, a `COUNT(*)` row count. This is the "index your schema for context" piece: read it before writing NL→SQL, persist it into the KB, and store business rules as memory facts. Built on the seam's existing `ListTables`/`DescribeTable` + a cross-engine `COUNT` query (bounded at 200 tables with a note).
- **`db_explain`** — plans a query **without running it** (SQLite `EXPLAIN QUERY PLAN`; `EXPLAIN` elsewhere) and returns the plan plus `full_scans` (tables read without an index) and an index hint. The index-advisor loop: `db_explain` → add index with `db_execute` → re-run `db_explain` to confirm the plan switched to `SEARCH … USING INDEX`.

Both are `tcReadOnly`, so they **auto-project over the MCP server** (Phase 3) — an external host gets schema grounding + query-plan analysis for free.

## Safety notes

- `db_explain` only *plans*, so it's read-only regardless of the inner verb — verified by a test that plans a `DELETE` and confirms no rows were removed. Statement stacking is rejected.
- The full-scan heuristic reads SQLite plan `detail` strings and handles both `SCAN t` (newer) and `SCAN TABLE t` (older), ignoring `… USING INDEX` (covering/secondary index).

## Composition (the rest of the "DBA layer")

`docs/database-tools.md` gains a **DBA layer** section showing how these compose:
- **Business glossary** → memory facts (plain-English rules persist + surface via `memory_search`).
- **Slow-query audit** → a saved workflow (pull `pg_stat_statements` with `db_query` → `db_explain` each → propose indexes → post to a channel) on a cron. Includes a workflow JSON template.

No new engine code was needed for the glossary/cron pieces — they're existing primitives.

## Tests
`db_tools_tests` gains: the schema digest (tables / columns / row_count), a full scan **flagged** then **cleared** after adding an index, and the plan-doesn't-execute-a-DELETE guarantee. `make test-db-tools` → OK, `make test-mcp-server` → OK, `make all` links clean.

## Notes
- Pure tool-layer code reusing the seam — no new `IFDEF` branches, so no `dcc` caveat this time. `db_schema` row counts and `db_explain` planning are cross-engine; the full-scan **hint** is SQLite-specific in this phase (other engines still return the raw plan), noted for a later extension.

This completes the database-tools arc (Phases 1–4). 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_