### PR TITLE
Delphi: enable macOS (OSXARM64 + OSX64) target platforms

### DIFF
--- a/src/pasclaw/PasClaw.dproj
+++ b/src/pasclaw/PasClaw.dproj
@@ -31,6 +31,16 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSXARM64' and '$(Base)'=='true') or '$(Base_OSXARM64)'!=''">
+        <Base_OSXARM64>true</Base_OSXARM64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Base)'=='true') or '$(Base_OSX64)'!=''">
+        <Base_OSX64>true</Base_OSX64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
         <Cfg_1>true</Cfg_1>
         <CfgParent>Base</CfgParent>
@@ -103,6 +113,16 @@
     <PropertyGroup Condition="'$(Base_Linux64)'!=''">
         <DCC_UsePackage>rtl;$(DCC_UsePackage)</DCC_UsePackage>
         <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSXARM64)'!=''">
+        <DCC_UsePackage>rtl;$(DCC_UsePackage)</DCC_UsePackage>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSX64)'!=''">
+        <DCC_UsePackage>rtl;$(DCC_UsePackage)</DCC_UsePackage>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
@@ -420,6 +440,8 @@
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
                 <Platform value="Linux64">True</Platform>
+                <Platform value="OSXARM64">True</Platform>
+                <Platform value="OSX64">True</Platform>
             </Platforms>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>


### PR DESCRIPTION
Split out from #472 (which merged with just the db search-path fix) so the macOS platform change lands as its own PR.

## Problem
`PasClaw.dproj` declared only Win32/Win64/Linux64, so the Delphi IDE wouldn't let you add a macOS target.

## Fix
- Added **OSXARM64** (Apple Silicon) and **OSX64** (Intel) to `<Platforms>`.
- Mirrored Linux64's base + settings `PropertyGroup`s for both, so the IDE has proper config groups instead of deriving from scratch.

macOS is POSIX — the same target family as the already-supported **Linux64** Delphi build — so PasClaw's POSIX code paths already apply. The macOS SDK and PAServer profile are chosen per-machine by the IDE, so nothing host-specific is hardcoded.

## Notes
- FPC builds unaffected. I can't run `dcc64` / a macOS PAServer build here, so this enables + wires the platform (the IDE blocker); the first macOS compile may surface a few POSIX gaps to patch, same as when Linux64 was brought up. `.dproj` validated as well-formed XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_