### PR TITLE
Studio parity 1: mid-turn steering + session import/export + evaluation doc

### DIFF
--- a/docs/studio-parity.md
+++ b/docs/studio-parity.md
@@ -1,0 +1,81 @@
+# PasClaw Studio (FMX) ↔ Web UI parity
+
+Code-level evaluation of `studio/MasterDetail.pas` against `src/pkg/gateway/webui.html`,
+with the exact gateway contracts the client must honor. Updated as parity work lands.
+
+## Verified contracts (ground truth from the gateway source)
+
+**Tool side-channel (SSE).** During `/v1/chat/completions` streaming the gateway
+emits SSE *comment* lines:
+
+```
+: pasclaw-tool {"kind":"call","name":"<tool>","args":<argsJSON>}
+: pasclaw-tool {"kind":"result","name":"<tool>","result":"...","error":"..."}
+```
+
+(`TSSEStreamer.NoteToolCall/NoteToolResult` → `WriteComment('pasclaw-tool ' + …)`).
+Studio's `StreamChat` parser handles this correctly, including comment-only
+events (`data:`-less blocks) and CRLF normalization — the structure is right;
+what remains is the live soak test.
+
+**tool_details persistence.** `PUT /v1/sessions/<id>` accepts a top-level
+`tool_details` (bare JSON array, index-aligned to the flattened user/assistant
+turn sequence); `GET` returns it. Studio writes it (`AddPair('tool_details', …)`)
+and reads it on load — shape matches the store (`Session.Store` treats it as an
+opaque blob).
+
+**Steering.** `POST /v1/steer` body `{"text":"…"}` + `X-PasClaw-Session` header
+(or `"session"` field). Queued server-side; folded into the running turn at the
+next loop iteration as `[user steering]: …`. Bearer-gated.
+
+**Import/export.** `POST /v1/sessions/import` (body = raw export file; server
+auto-detects ChatGPT / Claude Code / Pi / OpenClaw / PasClaw; returns
+`{imported, ids}`); `GET /v1/sessions/<id>/export[?format=md]` returns a
+download. OpenCode is CLI-only (directory import).
+
+## Endpoint coverage diff (grep-verified)
+
+Studio already calls every `/v1/*` route the web UI does **except**, before this
+pass: `/v1/steer`, `/v1/sessions/import`, `/v1/sessions/<id>/export`.
+All three are added by the first parity PR (see below).
+
+## Persistence mapping (web localStorage → studio INI)
+
+| Web (localStorage)        | Studio (INI)                  | Status |
+|---------------------------|-------------------------------|--------|
+| `pasclaw.gw_token.v1`     | `[gateway] token` (+ url)     | ✅ |
+| `pasclaw.model.v1`        | `[chat] model`                | ✅ |
+| `pasclaw.mode.v1`         | `[chat] mode`                 | ✅ |
+| `pasclaw.params.v1`       | `[chat] temperature/max_tokens/system` + per-session `SaveChatParams` | ✅ |
+| `pasclaw.theme.v1`        | `[ui] dark_style`             | ✅ |
+| `pasclaw.tooldetails.v1` (cards on/off) | —               | ❌ add `[chat] tool_details_visible` |
+| `pasclaw.presets.v1` (prompt presets)   | `LoadPromptPresets` exists — verify save side | ⚠️ |
+| (sidebar width — web: none)| `[sidebar] width/visible`    | studio-only, fine |
+
+## Gap matrix (operator's assessment, annotated)
+
+| Area | Finding | Priority |
+|------|---------|----------|
+| Chat side-channel | Parser structurally correct (see contracts). Needs the live soak: long tool args crossing socket chunk boundaries, and reload-after-save alignment when system/tool turns are present (web aligns to the *flattened* user/assistant view — mirror exactly or cards shift by one). | **P1 — live test** |
+| Mid-turn steering | Was absent entirely (Send during streaming = abort only). **Added**: non-empty composer mid-turn → `/v1/steer`; empty → abort (Stop) as before. | **fixed in PR 1** |
+| Session import/export | Absent. **Added**: Import/Export buttons in the sessions sidebar → the gateway endpoints above. | **fixed in PR 1** |
+| Chat markdown | Web renders tables/links/nested lists/inline+block code (`PasClaw.Markdown` renderer server-side + webui CSS). FMX rendering simpler. Needs an FMX markdown pass — biggest visual gap in chat. | P1 |
+| Generated-file affordances | Web chat inlines produced-file cards w/ download; FMX has Files-tab discovery but not transcript-integrated cards. | P2 |
+| Workflow editor | FMX has graph editing/inspectors/run. Web extras to port: derived INPUT/OUTPUT boxes with dashed wires, drag-node-output→output-field template authoring, loop editor (`max`/`until`/feedback), reserved IO gutter so nodes can't spawn under boxes. | P2 |
+| Relay/WebLLM | Web runs a WebLLM worker in-tab with a relay-scoped token (never the main token). FMX equivalent = LocalPal-backed worker; the **scoped-token rule must carry over** (worker gets `/v1/relay/*` only). | P2 |
+| MCP tab | CRUD + invoke exist; gaps are nested-schema form handling and result presentation. Web renders results as MCP `content[]` text blocks — mirror that. | P3 |
+| Files/KB/Memory | Panels exist; wire click-throughs (memory/kb hit → file preview) like web's result cards. | P3 |
+| Cron/Stats/Checkpoints/Logs | Native versions exist; polish + consistent auto-refresh cadence (web refreshes stats on tab focus + 30s). | P3 |
+| Visual QA | Full tab-by-tab pass on Air.style + Light.Style after IDE save/reload. | P3 |
+
+## Live parity test script (run against a real gateway)
+
+1. sessions: create → chat → reload → delete (verify tool cards survive reload)
+2. stream a multi-tool turn; confirm `: pasclaw-tool` cards render live and args
+   > 8 KB don't tear across chunks
+3. mid-turn: type + Send → gateway log shows `steer queued`; reply reflects it
+4. Send with empty composer mid-turn → abort still works
+5. import a ChatGPT `conversations.json` and a Claude Code `.jsonl`; verify
+   list refresh + transcripts; export a session and re-import it
+6. skills install/remove, MCP invoke, workflow create/run/save/load
+7. relay connect; light/dark switch; restart app → all INI settings restored

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -9307,9 +9307,9 @@ end;
 procedure TMasterDetailForm.SessionImportClick(Sender: TObject);
 var
   Base: string;
