### PR TITLE
Studio: icon-only chrome controls, window-edge footer, tool-card header order

### DIFF
--- a/scripts/gen-studio-icons.py
+++ b/scripts/gen-studio-icons.py
@@ -63,7 +63,10 @@ STYLES = [
 # blanks its caption and renders empty on the fallback path), so it carries the
 # same list as PASCLAW_ONLY_LOOKUPS and --check verifies the two agree.
 CUSTOM = {"SunToolButton", "MoonToolButton",
-          "ImportToolButton", "ExportToolButton"}
+          "ImportToolButton", "ExportToolButton",
+          "MenuToolButton", "SlidersToolButton",
+          "ExpandToolButton", "CollapseToolButton",
+          "LinkedToolButton", "UnlinkedToolButton"}
 
 PAS_SOURCE = "studio/MasterDetail.pas"
 
@@ -169,6 +172,29 @@ _CHEV_L = [[(x, 0.50), (x + 0.26, 0.06), (x + 0.40, 0.14),
             (x + 0.19, 0.50), (x + 0.40, 0.86), (x + 0.26, 0.94)]
            for x in (0.06, 0.48)]
 
+# Chrome controls that carry no caption at all. Each is a shape that has to
+# survive at 8px, so they are built from bars, discs and blunt arrows -- a
+# chain link or a plug would be mush at this size.
+_MENU = [rect(0.05, 0.13, 0.95, 0.27),
+         rect(0.05, 0.43, 0.95, 0.57),
+         rect(0.05, 0.73, 0.95, 0.87)]
+
+# two tracks, each with its handle at a different position
+_SLIDERS = [rect(0.04, 0.17, 0.96, 0.29), rect(0.58, 0.07, 0.78, 0.39),
+            rect(0.04, 0.61, 0.96, 0.73), rect(0.22, 0.51, 0.42, 0.83)]
+
+# arrows leaving the centre (expand) and arriving at it (collapse)
+_ARROW_OUT_L = [(0.02, 0.50), (0.30, 0.20), (0.30, 0.39),
+                (0.46, 0.39), (0.46, 0.61), (0.30, 0.61), (0.30, 0.80)]
+_EXPAND = [_ARROW_OUT_L, flip_x(_ARROW_OUT_L)]
+_ARROW_IN_L = [(0.46, 0.50), (0.18, 0.20), (0.18, 0.39),
+               (0.02, 0.39), (0.02, 0.61), (0.18, 0.61), (0.18, 0.80)]
+_COLLAPSE = [_ARROW_IN_L, flip_x(_ARROW_IN_L)]
+
+# live = solid, offline = hollow; the oldest status convention there is
+_LINKED = [arc(0.5, 0.5, 0.35, 0.0, 360.0)]
+_UNLINKED = [ring(0.5, 0.5, 0.37, 0.21)]
+
 # ------------------------------------------------------------------ glyphs --
 # Each entry: lookup name -> list of closed subpaths.
 
