### PR TITLE
MCP: dual-era server — 2026-07-28 stateless + legacy initialize

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1139,8 +1139,10 @@ var
   Bytes: TBytes;
   Core: TMCPServerCore;
   RespLine: string;
+  McpHttpStatus: Integer;
 begin
   Body := '';
+  McpHttpStatus := 200;
   if ARequest.PostStream <> nil then
   begin
     ARequest.PostStream.Position := 0;
@@ -1176,7 +1178,10 @@ begin
     cleared in finally, same contract as DispatchOneToolCall. }
   if FToolsHonorInMemoryConfig then SetActiveConfig(FCfg);
   try
-    RespLine := Core.HandleRequest(Body);
+    { Transport-aware overload: McpHttpStatus is 400 for the 2026-07-28
+      UnsupportedProtocolVersionError (Streamable HTTP requires the JSON-RPC
+      error to ride a 400, not a 200), 200 otherwise. }
+    RespLine := Core.HandleRequest(Body, McpHttpStatus);
   finally
     if FToolsHonorInMemoryConfig then SetActiveConfig(nil);
   end;
@@ -1189,7 +1194,7 @@ begin
   end;
   if FDebugIO then
     LogDebug('mcp -> %s', [Copy(RespLine, 1, 200)]);
-  WriteJSON(AResp, 200, RespLine);
+  WriteJSON(AResp, McpHttpStatus, RespLine);
 end;
 
 { TGatewayServer.WriteSSE removed -- dead method, see class

--- a/src/pkg/mcp/PasClaw.MCP.Server.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Server.pas
@@ -25,10 +25,19 @@
   fs_write / shell on the operator's box is exactly the bad outcome
   the sandbox layer exists to prevent.
 
-  Implements just enough of the MCP spec for the read-corpus case:
+  Implements just enough of the MCP spec for the read-corpus case, serving
+  BOTH protocol eras from one dispatcher (the core was per-request stateless
+  from day one, so the 2026-07-28 "stateless" revision mostly named what we
+  already did):
 
+    modern (2026-07-28, per-request _meta, no handshake):
+    - server/discover             -> supportedVersions + capabilities + serverInfo
+    - a declared _meta protocol version we don't serve gets
+      UnsupportedProtocolVersionError (-32022) with the supported list
+    legacy (2024-11-05, initialize handshake):
     - initialize                  -> serverInfo + capabilities
     - notifications/initialized   -> ack (no response, void)
+    both eras:
     - ping                        -> {}
     - tools/list                  -> tool descriptors
     - tools/call                  -> dispatch via TToolRegistry
@@ -55,7 +64,8 @@ uses
   PasClaw.Tools.Registry;
 
 const
-  MCPServerProtocolVersion = '2024-11-05';
+  MCPServerProtocolVersion = '2024-11-05';   { legacy (initialize handshake) }
+  MCPServerProtocolModern  = '2026-07-28';   { stateless (per-request _meta) }
   MCPServerName            = 'pasclaw';
 
 type
@@ -67,11 +77,14 @@ type
     FVersion:       string;
     function IsExposed(const Name: string): Boolean;
     function HandleInitialize(const Params, Id: string): string;
+    function HandleDiscover(const Id: string): string;
     function HandleToolsList(const Id: string): string;
     function HandleToolsCall(const Params, Id: string): string;
     function HandlePing(const Id: string): string;
     function ErrorResponse(const Id: string; Code: Integer;
                             const Message: string): string;
+    function ErrorResponseData(const Id: string; Code: Integer;
+                                const Message, DataJSON: string): string;
     function SuccessResponse(const Id, ResultJSON: string): string;
   public
     constructor Create(ARegistry: TToolRegistry; AAllowMutating: Boolean;
@@ -169,6 +182,29 @@ begin
     Err := TJsonObject.Create;
     Err.PutInt('code',    Code);
     Err.PutStr('message', Message);
+    Root.PutObject('error', Err);
+    Result := Root.ToJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TMCPServerCore.ErrorResponseData(const Id: string; Code: Integer;
+                                          const Message, DataJSON: string): string;
+var
+  Root, Err: TJsonObject;
+begin
+  Root := TJsonObject.Create;
+  try
+    Root.PutStr('jsonrpc', '2.0');
+    if (Id = '') or (Id = 'null') then
+      Root.PutRaw('id', 'null')
+    else
+      Root.PutRaw('id', Id);
+    Err := TJsonObject.Create;
+    Err.PutInt('code',    Code);
+    Err.PutStr('message', Message);
+    if DataJSON <> '' then Err.PutRaw('data', DataJSON);
     Root.PutObject('error', Err);
     Result := Root.ToJSON;
   finally
@@ -393,10 +429,43 @@ begin
   Result := IntToStr(I);
 end;
 
+function TMCPServerCore.HandleDiscover(const Id: string): string;
+(* server/discover -- the modern (2026-07-28 stateless) entry point. Modern
+   servers MUST implement it; clients may call it to learn versions +
+   capabilities up front, and dual-era clients use it as the stdio probe
+   that distinguishes a modern server from a legacy one. *)
+var
+  ResObj, Caps, ToolsCap, Meta, ServerInfo: TJsonObject;
+  Vers: TJsonArray;
+begin
+  ResObj := TJsonObject.Create;
+  try
+    ResObj.PutStr('resultType', 'complete');
+    Vers := TJsonArray.Create;
+    Vers.AddStr(MCPServerProtocolModern);
+    Vers.AddStr(MCPServerProtocolVersion);   { dual-era: legacy still served }
+    ResObj.PutArray('supportedVersions', Vers);
+    Caps := TJsonObject.Create;
+    ToolsCap := TJsonObject.Create;
+    ToolsCap.PutBool('listChanged', False);
+    Caps.PutObject('tools', ToolsCap);
+    ResObj.PutObject('capabilities', Caps);
+    Meta := TJsonObject.Create;
+    ServerInfo := TJsonObject.Create;
+    ServerInfo.PutStr('name',    MCPServerName);
+    ServerInfo.PutStr('version', FVersion);
+    Meta.PutObject('io.modelcontextprotocol/serverInfo', ServerInfo);
+    ResObj.PutObject('_meta', Meta);
+    Result := SuccessResponse(Id, ResObj.ToJSON);
+  finally
+    ResObj.Free;
+  end;
+end;
+
 function TMCPServerCore.HandleRequest(const ALine: string): string;
 var
-  Obj, ParamsObj: TJsonObject;
-  Method, Id, Params: string;
+  Obj, ParamsObj, MetaObj: TJsonObject;
+  Method, Id, Params, ReqVer: string;
 begin
   Result := '';
   if Trim(ALine) = '' then Exit;
@@ -416,11 +485,17 @@ begin
   try
     Method := Obj.GetStr('method', '');
     Id     := ExtractIdRaw(Obj);
+    ReqVer := '';
     ParamsObj := Obj.ChildObject('params');
     Params := '';
     if ParamsObj <> nil then
     try
       Params := ParamsObj.ToJSON;
+      { Modern (2026-07-28) requests declare their protocol version in
+        params._meta on every request -- there is no handshake. }
+      MetaObj := ParamsObj.ChildObject('_meta');
+      if MetaObj <> nil then
+        ReqVer := MetaObj.GetStr('io.modelcontextprotocol/protocolVersion', '');
     finally
       ParamsObj.Free;
     end;
@@ -434,6 +509,19 @@ begin
     Exit;
   end;
 
+  { Per-request version gate (modern era). A declared version we don't
+    serve MUST get UnsupportedProtocolVersionError (-32022) listing what we
+    do support, so the client can retry with a mutual version. Requests
+    with no _meta version are legacy-era and flow through unchanged. }
+  if (ReqVer <> '') and (ReqVer <> MCPServerProtocolModern)
+     and (ReqVer <> MCPServerProtocolVersion) then
+  begin
+    Result := ErrorResponseData(Id, -32022, 'Unsupported protocol version',
+      '{"supported":["' + MCPServerProtocolModern + '","' +
+      MCPServerProtocolVersion + '"],"requested":"' + JsonEscape(ReqVer) + '"}');
+    Exit;
+  end;
+
   { Notifications: methods that start with "notifications/" carry no
     id, expect no response. Silence is the correct reply. }
   if (Id = 'null') and (Copy(Method, 1, Length('notifications/')) = 'notifications/') then
@@ -443,10 +531,14 @@ begin
     Exit;
   end;
 
-  if      Method = 'initialize'  then Result := HandleInitialize(Params, Id)
-  else if Method = 'tools/list'  then Result := HandleToolsList(Id)
-  else if Method = 'tools/call'  then Result := HandleToolsCall(Params, Id)
-  else if Method = 'ping'        then Result := HandlePing(Id)
+  { Dual-era dispatch: server/discover + per-request _meta serve modern
+    stateless clients; initialize keeps serving legacy (2024-11-05)
+    handshake clients. tools/list & tools/call were stateless all along. }
+  if      Method = 'initialize'      then Result := HandleInitialize(Params, Id)
+  else if Method = 'server/discover' then Result := HandleDiscover(Id)
+  else if Method = 'tools/list'      then Result := HandleToolsList(Id)
+  else if Method = 'tools/call'      then Result := HandleToolsCall(Params, Id)
+  else if Method = 'ping'            then Result := HandlePing(Id)
   else
     Result := ErrorResponse(Id, -32601, 'method not found: ' + Method);
 end;

--- a/src/pkg/mcp/PasClaw.MCP.Server.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Server.pas
@@ -78,8 +78,8 @@ type
     function IsExposed(const Name: string): Boolean;
     function HandleInitialize(const Params, Id: string): string;
     function HandleDiscover(const Id: string): string;
-    function HandleToolsList(const Id: string): string;
-    function HandleToolsCall(const Params, Id: string): string;
+    function HandleToolsList(const Id: string; Modern: Boolean): string;
+    function HandleToolsCall(const Params, Id: string; Modern: Boolean): string;
     function HandlePing(const Id: string): string;
     function ErrorResponse(const Id: string; Code: Integer;
                             const Message: string): string;
@@ -103,7 +103,13 @@ type
         get no response).
       Idempotent + thread-safe (TToolRegistry handles its own locking).
       Never raises; all errors land as JSON-RPC error responses. }
