### PR TITLE
session_read tool: use past sessions as extra context windows

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.SessionSearch.pas
+++ b/src/pkg/tools/PasClaw.Tools.SessionSearch.pas
@@ -169,6 +169,20 @@ begin
   LogDebug('session_search query=%s k=%d hits=%d', [Query, K, Length(Hits)]);
 end;
 
+{ Truncate S to at most MaxBytes WITHOUT splitting a UTF-8 sequence: back the
+  cut off while the first excluded byte is a continuation byte (10xxxxxx), so
+  the result stays valid UTF-8 (a mid-character cut would corrupt the tool
+  output and can be rejected downstream in provider-request JSON). }
+function Utf8SafeTruncate(const S: string; MaxBytes: Integer): string;
+var
+  n: Integer;
+begin
+  if Length(S) <= MaxBytes then Exit(S);
+  n := MaxBytes;
+  while (n > 0) and ((Byte(S[n + 1]) and $C0) = $80) do Dec(n);
+  Result := Copy(S, 1, n);
+end;
+
 function Tool_SessionRead(const ArgsJSON: string; out ErrMsg: string): string;
 const
   DefaultCount = 20;
@@ -177,10 +191,11 @@ const
   MaxChars     = 8000;
 var
   Id, Query, QueryLC, Body, RoleStr: string;
-  Start, Count, CapChars, i, j, Shown, Matched: Integer;
+  Start, Count, CapChars, i, j, Shown, Matched, ConvIdx: Integer;
   S: TSession;
   Lines: TStringList;
-  Idx: array of Integer;   { message indexes surviving the role/query filter }
+  Idx:  array of Integer;  { message indexes surviving the role/query filter }
+  Ords: array of Integer;  { each survivor's ORIGINAL conversation ordinal }
 begin
   ErrMsg := '';
   Result := '';
@@ -215,17 +230,23 @@ begin
     end;
 
     { Filter pass: skip system turns (compacted prompt blobs, not
-      conversation), apply the optional substring query over content. The
-      surviving ORIGINAL indexes go into Idx so the numbering is stable
-      across calls regardless of filters. }
+      conversation), apply the optional substring query over content. Each
+      survivor keeps its ORIGINAL conversation ordinal (position among all
+      non-system turns) in Ords, so the displayed [N] numbering is stable
+      across calls regardless of query filters. }
     SetLength(Idx, 0);
+    SetLength(Ords, 0);
+    ConvIdx := 0;
     for i := 0 to High(S.Messages) do
     begin
       if S.Messages[i].Role = mrSystem then Continue;
+      Inc(ConvIdx);
       if (QueryLC <> '') and
          (Pos(QueryLC, LowerCase(S.Messages[i].Content)) = 0) then Continue;
       SetLength(Idx, Length(Idx) + 1);
       Idx[High(Idx)] := i;
+      SetLength(Ords, Length(Ords) + 1);
+      Ords[High(Ords)] := ConvIdx;
     end;
     Matched := Length(Idx);
     if Matched = 0 then
@@ -257,8 +278,8 @@ begin
         if (Body = '') and (Length(S.Messages[i].ToolCalls) > 0) then
           Body := '(tool call: ' + S.Messages[i].ToolCalls[0].Func.Name + ')';
         if Length(Body) > CapChars then
-          Body := Copy(Body, 1, CapChars) + '...[truncated]';
-        Lines.Add(Format('[%d] %s: %s', [j + 1, RoleStr, Body]));
+          Body := Utf8SafeTruncate(Body, CapChars) + '...[truncated]';
+        Lines.Add(Format('[%d] %s: %s', [Ords[j], RoleStr, Body]));
         Inc(Shown);
       end;
       if Start - 1 + Shown < Matched then