@@ -198,6 +224,13 @@ GLYPHS = {
     "RefreshToolButton":    [_REFRESH_RING, _REFRESH_HEAD],
 
     # lens ring + handle
+    "MenuToolButton":       _MENU,
+    "SlidersToolButton":    _SLIDERS,
+    "ExpandToolButton":     _EXPAND,
+    "CollapseToolButton":   _COLLAPSE,
+    "LinkedToolButton":     _LINKED,
+    "UnlinkedToolButton":   _UNLINKED,
+
     "SunToolButton":        _SUN,
     "MoonToolButton":       _MOON,
 

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -614,6 +614,7 @@ type
     procedure UpdateClearAttachmentsButton;
     function FriendlyAge(const StampText: string): string;
     class function IsIconified(Button: TButton): Boolean; static;
+    procedure SetButtonWidth(Button: TButton; W: Single);
     procedure UseStyledLabelColor(LabelControl: TLabel);
     procedure StyleLabel(LabelControl: TLabel; Color: TAlphaColor;
       Size: Single; Bold: Boolean);
@@ -2398,10 +2399,7 @@ begin
   if FSessionToggleButton <> nil then
   begin
     FSessionToggleButton.Visible := True;
-    { width and caption belong to SetIconButton -- writing the glyph char
-      back here would give the icon a text face again on every resize }
-    if not IsIconified(FSessionToggleButton) then
-      FSessionToggleButton.Width := 42;
+    SetButtonWidth(FSessionToggleButton, 42);
   end;
 
   { The drawer-header buttons are not resized here: the drawer's width does
@@ -2409,14 +2407,13 @@ begin
     icon-less fallback already fits. }
   if FRefreshButton <> nil then
   begin
-    FRefreshButton.Width := IfThen(Narrow, 44, IfThen(Compact, 78, 92));
+    SetButtonWidth(FRefreshButton, IfThen(Narrow, 44, IfThen(Compact, 78, 92)));
     RenderConnectButton;   { caption follows connection state, not layout }
   end;
   if FThemeButton <> nil then
   begin
     FThemeButton.Visible := not Narrow;
-    if not IsIconified(FThemeButton) then
-      FThemeButton.Width := IfThen(Compact, 62, 70);
+    SetButtonWidth(FThemeButton, IfThen(Compact, 62, 70));
   end;
   if FStatusLabel <> nil then
     FStatusLabel.Visible := not Narrow;
@@ -2426,12 +2423,12 @@ begin
   if FTokenShowButton <> nil then
   begin
     FTokenShowButton.Visible := not Narrow;
-    FTokenShowButton.Width := IfThen(Compact, 52, 58);
+    SetButtonWidth(FTokenShowButton, IfThen(Compact, 52, 58));
   end;
   if FTokenClearButton <> nil then
   begin
     FTokenClearButton.Visible := not Narrow;
-    FTokenClearButton.Width := IfThen(Compact, 52, 58);
+    SetButtonWidth(FTokenClearButton, IfThen(Compact, 52, 58));
   end;
 
   if FNavHost <> nil then
@@ -2510,15 +2507,15 @@ begin
     FNavCombo.Visible := False;
 
   if FModeButton <> nil then
-    FModeButton.Width := IfThen(Narrow, 76, 94);
+    SetButtonWidth(FModeButton, IfThen(Narrow, 76, 94));
   if FModelCombo <> nil then
     FModelCombo.Width := IfThen(Narrow, 150, IfThen(Compact, 210, 260));
   if FParamsToggleButton <> nil then
-    FParamsToggleButton.Width := IfThen(Narrow, 64, 82);
+    SetButtonWidth(FParamsToggleButton, IfThen(Narrow, 64, 82));
   if FToolsToggleButton <> nil then
   begin
     FToolsToggleButton.Visible := ChatW >= 560;
-    FToolsToggleButton.Width := IfThen(Narrow, 72, 86);
+    SetButtonWidth(FToolsToggleButton, IfThen(Narrow, 72, 86));
   end;
   if FParamsSummaryLabel <> nil then
   begin
@@ -2557,15 +2554,14 @@ begin
   if FTemperatureTrack <> nil then
     FTemperatureTrack.Width := IfThen(Narrow, 140, IfThen(Compact, 170, 210));
   UpdateComposerState;
-  if (FSendButton <> nil) and not IsIconified(FSendButton) then
-    FSendButton.Width := IfThen(Narrow, 78, 96);
-  if (FAttachButton <> nil) and not IsIconified(FAttachButton) then
-    FAttachButton.Width := IfThen(Narrow, 76, 86);
+  if FSendButton <> nil then
+    SetButtonWidth(FSendButton, IfThen(Narrow, 78, 96));
+  if FAttachButton <> nil then
+    SetButtonWidth(FAttachButton, IfThen(Narrow, 76, 86));
   if FClearAttachmentsButton <> nil then
   begin
     UpdateClearAttachmentsButton;
-    if not IsIconified(FClearAttachmentsButton) then
-      FClearAttachmentsButton.Width := IfThen(Compact, 64, 74);
+    SetButtonWidth(FClearAttachmentsButton, IfThen(Compact, 64, 74));
   end;
   if FMaxTokensLabel <> nil then
     FMaxTokensLabel.Visible := not ToolbarCompact;
@@ -2579,19 +2575,19 @@ begin
   if FPresetNameEdit <> nil then
     FPresetNameEdit.Visible := not Narrow;
   if FPresetSaveButton <> nil then
-    FPresetSaveButton.Width := IfThen(Narrow, 56, 62);
+    SetButtonWidth(FPresetSaveButton, IfThen(Narrow, 56, 62));
   if FParamsResetButton <> nil then
-    FParamsResetButton.Width := IfThen(Narrow, 56, 62);
+    SetButtonWidth(FParamsResetButton, IfThen(Narrow, 56, 62));
   if FPresetDeleteButton <> nil then
-    FPresetDeleteButton.Width := IfThen(Narrow, 58, 68);
+    SetButtonWidth(FPresetDeleteButton, IfThen(Narrow, 58, 68));
   if FUndoButton <> nil then
-    FUndoButton.Width := IfThen(Narrow, 58, 70);
+    SetButtonWidth(FUndoButton, IfThen(Narrow, 58, 70));
   if FRedoButton <> nil then
-    FRedoButton.Width := IfThen(Narrow, 58, 70);
+    SetButtonWidth(FRedoButton, IfThen(Narrow, 58, 70));
   if FChatCopyButton <> nil then
   begin
     FChatCopyButton.Visible := ChatW >= 760;
-    FChatCopyButton.Width := IfThen(ToolbarCompact, 58, 62);
+    SetButtonWidth(FChatCopyButton, IfThen(ToolbarCompact, 58, 62));
   end;
   if FChatTurnEdit <> nil then
     FChatTurnEdit.Width := IfThen(Narrow, 42, 52);
@@ -2952,13 +2948,13 @@ begin
   if FRelayUrlEdit <> nil then
     FRelayUrlEdit.Width := IfThen(Narrow, 170, IfThen(Compact, 230, 300));
   if FRelayShowTokenButton <> nil then
-    FRelayShowTokenButton.Width := IfThen(Narrow, 58, 68);
+    SetButtonWidth(FRelayShowTokenButton, IfThen(Narrow, 58, 68));
   if FRelayWorkerCommandEdit <> nil then
     FRelayWorkerCommandEdit.Width := IfThen(Narrow, 104, IfThen(Compact, 146, 190));
   if FRelayWorkerConnectButton <> nil then
-    FRelayWorkerConnectButton.Width := IfThen(Narrow, 72, 82);
+    SetButtonWidth(FRelayWorkerConnectButton, IfThen(Narrow, 72, 82));
   if FRelayWorkerDisconnectButton <> nil then
-    FRelayWorkerDisconnectButton.Width := IfThen(Narrow, 82, 92);
+    SetButtonWidth(FRelayWorkerDisconnectButton, IfThen(Narrow, 82, 92));
   if FRelayWorkerProfileCombo <> nil then
     FRelayWorkerProfileCombo.Width := IfThen(Narrow, 96, IfThen(Compact, 116, 136));
   if FRelayWorkerIdEdit <> nil then
@@ -15557,6 +15553,22 @@ begin
   Result := (FTabControl <> nil) and (FTabControl.TabIndex >= 0) and
     (FTabControl.TabIndex < FTabControl.TabCount) and
     SameText(FTabControl.Tabs[FTabControl.TabIndex].Text, Caption);
+end;
+
+procedure TMasterDetailForm.SetButtonWidth(Button: TButton; W: Single);
+{ The ONE place a responsive width is applied to a button.
+
+  An iconified button's width belongs to the icon system (ICON_BTN_W), and
+  the layout pass runs on construction, on every resize, and right after a
+  toggle -- so any width it writes wins. Guarding each call site was tried
+  and failed the way per-site rules always do here: two of them were added
+  with the icons and the two that already existed were missed, leaving
+  Params and Tools as wide, mostly empty pills. The rule lives here now, so
+  a new call site cannot forget it. }
+begin
+  if (Button = nil) or IsIconified(Button) then
+    Exit;
+  Button.Width := W;
 end;
 
 class function TMasterDetailForm.IsIconified(Button: TButton): Boolean;

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -562,6 +562,10 @@ type
     procedure RenderModeButton;
     procedure RenderParamsButton;
     procedure RenderConnectButton;
+    procedure RenderToolsButton;
+    procedure UpdateFooterVisibility;
+    procedure SetIconButton(Button: TButton; const Lookup, HintText,
+      FallbackCaption: string);
     function GatewayIdentity: string;
     procedure GatewaySettingsChange(Sender: TObject);
     procedure RenderSessionSearchBox;
@@ -758,8 +762,11 @@ const
      equivalent and must not be trusted when no book is loaded.
      scripts/gen-studio-icons.py --check verifies this list against the
      generator's own CUSTOM set, so the two cannot drift. *)
-  PASCLAW_ONLY_LOOKUPS: array[0..3] of string = (
-    'exporttoolbutton', 'importtoolbutton', 'moontoolbutton', 'suntoolbutton');
+  PASCLAW_ONLY_LOOKUPS: array[0..9] of string = (
+    'collapsetoolbutton', 'expandtoolbutton', 'exporttoolbutton',
+    'importtoolbutton', 'linkedtoolbutton', 'menutoolbutton',
+    'moontoolbutton', 'sliderstoolbutton', 'suntoolbutton',
+    'unlinkedtoolbutton');
   WF_IO_W = 104;
   WF_GUTTER = 128;
   WIN_CREATE_ALWAYS = 2;
@@ -2391,8 +2398,10 @@ begin
   if FSessionToggleButton <> nil then
   begin
     FSessionToggleButton.Visible := True;
-    FSessionToggleButton.Width := 42;
-    FSessionToggleButton.Text := #$2630;
+    { width and caption belong to SetIconButton -- writing the glyph char
+      back here would give the icon a text face again on every resize }
+    if not IsIconified(FSessionToggleButton) then
+      FSessionToggleButton.Width := 42;
   end;
 
   { The drawer-header buttons are not resized here: the drawer's width does
@@ -2525,7 +2534,7 @@ begin
       FChatParamsLayout.Height := 0;
   end;
   if FChatStatsLabel <> nil then
-    FChatStatsLabel.Height := IfThen(Narrow, 0, 22);
+    UpdateFooterVisibility;   { one owner for the footer's size }
   if FSandboxLabel <> nil then
   begin
     FSandboxLabel.Visible := (ClientHeight >= 900) and (ChatW >= 860);
@@ -3131,8 +3140,9 @@ begin
   FSessionToggleButton.Parent := FHeaderRow;
   FSessionToggleButton.Align := TAlignLayout.Left;
   FSessionToggleButton.Width := 42;
-  FSessionToggleButton.Text := #$2630;
   FSessionToggleButton.OnClick := ToggleSessionsClick;
+  SetIconButton(FSessionToggleButton, 'menutoolbutton',
+    'Show or hide the sessions drawer', #$2630);
   SetControlMargins(FSessionToggleButton, 0, 0, 8, 0);
 
   LabelControl := TLabel.Create(Self);
@@ -3613,12 +3623,9 @@ begin
   TopLine.Height := 44;
   SetControlPadding(TopLine, 10, 5, 10, 3);
 
-  Chrome := TRectangle.Create(Self);
-  Chrome.Parent := TopLine;
-  Chrome.Align := TAlignLayout.Client;
-  StyleChromeRect(Chrome, UI_PANEL, UI_BORDER, 6, False);
-  Chrome.SendToBack;
-
+  { No chrome rect behind the chat toolbar: with the buttons iconified it
+    framed mostly empty space, and an outlined box holding nothing reads as
+    a control that failed to load. The row needs no ground of its own. }
   FParamsToggleButton := TButton.Create(Self);
   FParamsToggleButton.Parent := TopLine;
   { far right, captioned like the drop-down it actually is }
@@ -3632,8 +3639,8 @@ begin
   FToolsToggleButton.Parent := TopLine;
   FToolsToggleButton.Align := TAlignLayout.Left;
   FToolsToggleButton.Width := 86;
-  FToolsToggleButton.Text := 'Tools +';
   FToolsToggleButton.OnClick := ChatToolsToggleClick;
+  RenderToolsButton;
   SetControlMargins(FToolsToggleButton, 0, 0, 8, 0);
 
   FParamsSummaryLabel := TLabel.Create(Self);
@@ -3805,12 +3812,12 @@ begin
   FSystemMemo.OnChange := ChatParamsChanged;
   LoadPromptPresets;
 
-  { Bottom, not Top: turn counts are a footnote about the transcript, and
-    directly above it they were the first thing read on entering the tab.
-    Created before the composer, so it takes the bottom edge and the
-    composer stacks above it. Centred to sit under the reading column. }
+  { A window-level footer, not a tab child: 'below the composer' still left
+    it inside the chat tab's padding, a little adrift. On the form's bottom
+    edge it is unambiguously the last line on screen. It belongs to the
+    chat, so UpdateFooterVisibility hides it on every other tab. }
   FChatStatsLabel := TLabel.Create(Self);
-  FChatStatsLabel.Parent := Tab;
+  FChatStatsLabel.Parent := Self;
   FChatStatsLabel.Align := TAlignLayout.Bottom;
   FChatStatsLabel.Height := 20;
   FChatStatsLabel.Text := '0 turns';
@@ -4164,6 +4171,7 @@ end;
 procedure TMasterDetailForm.TabControlChange(Sender: TObject);
 begin
   UpdateNavButtons;
+  UpdateFooterVisibility;
   ActivateCurrentTab(False);
 end;
 
@@ -12797,6 +12805,38 @@ begin
     SetStatus('model: ' + FSavedModel);
 end;
 
+procedure TMasterDetailForm.SetIconButton(Button: TButton;
+  const Lookup, HintText, FallbackCaption: string);
+{ For buttons whose GLYPH changes with state.
+
+  ApplyButtonIcon cannot do these: it maps caption -> lookup and then exits
+  early once the caption is blank, so a button that has already been
+  iconified can never be re-mapped when its state flips. Their Render*
+  procedures own them instead, and mark them 'noicon' so ApplyButtonIcon
+  keeps its hands off.
+
+  Same safety rule as everywhere else: only surrender the caption once the
+  glyph is known to exist, so a style without it degrades to readable text. }
+begin
+  if Button = nil then
+    Exit;
+  Button.TagString := 'noicon';
+  Button.Hint := HintText;
+  Button.ShowHint := True;
+  if FIconButtons and StyleLookupExists(Lookup) then
+  begin
+    Button.StyleLookup := Lookup;
+    Button.Text := '';
+    if Button.Width > ICON_BTN_W then
+      Button.Width := ICON_BTN_W;
+  end
+  else
+  begin
+    Button.StyleLookup := '';
+    Button.Text := FallbackCaption;
+  end;
+end;
+
 function TMasterDetailForm.GatewayIdentity: string;
 { What "connected" is connected TO. Compared against the identity that last
   answered, so changing either field invalidates the state by itself. }
@@ -12821,14 +12861,12 @@ begin
   if FRefreshButton = nil then
     Exit;
   Online := (FOnlineIdentity <> '') and (FOnlineIdentity = GatewayIdentity);
-  if ClientWidth < UI_NARROW_W then
-    FRefreshButton.Text := IfThen(Online, 'Online', 'Go')
+  if Online then
+    SetIconButton(FRefreshButton, 'linkedtoolbutton',
+      'Connected to the gateway - click to reload sessions', 'Connected')
   else
-    FRefreshButton.Text := IfThen(Online, 'Connected', 'Connect');
-  FRefreshButton.Hint := IfThen(Online,
-    'Connected to the gateway - click to reload sessions',
-    'Connect to the gateway');
-  FRefreshButton.ShowHint := True;
+    SetIconButton(FRefreshButton, 'unlinkedtoolbutton',
+      'Connect to the gateway', 'Connect');
 end;
 
 procedure TMasterDetailForm.RenderSessionSearchBox;
@@ -12867,6 +12905,28 @@ begin
   end;
 end;
 
+procedure TMasterDetailForm.UpdateFooterVisibility;
+{ The turn counter footer describes the transcript, so it only belongs on
+  the tab that shows one. }
+begin
+  if FChatStatsLabel = nil then
+    Exit;
+  FChatStatsLabel.Visible := ActiveTabIs('Chat');
+  FChatStatsLabel.Height := IfThen(FChatStatsLabel.Visible, 20, 0);
+end;
+
+procedure TMasterDetailForm.RenderToolsButton;
+{ Arrows out = expand, arrows in = collapse: the glyph shows what the click
+  DOES, which is the only thing a caption-less control can say. }
+begin
+  if FChatToolsExpanded then
+    SetIconButton(FToolsToggleButton, 'collapsetoolbutton',
+      'Collapse the tool activity cards', 'Tools ' + #$25B4)
+  else
+    SetIconButton(FToolsToggleButton, 'expandtoolbutton',
+      'Expand the tool activity cards', 'Tools ' + #$25BE);
+end;
+
 procedure TMasterDetailForm.RenderParamsButton;
 { The ONLY place the params button's caption is decided -- it was set from
   three (build, toggle, settings load), which is how a disclosure control
@@ -12874,17 +12934,10 @@ procedure TMasterDetailForm.RenderParamsButton;
 begin
   if FParamsToggleButton = nil then
     Exit;
-  if FChatParamsVisible then
-  begin
-    FParamsToggleButton.Text := 'Params ' + #$25B4;
-    FParamsToggleButton.Hint := 'Hide sampling parameters';
-  end
-  else
-  begin
-    FParamsToggleButton.Text := 'Params ' + #$25BE;
-    FParamsToggleButton.Hint := 'Show sampling parameters';
-  end;
-  FParamsToggleButton.ShowHint := True;
+  SetIconButton(FParamsToggleButton, 'sliderstoolbutton',
+    IfThen(FChatParamsVisible, 'Hide sampling parameters',
+    'Show sampling parameters'),
+    IfThen(FChatParamsVisible, 'Params ' + #$25B4, 'Params ' + #$25BE));
 end;
 
 procedure TMasterDetailForm.ParamsToggleClick(Sender: TObject);
@@ -14394,17 +14447,11 @@ begin
 end;
 
 procedure TMasterDetailForm.UpdateToolsToggleCaption;
-{ Single place that derives the button caption from FChatToolsExpanded, so
-  the label can't drift from the state -- the toggle handler and the
-  settings-restore path both call it. Nil-safe: harmless if the chat tab
-  hasn't been built yet. }
+{ Single place that derives the button's FACE from FChatToolsExpanded, so it
+  can't drift from the state -- the toggle handler and the settings-restore
+  path both call it. Nil-safe via SetIconButton. }
 begin
-  if FToolsToggleButton = nil then
-    Exit;
-  if FChatToolsExpanded then
-    FToolsToggleButton.Text := 'Tools -'
-  else
-    FToolsToggleButton.Text := 'Tools +';
+  RenderToolsButton;
 end;
 
 procedure TMasterDetailForm.ResetParamsClick(Sender: TObject);
@@ -21896,7 +21943,7 @@ var
 
     { Returns the vertical space this section actually consumes, so the
       caller can size the panel to its children instead of guessing. }
-    function AddToolDetailSection(Panel: TRectangle; const TitleText,
+    function AddToolDetailSection(Host: TFmxObject; const TitleText,
       DetailText: string): Single;
     var
       Memo: TMemo;
@@ -21905,15 +21952,15 @@ var
       Result := 0;
       if Trim(DetailText) = '' then
         Exit;
-      SectionLabel := TLabel.Create(Panel);
-      SectionLabel.Parent := Panel;
+      SectionLabel := TLabel.Create(Host);
+      SectionLabel.Parent := Host;
       SectionLabel.Align := TAlignLayout.Top;
       SectionLabel.Height := 20;
       SectionLabel.HitTest := False;
       SectionLabel.Text := TitleText;
       StyleLabel(SectionLabel, UI_MUTED, 10, True);
-      Memo := TMemo.Create(Panel);
-      Memo.Parent := Panel;
+      Memo := TMemo.Create(Host);
+      Memo.Parent := Host;
       Memo.Align := TAlignLayout.Top;
       Memo.Height := Min(190, Max(58,
         EstimateTextLines(DetailText, CharsPerLine) * 18 + 24));
@@ -21935,6 +21982,7 @@ var
       I: Integer;
       Panel: TRectangle;
       ResultText: string;
+      SectionHost: TLayout;
       Root: TJSONValue;
       SectionsHeight: Single;
       TitleText: string;
@@ -21967,6 +22015,12 @@ var
           SetControlMargins(Panel, 0, 6, 0, 6);
           SetControlPadding(Panel, 10, 8, 10, 8);
 
+          { The header is a Top sibling and the sections live in a CLIENT
+            host, so the header's position no longer depends on how FMX
+            orders Align.Top siblings -- Client takes whatever is left after
+            the Top children, whichever way that iteration runs. Relying on
+            sibling order is what put the tool name underneath its own
+            output. }
           HeaderLabel := TLabel.Create(Panel);
           HeaderLabel.Parent := Panel;
           HeaderLabel.Align := TAlignLayout.Top;
@@ -21986,13 +22040,16 @@ var
               panel was routinely shorter than its own children -- and since
               the children are Align.Top with fixed heights, the overflow
               painted straight over the following chat bubbles. }
+            SectionHost := TLayout.Create(Panel);
+            SectionHost.Parent := Panel;
+            SectionHost.Align := TAlignLayout.Client;
             SectionsHeight := 0;
             SectionsHeight := SectionsHeight +
-              AddToolDetailSection(Panel, 'ARGS', ArgsText);
+              AddToolDetailSection(SectionHost, 'ARGS', ArgsText);
             SectionsHeight := SectionsHeight +
-              AddToolDetailSection(Panel, 'RESULT', ResultText);
+              AddToolDetailSection(SectionHost, 'RESULT', ResultText);
             SectionsHeight := SectionsHeight +
-              AddToolDetailSection(Panel, 'ERROR', ErrorText);
+              AddToolDetailSection(SectionHost, 'ERROR', ErrorText);
             { header + sections + the panel's own 8/8 vertical padding }
             Panel.Height := Max(44, HeaderLabel.Height + SectionsHeight + 16);
           end;
@@ -22139,17 +22196,8 @@ var
     Header.Align := TAlignLayout.Top;
     Header.Height := 26;
 
-    MetaLabel := TLabel.Create(Header);
-    MetaLabel.Parent := Header;
-    MetaLabel.Align := TAlignLayout.Right;
-    MetaLabel.Width := 110;
-    MetaLabel.HitTest := False;
-    MetaText := Format('turn %d/%d', [Index + 1, Total]);
-    MetaLabel.Text := MetaText;
-    MetaLabel.TextSettings.HorzAlign := TTextAlign.Trailing;
-    MetaLabel.TextSettings.VertAlign := TTextAlign.Center;
-    StyleLabel(MetaLabel, UI_MUTED, 11, False);
-
+    { Copy is created FIRST so it takes the outermost right slot; the turn
+      meta then sits to its left, reading "turn 3/8  [copy]" left to right. }
     HeaderCopyButton := TButton.Create(Header);
     HeaderCopyButton.Parent := Header;
     HeaderCopyButton.Align := TAlignLayout.Right;
@@ -22159,6 +22207,19 @@ var
     HeaderCopyButton.OnClick := ChatTurnActionClick;
     SetControlMargins(HeaderCopyButton, 8, 1, 0, 1);
     StyleButton(HeaderCopyButton, False);
+
+    MetaLabel := TLabel.Create(Header);
+    MetaLabel.Parent := Header;
+    MetaLabel.Align := TAlignLayout.Right;
+    MetaLabel.Width := 96;
+    MetaLabel.HitTest := False;
+    MetaText := Format('turn %d/%d', [Index + 1, Total]);
+    MetaLabel.Text := MetaText;
+    MetaLabel.TextSettings.HorzAlign := TTextAlign.Trailing;
+    MetaLabel.TextSettings.VertAlign := TTextAlign.Center;
+    { same tier as the turn-count footer -- both are notes about the
+      transcript, not part of it }
+    StyleLabel(MetaLabel, UI_MUTED, 10, False);
 
     ActionRow := TLayout.Create(Card);
     ActionRow.Parent := Card;

--- a/studio/PasclawDark.style
+++ b/studio/PasclawDark.style
@@ -3097,6 +3097,79 @@ end
     end
   end
   object TLayout
+    StyleName = 'collapsetoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claWhite
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF3BA7FF
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFFD6DDE6
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        10000000000000001F85EB3E0000003F01000000EC51383ECDCC4C3E01000000
+        EC51383E14AEC73E010000000AD7A33C14AEC73E010000000AD7A33CF6281C3F
+        01000000EC51383EF6281C3F01000000EC51383ECDCC4C3F010000001F85EB3E
+        0000003F00000000713D0A3F0000003F0100000085EB513FCDCC4C3E01000000
+        85EB513F14AEC73E0100000048E17A3F14AEC73E0100000048E17A3FF6281C3F
+        0100000085EB513FF6281C3F0100000085EB513FCDCC4C3F01000000713D0A3F
+        0000003F}
+    end
+  end
+  object TLayout
     StyleName = 'composetoolbutton'
     DesignVisible = False
     Height = 24.000000000000000000
@@ -3242,6 +3315,79 @@ end
         C3F5683F010000008FC2F53C0000403F00000000E17A943E0000403F01000000
         EC51783F0000403F01000000EC51783FC3F5683F01000000E17A943EC3F5683F
         01000000E17A943E0000403F}
+    end
+  end
+  object TLayout
+    StyleName = 'expandtoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claWhite
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF3BA7FF
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFFD6DDE6
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        10000000000000000AD7A33C0000003F010000009A99993ECDCC4C3E01000000
+        9A99993E14AEC73E010000001F85EB3E14AEC73E010000001F85EB3EF6281C3F
+        010000009A99993EF6281C3F010000009A99993ECDCC4C3F010000000AD7A33C
+        0000003F0000000048E17A3F0000003F010000003333333FCDCC4C3E01000000
+        3333333F14AEC73E01000000713D0A3F14AEC73E01000000713D0A3FF6281C3F
+        010000003333333FF6281C3F010000003333333FCDCC4C3F0100000048E17A3F
+        0000003F}
     end
   end
   object TLayout
@@ -3483,6 +3629,156 @@ end
         01000000E17A143F0AD7A33E010000003D0AD73E0AD7A33E010000003D0AD73E
         EC51383E000000003D0AD73ECDCCCC3E01000000E17A143FCDCCCC3E01000000
         E17A143F85EB513F010000003D0AD73E85EB513F010000003D0AD73ECDCCCC3E}
+    end
+  end
+  object TLayout
+    StyleName = 'linkedtoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claWhite
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF3BA7FF
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFFD6DDE6
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        1E000000000000009A99593F0000003F01000000825A573FCF1FD83E01000000
+        10BA503F7F3FB23E01000000560D463F4845903E010000005CDD373FA6CA673E
+        0100000040E0263FBF173D3E0100000019F0133FF995223E010000000000003F
+        9A99193E01000000CF1FD83EF995223E010000007F3FB23EBF173D3E01000000
+        4845903EA6CA673E01000000A6CA673E4845903E01000000BF173D3E7F3FB23E
+        01000000F995223ECF1FD83E010000009A99193E0000003F01000000F995223E
+        19F0133F01000000BF173D3E40E0263F01000000A6CA673E5CDD373F01000000
+        4845903E560D463F010000007F3FB23E10BA503F01000000CF1FD83E825A573F
+        010000000000003F9A99593F0100000019F0133F825A573F0100000040E0263F
+        10BA503F010000005CDD373F560D463F01000000560D463F5CDD373F01000000
+        10BA503F40E0263F01000000825A573F19F0133F010000009A99593F0000003F
+        010000009A99593F0000003F}
+    end
+  end
+  object TLayout
+    StyleName = 'menutoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claWhite
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF3BA7FF
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFFD6DDE6
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        0F00000000000000CDCC4C3DB81E053E010000003333733FB81E053E01000000
+        3333733F713D8A3E01000000CDCC4C3D713D8A3E01000000CDCC4C3DB81E053E
+        00000000CDCC4C3DF628DC3E010000003333733FF628DC3E010000003333733F
+        85EB113F01000000CDCC4C3D85EB113F01000000CDCC4C3DF628DC3E00000000
+        CDCC4C3D48E13A3F010000003333733F48E13A3F010000003333733F52B85E3F
+        01000000CDCC4C3D52B85E3F01000000CDCC4C3D48E13A3F}
     end
   end
   object TLayout
@@ -4113,6 +4409,80 @@ end
     end
   end
   object TLayout
+    StyleName = 'sliderstoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claWhite
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF3BA7FF
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFFD6DDE6
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        14000000000000000AD7233D7B142E3E010000008FC2753F7B142E3E01000000
+        8FC2753FE17A943E010000000AD7233DE17A943E010000000AD7233D7B142E3E
+        00000000E17A143F295C8F3D0100000014AE473F295C8F3D0100000014AE473F
+        14AEC73E01000000E17A143F14AEC73E01000000E17A143F295C8F3D00000000
+        0AD7233DF6281C3F010000008FC2753FF6281C3F010000008FC2753F48E13A3F
+        010000000AD7233D48E13A3F010000000AD7233DF6281C3F00000000AE47613E
+        5C8F023F010000003D0AD73E5C8F023F010000003D0AD73EE17A543F01000000
+        AE47613EE17A543F01000000AE47613E5C8F023F}
+    end
+  end
+  object TLayout
     StyleName = 'stoptoolbutton'
     DesignVisible = False
     Height = 24.000000000000000000
@@ -4357,6 +4727,98 @@ end
         7B142E3E01000000A470BD3E7B142E3E01000000A470BD3E0AD7233D00000000
         7B142E3EC3F5A83E01000000E17A543FC3F5A83E01000000A4703D3F8FC2753F
         01000000B81E853E8FC2753F010000007B142E3EC3F5A83E}
+    end
+  end
+  object TLayout
+    StyleName = 'unlinkedtoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claWhite
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF3BA7FF
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFFD6DDE6
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        430000000000000052B85E3F0000003F0100000065E65C3FC60ADB3E01000000
+        8782573F2481B73E01000000BEC14E3FB6C0963E0100000027FA423F6517743E
+        01000000A59F343F09F9443E010000006E3F243FE5F5213E010000009D7A123F
+        6B660C3E010000000000003FB81E053E01000000C60ADB3E6B660C3E01000000
+        2481B73EE5F5213E01000000B6C0963E09F9443E010000006517743E6517743E
+        0100000009F9443EB6C0963E01000000E5F5213E2481B73E010000006B660C3E
+        C60ADB3E01000000B81E053E0000003F010000006B660C3E9D7A123F01000000
+        E5F5213E6E3F243F0100000009F9443EA59F343F010000006517743E27FA423F
+        01000000B6C0963EBEC14E3F010000002481B73E8782573F01000000C60ADB3E
+        65E65C3F010000000000003F52B85E3F010000009D7A123F65E65C3F01000000
+        6E3F243F8782573F01000000A59F343FBEC14E3F0100000027FA423F27FA423F
+        01000000BEC14E3FA59F343F010000008782573F6E3F243F0100000065E65C3F
+        9D7A123F0100000052B85E3F0000003F010000008FC2353F0000003F01000000
+        1EBA343FF17C0A3F01000000F3AA313FB492143F0100000027B32C3F12DE1D3F
+        010000009903263F9903263F0100000012DE1D3F27B32C3F01000000B492143F
+        F3AA313F01000000F17C0A3F1EBA343F010000000000003F8FC2353F01000000
+        1E06EB3E1EBA343F0100000098DAD63EF3AA313F01000000DD43C43E27B32C3F
+        01000000CDF8B33E9903263F01000000B399A63E12DE1D3F010000001BAA9C3E
+        B492143F01000000C48B963EF17C0A3F01000000E17A943E0000003F01000000
+        C48B963E1E06EB3E010000001BAA9C3E98DAD63E01000000B399A63EDD43C43E
+        01000000CDF8B33ECDF8B33E01000000DD43C43EB399A63E0100000098DAD63E
+        1BAA9C3E010000001E06EB3EC48B963E010000000000003FE17A943E01000000
+        F17C0A3FC48B963E01000000B492143F1BAA9C3E0100000012DE1D3FB399A63E
+        010000009903263FCDF8B33E0100000027B32C3FDD43C43E01000000F3AA313F
+        98DAD63E010000001EBA343F1E06EB3E010000008FC2353F0000003F01000000
+        52B85E3F0000003F}
     end
   end
   object TLayout

--- a/studio/PasclawLight.style
+++ b/studio/PasclawLight.style
@@ -3109,6 +3109,79 @@ object TStyleContainer
     end
   end
   object TLayout
+    StyleName = 'collapsetoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claBlack
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF0969DA
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFF4A5563
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        10000000000000001F85EB3E0000003F01000000EC51383ECDCC4C3E01000000
+        EC51383E14AEC73E010000000AD7A33C14AEC73E010000000AD7A33CF6281C3F
+        01000000EC51383EF6281C3F01000000EC51383ECDCC4C3F010000001F85EB3E
+        0000003F00000000713D0A3F0000003F0100000085EB513FCDCC4C3E01000000
+        85EB513F14AEC73E0100000048E17A3F14AEC73E0100000048E17A3FF6281C3F
+        0100000085EB513FF6281C3F0100000085EB513FCDCC4C3F01000000713D0A3F
+        0000003F}
+    end
+  end
+  object TLayout
     StyleName = 'composetoolbutton'
     DesignVisible = False
     Height = 24.000000000000000000
@@ -3254,6 +3327,79 @@ object TStyleContainer
         C3F5683F010000008FC2F53C0000403F00000000E17A943E0000403F01000000
         EC51783F0000403F01000000EC51783FC3F5683F01000000E17A943EC3F5683F
         01000000E17A943E0000403F}