-    function HandleRequest(const ALine: string): string;
+    function HandleRequest(const ALine: string): string; overload;
+    { Transport-aware variant: HttpStatus is the HTTP status an HTTP binding
+      should send with the response -- 400 for UnsupportedProtocolVersionError
+      (per the 2026-07-28 Streamable HTTP rules), 200 otherwise. The stdio
+      loop uses the plain overload and ignores it. }
+    function HandleRequest(const ALine: string;
+                           out HttpStatus: Integer): string; overload;
 
     property AllowMutating: Boolean read FAllowMutating;
   end;
@@ -260,7 +266,7 @@ begin
   end;
 end;
 
-function TMCPServerCore.HandleToolsList(const Id: string): string;
+function TMCPServerCore.HandleToolsList(const Id: string; Modern: Boolean): string;
 var
   ResObj, ToolObj: TJsonObject;
   Arr: TJsonArray;
@@ -291,13 +297,21 @@ begin
       end;
     end;
     ResObj.PutArray('tools', Arr);
+    { Modern (2026-07-28) result schema additionally requires resultType +
+      cache directives; legacy clients get the unchanged 2024-11-05 shape. }
+    if Modern then
+    begin
+      ResObj.PutStr('resultType', 'complete');
+      ResObj.PutInt('ttlMs', 0);
+      ResObj.PutStr('cacheScope', 'private');
+    end;
     Result := SuccessResponse(Id, ResObj.ToJSON);
   finally
     ResObj.Free;
   end;
 end;
 
