### PR TITLE
Fix Delphi build: NativeInt instead of FPC-only PtrInt in Session.Port

### DIFF
--- a/src/pkg/session/PasClaw.Session.Port.pas
+++ b/src/pkg/session/PasClaw.Session.Port.pas
@@ -543,8 +543,8 @@ begin
         Entries[n].Id       := Obj.GetStr('id', '');
         Entries[n].ParentId := Obj.GetStr('parentId', '');
         b := Lookup.IndexOf(Entries[n].Id);
-        if b >= 0 then Lookup.Objects[b] := TObject(PtrInt(n))   { last wins }
-        else Lookup.AddObject(Entries[n].Id, TObject(PtrInt(n)));
+        if b >= 0 then Lookup.Objects[b] := TObject(NativeInt(n))   { last wins }
+        else Lookup.AddObject(Entries[n].Id, TObject(NativeInt(n)));
         Entries[n].IsMsg    := False;
         Entries[n].Role     := '';
         Entries[n].Body     := '';
@@ -626,7 +626,7 @@ begin
     if Cur = '' then Break;
     { constant-ish parent hop via the sorted id index }
     b := Lookup.IndexOf(Cur);
-    if b >= 0 then i := PtrInt(Lookup.Objects[b])
+    if b >= 0 then i := NativeInt(Lookup.Objects[b])
     else i := -1;
     Inc(Depth);
   end;


### PR DESCRIPTION
## Problem

```
[dcc64 Error] PasClaw.Session.Port.pas(546): E2003 Undeclared identifier: 'PtrInt'
[dcc64 Fatal Error] PasClaw.Gateway.Server.pas(57): F2063 Could not compile used unit 'PasClaw.Session.Port.pas'
```

The id→index lookup added in #479's O(n log n) perf fix cast array indexes through `PtrInt` — an **FPC-only** type, so the Delphi build broke.

## Fix

Replace all three `PtrInt` casts with **`NativeInt`**, the pointer-sized integer that exists on *both* compilers (Delphi 2009+ and FPC) — no `IFDEF` needed.

## Verification
- `make test-session-port` → OK (FPC semantics unchanged).
- `make all` links clean.
- The `dcc64` error at the reported line is resolved by construction (`NativeInt` is a standard Delphi type); please confirm with your Delphi build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_