+    end
+  end
+  object TLayout
+    StyleName = 'expandtoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claBlack
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF0969DA
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFF4A5563
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        10000000000000000AD7A33C0000003F010000009A99993ECDCC4C3E01000000
+        9A99993E14AEC73E010000001F85EB3E14AEC73E010000001F85EB3EF6281C3F
+        010000009A99993EF6281C3F010000009A99993ECDCC4C3F010000000AD7A33C
+        0000003F0000000048E17A3F0000003F010000003333333FCDCC4C3E01000000
+        3333333F14AEC73E01000000713D0A3F14AEC73E01000000713D0A3FF6281C3F
+        010000003333333FF6281C3F010000003333333FCDCC4C3F0100000048E17A3F
+        0000003F}
     end
   end
   object TLayout
@@ -3495,6 +3641,156 @@ object TStyleContainer
         01000000E17A143F0AD7A33E010000003D0AD73E0AD7A33E010000003D0AD73E
         EC51383E000000003D0AD73ECDCCCC3E01000000E17A143FCDCCCC3E01000000
         E17A143F85EB513F010000003D0AD73E85EB513F010000003D0AD73ECDCCCC3E}
+    end
+  end
+  object TLayout
+    StyleName = 'linkedtoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claBlack
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF0969DA
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFF4A5563
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        1E000000000000009A99593F0000003F01000000825A573FCF1FD83E01000000
+        10BA503F7F3FB23E01000000560D463F4845903E010000005CDD373FA6CA673E
+        0100000040E0263FBF173D3E0100000019F0133FF995223E010000000000003F
+        9A99193E01000000CF1FD83EF995223E010000007F3FB23EBF173D3E01000000
+        4845903EA6CA673E01000000A6CA673E4845903E01000000BF173D3E7F3FB23E
+        01000000F995223ECF1FD83E010000009A99193E0000003F01000000F995223E
+        19F0133F01000000BF173D3E40E0263F01000000A6CA673E5CDD373F01000000
+        4845903E560D463F010000007F3FB23E10BA503F01000000CF1FD83E825A573F
+        010000000000003F9A99593F0100000019F0133F825A573F0100000040E0263F
+        10BA503F010000005CDD373F560D463F01000000560D463F5CDD373F01000000
+        10BA503F40E0263F01000000825A573F19F0133F010000009A99593F0000003F
+        010000009A99593F0000003F}
+    end
+  end
+  object TLayout
+    StyleName = 'menutoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claBlack
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF0969DA
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFF4A5563
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        0F00000000000000CDCC4C3DB81E053E010000003333733FB81E053E01000000
+        3333733F713D8A3E01000000CDCC4C3D713D8A3E01000000CDCC4C3DB81E053E
+        00000000CDCC4C3DF628DC3E010000003333733FF628DC3E010000003333733F
+        85EB113F01000000CDCC4C3D85EB113F01000000CDCC4C3DF628DC3E00000000
+        CDCC4C3D48E13A3F010000003333733F48E13A3F010000003333733F52B85E3F
+        01000000CDCC4C3D52B85E3F01000000CDCC4C3D48E13A3F}
     end
   end
   object TLayout
