### PR TITLE
Studio parity 4: persist the chat tool-card visibility preference

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -465,6 +465,7 @@ type
     procedure KbSearchClick(Sender: TObject);
     procedure KbSourcesChange(Sender: TObject);
     procedure KbSourcesLoadClick(Sender: TObject);
+    procedure UpdateToolsToggleCaption;
     procedure LoadLocalSettings;
     procedure LoadAirStyle;
     procedure LoadChatParams(const SessionId: string);
@@ -13141,13 +13142,23 @@ end;
 procedure TMasterDetailForm.ChatToolsToggleClick(Sender: TObject);
 begin
   FChatToolsExpanded := not FChatToolsExpanded;
-  if FToolsToggleButton <> nil then
-    if FChatToolsExpanded then
-      FToolsToggleButton.Text := 'Tools -'
-    else
-      FToolsToggleButton.Text := 'Tools +';
+  UpdateToolsToggleCaption;
   SaveLocalSettings;   { the toggle is a persisted preference }
   RenderChat;
+end;
+
+procedure TMasterDetailForm.UpdateToolsToggleCaption;
+{ Single place that derives the button caption from FChatToolsExpanded, so
+  the label can't drift from the state -- the toggle handler and the
+  settings-restore path both call it. Nil-safe: harmless if the chat tab
+  hasn't been built yet. }
+begin
+  if FToolsToggleButton = nil then
+    Exit;
+  if FChatToolsExpanded then
+    FToolsToggleButton.Text := 'Tools -'
+  else
+    FToolsToggleButton.Text := 'Tools +';
 end;
 
 procedure TMasterDetailForm.ResetParamsClick(Sender: TObject);
@@ -13331,6 +13342,9 @@ begin
         FParamsToggleButton.Text := 'Params +';
     FChatToolsExpanded := Ini.ReadBool('chat', 'tool_details_expanded',
       FChatToolsExpanded);
+    { BuildInterface has already created the button captioned "Tools +";
+      restoring an expanded preference must move the label with it. }
+    UpdateToolsToggleCaption;
     FOnboardingDismissed := Ini.ReadBool('onboarding', 'dismissed', False);
   finally
     Ini.Free;

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -13146,6 +13146,7 @@ begin
       FToolsToggleButton.Text := 'Tools -'
     else
       FToolsToggleButton.Text := 'Tools +';
+  SaveLocalSettings;   { the toggle is a persisted preference }
   RenderChat;
 end;
 
@@ -13328,6 +13329,8 @@ begin
         FParamsToggleButton.Text := 'Params -'
       else
         FParamsToggleButton.Text := 'Params +';
+    FChatToolsExpanded := Ini.ReadBool('chat', 'tool_details_expanded',
+      FChatToolsExpanded);
     FOnboardingDismissed := Ini.ReadBool('onboarding', 'dismissed', False);
   finally
     Ini.Free;
@@ -13357,6 +13360,10 @@ begin
       FSessionDrawerWidth := FSessionDrawer.Width;
     Ini.WriteInteger('sidebar', 'width', Round(FSessionDrawerWidth));
     Ini.WriteBool('ui', 'dark_style', FDarkStyleEnabled);
+    { Web-UI parity (pasclaw.tooldetails.v1): the tool-card expand/collapse
+      choice is a per-operator preference, not per-session -- it was toggled
+      at runtime but reset to collapsed on every restart. }
+    Ini.WriteBool('chat', 'tool_details_expanded', FChatToolsExpanded);
     Ini.WriteBool('onboarding', 'dismissed', FOnboardingDismissed);
   finally
     Ini.Free;


### PR DESCRIPTION
Fourth FMX-parity pass — closes the one persistence gap found in the audit table in `docs/studio-parity.md`.

## The gap

The web UI stores the chat tool-detail card expand/collapse choice under `pasclaw.tooldetails.v1`. The FMX client toggled `FChatToolsExpanded` at runtime but **never saved it** — it reset to collapsed on every restart. It was the only web local-setting with no INI equivalent (everything else — token, url, model, mode, temperature, max_tokens, system prompt, theme, sidebar — already round-trips).

## Fix

- Save as `[chat] tool_details_expanded`
- Restore in `LoadLocalSettings`
- Write through on toggle, so the choice sticks the way the other chat preferences do

Small, but it's the difference between a preference and a per-run accident — and it completes the persistence column of the parity matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_