-function TMCPServerCore.HandleToolsCall(const Params, Id: string): string;
+function TMCPServerCore.HandleToolsCall(const Params, Id: string; Modern: Boolean): string;
 var
   ParamsObj, ArgsObj, ResObj, ContentObj: TJsonObject;
   Arr: TJsonArray;
@@ -359,6 +373,7 @@ begin
       Arr.AddObject(ContentObj);
       ResObj.PutArray('content', Arr);
       ResObj.PutBool('isError', True);
+      if Modern then ResObj.PutStr('resultType', 'complete');
       Result := SuccessResponse(Id, ResObj.ToJSON);
     finally
       ResObj.Free;
@@ -374,6 +389,8 @@ begin
     ContentObj.PutStr('text', Output);
     Arr.AddObject(ContentObj);
     ResObj.PutArray('content', Arr);
+    { Modern result schema requires resultType on call results too. }
+    if Modern then ResObj.PutStr('resultType', 'complete');
     Result := SuccessResponse(Id, ResObj.ToJSON);
   finally
     ResObj.Free;
@@ -456,6 +473,10 @@ begin
     ServerInfo.PutStr('version', FVersion);
     Meta.PutObject('io.modelcontextprotocol/serverInfo', ServerInfo);
     ResObj.PutObject('_meta', Meta);
