### PR TITLE
Delphi .dproj build fixes: db unit search path + macOS target platforms

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -70,7 +70,7 @@
         <Manifest_File>None</Manifest_File>
         <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <!-- Every src/pkg/* directory + src/cmd, relative to src/pasclaw/ -->
-        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\mcp;..\pkg\workflow;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;..\pkg\vendor\zpaq;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\cmd;..\pkg\cliui;..\pkg\utils;..\pkg\logger;..\pkg\config;..\pkg\json;..\pkg\providers;..\pkg\stream;..\pkg\tokenizer;..\pkg\tools;..\pkg\db;..\pkg\mcp;..\pkg\workflow;..\pkg\gateway;..\pkg\channels;..\pkg\crypto;..\pkg\net;..\pkg\search;..\pkg\cron;..\pkg\skills;..\pkg\checkpoints;..\pkg\condense;..\pkg\session;..\pkg\identity;..\pkg\agent;..\pkg\memory;..\pkg\memory\localvector;..\pkg\kb;..\pkg\updater;..\pkg\membench;..\pkg\tui;..\pkg\platform;..\pkg\hashline;..\pkg\component;..\pkg\markdown;..\pkg\shell;..\pkg\otel;..\pkg\vendor\dmvcframework;..\pkg\vendor\zpaq;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <!--
           DCC_Namespace lets dcc32/dcc64 resolve bare unit names ("SysUtils",
           "Classes", "Windows") back to their fully qualified modern names


### PR DESCRIPTION
Two Delphi project-file fixes.

## 1. `db` unit search path (fixes the F2613)

```
[dcc64 Fatal Error] PasClaw.Tools.DB.pas(33): F2613 Unit 'PasClaw.DB' not found.
```

`src/pkg/db/PasClaw.DB.pas` (from the Phase 1 db work, #468) was in the Makefile's `UNIT_DIRS` for FPC but not in `PasClaw.dproj`'s `DCC_UnitSearchPath`. Added `..\pkg\db` between `..\pkg\tools` and `..\pkg\mcp` to match the Makefile order.

## 2. macOS target platforms

The project declared only Win32/Win64/Linux64, so the IDE wouldn't offer a macOS target. Added **OSXARM64** (Apple Silicon) and **OSX64** (Intel) to `<Platforms>` and mirrored Linux64's base/settings `PropertyGroup`s for them. macOS is POSIX — the same target family as the already-supported Linux64 Delphi build — so PasClaw's POSIX code paths already apply. The SDK and PAServer profile are chosen per-machine by the IDE, so nothing host-specific is hardcoded.

## Notes
- FPC builds are unaffected (they use the Makefile). I can't run `dcc64` / a macOS PAServer build in this environment, so this enables + wires the platform; the first macOS compile may surface additional POSIX gaps to fix (same story as when Linux64 was brought up). `.dproj` validated as well-formed XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6