@@ -4125,6 +4421,80 @@ object TStyleContainer
     end
   end
   object TLayout
+    StyleName = 'sliderstoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claBlack
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF0969DA
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFF4A5563
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        14000000000000000AD7233D7B142E3E010000008FC2753F7B142E3E01000000
+        8FC2753FE17A943E010000000AD7233DE17A943E010000000AD7233D7B142E3E
+        00000000E17A143F295C8F3D0100000014AE473F295C8F3D0100000014AE473F
+        14AEC73E01000000E17A143F14AEC73E01000000E17A143F295C8F3D00000000
+        0AD7233DF6281C3F010000008FC2753FF6281C3F010000008FC2753F48E13A3F
+        010000000AD7233D48E13A3F010000000AD7233DF6281C3F00000000AE47613E
+        5C8F023F010000003D0AD73E5C8F023F010000003D0AD73EE17A543F01000000
+        AE47613EE17A543F01000000AE47613E5C8F023F}
+    end
+  end
+  object TLayout
     StyleName = 'stoptoolbutton'
     DesignVisible = False
     Height = 24.000000000000000000
@@ -4369,6 +4739,98 @@ object TStyleContainer
         7B142E3E01000000A470BD3E7B142E3E01000000A470BD3E0AD7233D00000000
         7B142E3EC3F5A83E01000000E17A543FC3F5A83E01000000A4703D3F8FC2753F
         01000000B81E853E8FC2753F010000007B142E3EC3F5A83E}
