### PR TITLE
Prompt: stop weak models toolchain-hunting on small talk

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -238,7 +238,9 @@ begin
     'This PasClaw agent binary was built with ' + RuntimeString + '. That ' +
     'describes the agent program itself -- NOT the user''s project, toolchain, ' +
     'or machine. Do not go looking for compilers or build tools (dcc, fpc, ' +
-    'gcc, ...) unless the user''s task actually requires building something.';
+    'gcc, ...) on your own initiative -- only when the user''s task actually ' +
+    'concerns them (building something, or explicitly asking about, installing, ' +
+    'or configuring a toolchain).';
 end;
 
 function BuildWorkspaceSection: string;

--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -235,7 +235,10 @@ begin
     'not over-engineer.' + sLineBreak +
     sLineBreak +
     '## Runtime' + sLineBreak +
-    RuntimeString;
+    'This PasClaw agent binary was built with ' + RuntimeString + '. That ' +
+    'describes the agent program itself -- NOT the user''s project, toolchain, ' +
+    'or machine. Do not go looking for compilers or build tools (dcc, fpc, ' +
+    'gcc, ...) unless the user''s task actually requires building something.';
 end;
 
 function BuildWorkspaceSection: string;
@@ -643,7 +646,10 @@ begin
     'destined for a file) into your reply as prose or a code block: that ' +
     'creates nothing on disk and risks being cut off at the output-token ' +
     'limit mid-way. Put file content only inside a write_file / append_file / ' +
-    'apply_patch call.' + sLineBreak +
+    'apply_patch call. Conversely, when NO action is needed -- greetings, ' +
+    'small talk, questions you can answer from knowledge -- just reply. Do ' +
+    'not run tools to explore the machine, verify toolchains, or inventory ' +
+    'the environment unprompted.' + sLineBreak +
     sLineBreak +
     '2. **Be precise** -- match the language''s native idioms, name things ' +
     'clearly, do not introduce abstractions the task does not actually need. ' +


### PR DESCRIPTION
On a fresh Vultr Windows VPS with a Gemini provider, saying "hello" sent the agent on a ~25-tool-call hunt for `dcc`.

## Root cause

Two system-prompt lines conspired, and neither involves the `delphi_build` tool (which correctly self-gates on RAD Studio being installed and wasn't registered):

1. The identity's `## Runtime` section read literally **"Delphi on win/x86_64"** — it describes what the *PasClaw binary* was compiled with, but to a literal-minded model it reads as "your runtime environment is Delphi on Windows" → "verify I have a Delphi compiler" → `where dcc32`, directory sweeps, etc.
2. Rule 1 says "**ALWAYS use tools** when an action is needed" with no counterweight for turns that need *no* action — so a weak model treats even "hello" as something to act on.

## Fix

- `## Runtime` now states the build info describes the **agent binary**, not the user's project/toolchain/machine, and explicitly says not to go looking for compilers (`dcc`, `fpc`, `gcc`, …) unless the task actually requires building.
- Rule 1 gains the converse clause: greetings / small talk / knowledge questions get a direct reply — do not run tools to explore the machine, verify toolchains, or inventory the environment unprompted.

## Verification
- `make all` links clean; `test-orient-preamble` passes (no test pins the changed strings).
- Behavioral fix is prompt-only, so the definitive check is the reported scenario: fresh box + Gemini + "hello" should now answer directly. Worth a quick re-test on the next VPS deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_