-  Body: string;
   Dialog: TOpenDialog;
   FilePath: string;
+  SessionId: string;
   Token: string;
 begin
   Dialog := TOpenDialog.Create(Self);
@@ -9322,13 +9322,14 @@ begin
   finally
     Dialog.Free;
   end;
-  Body := TFile.ReadAllText(FilePath, TEncoding.UTF8);
   Base := GatewayBaseUrl;
   Token := FTokenEdit.Text;
+  SessionId := FActiveSessionId;
   SetStatus('importing sessions...');
   TTask.Run(
     procedure
     var
+      Body: string;
       CountText: string;
       ErrorText: string;
       ResponseText: string;
@@ -9337,7 +9338,12 @@ begin
     begin
       CountText := '';
       try
-        ResponseText := HttpText(Base, Token, FActiveSessionId, 'POST',
+        { Read on the worker, not the UI thread: a full ChatGPT
+          conversations.json can be hundreds of MB, which would freeze the
+          form -- and read/decode failures belong inside this try so they
+          surface as a status message instead of escaping. }
+        Body := TFile.ReadAllText(FilePath, TEncoding.UTF8);
+        ResponseText := HttpText(Base, Token, SessionId, 'POST',
           '/v1/sessions/import', Body, 'application/json',
           'application/json', Status);
         if not IsHttpOk(Status) then

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -546,6 +546,9 @@ type
     procedure SaveLocalSettings;
     procedure SavePresetClick(Sender: TObject);
     procedure SendClick(Sender: TObject);
+    procedure SteerActiveTurn(const SteerText: string);
+    procedure SessionExportClick(Sender: TObject);
+    procedure SessionImportClick(Sender: TObject);
     procedure SessionListChange(Sender: TObject);
     procedure SessionSearchChange(Sender: TObject);
     procedure SessionSplitterMoved(Sender: TObject);
@@ -2615,6 +2618,24 @@ begin
   FDeleteSessionButton.Align := TAlignLayout.Client;
   FDeleteSessionButton.Text := 'Delete Session';
   FDeleteSessionButton.OnClick := DeleteSessionClick;
+
+  { Web-UI parity: per-session export (portable JSON) + import (ChatGPT /
+    Claude Code / Pi / OpenClaw / PasClaw exports, auto-detected server-side). }
+  Btn := TButton.Create(Self);
+  Btn.Parent := SessionButtons;
+  Btn.Align := TAlignLayout.Right;
+  Btn.Width := 62;
+  Btn.Text := 'Export';
+  Btn.OnClick := SessionExportClick;
+  SetControlMargins(Btn, 6, 0, 0, 0);
+
+  Btn := TButton.Create(Self);
+  Btn.Parent := SessionButtons;
+  Btn.Align := TAlignLayout.Right;
+  Btn.Width := 62;
+  Btn.Text := 'Import';
+  Btn.OnClick := SessionImportClick;
+  SetControlMargins(Btn, 6, 0, 0, 0);
 
   FSessionSplitter := TSplitter.Create(Self);
   FSessionSplitter.Parent := FBodyLayout;
@@ -9170,6 +9191,181 @@ begin
             SetStatus('facts export failed')
           else
             SetStatus('facts exported');
+        end);
+    end);
+end;
+
+procedure TMasterDetailForm.SteerActiveTurn(const SteerText: string);
+var
+  Base: string;
+  Body: string;
+  Payload: TJSONObject;
+  SessionId: string;
+  Token: string;
+begin
+  Base := GatewayBaseUrl;
+  Token := FTokenEdit.Text;
+  SessionId := FActiveSessionId;
+  if SessionId = '' then
+  begin
+    SetStatus('steer needs an active session');
+    Exit;
+  end;
+  Payload := TJSONObject.Create;
+  try
+    Payload.AddPair('text', SteerText);
+    Body := Payload.ToJSON;
+  finally
+    Payload.Free;
+  end;
+  SetStatus('steering...');
+  TTask.Run(
+    procedure
+    var
+      ErrorText: string;
+      ResponseText: string;
+      Status: Integer;
+    begin
+      try
+        ResponseText := HttpText(Base, Token, SessionId, 'POST', '/v1/steer',
+          Body, 'application/json', 'application/json', Status);
+        if not IsHttpOk(Status) then
+          raise Exception.CreateFmt('steer HTTP %d: %s',
+            [Status, ResponseText]);
+      except
+        on E: Exception do
+          ErrorText := E.Message;
+      end;
+      TThread.Queue(nil,
+        procedure
+        begin
+          if ErrorText <> '' then
+            SetStatus('steer failed: ' + ErrorText)
+          else
+            SetStatus('steering sent (folds into the running turn)');
+        end);
+    end);
+end;
+
+procedure TMasterDetailForm.SessionExportClick(Sender: TObject);
+var
+  Base: string;
+  Dialog: TSaveDialog;
+  FilePath: string;
+  SessionId: string;
+  Token: string;
+begin
+  SessionId := FActiveSessionId;
+  if SessionId = '' then
+  begin
+    SetStatus('select a session to export');
+    Exit;
+  end;
+  Dialog := TSaveDialog.Create(Self);
+  try
+    Dialog.Filter := 'Session JSON|*.json|All files|*.*';
+    Dialog.FileName := SessionId + '.json';
+    if not Dialog.Execute then
+      Exit;
+    FilePath := Dialog.FileName;
+  finally
+    Dialog.Free;
+  end;
+  Base := GatewayBaseUrl;
+  Token := FTokenEdit.Text;
+  SetStatus('exporting session...');
+  TTask.Run(
+    procedure
+    var
+      ErrorText: string;
+      ResponseText: string;
+      Status: Integer;
+    begin
+      try
+        ResponseText := HttpText(Base, Token, SessionId, 'GET',
+          '/v1/sessions/' + SessionId + '/export', '', '',
+          'application/json', Status);
+        if not IsHttpOk(Status) then
+          raise Exception.CreateFmt('session export HTTP %d: %s',
+            [Status, ResponseText]);
+        TFile.WriteAllText(FilePath, ResponseText, TEncoding.UTF8);
+      except
+        on E: Exception do
+          ErrorText := E.Message;
+      end;
+      TThread.Queue(nil,
+        procedure
+        begin
+          if ErrorText <> '' then
+            SetStatus('session export failed: ' + ErrorText)
+          else
+            SetStatus('session exported to ' + FilePath);
+        end);
+    end);
+end;
+
+procedure TMasterDetailForm.SessionImportClick(Sender: TObject);
+var
+  Base: string;
+  Body: string;
+  Dialog: TOpenDialog;
+  FilePath: string;
+  Token: string;
+begin
+  Dialog := TOpenDialog.Create(Self);
+  try
+    Dialog.Filter :=
+      'Chat exports|*.json;*.jsonl|JSON|*.json|JSONL|*.jsonl|All files|*.*';
+    if not Dialog.Execute then
+      Exit;
+    FilePath := Dialog.FileName;
+  finally
+    Dialog.Free;
+  end;
+  Body := TFile.ReadAllText(FilePath, TEncoding.UTF8);
+  Base := GatewayBaseUrl;
+  Token := FTokenEdit.Text;
+  SetStatus('importing sessions...');
+  TTask.Run(
+    procedure
+    var
+      CountText: string;
+      ErrorText: string;
+      ResponseText: string;
+      Root: TJSONValue;
+      Status: Integer;
+    begin
+      CountText := '';
+      try
+        ResponseText := HttpText(Base, Token, FActiveSessionId, 'POST',
+          '/v1/sessions/import', Body, 'application/json',
+          'application/json', Status);
+        if not IsHttpOk(Status) then
+          raise Exception.CreateFmt('session import HTTP %d: %s',
+            [Status, ResponseText]);
+        Root := TJSONObject.ParseJSONValue(ResponseText);
+        try
+          if Root is TJSONObject then
+            CountText := JsonAsString(TJSONObject(Root), 'imported');
+        finally
+          Root.Free;
+        end;
+      except
+        on E: Exception do
+          ErrorText := E.Message;
+      end;
+      TThread.Queue(nil,
+        procedure
+        begin
+          if ErrorText <> '' then
+            SetStatus('session import failed: ' + ErrorText)
+          else
+          begin
+            if CountText = '' then
+              CountText := '?';
+            SetStatus('imported ' + CountText + ' session(s)');
+            LoadSessions;
+          end;
         end);
     end);
 end;