+    end
+  end
+  object TLayout
+    StyleName = 'unlinkedtoolbutton'
+    DesignVisible = False
+    Height = 24.000000000000000000
+    Width = 34.000000000000000000
+    object TRectangle
+      StyleName = 'hoverwash'
+      Align = Contents
+      Fill.Color = claBlack
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Kind = None
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.150000005960464500
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 0.100000001490116100
+        Trigger = 'IsMouseOver=true'
+        TriggerInverse = 'IsMouseOver=false'
+      end
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.100000001490116100
+        StopValue = 0.200000002980232200
+        Trigger = 'IsPressed=true'
+        TriggerInverse = 'IsPressed=false'
+      end
+    end
+    object TRectangle
+      StyleName = 'focusring'
+      Align = Contents
+      Fill.Kind = None
+      HitTest = False
+      Locked = True
+      Opacity = 0.000000000000000000
+      Stroke.Color = xFF0969DA
+      Stroke.Thickness = 1.500000000000000000
+      XRadius = 6.000000000000000000
+      YRadius = 6.000000000000000000
+      object TFloatAnimation
+        Duration = 0.100000001490116100
+        PropertyName = 'Opacity'
+        StartValue = 0.000000000000000000
+        StopValue = 1.000000000000000000
+        Trigger = 'IsFocused=true'
+        TriggerInverse = 'IsFocused=false'
+      end
+    end
+    object TPath
+      StyleName = 'icon'
+      Align = Center
+      Fill.Color = xFF4A5563
+      Fill.Kind = Solid
+      HitTest = False
+      Locked = True
+      Stroke.Kind = None
+      WrapMode = Fit
+      Height = 8.000000000000000000
+      Width = 8.000000000000000000
+      Data.Path = {
+        430000000000000052B85E3F0000003F0100000065E65C3FC60ADB3E01000000
+        8782573F2481B73E01000000BEC14E3FB6C0963E0100000027FA423F6517743E
+        01000000A59F343F09F9443E010000006E3F243FE5F5213E010000009D7A123F
+        6B660C3E010000000000003FB81E053E01000000C60ADB3E6B660C3E01000000
+        2481B73EE5F5213E01000000B6C0963E09F9443E010000006517743E6517743E
+        0100000009F9443EB6C0963E01000000E5F5213E2481B73E010000006B660C3E
+        C60ADB3E01000000B81E053E0000003F010000006B660C3E9D7A123F01000000
+        E5F5213E6E3F243F0100000009F9443EA59F343F010000006517743E27FA423F
+        01000000B6C0963EBEC14E3F010000002481B73E8782573F01000000C60ADB3E
+        65E65C3F010000000000003F52B85E3F010000009D7A123F65E65C3F01000000
+        6E3F243F8782573F01000000A59F343FBEC14E3F0100000027FA423F27FA423F
+        01000000BEC14E3FA59F343F010000008782573F6E3F243F0100000065E65C3F
+        9D7A123F0100000052B85E3F0000003F010000008FC2353F0000003F01000000
+        1EBA343FF17C0A3F01000000F3AA313FB492143F0100000027B32C3F12DE1D3F
+        010000009903263F9903263F0100000012DE1D3F27B32C3F01000000B492143F
+        F3AA313F01000000F17C0A3F1EBA343F010000000000003F8FC2353F01000000
+        1E06EB3E1EBA343F0100000098DAD63EF3AA313F01000000DD43C43E27B32C3F
+        01000000CDF8B33E9903263F01000000B399A63E12DE1D3F010000001BAA9C3E
+        B492143F01000000C48B963EF17C0A3F01000000E17A943E0000003F01000000
+        C48B963E1E06EB3E010000001BAA9C3E98DAD63E01000000B399A63EDD43C43E
+        01000000CDF8B33ECDF8B33E01000000DD43C43EB399A63E0100000098DAD63E
+        1BAA9C3E010000001E06EB3EC48B963E010000000000003FE17A943E01000000
+        F17C0A3FC48B963E01000000B492143F1BAA9C3E0100000012DE1D3FB399A63E
+        010000009903263FCDF8B33E0100000027B32C3FDD43C43E01000000F3AA313F
+        98DAD63E010000001EBA343F1E06EB3E010000008FC2353F0000003F01000000
+        52B85E3F0000003F}
     end
   end
   object TLayout


