### PR TITLE
Fix dcc64 build: const/var block split and IRoot cast

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -712,6 +712,7 @@ const
   WIN_STARTF_USESHOWWINDOW = $00000001;
   WIN_STARTF_USESTDHANDLES = $00000100;
   WIN_STILL_ACTIVE = 259;
+  WIN_SW_HIDE = 0;
 
 var
   (* Visual hierarchy, assigned per theme in ApplyTheme. These cannot be
@@ -732,7 +733,6 @@ var
   UI_USER_BORDER: TAlphaColor  = $FF2F4560;
   UI_COMPOSER_FILL: TAlphaColor   = $FF1A1E24; { 3 -- composer }
   UI_COMPOSER_BORDER: TAlphaColor = $FF3BA7FF;
-  WIN_SW_HIDE = 0;
 
 type
   TWinSecurityAttributes = record
@@ -1783,8 +1783,10 @@ begin
   if StyleBook = nil then
     Exit(True);            { platform style in use -- its icons exist }
   Found := False;
-  if StyleBook.Root <> nil then
-    Walk(StyleBook.Root);
+  { TStyleBook.Root is an IRoot, not a TFmxObject -- reach the object behind
+    the interface and only walk it when it really is an FMX node. }
+  if (StyleBook.Root <> nil) and (StyleBook.Root.GetObject is TFmxObject) then
+    Walk(TFmxObject(StyleBook.Root.GetObject));
   Result := Found;
 end;
 


### PR DESCRIPTION
Fixes the two `dcc64` errors from #490.

```
[dcc64 Error] MasterDetail.pas(735):  E2029 ',' or ':' expected but '=' found
[dcc64 Error] MasterDetail.pas(1787): E2010 Incompatible types:
              'FMX.Types.TFmxObject' and 'FMX.Types.IRoot'
```

## 735 — `var` block split the `const` block

I inserted the hierarchy tokens (`UI_CHAT_TEXT` etc.) as a `var` section in the **middle** of the unit's `const` block. Everything after the insertion point — `WIN_SW_HIDE = 0;` — was then parsed as a *variable* declaration, where `=` is a syntax error rather than an initialiser.

Moved `WIN_SW_HIDE` back among the constants so the `const` section is contiguous and the `var` section starts cleanly after it.

## 1787 — `TStyleBook.Root` is an interface

`Root` is an `IRoot`, not a `TFmxObject`, so it can't be passed to the style-walker directly. Now reaches the object behind the interface via `GetObject`, guarded with an `is` test before the cast:

```pascal
if (StyleBook.Root <> nil) and (StyleBook.Root.GetObject is TFmxObject) then
  Walk(TFmxObject(StyleBook.Root.GetObject));
```

## Note

Both are the same category as the earlier brace-comment break: `studio/` is Delphi-only and nothing in this environment compiles it, so a `dcc64` build is the first real check this code gets. The const/var one in particular is exactly the kind of structural mistake an FPC pass would have caught in a second — worth considering a syntax-only FPC lint over the unit if that's feasible, since it'd catch declaration-shape errors even though FMX itself can't be built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_