### PR TITLE
OpenCode directory import over the gateway + Studio folder picker

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -265,6 +265,13 @@ type
       auto-detected); imports into the store and returns the new ids. }
     procedure HandleSessionsImport(ARequest: TIdHTTPRequestInfo;
                                    AResp: TIdHTTPResponseInfo);
+    (* POST /v1/sessions/import-dir -- body carries a "path" string. OpenCode
+       splits a session across per-message files, so there is no single blob
+       to POST; the directory is read SERVER-SIDE (the path is the gateway
+       host's, which is the desktop-studio-to-localhost case). Bearer-gated
+       like the rest. *)
+    procedure HandleSessionsImportDir(ARequest: TIdHTTPRequestInfo;
+                                      AResp: TIdHTTPResponseInfo);
     { Read a request's POST body as a UTF-8 string ('' when none). }
     function  ReadRequestBody(ARequest: TIdHTTPRequestInfo): string;
     { Fill S.Messages + title/model/provider from a messages/title/model
@@ -1372,6 +1379,7 @@ begin
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/sessions') then HandleSessionsList(AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/sessions') then HandleSessionCreate(ARequest, AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/sessions/import') then HandleSessionsImport(ARequest, AResponse)
+    else if (ARequest.Command = 'POST') and (Doc = '/v1/sessions/import-dir') then HandleSessionsImportDir(ARequest, AResponse)
     else if (Copy(Doc, 1, 13) = '/v1/sessions/') then HandleSessionItem(Doc, ARequest, AResponse)
     else if (ARequest.Command = 'GET')  and (Doc = '/v1/workflows') then HandleWorkflowsList(AResponse)
     else if (ARequest.Command = 'POST') and (Doc = '/v1/workflows') then HandleWorkflowCreate(ARequest, AResponse)
@@ -3456,6 +3464,58 @@ begin
     Exit;
   end;
   N := ImportSessions(Body, Ids, Err);
+  if N = 0 then
+  begin
+    if Err = '' then Err := 'nothing importable found';
+    WriteJSON(AResp, 400, '{"error":"' + JsonEscape(Err) + '"}');
+    Exit;
+  end;
+  Root := TJsonObject.Create;
+  try
+    Root.PutInt('imported', N);
+    Arr := TJsonArray.Create;
+    for i := 0 to High(Ids) do Arr.AddStr(Ids[i]);
+    Root.PutArray('ids', Arr);
+    WriteJSON(AResp, 200, Root.ToJSON);
+  finally
+    Root.Free;
+  end;
+end;
+
+procedure TGatewayServer.HandleSessionsImportDir(ARequest: TIdHTTPRequestInfo;
+                                                 AResp: TIdHTTPResponseInfo);
+var
+  Body, DirPath, Err: string;
+  Ids: TImportedIds;
+  N, i: Integer;
+  Req, Root: TJsonObject;
+  Arr: TJsonArray;
+begin
+  Body := ReadRequestBody(ARequest);
+  DirPath := '';
+  if Trim(Body) <> '' then
+  begin
+    try Req := TJsonObject.Parse(Body); except Req := nil; end;
+    if Req <> nil then
+    try
+      DirPath := Trim(Req.GetStr('path', ''));
+    finally
+      Req.Free;
+    end;
+  end;
+  if DirPath = '' then
+  begin
+    WriteJSON(AResp, 400,
+      '{"error":"import-dir needs a "path" (an OpenCode data directory on the gateway host)"}');
+    Exit;
+  end;
+  if not DirectoryExists(DirPath) then
+  begin
+    WriteJSON(AResp, 404,
+      '{"error":"no such directory on the gateway host: ' + JsonEscape(DirPath) + '"}');
+    Exit;
+  end;
+  N := ImportOpenCodeDir(DirPath, Ids, Err);
   if N = 0 then
   begin
     if Err = '' then Err := 'nothing importable found';

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -3485,7 +3485,7 @@ end;
 procedure TGatewayServer.HandleSessionsImportDir(ARequest: TIdHTTPRequestInfo;
                                                  AResp: TIdHTTPResponseInfo);
 var
-  Body, DirPath, Err: string;
+  Body, DirPath, Err, Reason: string;
   Ids: TImportedIds;
   N, i: Integer;
   Req, Root: TJsonObject;
@@ -3507,6 +3507,18 @@ begin
   begin
     WriteJSON(AResp, 400,
       '{"error":"import-dir needs a "path" (an OpenCode data directory on the gateway host)"}');
+    Exit;
+  end;
+  { The gateway's invariant is that an HTTP client cannot read arbitrary host
+    paths -- every /v1/fs handler gates on CanReadPathHTTP first. This route
+    reads message files and PERSISTS them as sessions the same client can then
+    fetch back, so skipping the gate would hand any caller (and, when no token
+    is configured, any unauthenticated caller) an arbitrary-file-read
+    primitive. Gate BEFORE the existence check so the response can't be used
+    to probe for paths outside the sandbox either. }
+  if not CanReadPathHTTP(DirPath, Reason) then
+  begin
+    WriteJSON(AResp, 403, '{"error":"' + JsonEscape(Reason) + '"}');
     Exit;
   end;
   if not DirectoryExists(DirPath) then

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -551,6 +551,7 @@ type
     procedure SteerActiveTurn(const SteerText: string);
     procedure SessionExportClick(Sender: TObject);
     procedure SessionImportClick(Sender: TObject);
+    procedure SessionImportDirClick(Sender: TObject);
     procedure SessionListChange(Sender: TObject);
     procedure SessionSearchChange(Sender: TObject);
     procedure SessionSplitterMoved(Sender: TObject);
@@ -2708,6 +2709,16 @@ begin
   Btn.Width := 62;
   Btn.Text := 'Import';
   Btn.OnClick := SessionImportClick;
+  SetControlMargins(Btn, 6, 0, 0, 0);
+
+  { OpenCode keeps a session split across per-message files, so it imports as
+    a DIRECTORY rather than a single export blob. }
+  Btn := TButton.Create(Self);
+  Btn.Parent := SessionButtons;
+  Btn.Align := TAlignLayout.Right;
+  Btn.Width := 74;
+  Btn.Text := 'Import Dir';
+  Btn.OnClick := SessionImportDirClick;
   SetControlMargins(Btn, 6, 0, 0, 0);
 
   FSessionSplitter := TSplitter.Create(Self);
@@ -9443,6 +9454,80 @@ begin
             if CountText = '' then
               CountText := '?';
             SetStatus('imported ' + CountText + ' session(s)');
+            LoadSessions;
+          end;
+        end);
+    end);
+end;
+
+procedure TMasterDetailForm.SessionImportDirClick(Sender: TObject);
+{ Import an OpenCode data directory (~/.local/share/opencode). The gateway
+  reads the directory itself -- OpenCode fragments a session across
+  storage/session + storage/message + storage/part files, so there is no
+  single body to POST. The path is therefore resolved on the GATEWAY HOST,
+  which is the desktop-studio-against-localhost case; a remote gateway needs
+  a path that exists on the server. }
+var
+  Base: string;
+  Body: string;
+  DirPath: string;
+  Payload: TJSONObject;
+  Token: string;
+begin
+  DirPath := '';
+  if not SelectDirectory('Select the OpenCode data directory', '', DirPath) then
+    Exit;
+  DirPath := Trim(DirPath);
+  if DirPath = '' then
+    Exit;
+  Payload := TJSONObject.Create;
+  try
+    Payload.AddPair('path', DirPath);
+    Body := Payload.ToJSON;
+  finally
+    Payload.Free;
+  end;
+  Base := GatewayBaseUrl;
+  Token := FTokenEdit.Text;
+  SetStatus('importing OpenCode sessions...');
+  TTask.Run(
+    procedure
+    var
+      CountText: string;
+      ErrorText: string;
+      ResponseText: string;
+      Root: TJSONValue;
+      Status: Integer;
+    begin
+      CountText := '';
+      try
+        ResponseText := HttpText(Base, Token, '', 'POST',
+          '/v1/sessions/import-dir', Body, 'application/json',
+          'application/json', Status);
+        if not IsHttpOk(Status) then
+          raise Exception.CreateFmt('import-dir HTTP %d: %s',
+            [Status, ResponseText]);
+        Root := TJSONObject.ParseJSONValue(ResponseText);
+        try
+          if Root is TJSONObject then
+            CountText := JsonAsString(TJSONObject(Root), 'imported');
+        finally
+          Root.Free;
+        end;
+      except
+        on E: Exception do
+          ErrorText := E.Message;
+      end;
+      TThread.Queue(nil,
+        procedure
+        begin
+          if ErrorText <> '' then
+            SetStatus('OpenCode import failed: ' + ErrorText)
+          else
+          begin
+            if CountText = '' then
+              CountText := '?';
+            SetStatus('imported ' + CountText + ' OpenCode session(s)');
             LoadSessions;
           end;
         end);


### PR DESCRIPTION
Closes the last *functional* import gap: OpenCode was CLI-only.

## Why it needed a different endpoint

OpenCode fragments a session across `storage/session/<proj>/<id>.json` + `storage/message/<id>/msg_*.json` (+ per-part files), so there's **no single blob** to POST at `/v1/sessions/import` — neither the web UI nor Studio could reach the importer that already existed in `PasClaw.Session.Port`.

## Gateway

`POST /v1/sessions/import-dir` with a `path` string → calls the existing `ImportOpenCodeDir` → returns `{imported, ids}` like its file-based sibling. Bearer-gated; 400 on a missing path, 404 when the directory isn't on the host.

**Scope note, stated in the code and the error text:** the path resolves on the **gateway host**. That's exactly right for the desktop-Studio-against-localhost case; a remote gateway needs a path that exists server-side, and the 404 says so rather than failing mysteriously.

## Studio

An **"Import Dir"** button beside Import opens a folder picker and posts the chosen directory, reporting the imported count and refreshing the session list — same shape as the file import from #481.

## Verification
- `make all` links clean (gateway side compiled here).
- The importer itself is already covered by `session_port_tests` (all three OpenCode text layouts, ms→s normalization, the not-an-OpenCode-dir error); this PR is the transport in front of it.
- FMX side needs a Delphi build as usual. One brace-comment hazard bit during this change (`{"path":"…"}` inside a `{ }` doc comment closed it early) — caught and fixed by the FPC build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_