### PR DESCRIPTION
All items from this round, including the two sent mid-work. **Based on `main` directly.**

## Icon-only chrome controls
Six new glyphs, previewed at both display size and true 8px before shipping:

| control | glyph |
|---|---|
| Params | sliders |
| Tools | arrows **out** (expand) / arrows **in** (collapse) |
| Connect | filled disc (linked) / hollow ring (unlinked) |
| Sessions hamburger | real menu glyph |

The tools glyph shows what the click *does* rather than what's currently true, which is the only thing a caption-less toggle can usefully say. The hamburger was the last button on screen still wearing a text button's border.

### Why these needed new machinery
`ApplyButtonIcon` maps *caption → lookup* and then exits early once the caption is blank — so a button it has already iconified can **never be re-mapped when its state flips**. `SetIconButton` is the seam for that case: the `Render*` procedures own those four buttons and mark them `noicon` so the caption-driven pass leaves them alone. Same safety rule as everywhere else — the caption is only surrendered once the glyph is known to exist, and all six names are registered in `PASCLAW_ONLY_LOOKUPS` (now 10, guard verified) so the no-style-book fallback keeps readable text.

## Layout
- **Turn counter → the form's bottom edge.** "Below the composer" still left it inside the tab's padding and reading as adrift; it's now the last line on screen, and hidden on tabs with no transcript to count.
- **Copy button after the turn text.** Copy is created first so it takes the outermost right slot — the row reads `turn 3/8  [copy]` left to right. The meta drops to the same muted tier as the footer; both are notes *about* the transcript, not part of it.
- **Expanded tool cards put the tool name back on top.** The header is a Top sibling and the sections now live in a **Client** host, so the header's position no longer depends on how FMX orders `Align.Top` siblings — which is what buried the tool name under its own output. Structural fix rather than a reordering guess, so it holds either way.
- **Chat toolbar loses its chrome rect.** With the buttons iconified it framed mostly empty space, and an outlined box holding nothing reads as a control that failed to load.

`make lint-studio` green (structural + DFM validation + 28 icons/book + custom-list guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_