@@ -21551,6 +21747,17 @@ var
 begin
   if FSending then
   begin
+    { Mid-turn parity with the web UI: a NON-EMPTY composer steers the
+      running turn (POST /v1/steer; the gateway folds it in at the next
+      loop iteration). An empty composer keeps the old behaviour: abort. }
+    Prompt := Trim(FPromptMemo.Lines.Text);
+    if Prompt <> '' then
+    begin
+      SteerActiveTurn(Prompt);
+      FPromptMemo.Lines.Clear;
+      UpdateComposerState;
+      Exit;
+    end;
     FChatAbort := True;
     UpdateComposerState;
     SetStatus('stopping chat...');


### PR DESCRIPTION
First FMX-parity pass for the new `studio/` client, driven by a code-level evaluation against the web UI. The full evaluation — verified gateway contracts, endpoint diff, persistence mapping, prioritized gap matrix, and a live test script — is in **`docs/studio-parity.md`** (part of this PR).

## Evaluation highlights

**Good news first:** a grep-verified endpoint diff shows studio already calls every `/v1/*` route the web UI uses except three, and two load-bearing contracts are already *correct* in the studio code:
- The SSE `: pasclaw-tool {…}` side-channel parser matches the gateway's `WriteComment` framing exactly (including comment-only events and CRLF normalization) — the remaining risk is live-soak behavior (chunk-boundary tearing on big args, reload alignment), covered in the doc's test script.
- `tool_details` round-trips PUT/GET in the store's shape.

