### PR TITLE
Studio: fix theme-switch AV — don't iterate a live children list while restyling mutates it

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -1553,16 +1553,21 @@ end;
 procedure TMasterDetailForm.ThemeClick(Sender: TObject);
 begin
   FDarkStyleEnabled := not FDarkStyleEnabled;
-  ApplyTheme;                { swaps StyleBook and restyles the tree itself }
+  ApplyTheme;                { palette globals + StyleBook swap only }
   SaveLocalSettings;
-  { ApplyTheme already ran RestyleCoreControls -- calling it again here just
-    doubled the exposure. The three renders below free and rebuild hundreds
-    of controls; doing that while this button's own click event is still on
-    the stack, in the middle of FMX's style-swap cascade, is the same hazard
-    the walk itself had. Let the frame finish first. }
+  { RestyleCoreControls is REQUIRED here -- ApplyTheme does not call it, and
+    it is the only thing that repaints controls carrying an explicit colour
+    (FPromptMemo would keep the dark theme's near-white ink on the light
+    composer; none of the renders below touch it).
+
+    All four run deferred: they free and rebuild hundreds of controls, and
+    doing that while this button's own click event is still on the stack, in
+    the middle of FMX's style-swap cascade, is the same hazard the walk
+    itself had. Let the frame finish, then restyle, then re-render. }
   TThread.ForceQueue(nil,
     procedure
     begin
+      RestyleCoreControls;
       RenderChat;
       RenderAttachments;
       RenderSessionList;

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -111,6 +111,7 @@ type
     FSandboxLabel: TLabel;
     FChatTurnEdit: TEdit;
     FLoadingSessions: Boolean;
+    FRestyling: Boolean;          { re-entrancy guard for RestyleCoreControls }
     { last payload each auto-refresh rendered, so an unchanged tick is a
       no-op instead of a clear-and-rebuild -- see StatsTimerTick }
     FLastRelayPayload: string;
@@ -1552,12 +1553,20 @@ end;
 procedure TMasterDetailForm.ThemeClick(Sender: TObject);
 begin
   FDarkStyleEnabled := not FDarkStyleEnabled;
-  ApplyTheme;
-  RestyleCoreControls;
-  RenderChat;
-  RenderAttachments;
-  RenderSessionList;
+  ApplyTheme;                { swaps StyleBook and restyles the tree itself }
   SaveLocalSettings;
+  { ApplyTheme already ran RestyleCoreControls -- calling it again here just
+    doubled the exposure. The three renders below free and rebuild hundreds
+    of controls; doing that while this button's own click event is still on
+    the stack, in the middle of FMX's style-swap cascade, is the same hazard
+    the walk itself had. Let the frame finish first. }
+  TThread.ForceQueue(nil,
+    procedure
+    begin
+      RenderChat;
+      RenderAttachments;
+      RenderSessionList;
+    end);
   if FDarkStyleEnabled then
     SetStatus('dark style enabled')
   else if FLightStyleBook <> nil then
@@ -2180,15 +2189,33 @@ begin
 end;
 
 procedure TMasterDetailForm.RestyleCoreControls;
+{ Re-applies the palette to the whole control tree.
+
+  The walk MUST NOT iterate a live children list. Every branch below can
+  rebuild the control's applied style (assigning StyleLookup, StyledSettings,
+  padding or font all mark it for re-application), and in FMX a control's
+  applied style objects ARE its children -- so styling a node can destroy and
+  re-create the very collection the loop is indexing. Assigning StyleBook, as
+  ApplyTheme does immediately before calling this, marks every control in the
+  form for exactly that rebuild.
+
+  That is the theme-switch access violation: intermittent because it needs a
+  rebuild to land inside the loop, and hard to repeat because by the second
+  switch most controls are already settled. Snapshot the children after
+  styling the node, then walk the snapshot, skipping anything the restyle
+  detached. }
   procedure Walk(Obj: TFmxObject);
   var
     Button: TButton;
     Check: TCheckBox;
     Combo: TComboBox;
     I: Integer;
