### PR TITLE
Fix dcc64 build: comment ended early by a JSON example

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -17238,10 +17238,12 @@ begin
   try
     if Root is TJSONObject then
     begin
-      { An MCP text content block is the payload the operator actually wants
-        to read. Showing JsonPretty of {"type":"text","text":"..."} buries it
-        in escapes -- render the text itself, with the raw block underneath
-        for anything a caller still needs (annotations, mime types). }
+      (* An MCP text content block is the payload the operator actually wants
+         to read. Pretty-printing the whole block buries it in escapes --
+         render the text itself, with the raw block underneath for anything a
+         caller still needs (annotations, mime types). Paren-star delimiters:
+         a JSON example inside a curly-brace comment ends it at the first
+         '}', which is what broke the dcc64 build. *)
       TextValue := JsonAsString(TJSONObject(Root), 'text');
       if (TextValue <> '') and
         SameText(JsonAsString(TJSONObject(Root), 'type'), 'text') then


### PR DESCRIPTION
Fixes the `dcc64` build break you hit. This never had a PR — I pushed the branch but never opened one, so it wasn't in #488 or anywhere else. Main still has the broken comment.

## The error

```
[dcc64 Error] MasterDetail.pas(17242): E2003 Undeclared identifier: 'buries'
[dcc64 Error] MasterDetail.pas(17243): E2003 Undeclared identifier: 'escapes'
[dcc64 Error] MasterDetail.pas(17243): E2029 'END' expected but ',' found
```

## Cause

The comment I added in #486 embedded a JSON example inside curly-brace delimiters:

```pascal
{ ... Showing JsonPretty of {"type":"text","text":"..."} buries it
  in escapes -- render the text itself ... }
```

Pascal ends a `{ }` comment at the **first** `}` — which is the JSON's, not mine. Everything after it (`buries it in escapes -- render...`) was parsed as code.

## Fix

Reworded without the JSON literal and switched to `(* *)` delimiters, with a note saying why. Verified with a comment-state scan of the whole unit (tracking string literals and `(* *)` blocks so it doesn't false-positive on the JSON *strings* in the file): **no other brace comment contains a JSON-ish fragment**.

## Why this reached you

The identical hazard has been caught and fixed several times under `src/` — FPC flags it in seconds. It got through here because **nothing in this environment compiles `studio/`**: it's Delphi-only, so for that directory your build is the only compiler in the loop. That's an argument for either a syntax-only FPC pass over the studio unit or keeping JSON out of `{ }` comments there by rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_