## Gaps closed in this PR (the three missing endpoints)

1. **Mid-turn steering (`/v1/steer`)** — Send during a running turn used to mean *abort only*. Now a **non-empty composer** steers the running turn (same semantics as the web UI from #461: gateway folds it in at the next loop iteration); an **empty composer** keeps Stop/abort.
2. **Session import (`/v1/sessions/import`)** — Import button in the sessions sidebar: file picker → posts the raw export (ChatGPT / Claude Code / Pi / OpenClaw / PasClaw, auto-detected server-side) → reports imported count → refreshes the list.
3. **Session export (`/v1/sessions/<id>/export`)** — Export button: saves the active session's portable JSON via a save dialog.

All three follow the file's existing idioms (`GatewayBaseUrl`/`FTokenEdit`, `HttpText`, `TTask.Run` + `TThread.Queue` + `SetStatus`, the `MemoryFactsExportClick` dialog pattern); the new buttons inherit theming from the global `TButton` restyle pass.

## What the doc prioritizes next

P1: live soak of the tool side-channel (script included) and an FMX markdown-rendering pass for chat. P2: workflow-editor extras (IO boxes, drag-to-wire, loop editor), transcript-integrated file cards, LocalPal WebLLM worker **with the relay-scoped-token rule preserved**. P3: MCP nested-schema forms, click-throughs, refresh cadence, tab-by-tab visual QA. Persistence mapping shows the INI already covers nearly all web localStorage equivalents (two small gaps noted).

## ⚠️ Verification caveat

FMX cannot be compiled in this environment (FPC-only). The changes are pattern-matched to the surrounding code and deliberately mechanical, but they need a **Delphi build** plus the doc's live test script against a real gateway. If `dcc` complains, send the errors and I'll fix on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_