+    { Required cache directives: ttlMs=0 + private -- our tool surface can
+      change per process (skills/config), so tell clients not to cache. }
+    ResObj.PutInt('ttlMs', 0);
+    ResObj.PutStr('cacheScope', 'private');
     Result := SuccessResponse(Id, ResObj.ToJSON);
   finally
     ResObj.Free;
@@ -464,10 +485,20 @@ end;
 
 function TMCPServerCore.HandleRequest(const ALine: string): string;
 var
+  Ignored: Integer;
+begin
+  Result := HandleRequest(ALine, Ignored);
+end;
+
+function TMCPServerCore.HandleRequest(const ALine: string;
+                                      out HttpStatus: Integer): string;
+var
   Obj, ParamsObj, MetaObj: TJsonObject;
   Method, Id, Params, ReqVer: string;
+  Modern: Boolean;
 begin
   Result := '';
+  HttpStatus := 200;
   if Trim(ALine) = '' then Exit;
 
   Obj := nil;
@@ -492,10 +523,15 @@ begin
     try
       Params := ParamsObj.ToJSON;
       { Modern (2026-07-28) requests declare their protocol version in
-        params._meta on every request -- there is no handshake. }
+        params._meta on every request -- there is no handshake. ChildObject
+        allocates a fresh wrapper; free it or every modern request leaks one. }
       MetaObj := ParamsObj.ChildObject('_meta');
       if MetaObj <> nil then
+      try
         ReqVer := MetaObj.GetStr('io.modelcontextprotocol/protocolVersion', '');
+      finally
+        MetaObj.Free;
+      end;
     finally
       ParamsObj.Free;
     end;
@@ -516,11 +552,15 @@ begin
   if (ReqVer <> '') and (ReqVer <> MCPServerProtocolModern)
      and (ReqVer <> MCPServerProtocolVersion) then
   begin
+    { Streamable HTTP sends this JSON-RPC error with HTTP 400 so proxies /
+      clients see a protocol failure, not a success. stdio ignores the hint. }
+    HttpStatus := 400;
     Result := ErrorResponseData(Id, -32022, 'Unsupported protocol version',
       '{"supported":["' + MCPServerProtocolModern + '","' +
       MCPServerProtocolVersion + '"],"requested":"' + JsonEscape(ReqVer) + '"}');
     Exit;
   end;
+  Modern := ReqVer = MCPServerProtocolModern;
 
   { Notifications: methods that start with "notifications/" carry no
     id, expect no response. Silence is the correct reply. }
@@ -536,8 +576,8 @@ begin
     handshake clients. tools/list & tools/call were stateless all along. }
   if      Method = 'initialize'      then Result := HandleInitialize(Params, Id)
   else if Method = 'server/discover' then Result := HandleDiscover(Id)
-  else if Method = 'tools/list'      then Result := HandleToolsList(Id)
-  else if Method = 'tools/call'      then Result := HandleToolsCall(Params, Id)
+  else if Method = 'tools/list'      then Result := HandleToolsList(Id, Modern)
+  else if Method = 'tools/call'      then Result := HandleToolsCall(Params, Id, Modern)
   else if Method = 'ping'            then Result := HandlePing(Id)
   else
     Result := ErrorResponse(Id, -32601, 'method not found: ' + Method);

--- a/src/tests/mcp_server_tests.pas
+++ b/src/tests/mcp_server_tests.pas
@@ -558,6 +558,7 @@ var
   Reg: TToolRegistry;
   Srv: TMCPServerCore;
   Resp: string;
+  HttpStatus: Integer;
 begin
   Reg := TToolRegistry.Create;
   try
@@ -577,24 +578,43 @@ begin
       AssertContains(Resp, '"name":"pasclaw"', 'discover: server name');
       AssertContains(Resp, '"version":"9.9.9"', 'discover: server version');
       AssertContains(Resp, '"tools":{', 'discover: tools capability');