--- a/src/pkg/tools/PasClaw.Tools.SessionSearch.pas
+++ b/src/pkg/tools/PasClaw.Tools.SessionSearch.pas
@@ -1,12 +1,20 @@
 (*
-  PasClaw.Tools.SessionSearch - registers the session_search tool.
+  PasClaw.Tools.SessionSearch - registers the session_search and
+  session_read tools.
 
-  Lets the model search the text of EVERY saved session, not just
-  the current conversation. Backed by PasClaw.Session.Search's FTS5
-  index over $PASCLAW_HOME/workspace/sessions/*.json. Returns
+  session_search lets the model search the text of EVERY saved session,
+  not just the current conversation. Backed by PasClaw.Session.Search's
+  FTS5 index over $PASCLAW_HOME/workspace/sessions/*.json. Returns
   session id + title + snippet + bm25 score; the model can then
   suggest the operator resume that session (`pasclaw resume <id>`)
   or surface the recalled fact directly.
+
+  session_read is the second half of the loop: given a session id from
+  session_search, pull that conversation's messages into the current
+  context (optionally filtered by a substring, windowed by start/count,
+  each message capped). Together they make past sessions usable as
+  extra context windows: search -> read, the same grep -> read pattern
+  the model already knows from files.
 
   Index DB lives at workspace/sessions/.search.db -- a derived
   cache, rebuilt lazily from the JSON files on each call (Sync
@@ -43,6 +51,8 @@ uses
   PasClaw.Config,
   PasClaw.Logger,
   PasClaw.Tools.Types,
+  PasClaw.Providers.Types,
+  PasClaw.Session.Store,
   PasClaw.Session.Search;
 
 function ParseStringArg(const ArgsJSON, Field: string; out V: string): Boolean;
@@ -159,6 +169,113 @@ begin
   LogDebug('session_search query=%s k=%d hits=%d', [Query, K, Length(Hits)]);
 end;
 
+function Tool_SessionRead(const ArgsJSON: string; out ErrMsg: string): string;
+const
+  DefaultCount = 20;
+  MaxCount     = 100;
+  DefaultChars = 1500;
+  MaxChars     = 8000;
+var
+  Id, Query, QueryLC, Body, RoleStr: string;
+  Start, Count, CapChars, i, j, Shown, Matched: Integer;
+  S: TSession;
+  Lines: TStringList;
+  Idx: array of Integer;   { message indexes surviving the role/query filter }
+begin
+  ErrMsg := '';
+  Result := '';
+
+  if not ParseStringArg(ArgsJSON, 'session_id', Id) then
+  begin
+    ErrMsg := 'missing required argument: session_id (find ids with session_search)';
+    Exit;
+  end;
+  if not IsSafeSessionId(Id) then
+  begin
+    ErrMsg := 'invalid session id: ' + Id;
+    Exit;
+  end;
+  ParseStringArg(ArgsJSON, 'query', Query);   { optional }
+  QueryLC := LowerCase(Query);
+  Start := ParseIntArg(ArgsJSON, 'start', 1);
+  if Start < 1 then Start := 1;
+  Count := ParseIntArg(ArgsJSON, 'count', DefaultCount);
+  if Count < 1        then Count := 1;
+  if Count > MaxCount then Count := MaxCount;
+  CapChars := ParseIntArg(ArgsJSON, 'max_chars', DefaultChars);
+  if CapChars < 100      then CapChars := 100;
+  if CapChars > MaxChars then CapChars := MaxChars;
+
+  S := TSession.Create(Id);
+  try
+    if not S.MetaExists then
+    begin
+      ErrMsg := 'no such session: ' + Id + ' -- find ids with session_search';
+      Exit;
+    end;
+
+    { Filter pass: skip system turns (compacted prompt blobs, not
+      conversation), apply the optional substring query over content. The
+      surviving ORIGINAL indexes go into Idx so the numbering is stable
+      across calls regardless of filters. }
+    SetLength(Idx, 0);
+    for i := 0 to High(S.Messages) do
+    begin
+      if S.Messages[i].Role = mrSystem then Continue;
+      if (QueryLC <> '') and
+         (Pos(QueryLC, LowerCase(S.Messages[i].Content)) = 0) then Continue;
+      SetLength(Idx, Length(Idx) + 1);
+      Idx[High(Idx)] := i;
+    end;
+    Matched := Length(Idx);
+    if Matched = 0 then
+    begin
+      if Query <> '' then
+        Exit(Format('(session %s has no messages containing "%s")', [Id, Query]))
+      else
+        Exit(Format('(session %s has no conversation messages)', [Id]));
+    end;
+
+    Lines := TStringList.Create;
+    try
+      if Query <> '' then
+        RoleStr := ' matching "' + Query + '"'   { reuse the local as a suffix }
+      else
+        RoleStr := '';
+      Lines.Add(Format('session %s  "%s"  (%s, %d message(s)%s)',
+        [S.Meta.Id, S.Meta.Title, S.Meta.Model, Matched, RoleStr]));
+      Lines.Add('');
+      Shown := 0;
+      for j := Start - 1 to Matched - 1 do
+      begin
+        if Shown >= Count then Break;
+        i := Idx[j];
+        RoleStr := MsgRoleToString(S.Messages[i].Role);
+        Body := S.Messages[i].Content;
+        { An assistant tool-call turn often has empty content -- surface the
+          call itself so the transcript stays readable. }
+        if (Body = '') and (Length(S.Messages[i].ToolCalls) > 0) then
+          Body := '(tool call: ' + S.Messages[i].ToolCalls[0].Func.Name + ')';
+        if Length(Body) > CapChars then
+          Body := Copy(Body, 1, CapChars) + '...[truncated]';
+        Lines.Add(Format('[%d] %s: %s', [j + 1, RoleStr, Body]));
+        Inc(Shown);
+      end;
+      if Start - 1 + Shown < Matched then
+        Lines.Add(Format('(showing %d-%d of %d -- call again with start=%d for more)',
+          [Start, Start - 1 + Shown, Matched, Start + Shown]));
+      Result := Lines.Text;
+    finally
+      Lines.Free;
+    end;
+  finally
+    S.Free;
+  end;
+
+  LogDebug('session_read id=%s start=%d count=%d matched=%d',
+           [Id, Start, Count, Matched]);
+end;
+
 procedure RegisterSessionSearchTool(R: TToolRegistry);
 var
   T: TTool;
@@ -172,7 +289,8 @@ begin
     'before", "my deploy preferences") that isn''t in the current context. ' +
     'Returns up to k matches as session-id + title + snippet + score ' +
     '(smaller score = stronger match), each with the `pasclaw resume` ' +
-    'command to reopen that session.';
+    'command to reopen that session. To actually READ a matched ' +
+    'conversation, follow up with session_read on its session-id.';
   T.Schema      :=
     '{"type":"object",' +
     '"properties":{' +
@@ -184,6 +302,30 @@ begin
   T.HandlerObj  := nil;
   T.IsCore      := True;
   T.Category    := tcReadOnly;  { SQLite SELECT only }
+  R.Register(T);
+
+  T.Name        := 'session_read';
+  T.Description :=
+    'Read the messages of a PAST saved session by id -- your other context ' +
+    'windows. Use after session_search points at a conversation ("check the ' +
+    'session where we set up the deploy"): pass its session_id to pull the ' +
+    'actual exchange into this context. Optional "query" filters to messages ' +
+    'containing a substring; "start"/"count" page through long sessions ' +
+    '(message numbering is stable across calls). System turns are skipped; ' +
+    'long messages are truncated to max_chars.';
+  T.Schema      :=
+    '{"type":"object",' +
+    '"properties":{' +
+    '"session_id":{"type":"string","description":"Session id from session_search (e.g. 20260601T134215-a3f4c2e1)."},' +
+    '"query":{"type":"string","description":"Only return messages containing this substring (case-insensitive)."},' +
+    '"start":{"type":"integer","minimum":1,"description":"1-based first message to return (default 1)."},' +
+    '"count":{"type":"integer","minimum":1,"maximum":100,"description":"Max messages to return (default 20)."},' +
+    '"max_chars":{"type":"integer","minimum":100,"maximum":8000,"description":"Per-message content cap (default 1500)."}' +
+    '},"required":["session_id"]}';
+  T.Handler     := Tool_SessionRead;
+  T.HandlerObj  := nil;
+  T.IsCore      := True;
+  T.Category    := tcReadOnly;  { reads one JSON file }
   R.Register(T);
 end;
 

--- a/src/tests/session_search_tests.pas
+++ b/src/tests/session_search_tests.pas
@@ -29,7 +29,7 @@ program session_search_tests;
 {$IFDEF FPC}{$CODEPAGE UTF8}{$ENDIF}
 
 uses
-  SysUtils, Classes,
+  SysUtils, Classes, StrUtils,
   PasClaw.Utils,
   PasClaw.Config,
   PasClaw.Providers.Types,
@@ -371,6 +371,17 @@ begin
   end;
 end;
 
+{ Whole-string UTF-8 validity via PasClaw.Utils.BytesAreValidUTF8. }
+function StrBytesValidUTF8(const S: string): Boolean;
+var
+  B: TBytes;
+  i: Integer;
+begin
+  SetLength(B, Length(S));
+  for i := 1 to Length(S) do B[i - 1] := Byte(S[i]);
+  Result := BytesAreValidUTF8(B);
+end;
+
 procedure TestSessionReadTool;
 (* session_read: the second half of the cross-session loop. Pins:
    - reads a saved session's messages by id with role labels + title
@@ -414,10 +425,14 @@ begin
     AssertTrue(Pos('[1] user: how did we deploy', Res) > 0, 'read: first user turn numbered');
     AssertTrue(Pos('system prompt blob', Res) = 0, 'read: system content not leaked');
 
-    { query filter }
+    { query filter -- displayed numbering keeps the ORIGINAL conversation
+      ordinal ([2]), not the filtered position ([1]), so references from a
+      filtered read line up with an unfiltered one }
     Res := Reg.RunTool('session_read', '{"session_id":"sess-read","query":"helm"}', Err);
     AssertTrue((Err = '') and (Pos('helm chart', Res) > 0), 'read: query filter matches');
     AssertTrue(Pos('how did we deploy', Res) = 0, 'read: query filter excludes others');
+    AssertTrue(Pos('[2] assistant:', Res) > 0,
+               'read: filtered numbering keeps original ordinal (got ' + Res + ')');
 
     { paging: 2 per page, second page announces continuation }
     Res := Reg.RunTool('session_read', '{"session_id":"sess-read","count":2}', Err);
@@ -428,6 +443,23 @@ begin
     { truncation }
     Res := Reg.RunTool('session_read', '{"session_id":"sess-read","start":4,"max_chars":200}', Err);
     AssertTrue(Pos('...[truncated]', Res) > 0, 'read: long content truncated');
+
+    { UTF-8-safe truncation: an odd max_chars over 2-byte characters would
+      split a sequence with a naive byte Copy; the whole tool output must
+      stay valid UTF-8 }
+    S := TSession.Create('sess-utf8');
+    try
+      S.Meta.Title := 'Unicode';
+      SetLength(S.Messages, 1);
+      S.Messages[0] := MakeMessage(mrUser, DupeString('é', 300));   { 600 bytes }
+      S.Touch;
+      S.Save;
+    finally
+      S.Free;
+    end;
+    Res := Reg.RunTool('session_read', '{"session_id":"sess-utf8","max_chars":101}', Err);
+    AssertTrue(Pos('...[truncated]', Res) > 0, 'read: utf8 content truncated');
+    AssertTrue(StrBytesValidUTF8(Res), 'read: truncation kept output valid UTF-8');
 
     { errors }
     Reg.RunTool('session_read', '{"session_id":"no-such-session"}', Err);

--- a/src/tests/session_search_tests.pas
+++ b/src/tests/session_search_tests.pas
@@ -34,7 +34,9 @@ uses
   PasClaw.Config,
   PasClaw.Providers.Types,
   PasClaw.Session.Store,
-  PasClaw.Session.Search;
+  PasClaw.Session.Search,
+  PasClaw.Tools.Registry,
+  PasClaw.Tools.SessionSearch;
 
 procedure Fail_(const Msg: string);
 begin
@@ -369,6 +371,76 @@ begin
   end;
 end;
 
+procedure TestSessionReadTool;
+(* session_read: the second half of the cross-session loop. Pins:
+   - reads a saved session's messages by id with role labels + title
+   - system turns are skipped; stable 1-based numbering
+   - "query" filters to matching messages (numbering unchanged)
+   - start/count page through, with a "call again with start=N" tail
+   - long content is truncated to max_chars
+   - bad / unknown ids error with guidance, not a crash *)
+var
+  S: TSession;
+  Reg: TToolRegistry;
+  Res, Err, LongMsg: string;
+begin
+  WipeStore;
+  LongMsg := StringOfChar('x', 3000);
+  S := TSession.Create('sess-read');
+  try
+    S.Meta.Title := 'Read me';
+    S.Meta.Model := 'test-model';
+    SetLength(S.Messages, 5);
+    S.Messages[0] := MakeMessage(mrSystem,    'system prompt blob');
+    S.Messages[1] := MakeMessage(mrUser,      'how did we deploy the gateway');
+    S.Messages[2] := MakeMessage(mrAssistant, 'we used the helm chart with make ship');
+    S.Messages[3] := MakeMessage(mrUser,      'and the port?');
+    S.Messages[4] := MakeMessage(mrAssistant, LongMsg);
+    S.Touch;
+    S.Save;
+  finally
+    S.Free;
+  end;
+
+  Reg := TToolRegistry.Create;
+  try
+    RegisterSessionSearchTool(Reg);
+
+    { basics: title, roles, system skipped (4 conversation messages) }
+    Res := Reg.RunTool('session_read', '{"session_id":"sess-read"}', Err);
+    AssertTrue(Err = '', 'read: no error (' + Err + ')');
+    AssertTrue(Pos('"Read me"', Res) > 0, 'read: title present');
+    AssertTrue(Pos('4 message(s)', Res) > 0, 'read: system turn skipped from count');
+    AssertTrue(Pos('[1] user: how did we deploy', Res) > 0, 'read: first user turn numbered');
+    AssertTrue(Pos('system prompt blob', Res) = 0, 'read: system content not leaked');
+
+    { query filter }
+    Res := Reg.RunTool('session_read', '{"session_id":"sess-read","query":"helm"}', Err);
+    AssertTrue((Err = '') and (Pos('helm chart', Res) > 0), 'read: query filter matches');
+    AssertTrue(Pos('how did we deploy', Res) = 0, 'read: query filter excludes others');
+
+    { paging: 2 per page, second page announces continuation }
+    Res := Reg.RunTool('session_read', '{"session_id":"sess-read","count":2}', Err);
+    AssertTrue(Pos('start=3', Res) > 0, 'read: paging tail points at next start');
+    Res := Reg.RunTool('session_read', '{"session_id":"sess-read","start":3,"count":2}', Err);
+    AssertTrue(Pos('[3] user: and the port?', Res) > 0, 'read: page 2 keeps numbering');
+
+    { truncation }
+    Res := Reg.RunTool('session_read', '{"session_id":"sess-read","start":4,"max_chars":200}', Err);
+    AssertTrue(Pos('...[truncated]', Res) > 0, 'read: long content truncated');
+
+    { errors }
+    Reg.RunTool('session_read', '{"session_id":"no-such-session"}', Err);
+    AssertTrue(Pos('no such session', Err) > 0, 'read: unknown id errors with guidance');
+    Reg.RunTool('session_read', '{"session_id":"../../etc/passwd"}', Err);
+    AssertTrue(Err <> '', 'read: unsafe id rejected');
+    Reg.RunTool('session_read', '{}', Err);
+    AssertTrue(Pos('session_id', Err) > 0, 'read: missing id names the argument');
+  finally
+    Reg.Free;
+  end;
+end;
+
 begin
   TestSearchFindsByContent;
   TestHitCarriesIdAndTitle;
@@ -377,5 +449,6 @@ begin
   TestReindexCatchesSameSecondSave;
   TestRankingPrefersStrongerMatch;
   TestGatewayBucketsExcluded;
+  TestSessionReadTool;
   WriteLn('session_search_tests: OK');
 end.


### PR DESCRIPTION
First of three PRs from the "sessions as extra context windows + import/export + MCP stateless" plan.

## What it does

`session_search` finds past conversations but the model had no way to **read** one — "check the session where we set up the deploy" dead-ended at a BM25 snippet. This adds **`session_read`**: given a session id, return that conversation's messages into the current context.

```
session_search("deploy setup")  →  id + title + snippet
session_read(id)                →  the actual exchange, role-labelled + numbered
```

The same grep→read pattern the model already knows from files, applied to sessions.

## Behavior

- **System turns skipped** (compacted prompt blobs, not conversation) — count and numbering reflect conversation messages only.
- **`query`** filters to messages containing a substring (case-insensitive); numbering stays stable across filtered/unfiltered calls.
- **`start`/`count`** page through long sessions; the tail line says exactly what `start` to pass next.
- **`max_chars`** caps each message (default 1500); an assistant turn with empty content surfaces its tool-call name instead of a blank line.
- Ids are validated with `IsSafeSessionId` before touching the filesystem; unknown ids error with "find ids with session_search".
- Registered from `RegisterSessionSearchTool`, so all surfaces (CLI, TUI, gateway, serve, MCP projection — it's `tcReadOnly`) get it with **zero call-site changes**. `session_search`'s description now points at `session_read` as the follow-up.

## Tests
`TestSessionReadTool` in `session_search_tests` pins: roles/title/numbering, system-turn skipping + no system-content leak, query filter include/exclude, paging with stable numbering, truncation, and all three error paths (unknown id, path-traversal id, missing arg). `make test-session-search` → OK; `make all` links clean.

Next up: PR B (session import/export — ChatGPT `conversations.json` + Claude Code JSONL), PR C (MCP 2026-07-28 stateless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_