+    Kids: TArray<TFmxObject>;
     LabelControl: TLabel;
     ListBox: TListBox;
   begin
+    if Obj = nil then
+      Exit;
     if Obj is TLabel then
     begin
       LabelControl := TLabel(Obj);
@@ -2226,11 +2253,28 @@ procedure TMasterDetailForm.RestyleCoreControls;
     else if Obj is TMemo then
       StyleTextControl(TControl(Obj), UI_TEXT, 12);
 
+    { snapshot AFTER styling Obj, so it reflects any style rebuild that just
+      happened rather than the collection that rebuild replaced }
+    SetLength(Kids, Obj.ChildrenCount);
     for I := 0 to Obj.ChildrenCount - 1 do
-      Walk(Obj.Children[I]);
+      Kids[I] := Obj.Children[I];
+    for I := 0 to High(Kids) do
+      { Parent still Obj means the node survived this pass; a style rebuild
+        re-parents or drops its old objects, and those must not be followed }
+      if (Kids[I] <> nil) and (Kids[I].Parent = Obj) then
+        Walk(Kids[I]);
   end;
 begin
-  Walk(Self);
+  { A restyle can raise events that call back in here; a nested walk would
+    style half the tree against a collection the outer walk is still holding }
+  if FRestyling then
+    Exit;
+  FRestyling := True;
+  try
+    Walk(Self);
+  finally
+    FRestyling := False;
+  end;
   UpdateNavButtons;
 end;
 


### PR DESCRIPTION
Fixes the theme-switch access violation reported from the KB tab — crashed once, wouldn't repeat.

**Based on `main` directly.**

## Root cause
`RestyleCoreControls` iterates `Obj.Children[I]` **live** while styling each node. Every branch in that walk can rebuild the control's applied style — assigning `StyleLookup`, `StyledSettings`, padding or font all mark it for re-application — and **in FMX a control's applied style objects are its children**. So styling a node can destroy and re-create the very collection the loop is indexing.

`ApplyTheme` assigns `StyleBook` — marking every control in the form for rebuild — and `ThemeClick` then runs the walk immediately, in the same click frame. That's the widest possible window for a rebuild to land mid-loop.

That accounts for all three details of the report:
- **Intermittent** — it needs a rebuild to fire *inside* the loop, not merely to be pending.
- **Wouldn't repeat** — by the second switch most controls are already settled.
- **On a tab** — the active tab is where styles are realized; inactive tabs have less to rebuild.

## Fixes
- The walk **snapshots** each node's children *after* styling that node, then walks the snapshot, skipping any child the restyle detached (`Parent` no longer the node).
- **Re-entrancy guard** — a restyle can raise events that call back in; a nested walk would style against a collection the outer walk still holds.
- `ThemeClick` **defers** `RestyleCoreControls` + the three render calls out of the click event and out of the style-swap cascade: restyle first, then re-render.

## Review correction (worth reading)
An earlier revision of this PR *removed* the `RestyleCoreControls` call from `ThemeClick`, on my incorrect claim that `ApplyTheme` already made it. It does not — `ApplyTheme` only sets the palette globals and swaps `StyleBook`. My `grep -A60` ran past its 40-line end into `ThemeClick` and matched the very call I then deleted.

That would have been a real regression: nothing repaints controls carrying an explicit colour, so dark → light left the composer memo on the dark theme's near-white ink. The call is restored inside the deferred block. Deferring is what this PR made safe; it was never a reason to drop the walk.

## Audit
The other two `ChildrenCount` loops: `StyleLookupExists` walks the *style book's* graph read-only, and the remaining one is this fix's own snapshot read. Neither mutates.

`make lint-studio` green.

**Cannot be verified without a build** — the crash was intermittent to begin with, so an absence of AVs on one run isn't proof. If it recurs, the exception address/module will narrow it further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6