+      AssertContains(Resp, '"ttlMs":0', 'discover: ttlMs cache directive');
+      AssertContains(Resp, '"cacheScope":"private"', 'discover: cacheScope directive');
 
-      { modern tools/list with per-request _meta and NO initialize first }
+      { modern tools/list with per-request _meta and NO initialize first --
+        result carries the modern schema fields }
       Resp := Srv.HandleRequest(
         '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":{' +
         '"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}');
       AssertContains(Resp, '"name":"memory_search"', 'stateless: tools/list works sans handshake');
+      AssertContains(Resp, '"resultType":"complete"', 'stateless: modern list has resultType');
+      AssertContains(Resp, '"ttlMs":0', 'stateless: modern list has ttlMs');
+      AssertContains(Resp, '"cacheScope":"private"', 'stateless: modern list has cacheScope');
 
-      { unsupported declared version -> -32022 with supported+requested }
+      { modern tools/call result carries resultType too }
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{' +
+        '"name":"memory_search","arguments":{"q":"x"},"_meta":{' +
+        '"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}');
+      AssertContains(Resp, 'mem-result for q=x', 'stateless: modern call dispatches');
+      AssertContains(Resp, '"resultType":"complete"', 'stateless: modern call has resultType');
+
+      { unsupported declared version -> -32022 with supported+requested,
+        and the HTTP-binding status hint is 400 }
       Resp := Srv.HandleRequest(
         '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{"_meta":{' +
-        '"io.modelcontextprotocol/protocolVersion":"1900-01-01"}}}');
+        '"io.modelcontextprotocol/protocolVersion":"1900-01-01"}}}', HttpStatus);
       AssertContains(Resp, '-32022', 'version gate: UnsupportedProtocolVersionError code');
       AssertContains(Resp, '"supported"', 'version gate: supported list present');
       AssertContains(Resp, '"requested":"1900-01-01"', 'version gate: requested echoed');
+      AssertTrue(HttpStatus = 400, 'version gate: HTTP status hint is 400');
 
-      { no _meta version at all -> legacy era, still served }
-      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":4,"method":"tools/list"}');
+      { no _meta version at all -> legacy era, still served, status 200,
+        and NO modern-only fields leak into the legacy shape }
+      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":4,"method":"tools/list"}', HttpStatus);
       AssertContains(Resp, '"name":"memory_search"', 'legacy era: bare tools/list still works');
+      AssertNotContains(Resp, 'resultType', 'legacy era: no modern fields in legacy list');
+      AssertTrue(HttpStatus = 200, 'legacy era: HTTP status hint stays 200');
     finally
       Srv.Free;
     end;

--- a/src/tests/mcp_server_tests.pas
+++ b/src/tests/mcp_server_tests.pas
@@ -551,6 +551,58 @@ begin
   end;
 end;
 
+(* MCP 2026-07-28 stateless era: server/discover, per-request _meta version
+   gate, and modern calls working with no initialize handshake. *)
+procedure TestStatelessDiscoverAndVersionGate;
+var
+  Reg: TToolRegistry;
+  Srv: TMCPServerCore;
+  Resp: string;
+begin
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFakeTools(Reg);
+    Srv := TMCPServerCore.Create(Reg, False, '9.9.9');
+    try
+      { server/discover: DiscoverResult shape }
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{' +
+        '"io.modelcontextprotocol/protocolVersion":"2026-07-28",' +
+        '"io.modelcontextprotocol/clientInfo":{"name":"t","version":"0"}}}}');
+      AssertContains(Resp, '"resultType":"complete"', 'discover: resultType complete');
+      AssertContains(Resp, '2026-07-28', 'discover: modern version listed');
+      AssertContains(Resp, '2024-11-05', 'discover: legacy version listed (dual-era)');
+      AssertContains(Resp, 'supportedVersions', 'discover: supportedVersions present');
+      AssertContains(Resp, 'io.modelcontextprotocol/serverInfo', 'discover: serverInfo meta key');
+      AssertContains(Resp, '"name":"pasclaw"', 'discover: server name');
+      AssertContains(Resp, '"version":"9.9.9"', 'discover: server version');
+      AssertContains(Resp, '"tools":{', 'discover: tools capability');
+
+      { modern tools/list with per-request _meta and NO initialize first }
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":{' +
+        '"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}');
+      AssertContains(Resp, '"name":"memory_search"', 'stateless: tools/list works sans handshake');
+
+      { unsupported declared version -> -32022 with supported+requested }
+      Resp := Srv.HandleRequest(
+        '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{"_meta":{' +
+        '"io.modelcontextprotocol/protocolVersion":"1900-01-01"}}}');
+      AssertContains(Resp, '-32022', 'version gate: UnsupportedProtocolVersionError code');
+      AssertContains(Resp, '"supported"', 'version gate: supported list present');
+      AssertContains(Resp, '"requested":"1900-01-01"', 'version gate: requested echoed');
+
+      { no _meta version at all -> legacy era, still served }
+      Resp := Srv.HandleRequest('{"jsonrpc":"2.0","id":4,"method":"tools/list"}');
+      AssertContains(Resp, '"name":"memory_search"', 'legacy era: bare tools/list still works');
+    finally
+      Srv.Free;
+    end;
+  finally
+    Reg.Free;
+  end;
+end;
+
 begin
   TestInitializeRoundTrip;                  WriteLn('  ok: initialize');
   TestInitializedNotificationHasNoResponse; WriteLn('  ok: initialized notification (no response)');
@@ -566,5 +618,6 @@ begin
   TestIdNestedInParamsDoesNotConfuseEcho;   WriteLn('  ok: id-in-params does not leak into echo');
   TestPingRoundTrip;                        WriteLn('  ok: ping round-trip');
   TestDatabaseToolsProjected;               WriteLn('  ok: db_* tools projected over MCP');
+  TestStatelessDiscoverAndVersionGate;      WriteLn('  ok: 2026-07-28 stateless (discover + version gate)');
   WriteLn('PASS');
 end.


### PR DESCRIPTION
Third PR of the arc (after #476, #477): support the MCP **2026-07-28 stateless revision** while keeping legacy clients working — the spec's dual-era server pattern.

## Background

The July 2026 spec removed the `initialize`/`initialized` handshake and `Mcp-Session-Id` entirely: every request stands alone, declaring protocol version + client identity in `params._meta` (`io.modelcontextprotocol/protocolVersion`, `…/clientInfo`), and servers **MUST** implement `server/discover` ([versioning](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning), [discover](https://modelcontextprotocol.io/specification/2026-07-28/server/discover)). `TMCPServerCore` was per-request stateless from day one (it never enforced initialize-before-tools), so this mostly names what we already did.

## Changes (all in `PasClaw.MCP.Server`)

- **`server/discover`** → `DiscoverResult` per spec: `resultType: "complete"`, `supportedVersions: ["2026-07-28", "2024-11-05"]`, tools capability, and `serverInfo` under the `io.modelcontextprotocol/serverInfo` `_meta` key. This doubles as the stdio backward-compat probe dual-era *clients* use to detect a modern server.
- **Per-request version gate**: a declared `_meta` protocol version we don't serve gets `UnsupportedProtocolVersionError` (**-32022**) with `data.supported` + `data.requested`, so modern clients retry with a mutual version. Requests without a `_meta` version flow through unchanged (legacy era).
- **`initialize` keeps working** for 2024-11-05 handshake clients — both eras served concurrently on the same endpoint/process, exactly the spec's dual-era pattern. `tools/list` / `tools/call` / `ping` are era-agnostic.

Both surfaces inherit it: `pasclaw mcp stdio` and the gateway's `POST /mcp` route go through the same `HandleRequest`.

## Tests

New `TestStatelessDiscoverAndVersionGate` in `mcp_server_tests`: discover shape (versions incl. both eras, serverInfo meta key, name/version, tools capability), modern `tools/list` succeeding **with no handshake**, the -32022 gate echoing `supported`/`requested`, and bare legacy requests still served. All existing era-2025 tests untouched and green. `make all` links clean.

## Scope note
This is the JSON-RPC-level support (complete for stdio). The Streamable-HTTP `MCP-Protocol-Version` *header* validation on `/mcp` is not enforced — modern clients that send `_meta` (which is required) are fully handled; header-level strictness can follow if a real client needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_