### PR TITLE
Studio: fix stretched light combo arrow; retone light theme onto warm paper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ test-read-file-encoding: | $(BUILDDIR)
 lint-studio:
 	@python3 scripts/lint-studio.py studio/MasterDetail.pas
 	@python3 scripts/gen-studio-icons.py --check
+	@python3 scripts/retone-light.py --check
 
 # Database tools (Phase 1): engine-agnostic seam + agent tools against a
 # throwaway SQLite file -- SQL classification, mode gating, param binding,

--- a/scripts/gen-studio-icons.py
+++ b/scripts/gen-studio-icons.py
@@ -54,7 +54,10 @@ import sys
 STYLES = [
     # path,                       icon fill,   hover wash,  focus ring
     ("studio/PasclawDark.style",  "xFFD6DDE6", "claWhite",  "xFF3BA7FF"),
-    ("studio/PasclawLight.style", "xFF4A5563", "claBlack",  "xFF0969DA"),
+    # already in the retoned gamut -- scripts/retone-light.py owns this book's
+    # palette, so writing pre-retone values here would make the two generators
+    # fight over the same bytes and neither --check could ever pass
+    ("studio/PasclawLight.style", "xFF5C5851", "claBlack",  "xFF3B6EA8"),
 ]
 
 # Lookups with NO Embarcadero platform equivalent -- they exist only because

--- a/scripts/retone-light.py
+++ b/scripts/retone-light.py
@@ -35,6 +35,20 @@ import sys
 
 TARGET = "studio/PasclawLight.style"
 
+# FMX named colours (TAlphaColorRec) that appear in this book. They are just
+# literals under another spelling, and skipping them left 16 claWhite and 10
+# claWhitesmoke references pure white and cool while --check happily reported
+# the file fully retoned. Only the 'cla' prefix is a colour: 'clearbutton' and
+# 'clearingeditstyle' are STYLE NAMES and must not be touched.
+NAMED = {
+    "claBlack": "FF000000",
+    "claWhite": "FFFFFFFF",
+    "claWhitesmoke": "FFF5F5F5",
+    "claGainsboro": "FFDCDCDC",
+    "claGray": "FF808080",
+    "claNull": "00000000",
+}
+
 # Classification must be a FIXED POINT: the output of a rule has to fall back
 # into the same rule, or a second run would keep transforming. Neutrals land on
 # a warm hue outside the accent band, and accents land inside it, so both are
@@ -132,23 +146,43 @@ def retone(hexstr):
 
 
 def transform(text):
+    """Retone every colour, however it is spelled. Returns (text, map, unknown)."""
     seen = {}
+    unknown = set()
 
-    def repl(m):
-        src = m.group(1)
+    def repl_hex(m):
+        src = m.group(1).upper()
         if src not in seen:
             seen[src] = retone(src)
         return "x" + seen[src]
 
-    return re.sub(r"\bx([0-9A-Fa-f]{8})\b", repl, text), seen
+    def repl_named(m):
+        name = m.group(0)
+        hexval = NAMED.get(name)
+        if hexval is None:
+            unknown.add(name)
+            return name
+        out = retone(hexval)
+        if out == hexval:
+            # identity (claBlack, claNull): leave the name alone rather than
+            # churn it into a literal -- gen-studio-icons.py writes claBlack
+            # into this same file, and rewriting it here would set the two
+            # generators fighting over the same bytes.
+            return name
+        seen[hexval] = out
+        return "x" + out
+
+    text = re.sub(r"\bx([0-9A-Fa-f]{8})\b", repl_hex, text)
+    text = re.sub(r"\bcla[A-Za-z]\w*\b", repl_named, text)
+    return text, seen, unknown
 
 
 def main(argv):
     text = open(TARGET, encoding="utf-8", errors="replace").read()
-    out, mapping = transform(text)
+    out, mapping, unknown = transform(text)
 
     # idempotence: the output must be a fixed point of the same transform
-    again, _ = transform(out)
+    again, _, _ = transform(out)
     if again != out:
         print("NOT IDEMPOTENT -- retoning twice changes the file")
         return 1
@@ -159,6 +193,14 @@ def main(argv):
         for s, d in rows:
             print("x%-9s -> x%-9s" % (s, d))
         print("%d distinct colours, %d changed" % (len(mapping), len(rows)))
+
+    if unknown:
+        # an unrecognised colour constant would pass straight through and sit
+        # outside the palette unnoticed, which is the exact failure this fix
+        # is for -- refuse rather than half-retone.
+        print("unknown FMX colour constants (add to NAMED): %s"
+              % ", ".join(sorted(unknown)))
+        return 1
 
     if "--check" in argv:
         if out != text:

--- a/scripts/retone-light.py
+++ b/scripts/retone-light.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Retone PasclawLight.style onto a warm, low-arousal palette.
+
+Why
+---
+The light book was built from the stock FMX light style: pure #FFFFFF
+grounds, perfectly neutral greys (chroma 0), and a single very saturated
+blue (#0969DA, chroma 209) used sixty times. That combination is what makes
+it tiring to read -- maximum glare from the paper, no warmth to soften it,
+and an accent loud enough to pull the eye everywhere at once.
+
+The approach is borrowed from FMXExpress/Cross-Platform-Retro-OS-Styles,
+whose generator classifies every source colour "by chroma and lightness
+before mapping it to a role" rather than editing values by hand, and whose
+Vellum style is built on "low-arousal neutrals and processing fluency" --
+warm paper, hairline rules, one accent. Same idea here:
+
+  * neutrals become WARM neutrals on one hue, saturated at the paper end and
+    fading to near-neutral ink, so paper and rules share a family instead of
+    reading as clinical grey while the text stays honest black;
+  * nothing stays pure white -- the lightest paper is capped, which is the
+    single biggest comfort win;
+  * chromatic colours all collapse onto ONE accent hue at roughly half the
+    original saturation, keeping the blue identity while removing the glare,
+    and folding in the stray cyans the stock style left behind.
+
+Deterministic and idempotent: re-running maps the output to itself, which
+`--check` verifies, so the style file and this script cannot drift.
+
+    usage: python3 scripts/retone-light.py [--check] [--report]
+"""
+import colorsys
+import re
+import sys
+
+TARGET = "studio/PasclawLight.style"
+
+# Classification must be a FIXED POINT: the output of a rule has to fall back
+# into the same rule, or a second run would keep transforming. Neutrals land on
+# a warm hue outside the accent band, and accents land inside it, so both are
+# stable.
+CHROMA_MIN = 25          # below this a colour is neutral whatever its hue
+ACCENT_BAND = (160.0, 270.0)   # degrees: the blues and cyans in this book
+
+WARM_HUE = 40.0 / 360.0  # the paper/ink family
+# Warmth belongs to the PAPER, not the ink. The reference palette is warm at
+# the light end (#FAF9F5 is ~24% saturated) and almost neutral at the dark end
+# (#141413 is ~4%): tinting the darks instead turns mid greys olive, which is
+# what the first attempt at this ramp did.
+WARM_SAT_LIGHT = 0.20    # saturation at the paper end
+WARM_SAT_DARK = 0.04     # saturation at the ink end
+PAPER_CEILING = 0.972    # no pure white anywhere
+PAPER_KNEE = 0.90        # above this lightness the ramp is compressed
+
+ACCENT_HUE = 212.0 / 360.0
+# A CAP, not a scale: capping is idempotent (min(x,c) applied twice is
+# min(x,c)) and it leaves already-muted blues untouched instead of bleaching
+# them further on every run.
+ACCENT_SAT_CAP = 0.48
+
+
+def parse(hexstr):
+    a = int(hexstr[0:2], 16)
+    r = int(hexstr[2:4], 16) / 255.0
+    g = int(hexstr[4:6], 16) / 255.0
+    b = int(hexstr[6:8], 16) / 255.0
+    return a, r, g, b
+
+
+def fmt(a, r, g, b):
+    def c(v):
+        return max(0, min(255, int(round(v * 255))))
+    return "%02X%02X%02X%02X" % (a, c(r), c(g), c(b))
+
+
+def chroma255(r, g, b):
+    return (max(r, g, b) - min(r, g, b)) * 255.0
+
+
+def in_gamut(h, l, s, chroma):
+    """Is this colour already one of our own outputs?
+
+    Needed because the paper compression is not a fixed point on its own --
+    feeding F9F8F6 back through would compress it again, and again.
+
+    The tolerance has to widen as chroma falls: at chroma 5 an 8-bit round
+    trip can move the measured hue by eight degrees, so a tight test rejects
+    the transform's own output and it drifts forever. Near-neutrals are
+    therefore accepted on a warm BAND rather than an exact hue.
+    """
+    if chroma < 1.0:                       # pure grey/black/white: no hue
+        return False
+    hue_deg = h * 360.0
+    if chroma < 30.0:                      # warm neutral family
+        return 15.0 <= hue_deg <= 75.0 and l <= PAPER_CEILING + 1e-3
+    if abs(hue_deg - ACCENT_HUE * 360.0) < 2.0:
+        return s <= ACCENT_SAT_CAP + 1e-3
+    if abs(hue_deg - WARM_HUE * 360.0) < 2.0:
+        return l <= PAPER_CEILING + 1e-3
+    return False
+
+
+def retone(hexstr):
+    a, r, g, b = parse(hexstr)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    if in_gamut(h, l, s, chroma255(r, g, b)):
+        return hexstr.upper()
+    hue_deg = h * 360.0
+    is_accent = (chroma255(r, g, b) >= CHROMA_MIN and
+                 ACCENT_BAND[0] <= hue_deg <= ACCENT_BAND[1])
+    if not is_accent:
+        # neutral -> warm neutral; warmth grows as it darkens
+        # squared, not linear: a linear ramp still leaves mid greys visibly
+        # olive and drags body ink towards brown. Warmth has to fall away fast
+        # so only the papers carry it.
+        new_s = WARM_SAT_DARK + (WARM_SAT_LIGHT - WARM_SAT_DARK) * l * l
+        # COMPRESS the top of the range instead of clamping it: a hard cap
+        # mapped both #FFFFFF and #F6F8FA onto one value, collapsing panel and
+        # background into the same colour and losing the layering entirely.
+        if l > PAPER_KNEE:
+            new_l = PAPER_KNEE + (l - PAPER_KNEE) * (
+                (PAPER_CEILING - PAPER_KNEE) / (1.0 - PAPER_KNEE))
+        else:
+            new_l = l
+        new_h = WARM_HUE
+    else:
+        new_h = ACCENT_HUE
+        new_s = min(s, ACCENT_SAT_CAP)
+        new_l = l
+    nr, ng, nb = colorsys.hls_to_rgb(new_h, new_l, new_s)
+    return fmt(a, nr, ng, nb)
+
+
+def transform(text):
+    seen = {}
+
+    def repl(m):
+        src = m.group(1)
+        if src not in seen:
+            seen[src] = retone(src)
+        return "x" + seen[src]
+
+    return re.sub(r"\bx([0-9A-Fa-f]{8})\b", repl, text), seen
+
+
+def main(argv):
+    text = open(TARGET, encoding="utf-8", errors="replace").read()
+    out, mapping = transform(text)
+
+    # idempotence: the output must be a fixed point of the same transform
+    again, _ = transform(out)
+    if again != out:
+        print("NOT IDEMPOTENT -- retoning twice changes the file")
+        return 1
+
+    if "--report" in argv:
+        rows = sorted(set((s, d) for s, d in mapping.items() if s != d))
+        print("%-10s -> %-10s" % ("from", "to"))
+        for s, d in rows:
+            print("x%-9s -> x%-9s" % (s, d))
+        print("%d distinct colours, %d changed" % (len(mapping), len(rows)))
+
+    if "--check" in argv:
+        if out != text:
+            print("%s: OUT OF DATE -- run scripts/retone-light.py" % TARGET)
+            return 1
+        print("%s: retoned (%d colours)" % (TARGET, len(mapping)))
+        return 0
+
+    if out == text:
+        print("%s: already retoned" % TARGET)
+    else:
+        open(TARGET, "w", encoding="utf-8", newline="").write(out)
+        print("%s: retoned %d distinct colours" % (TARGET, len(mapping)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -1546,12 +1546,12 @@ begin
   end
   else
   begin
-    UI_CHAT_TEXT       := $FF10151C;
-    UI_CHROME_TEXT     := $FF5C6675;
-    UI_USER_FILL       := $FFEAF1FB;
-    UI_USER_BORDER     := $FFBFD4EE;
-    UI_COMPOSER_FILL   := $FFFFFFFF;
-    UI_COMPOSER_BORDER := $FF3BA7FF;
+    UI_CHAT_TEXT       := $FF171615;
+    UI_CHROME_TEXT     := $FF6F6B62;
+    UI_USER_FILL       := $FFF2F0EC;
+    UI_USER_BORDER     := $FFC3D5EA;
+    UI_COMPOSER_FILL   := $FFF9F8F6;
+    UI_COMPOSER_BORDER := $FF6E9ACC;
   end;
 
   if FDarkStyleEnabled then
@@ -1774,13 +1774,13 @@ procedure TMasterDetailForm.StyleChromeRect(Rect: TRectangle;
     if FDarkStyleEnabled then
       Exit;
     if Color = UI_BG then
-      Result := $FFF7F9FC
+      Result := $FFF6F5F2
     else if Color = UI_PANEL then
-      Result := $FFFFFFFF
+      Result := $FFF9F8F6
     else if Color = UI_PANEL_ALT then
-      Result := $FFF2F5FA
+      Result := $FFF4F2EF
     else if Color = UI_ACCENT_DIM then
-      Result := $FFE5F7FC;
+      Result := $FFF1EEEA;
   end;
   function ThemeStroke(Color: TAlphaColor): TAlphaColor;
   begin
@@ -1788,11 +1788,11 @@ procedure TMasterDetailForm.StyleChromeRect(Rect: TRectangle;
     if FDarkStyleEnabled then
       Exit;
     if Color = UI_BORDER then
-      Result := $FFD6DDE8
+      Result := $FFE4E1DA
     else if Color = UI_ACCENT_DIM then
-      Result := $FF9CDDEC
+      Result := $FFA8C2E0
     else if Color = UI_BG then
-      Result := $FFFFFFFF;
+      Result := $FFF9F8F6;
   end;
 begin
   if Rect = nil then
@@ -1821,19 +1821,19 @@ begin
   if FDarkStyleEnabled then
     Exit;
   if Color = UI_BG then
-    Result := $FFF7F9FC
+    Result := $FFF6F5F2
   else if Color = UI_PANEL then
-    Result := $FFFFFFFF
+    Result := $FFF9F8F6
   else if Color = UI_PANEL_ALT then
-    Result := $FFF2F5FA
+    Result := $FFF4F2EF
   else if Color = UI_ACCENT_DIM then
-    Result := $FFDDEBF7
+    Result := $FFE0E9F4
   else if Color = UI_BORDER then
-    Result := $FFD6DDE8
+    Result := $FFE4E1DA
   else if Color = UI_TEXT then
-    Result := $FF10151C
+    Result := $FF171615
   else if Color = UI_MUTED then
-    Result := $FF5C6675;
+    Result := $FF6F6B62;
 end;
 
 function TMasterDetailForm.ThemePaintStroke(Color: TAlphaColor): TAlphaColor;
@@ -1844,7 +1844,7 @@ function TMasterDetailForm.ThemePaintStroke(Color: TAlphaColor): TAlphaColor;
   through the fill mapping. Lines need the stronger ink. }
 begin
   if (not FDarkStyleEnabled) and (Color = UI_ACCENT_DIM) then
-    Result := $FF9CDDEC
+    Result := $FFA8C2E0
   else
     Result := ThemePaintColor(Color);
 end;

--- a/studio/PasclawLight.style
+++ b/studio/PasclawLight.style
@@ -8,18 +8,18 @@ object TStyleContainer
     ThumbPadding.Right = 1.000000000000000000
     ThumbPadding.Bottom = 1.000000000000000000
     Visible = False
-    Fill.Color = xFFF6F8FA
-    FillOn.Color = xFF0969DA
+    Fill.Color = xFFF5F4F0
+    FillOn.Color = xFF3B6EA8
     FillOn.Kind = Solid
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Stroke.Thickness = 2.000000000000000000
-    Thumb.Color = xFFFFFFFF
-    ThumbStroke.Color = xFFD0D7DE
+    Thumb.Color = xFFF9F8F6
+    ThumbStroke.Color = xFFDDD9D1
     Shape = Oval
   end
   object TEllipse
     StyleName = 'transparentcirclebuttonstyle'
-    Fill.Color = x00808080
+    Fill.Color = x008A8376
     HitTest = False
     Position.X = 397.000000000000000000
     Position.Y = 511.000000000000000000
@@ -31,15 +31,15 @@ object TStyleContainer
     object TColorAnimation
       Duration = 0.100000001490116100
       PropertyName = 'Fill.Color'
-      StartValue = x00808080
-      StopValue = xAF808080
+      StartValue = x008A8376
+      StopValue = xAF8A8376
       Trigger = 'IsMouseOver=true'
     end
     object TColorAnimation
       Duration = 0.100000001490116100
       PropertyName = 'Fill.color'
-      StartValue = xAF808080
-      StopValue = x00808080
+      StartValue = xAF8A8376
+      StopValue = x008A8376
       Trigger = 'IsMouseOver=false'
     end
     object TFloatAnimation
@@ -256,7 +256,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFEAEFF4
+          Color = xFFF0EDE9
           Offset = 0.000000000000000000
         end
         item
@@ -268,7 +268,7 @@ object TStyleContainer
       Size.Width = 73.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD0D7DE
+      Stroke.Color = xFFDDD9D1
       XRadius = 5.000000000000000000
       YRadius = 5.000000000000000000
       object TImage
@@ -290,7 +290,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF2080E0
+      GlowColor = xFF437CBD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -309,7 +309,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFE6EDF7
+      Fill.Color = xFFEFEDE9
       Locked = True
       HitTest = False
       Padding.Left = 1.000000000000000000
@@ -319,7 +319,7 @@ object TStyleContainer
       Size.Width = 116.999992370605500000
       Size.Height = 131.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFF8E8E8E
+      Stroke.Color = xFF989184
       object TLayout
         StyleName = 'content'
         Align = Client
@@ -410,7 +410,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'backgroundstyle'
-    Fill.Color = xFFF6F8FA
+    Fill.Color = xFFF5F4F0
     HitTest = False
     Position.X = 331.000000000000000000
     Position.Y = 322.000000000000000000
@@ -423,7 +423,7 @@ object TStyleContainer
   object TRectangle
     StyleName = 'multiviewstyle'
     Align = Center
-    Fill.Color = xFFF6F8FA
+    Fill.Color = xFFF5F4F0
     HitTest = False
     Size.Width = 50.000000000000000000
     Size.Height = 50.000000000000000000
@@ -432,54 +432,54 @@ object TStyleContainer
     Visible = False
     object TBrushObject
       StyleName = 'dropline'
-      Brush.Color = xFFF6F8FA
+      Brush.Color = xFFF5F4F0
     end
   end
   object TRectangle
     StyleName = 'panelstyle'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Position.X = 331.000000000000000000
     Position.Y = 322.000000000000000000
     Size.Width = 50.000000000000000000
     Size.Height = 50.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD5D5D5
+    Stroke.Color = xFFDBD7CF
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
     object TRectangle
       Align = Client
       Corners = [BottomLeft, BottomRight]
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       HitTest = False
       Margins.Top = 2.000000000000000000
       Sides = [Left, Bottom, Right]
       Size.Width = 50.000000000000000000
       Size.Height = 48.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
     end
   end
   object TCalloutRectangle
     StyleName = 'calloutpanelstyle'
-    Fill.Color = xFFF6F8FA
+    Fill.Color = xFFF5F4F0
     HitTest = False
     Position.X = 331.000000000000000000
     Position.Y = 322.000000000000000000
     Size.Width = 50.000000000000000000
     Size.Height = 50.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD5D5D5
+    Stroke.Color = xFFDBD7CF
     Visible = False
     CalloutWidth = 23.000000000000000000
     CalloutLength = 11.000000000000000000
   end
   object TRectangle
     StyleName = 'statusbarstyle'
-    Fill.Color = xFFF2F2F2
+    Fill.Color = xFFF2F0EB
     HitTest = False
     Position.X = 305.000000000000000000
     Position.Y = 333.000000000000000000
@@ -506,7 +506,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'toolbarstyle'
-    Fill.Color = xFFF2F2F2
+    Fill.Color = xFFF2F0EB
     HitTest = False
     Position.X = 330.000000000000000000
     Position.Y = 321.000000000000000000
@@ -514,7 +514,7 @@ object TStyleContainer
     Size.Width = 52.000000000000000000
     Size.Height = 51.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFFFFFFF
+    Stroke.Color = xFFF9F8F6
     Visible = False
   end
   object TLayout
@@ -534,7 +534,7 @@ object TStyleContainer
       Size.PlatformDefault = False
       object TRectangle
         Align = Center
-        Fill.Color = xFFFFFFFF
+        Fill.Color = xFFF9F8F6
         Locked = True
         HitTest = False
         Size.Width = 13.000000000000000000
@@ -544,7 +544,7 @@ object TStyleContainer
         object TRectangle
           StyleName = 'background'
           Align = Client
-          Fill.Color = xFFFFFFFF
+          Fill.Color = xFFF9F8F6
           Locked = True
           HitTest = False
           Margins.Left = 1.000000000000000000
@@ -554,10 +554,10 @@ object TStyleContainer
           Size.Width = 11.000000000000000000
           Size.Height = 11.000000000000000000
           Size.PlatformDefault = False
-          Stroke.Color = xFFD6D6D6
+          Stroke.Color = xFFDCD8D0
           object TGlowEffect
             Softness = 0.200000002980232200
-            GlowColor = xFF0969DA
+            GlowColor = xFF3B6EA8
             Opacity = 1.000000000000000000
             Trigger = 'IsFocused=true'
             Enabled = False
@@ -580,7 +580,7 @@ object TStyleContainer
             008A64440020D843010000000064644400D8D743010000000060644400D0D743
             01000000005C644400C8D7430100000000386444007CD7430100000000366444
             0080D74301000000000C6444002CD74303000000000C6444002CD743}
-          Fill.Color = xFF0969DA
+          Fill.Color = xFF3B6EA8
           Locked = True
           HitTest = False
           Margins.Left = 1.000000000000000000
@@ -592,8 +592,8 @@ object TStyleContainer
           object TColorAnimation
             Duration = 0.100000001490116100
             PropertyName = 'Fill.Color'
-            StartValue = x00FFFFFF
-            StopValue = xFF0969DA
+            StartValue = x00F9F8F6
+            StopValue = xFF3B6EA8
             Trigger = 'IsChecked=true'
             TriggerInverse = 'IsChecked=false'
           end
@@ -618,11 +618,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFEFEFEF
+          Color = xFFF0EDE9
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFC7C7C7
+          Color = xFFCFCABF
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -633,14 +633,14 @@ object TStyleContainer
       Size.Width = 19.000000000000000000
       Size.Height = 15.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD0D7DE
+      Stroke.Color = xFFDDD9D1
     end
     object TPath
       Align = Center
       Data.Path = {
         0400000000000000DB86E443E5D40144010000002489E643C097004401000000
         497AE843C0D7014403000000DB86E443E5D40144}
-      Fill.Color = xFF01BAE9
+      Fill.Color = xFF3D71AD
       Locked = True
       HitTest = False
       Margins.Left = 4.000000000000000000
@@ -663,7 +663,7 @@ object TStyleContainer
       Data.Path = {
         0400000000000000DB86E4439C9A0044010000002489E643C1D7014401000000
         497AE843C197004403000000DB86E4439C9A0044}
-      Fill.Color = xFF01BAE9
+      Fill.Color = xFF3D71AD
       Locked = True
       HitTest = False
       Opacity = 0.001000000047497451
@@ -694,12 +694,12 @@ object TStyleContainer
     TabOrder = 14
     object TRectangle
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       HitTest = False
       Size.Width = 162.000000000000000000
       Size.Height = 141.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
     end
     object TText
       StyleName = 'text'
@@ -712,7 +712,7 @@ object TStyleContainer
       Size.Height = 25.000000000000000000
       Size.PlatformDefault = False
       TextSettings.Font.StyleExt = {00070000000000000004000000}
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       TextSettings.WordWrap = False
       object TExpanderButton
         StyleName = 'button'
@@ -754,7 +754,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Client
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       Locked = True
       HitTest = False
       Size.Width = 131.000000000000000000
@@ -766,7 +766,7 @@ object TStyleContainer
       object TRectangle
         Align = Client
         Corners = [TopLeft, TopRight]
-        Fill.Color = xFFF6F8FA
+        Fill.Color = xFFF5F4F0
         Locked = True
         HitTest = False
         Margins.Left = 1.000000000000000000
@@ -795,7 +795,7 @@ object TStyleContainer
         Size.Width = 50.927082061767580000
         Size.Height = 16.875000000000000000
         Size.PlatformDefault = False
-        TextSettings.FontColor = xFF868686
+        TextSettings.FontColor = xFF90897C
         TextSettings.WordWrap = False
       end
     end
@@ -812,13 +812,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFBFBFB
+      Fill.Color = xFFF7F6F3
       Locked = True
       HitTest = False
       Size.Width = 73.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD6D6D6
+      Stroke.Color = xFFDCD8D0
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
       object TRectangle
@@ -831,7 +831,7 @@ object TStyleContainer
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 1.000000000000000000
           end>
         HitTest = False
@@ -840,7 +840,7 @@ object TStyleContainer
         Size.Width = 73.000000000000000000
         Size.Height = 24.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD5D5D5
+        Stroke.Color = xFFDBD7CF
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
         object TRectangle
@@ -849,7 +849,7 @@ object TStyleContainer
           Fill.Kind = Gradient
           Fill.Gradient.Points = <
             item
-              Color = xFFF0F3F6
+              Color = xFFF2F0EC
               Offset = 0.000000000000000000
             end
             item
@@ -864,7 +864,7 @@ object TStyleContainer
           Size.Width = 73.000000000000000000
           Size.Height = 24.000000000000000000
           Size.PlatformDefault = False
-          Stroke.Color = xFFD5D5D5
+          Stroke.Color = xFFDBD7CF
           XRadius = 2.000000000000000000
           YRadius = 2.000000000000000000
           object TFloatAnimation
@@ -902,20 +902,20 @@ object TStyleContainer
       Size.Height = 22.000000000000000000
       Size.PlatformDefault = False
       Text = 'button'
-      TextSettings.FontColor = xFF929292
+      TextSettings.FontColor = xFF9C9588
       object TColorAnimation
         Duration = 0.100000001490116100
         PropertyName = 'Fill.Color'
-        StartValue = xFF828282
-        StopValue = xFF12BEEA
+        StartValue = xFF8C8578
+        StopValue = xFF427ABA
         Trigger = 'IsMouseOver=true;IsPressed=false'
         TriggerInverse = 'IsMouseOver=false;IsPressed=false'
       end
       object TColorAnimation
         Duration = 0.200000002980232200
         PropertyName = 'Fill.Color'
-        StartValue = xFF12BEEA
-        StopValue = xFF828282
+        StartValue = xFF427ABA
+        StopValue = xFF8C8578
         Trigger = 'IsFocused=true'
         TriggerInverse = 'IsFocused=False'
       end
@@ -936,11 +936,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFF414141
+          Color = xFF44423E
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFECECEC
+          Color = xFFEEEBE6
           Offset = 1.000000000000000000
         end>
       Fill.Gradient.StopPosition.X = 1.000000000000000000
@@ -949,7 +949,7 @@ object TStyleContainer
       Size.Width = 50.000000000000000000
       Size.Height = 50.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFA0A0A0
+      Stroke.Color = xFFAAA396
     end
   end
   object TLayout
@@ -970,7 +970,7 @@ object TStyleContainer
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
       Text = 'label'
-      TextSettings.FontColor = xFFA1A1A1
+      TextSettings.FontColor = xFFABA497
     end
   end
   object TLayout
@@ -984,7 +984,7 @@ object TStyleContainer
     TabOrder = 19
     object TRoundRect
       Align = Contents
-      Fill.Color = xFFC7C7C7
+      Fill.Color = xFFCFCABF
       HitTest = False
       Size.Width = 95.000000000000000000
       Size.Height = 24.000000000000000000
@@ -1023,7 +1023,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFF4F4F6
+          Color = xFFF3F2EE
           Offset = 0.000000000000000000
         end
         item
@@ -1035,12 +1035,12 @@ object TStyleContainer
       Size.Width = 46.000000000000000000
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD9D9D9
+      Stroke.Color = xFFDFDBD3
       object TColorAnimation
         Duration = 0.000000999999997475
         PropertyName = 'Fill.Color'
         StartValue = claWhite
-        StopValue = xFFF4F4F6
+        StopValue = xFFF3F2EE
         Trigger = 'IsSelected=false'
       end
       object TRectAnimation
@@ -1084,13 +1084,13 @@ object TStyleContainer
         Size.Height = 15.000000000000000000
         Size.PlatformDefault = False
         Text = 'item'
-        TextSettings.FontColor = xFF898989
+        TextSettings.FontColor = xFF938C7F
         TextSettings.WordWrap = False
         object TColorAnimation
           Duration = 0.000000999999997475
           PropertyName = 'Fill.Color'
-          StartValue = xFF898989
-          StopValue = xFF00B9E8
+          StartValue = xFF938C7F
+          StopValue = xFF3C70AC
           Trigger = 'IsMouseOver=true'
           TriggerInverse = 'IsMouseOver=false'
         end
@@ -1104,7 +1104,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFF4F4F6
+          Color = xFFF3F2EE
           Offset = 0.000000000000000000
         end
         item
@@ -1117,12 +1117,12 @@ object TStyleContainer
       Size.Width = 46.000000000000000000
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD9D9D9
+      Stroke.Color = xFFDFDBD3
       object TColorAnimation
         Duration = 0.000000999999997475
         PropertyName = 'Fill.Color'
         StartValue = claWhite
-        StopValue = xFFF4F4F6
+        StopValue = xFFF3F2EE
         Trigger = 'IsSelected=false'
       end
       object TRectAnimation
@@ -1159,13 +1159,13 @@ object TStyleContainer
         Size.Height = 15.000000000000000000
         Size.PlatformDefault = False
         Text = 'item'
-        TextSettings.FontColor = xFF898989
+        TextSettings.FontColor = xFF938C7F
         TextSettings.WordWrap = False
         object TColorAnimation
           Duration = 0.000000999999997475
           PropertyName = 'Fill.Color'
-          StartValue = xFF898989
-          StopValue = xFF00B9E8
+          StartValue = xFF938C7F
+          StopValue = xFF3C70AC
           Trigger = 'IsMouseOver=true'
           TriggerInverse = 'IsMouseOver=false'
         end
@@ -1174,7 +1174,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'tabdotstyle'
-    Fill.Color = xFFD9D9D9
+    Fill.Color = xFFDFDBD3
     HitTest = False
     Size.Width = 50.000000000000000000
     Size.Height = 50.000000000000000000
@@ -1184,8 +1184,8 @@ object TStyleContainer
     object TColorAnimation
       Duration = 0.000200000009499490
       PropertyName = 'Fill.Color'
-      StartValue = xFFD9D9D9
-      StopValue = x8001BAE9
+      StartValue = xFFDFDBD3
+      StopValue = x803D71AD
       Trigger = 'IsSelected=true'
       TriggerInverse = 'IsSelected=false'
     end
@@ -1201,12 +1201,12 @@ object TStyleContainer
     TabOrder = 22
     object TRectangle
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       HitTest = False
       Size.Width = 142.000000000000000000
       Size.Height = 100.999992370605500000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD9D9D9
+      Stroke.Color = xFFDFDBD3
     end
   end
   object TLayout
@@ -1224,7 +1224,7 @@ object TStyleContainer
       Size.PlatformDefault = False
       object TRectangle
         Align = Center
-        Fill.Color = xFFFFFFFF
+        Fill.Color = xFFF9F8F6
         Locked = True
         HitTest = False
         Size.Width = 13.000000000000000000
@@ -1234,7 +1234,7 @@ object TStyleContainer
         object TRectangle
           StyleName = 'background'
           Align = Client
-          Fill.Color = xFFFFFFFF
+          Fill.Color = xFFF9F8F6
           Locked = True
           HitTest = False
           Margins.Left = 1.000000000000000000
@@ -1244,10 +1244,10 @@ object TStyleContainer
           Size.Width = 11.000000000000000000
           Size.Height = 11.000000000000000000
           Size.PlatformDefault = False
-          Stroke.Color = xFFD6D6D6
+          Stroke.Color = xFFDCD8D0
           object TGlowEffect
             Softness = 0.200000002980232200
-            GlowColor = xFF0969DA
+            GlowColor = xFF3B6EA8
             Opacity = 1.000000000000000000
             Trigger = 'IsFocused=true'
             Enabled = False
@@ -1270,7 +1270,7 @@ object TStyleContainer
             008A64440020D843010000000064644400D8D743010000000060644400D0D743
             01000000005C644400C8D7430100000000386444007CD7430100000000366444
             0080D74301000000000C6444002CD74303000000000C6444002CD743}
-          Fill.Color = x00FFFFFF
+          Fill.Color = x00F9F8F6
           Locked = True
           HitTest = False
           Margins.Left = 1.000000000000000000
@@ -1282,8 +1282,8 @@ object TStyleContainer
           object TColorAnimation
             Duration = 0.100000001490116100
             PropertyName = 'Fill.Color'
-            StartValue = x00FFFFFF
-            StopValue = xFF0969DA
+            StartValue = x00F9F8F6
+            StopValue = xFF3B6EA8
             Trigger = 'IsChecked=true'
             TriggerInverse = 'IsChecked=false'
           end
@@ -1302,7 +1302,7 @@ object TStyleContainer
       Size.Height = 13.000000000000000000
       Size.PlatformDefault = False
       Text = 'Text'
-      TextSettings.FontColor = xFF828282
+      TextSettings.FontColor = xFF8C8578
     end
   end
   object TLayout
@@ -1322,7 +1322,7 @@ object TStyleContainer
       object TPath
         StyleName = 'checkmark'
         Align = Client
-        Fill.Color = x40FFFFFF
+        Fill.Color = x40F9F8F6
         Locked = True
         HitTest = False
         Size.Width = 23.000000000000000000
@@ -1333,22 +1333,22 @@ object TStyleContainer
         object TColorAnimation
           Duration = 0.100000001490116100
           PropertyName = 'Fill.Color'
-          StartValue = x40034E9E
-          StopValue = xFF034E9E
+          StartValue = x402A4E77
+          StopValue = xFF2A4E77
           Trigger = 'IsChecked=true'
         end
         object TColorAnimation
           Duration = 0.100000001490116100
           Inverse = True
           PropertyName = 'Fill.Color'
-          StartValue = x40034E9E
-          StopValue = xFF034E9E
+          StartValue = x402A4E77
+          StopValue = xFF2A4E77
           Trigger = 'IsChecked=false'
         end
       end
       object TGlowEffect
         Softness = 0.200000002980232200
-        GlowColor = xFF2080E0
+        GlowColor = xFF437CBD
         Opacity = 1.000000000000000000
         Trigger = 'IsFocused=true'
         Enabled = False
@@ -1383,16 +1383,16 @@ object TStyleContainer
       object TEllipse
         StyleName = 'background'
         Align = Center
-        Fill.Color = xFFFFFFFF
+        Fill.Color = xFFF9F8F6
         Locked = True
         HitTest = False
         Size.Width = 13.000000000000000000
         Size.Height = 13.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD2D2D2
+        Stroke.Color = xFFD9D4CB
         object TGlowEffect
           Softness = 0.200000002980232200
-          GlowColor = xFF0969DA
+          GlowColor = xFF3B6EA8
           Opacity = 1.000000000000000000
           Trigger = 'IsFocused=true'
           Enabled = False
@@ -1415,13 +1415,13 @@ object TStyleContainer
             Duration = 0.100000001490116100
             PropertyName = 'Fill.Color'
             StartValue = claWhite
-            StopValue = xFF0969DA
+            StopValue = xFF3B6EA8
             Trigger = 'IsChecked=true'
           end
           object TColorAnimation
             Duration = 0.100000001490116100
             PropertyName = 'Fill.Color'
-            StartValue = xFF0969DA
+            StartValue = xFF3B6EA8
             StopValue = claWhite
             Trigger = 'IsChecked=false'
           end
@@ -1440,7 +1440,7 @@ object TStyleContainer
       Size.Height = 19.000000000000000000
       Size.PlatformDefault = False
       Text = 'RadioButton'
-      TextSettings.FontColor = xFF828282
+      TextSettings.FontColor = xFF8C8578
     end
   end
   object TLayout
@@ -1455,13 +1455,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'htrack'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 72.000000000000000000
       Size.Height = 60.999996185302730000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC4C0C1
+      Stroke.Color = xFFCAC5BA
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
       object TRectangle
@@ -1469,11 +1469,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFFECECEC
+            Color = xFFEEEBE6
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFE2E2E2
+            Color = xFFE7E4DD
             Offset = 0.800000011920929000
           end>
         Locked = True
@@ -1495,11 +1495,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFF00DDFB
+            Color = xFF4179BA
             Offset = 0.000000000000000000
           end
           item
-            Color = xFF00C5EE
+            Color = xFF3E73B0
             Offset = 0.800000011920929000
           end>
         Locked = True
@@ -1521,13 +1521,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'vtrack'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 72.000000000000000000
       Size.Height = 60.999996185302730000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC4C0C1
+      Stroke.Color = xFFCAC5BA
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
       object TRectangle
@@ -1535,11 +1535,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFFECECEC
+            Color = xFFEEEBE6
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFE2E2E2
+            Color = xFFE7E4DD
             Offset = 0.800000011920929000
           end>
         Fill.Gradient.StartPosition.Y = 0.500000000000000000
@@ -1564,11 +1564,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFF00DDFB
+            Color = xFF4179BA
             Offset = 0.000000000000000000
           end
           item
-            Color = xFF00C5EE
+            Color = xFF3E73B0
             Offset = 0.800000011920929000
           end>
         Fill.Gradient.StartPosition.Y = 0.500000000000000000
@@ -1634,7 +1634,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       Locked = True
       HitTest = False
       Padding.Left = 1.000000000000000000
@@ -1644,7 +1644,7 @@ object TStyleContainer
       Size.Width = 92.000000000000000000
       Size.Height = 59.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD6D6D6
+      Stroke.Color = xFFDCD8D0
     end
     object TFloatAnimation
       Duration = 0.100000001490116100
@@ -1660,15 +1660,15 @@ object TStyleContainer
     Fill.Kind = Gradient
     Fill.Gradient.Points = <
       item
-        Color = xFFFBFBFB
+        Color = xFFF7F6F3
         Offset = 0.000000000000000000
       end
       item
-        Color = xFFE5E5E5
+        Color = xFFE9E6E1
         Offset = 0.485611498355865500
       end
       item
-        Color = xFFD0D7DE
+        Color = xFFDDD9D1
         Offset = 1.000000000000000000
       end>
     HitTest = False
@@ -1677,21 +1677,21 @@ object TStyleContainer
     Size.Width = 15.000000000000000000
     Size.Height = 15.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFC4CBD3
+    Stroke.Color = xFFD3CEC4
     Visible = False
     object TColorAnimation
       Duration = 0.200000002980232200
       PropertyName = 'Fill.Color'
-      StartValue = xFFFBFBFB
-      StopValue = xFFEAEFF4
+      StartValue = xFFF7F6F3
+      StopValue = xFFF0EDE9
       Trigger = 'IsMouseOver=true'
     end
     object TColorAnimation
       Duration = 0.200000002980232200
       Inverse = True
       PropertyName = 'Fill.Color'
-      StartValue = xFFEAEFF4
-      StopValue = xFFFBFBFB
+      StartValue = xFFF0EDE9
+      StopValue = xFFF7F6F3
       Trigger = 'IsMouseOver=false'
     end
     object TPath
@@ -1704,7 +1704,7 @@ object TStyleContainer
         000048420000964201000000000070410000DC42010000000000A0C00000B442
         010000000000F04100005C42010000000000A0C0000070410300000000000000
         00000000}
-      Fill.Color = xFF121212
+      Fill.Color = xFF131211
       Locked = True
       HitTest = False
       Position.X = 3.000000000000000000
@@ -1726,12 +1726,12 @@ object TStyleContainer
     TabOrder = 30
     object TBrushObject
       StyleName = 'AlternatingRowBackground'
-      Brush.Color = x20D4D4D4
+      Brush.Color = x20DAD6CE
     end
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       Locked = True
       HitTest = False
       Padding.Left = 1.000000000000000000
@@ -1741,7 +1741,7 @@ object TStyleContainer
       Size.Width = 116.999992370605500000
       Size.Height = 140.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD6D6D6
+      Stroke.Color = xFFDCD8D0
       object TLayout
         StyleName = 'content'
         Align = Client
@@ -1751,7 +1751,7 @@ object TStyleContainer
         Size.PlatformDefault = False
         object TRectangle
           StyleName = 'selection'
-          Fill.Color = x8001BAE9
+          Fill.Color = x803D71AD
           HitTest = False
           Size.Width = 50.000000000000000000
           Size.Height = 50.000000000000000000
@@ -1760,7 +1760,7 @@ object TStyleContainer
         end
         object TRectangle
           StyleName = 'focusedselection'
-          Fill.Color = x8001BAE9
+          Fill.Color = x803D71AD
           HitTest = False
           Size.Width = 50.000000000000000000
           Size.Height = 50.000000000000000000
@@ -1827,7 +1827,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF01BAE9
+      GlowColor = xFF3D71AD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -1893,13 +1893,13 @@ object TStyleContainer
         Size.Width = 47.000000000000000000
         Size.Height = 40.000000000000000000
         Size.PlatformDefault = False
-        TextSettings.FontColor = xFF898989
+        TextSettings.FontColor = xFF938C7F
         TextSettings.WordWrap = False
         TextSettings.HorzAlign = Leading
         object TColorAnimation
           Duration = 0.200000002980232200
           PropertyName = 'Fill.Color'
-          StartValue = xFF898989
+          StartValue = xFF938C7F
           StopValue = claWhite
           Trigger = 'IsSelected=true'
           TriggerInverse = 'IsSelected=False'
@@ -1922,7 +1922,7 @@ object TStyleContainer
       Data.Path = {
         0500000000000000D36D3F431BEF4843010000001749E043BA09E54301000000
         D36D3F43C73B344401000000D36D3F431BEF484303000000D36D3F431BEF4843}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 8.000000000000000000
@@ -1943,7 +1943,7 @@ object TStyleContainer
       Data.Path = {
         0500000000000000CB11CF4379E93C4301000000CB11CF4396230A4401000000
         7DBF1E4296230A4401000000CB11CF4379E93C4303000000CB11CF4379E93C43}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Opacity = 0.001000000047497451
@@ -1973,7 +1973,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'htrack'
       Align = VertCenter
-      Fill.Color = xFFE3E3E3
+      Fill.Color = xFFE8E5DE
       Locked = True
       HitTest = False
       Margins.Left = 4.000000000000000000
@@ -1986,11 +1986,11 @@ object TStyleContainer
       Size.Width = 122.000000000000000000
       Size.Height = 9.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC0BEBF
+      Stroke.Color = xFFC7C2B7
       object TRectangle
         StyleName = 'background'
         Align = Client
-        Fill.Color = xFFE3E3E3
+        Fill.Color = xFFE8E5DE
         Locked = True
         HitTest = False
         Margins.Top = 1.000000000000000000
@@ -2005,7 +2005,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'vtrack'
       Align = HorzCenter
-      Fill.Color = xFFE3E3E3
+      Fill.Color = xFFE8E5DE
       Locked = True
       HitTest = False
       Margins.Left = 4.000000000000000000
@@ -2018,11 +2018,11 @@ object TStyleContainer
       Size.Width = 9.000000000000000000
       Size.Height = 6.000000953674316000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC0BEBF
+      Stroke.Color = xFFC7C2B7
       object TRectangle
         StyleName = 'background'
         Align = Contents
-        Fill.Color = xFFE3E3E3
+        Fill.Color = xFFE8E5DE
         Locked = True
         HitTest = False
         Margins.Left = 1.000000000000000000
@@ -2077,13 +2077,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD6D6D6
+      Stroke.Color = xFFDCD8D0
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TRectangle
@@ -2096,7 +2096,7 @@ object TStyleContainer
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 1.000000000000000000
           end>
         HitTest = False
@@ -2105,7 +2105,7 @@ object TStyleContainer
         Size.Width = 91.000000000000000000
         Size.Height = 22.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD5D5D5
+        Stroke.Color = xFFDBD7CF
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
       end
@@ -2124,11 +2124,11 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2146,13 +2146,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
     end
     object TLayout
       StyleName = 'content'
@@ -2181,15 +2181,15 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803DC9ED
+      Brush.Color = x806292C8
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2213,13 +2213,13 @@ object TStyleContainer
     object TRoundRect
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC1C1C1
+      Stroke.Color = xFFC9C4B9
     end
     object TLayout
       StyleName = 'content'
@@ -2235,15 +2235,15 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF373737
+      Brush.Color = xFF3A3834
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803870F7
+      Brush.Color = x806694C9
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF2080E0
+      GlowColor = xFF437CBD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2261,13 +2261,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD6D6D6
+      Stroke.Color = xFFDCD8D0
       XRadius = 10.000000000000000000
       YRadius = 10.000000000000000000
     end
@@ -2303,7 +2303,7 @@ object TStyleContainer
         Data.Path = {
           0400000000000000DBBAE7439C340244010000009240E5437833014401000000
           92C0E743E63A004403000000DBBAE7439C340244}
-        Fill.Color = xFF0969DA
+        Fill.Color = xFF3B6EA8
         HitTest = False
         Margins.Left = 6.000000000000000000
         Margins.Top = 6.000000000000000000
@@ -2335,7 +2335,7 @@ object TStyleContainer
         Data.Path = {
           04000000000000004946E5439C3402440100000092C0E7437833014401000000
           9240E543E63A0044030000004946E5439C340244}
-        Fill.Color = xFF0969DA
+        Fill.Color = xFF3B6EA8
         HitTest = False
         Margins.Left = 6.000000000000000000
         Margins.Top = 6.000000000000000000
@@ -2349,15 +2349,15 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803DC9ED
+      Brush.Color = x806292C8
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2375,13 +2375,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD6D6D6
+      Stroke.Color = xFFDCD8D0
     end
     object TLayout
       StyleName = 'content'
@@ -2420,7 +2420,7 @@ object TStyleContainer
           000048420000964201000000000070410000DC42010000000000A0C00000B442
           010000000000F04100005C42010000000000A0C0000070410300000000000000
           00000000}
-        Fill.Color = xFF898989
+        Fill.Color = xFF938C7F
         Locked = True
         HitTest = False
         Margins.Left = 4.000000000000000000
@@ -2435,15 +2435,15 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803DC9ED
+      Brush.Color = x806292C8
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2460,7 +2460,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Padding.Left = 1.000000000000000000
@@ -2470,7 +2470,7 @@ object TStyleContainer
       Size.Width = 116.999992370605500000
       Size.Height = 131.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD9D9D9
+      Stroke.Color = xFFDFDBD3
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
       object TLayout
@@ -2556,15 +2556,15 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x8001BAE9
+      Brush.Color = x803D71AD
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF01BAE9
+      GlowColor = xFF3D71AD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2582,12 +2582,12 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFF6F6F6
+      Fill.Color = xFFF4F2EF
       HitTest = False
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TRectangle
@@ -2600,7 +2600,7 @@ object TStyleContainer
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 1.000000000000000000
           end>
         HitTest = False
@@ -2609,20 +2609,20 @@ object TStyleContainer
         Size.Width = 91.000000000000000000
         Size.Height = 22.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD5D5D5
+        Stroke.Color = xFFDBD7CF
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
       end
       object TRectangle
         Align = Client
-        Fill.Color = xFF01BAE9
+        Fill.Color = xFF3D71AD
         Locked = True
         HitTest = False
         Opacity = 0.001000000047497451
         Size.Width = 91.000000000000000000
         Size.Height = 24.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFF01BAE9
+        Stroke.Color = xFF3D71AD
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
         object TFloatAnimation
@@ -2636,7 +2636,7 @@ object TStyleContainer
       end
       object TInnerGlowEffect
         Softness = 0.400000005960464500
-        GlowColor = xFF4F4848
+        GlowColor = xFF504D47
         Opacity = 0.299999982118606600
         Trigger = 'IsPressed=true'
         Enabled = False
@@ -2666,11 +2666,11 @@ object TStyleContainer
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
       Text = 'button'
-      TextSettings.FontColor = xFF828282
+      TextSettings.FontColor = xFF8C8578
       object TColorAnimation
         Duration = 0.200000002980232200
         PropertyName = 'Fill.Color'
-        StartValue = xFF828282
+        StartValue = xFF8C8578
         StopValue = claWhite
         Trigger = 'IsFocused=true'
         TriggerInverse = 'IsFocused=False'
@@ -2678,7 +2678,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF01BAE9
+      GlowColor = xFF3D71AD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -2723,7 +2723,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -2739,7 +2739,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -2796,7 +2796,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -2812,7 +2812,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -2867,7 +2867,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -2883,7 +2883,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -2937,7 +2937,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -2953,7 +2953,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3007,7 +3007,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3023,7 +3023,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3077,7 +3077,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3093,7 +3093,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3147,7 +3147,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3163,7 +3163,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3217,7 +3217,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3233,7 +3233,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3295,7 +3295,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3311,7 +3311,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3368,7 +3368,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3384,7 +3384,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3441,7 +3441,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3457,7 +3457,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3536,7 +3536,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3552,7 +3552,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3625,7 +3625,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3641,7 +3641,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3697,7 +3697,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3713,7 +3713,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3766,7 +3766,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3782,7 +3782,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3836,7 +3836,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3852,7 +3852,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3904,7 +3904,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3920,7 +3920,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3976,7 +3976,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3992,7 +3992,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4069,7 +4069,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -4085,7 +4085,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4163,7 +4163,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -4179,7 +4179,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4231,7 +4231,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -4247,7 +4247,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4338,7 +4338,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -4354,7 +4354,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4386,11 +4386,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFFCFCFC
+          Color = xFFF8F6F4
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFB8B8B8
+          Color = xFFC1BBAF
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -4398,12 +4398,12 @@ object TStyleContainer
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC9CFD6
+      Stroke.Color = xFFD6D2C9
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TInnerGlowEffect
         Softness = 0.400000005960464500
-        GlowColor = xFF4F4848
+        GlowColor = xFF504D47
         Opacity = 0.899999976158142100
         Trigger = 'IsPressed=true'
         Enabled = False
@@ -4434,7 +4434,7 @@ object TStyleContainer
         Data.Path = {
           04000000000000000000000000000000010000000000803F0000000001000000
           0000003F0000803F030000000000000000000000}
-        Fill.Color = xFFFFFFFF
+        Fill.Color = xFFF9F8F6
         HitTest = False
         Margins.Top = 2.000000000000000000
         Size.Width = 8.000000000000000000
@@ -4445,7 +4445,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF2080E0
+      GlowColor = xFF437CBD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -4466,11 +4466,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFFCFCFC
+          Color = xFFF8F6F4
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFB8B8B8
+          Color = xFFC1BBAF
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -4478,12 +4478,12 @@ object TStyleContainer
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFC9CFD6
+      Stroke.Color = xFFD6D2C9
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TInnerGlowEffect
         Softness = 0.400000005960464500
-        GlowColor = xFF4F4848
+        GlowColor = xFF504D47
         Opacity = 0.899999976158142100
         Trigger = 'IsPressed=true'
         Enabled = False
@@ -4492,7 +4492,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'fill'
       Align = Client
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Margins.Left = 6.000000000000000000
@@ -4522,7 +4522,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF2080E0
+      GlowColor = xFF437CBD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -4548,7 +4548,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFF0F3F6
+          Color = xFFF2F0EC
           Offset = 1.000000000000000000
         end>
       HitTest = False
@@ -4557,7 +4557,7 @@ object TStyleContainer
       Size.Width = 90.000000000000000000
       Size.Height = 22.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
     end
@@ -4585,11 +4585,11 @@ object TStyleContainer
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
       Text = 'button'
-      TextSettings.FontColor = xFF828282
+      TextSettings.FontColor = xFF8C8578
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF2080E0
+      GlowColor = xFF437CBD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -4607,13 +4607,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 107.000000000000000000
       Size.Height = 22.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TRectangle
@@ -4626,7 +4626,7 @@ object TStyleContainer
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 1.000000000000000000
           end>
         HitTest = False
@@ -4635,7 +4635,7 @@ object TStyleContainer
         Size.Width = 107.000000000000000000
         Size.Height = 20.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD5D5D5
+        Stroke.Color = xFFDBD7CF
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
       end
@@ -4651,7 +4651,7 @@ object TStyleContainer
         Data.Path = {
           0500000000000000000000000000803F010000000000803F0000803F01000000
           0000003F0000000001000000000000000000803F030000000000000000000000}
-        Fill.Color = xFF0969DA
+        Fill.Color = xFF3B6EA8
         HitTest = False
         Margins.Top = -9.000000000000000000
         Size.Width = 8.000000000000000000
@@ -4664,7 +4664,7 @@ object TStyleContainer
         Data.Path = {
           04000000000000000000000000000000010000000000803F0000000001000000
           0000003F0000803F030000000000000000000000}
-        Fill.Color = xFF0969DA
+        Fill.Color = xFF3B6EA8
         HitTest = False
         Margins.Top = 7.000000000000000000
         Size.Width = 8.000000000000000000
@@ -4686,12 +4686,12 @@ object TStyleContainer
       Size.Height = 12.000000000000000000
       Size.PlatformDefault = False
       Text = 'button'
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       TextSettings.WordWrap = False
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -4709,16 +4709,16 @@ object TStyleContainer
     object TEllipse
       StyleName = 'background'
       Align = Fit
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 26.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       object TInnerGlowEffect
         Softness = 0.400000005960464500
-        GlowColor = xFF4F4848
+        GlowColor = xFF504D47
         Opacity = 0.899999976158142100
         Trigger = 'IsPressed=true'
         Enabled = False
@@ -4742,7 +4742,7 @@ object TStyleContainer
           Size.PlatformDefault = False
           object TEllipse
             Align = Center
-            Fill.Color = xFFD5D5D5
+            Fill.Color = xFFDBD7CF
             Locked = True
             HitTest = False
             Size.Width = 4.000000000000000000
@@ -4763,7 +4763,7 @@ object TStyleContainer
       Size.PlatformDefault = False
       Text = 'text'
       TextSettings.Font.Size = 9.000000000000000000
-      TextSettings.FontColor = xFF101010
+      TextSettings.FontColor = xFF11100F
       TextSettings.WordWrap = False
     end
     object TText
@@ -4778,7 +4778,7 @@ object TStyleContainer
       Size.PlatformDefault = False
       Text = 'text'
       TextSettings.Font.Size = 9.000000000000000000
-      TextSettings.FontColor = xFF101010
+      TextSettings.FontColor = xFF11100F
       TextSettings.WordWrap = False
     end
   end
@@ -4797,11 +4797,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFD8D8D8
+          Color = xFFDEDAD2
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFFFFFFF
+          Color = xFFF9F8F6
           Offset = 1.000000000000000000
         end>
       Fill.Gradient.StopPosition.X = 1.000000000000000000
@@ -4811,7 +4811,7 @@ object TStyleContainer
       Size.Width = 9.999999046325684000
       Size.Height = 18.999998092651370000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD0D7DE
+      Stroke.Color = xFFDDD9D1
     end
   end
   object TLayout
@@ -4829,11 +4829,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFD8D8D8
+          Color = xFFDEDAD2
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFFFFFFF
+          Color = xFFF9F8F6
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -4841,7 +4841,7 @@ object TStyleContainer
       Size.Width = 18.999998092651370000
       Size.Height = 9.999999046325684000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD0D7DE
+      Stroke.Color = xFFDDD9D1
     end
   end
   object TRectangle
@@ -4890,7 +4890,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'scrollbarleftbutton'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Margins.Left = 1.000000000000000000
     Margins.Top = 1.000000000000000000
@@ -4901,7 +4901,7 @@ object TStyleContainer
     Size.Width = 19.000000000000000000
     Size.Height = 18.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
@@ -4913,7 +4913,7 @@ object TStyleContainer
         01000000FF1DB543C5E4964301000000FF1DB54355F29543010000006F10B643
         55F29543010000006F10B643CA589543010000001D1BB743B650954301000000
         1D1BB7431D4E9443010000008D0DB8431B4E9443030000008D0DB843AA689843}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 4.000000000000000000
@@ -4924,7 +4924,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'scrollbarrightbutton'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Margins.Left = 1.000000000000000000
     Margins.Top = 1.000000000000000000
@@ -4935,7 +4935,7 @@ object TStyleContainer
     Size.Width = 17.000000000000000000
     Size.Height = 18.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
@@ -4947,7 +4947,7 @@ object TStyleContainer
         010000008E0DB843C5E49643010000008E0DB84355F29543010000001E1BB743
         55F29543010000001E1BB743CA589543010000007010B643B650954301000000
         7010B6431D4E944301000000001EB5431B4E944303000000001EB543AA689843}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 4.000000000000000000
@@ -4958,7 +4958,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'scrollbartopbutton'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Margins.Left = 1.000000000000000000
     Margins.Top = 1.000000000000000000
@@ -4969,7 +4969,7 @@ object TStyleContainer
     Size.Width = 8.000000000000000000
     Size.Height = 5.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
@@ -4981,7 +4981,7 @@ object TStyleContainer
         01000000650CB6439DE3944301000000D5FEB6439DE3944301000000D5FEB643
         0DD69543010000006098B7430DD695430100000074A0B743BBE0964301000000
         0DA3B843BBE09643010000000FA3B8432BD39743030000008088B4432BD39743}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 6.000000000000000000
@@ -4992,7 +4992,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'scrollbarbottombutton'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Margins.Left = 1.000000000000000000
     Margins.Top = 1.000000000000000000
@@ -5003,7 +5003,7 @@ object TStyleContainer
     Size.Width = 8.000000000000000000
     Size.Height = 5.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
@@ -5015,7 +5015,7 @@ object TStyleContainer
         01000000650CB6432BD3974301000000D5FEB6432BD3974301000000D5FEB643
         BBE09643010000006098B743BBE096430100000074A0B7430DD6954301000000
         0DA3B8430DD69543010000000FA3B8439DE39443030000008088B4439DE39443}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 6.000000000000000000
@@ -5043,7 +5043,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFE2E0E1
+          Color = xFFE6E3DC
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -5053,7 +5053,7 @@ object TStyleContainer
       Size.Width = 60.999996185302730000
       Size.Height = 10.000000953674320000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD0D7DE
+      Stroke.Color = xFFDDD9D1
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
     end
@@ -5077,7 +5077,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFE2E0E1
+          Color = xFFE6E3DC
           Offset = 1.000000000000000000
         end>
       Fill.Gradient.StartPosition.Y = 0.500000000000000000
@@ -5090,7 +5090,7 @@ object TStyleContainer
       Size.Width = 7.999999046325684000
       Size.Height = 47.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD0D7DE
+      Stroke.Color = xFFDDD9D1
       XRadius = 2.000000000000000000
       YRadius = 2.000000000000000000
     end
@@ -5137,13 +5137,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 176.000000000000000000
       Size.Height = 30.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD9D9D9
+      Stroke.Color = xFFDFDBD3
     end
     object TSpeedButton
       StyleName = 'leftbutton'
@@ -5236,11 +5236,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFDADADA
+          Color = xFFE0DCD4
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFF0F3F6
+          Color = xFFF2F0EC
           Offset = 1.000000000000000000
         end>
       Fill.Gradient.StopPosition.X = 1.000000000000000000
@@ -5279,11 +5279,11 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = xFFDADADA
+          Color = xFFE0DCD4
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFF0F3F6
+          Color = xFFF2F0EC
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -5352,13 +5352,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 89.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TRectangle
@@ -5371,7 +5371,7 @@ object TStyleContainer
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 1.000000000000000000
           end>
         HitTest = False
@@ -5380,7 +5380,7 @@ object TStyleContainer
         Size.Width = 89.000000000000000000
         Size.Height = 24.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD5D5D5
+        Stroke.Color = xFFDBD7CF
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
       end
@@ -5390,22 +5390,23 @@ object TStyleContainer
       Data.Path = {
         0400000000000000DB86E4439C9A0044010000002489E643C1D7014401000000
         497AE843C197004403000000DB86E4439C9A0044}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF6D685F
       Locked = True
       HitTest = False
-      Margins.Top = 8.000000000000000000
-      Margins.Right = 5.000000000000000000
-      Margins.Bottom = 8.000000000000000000
-      Position.X = 76.000000000000000000
-      Position.Y = 8.000000000000000000
-      Size.Width = 8.000000000000000000
-      Size.Height = 10.000000000000000000
+      Margins.Top = 10.000000000000000000
+      Margins.Right = 6.000000000000000000
+      Margins.Bottom = 10.000000000000000000
+      Position.X = 74.000000000000000000
+      Position.Y = 10.000000000000000000
+      Size.Width = 10.000000000000000000
+      Size.Height = 6.000000000000000000
       Size.PlatformDefault = False
       Stroke.Kind = None
+      WrapMode = Fit
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TLayout
       StyleName = 'content'
@@ -5421,7 +5422,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -5439,13 +5440,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 89.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
       object TRectangle
@@ -5458,7 +5459,7 @@ object TStyleContainer
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 1.000000000000000000
           end>
         HitTest = False
@@ -5467,7 +5468,7 @@ object TStyleContainer
         Size.Width = 89.000000000000000000
         Size.Height = 24.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD5D5D5
+        Stroke.Color = xFFDBD7CF
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
       end
@@ -5478,7 +5479,7 @@ object TStyleContainer
       Data.Path = {
         0400000000000000DB86E4439C9A0044010000002489E643C1D7014401000000
         497AE843C197004403000000DB86E4439C9A0044}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Margins.Top = 8.000000000000000000
@@ -5493,11 +5494,11 @@ object TStyleContainer
     end
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x8001BAE9
+      Brush.Color = x803D71AD
     end
     object TLayout
       StyleName = 'content'
@@ -5513,7 +5514,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF01BAE9
+      GlowColor = xFF3D71AD
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -5530,12 +5531,12 @@ object TStyleContainer
     TabOrder = 63
     object TBrushObject
       StyleName = 'AlternatingRowBackground'
-      Brush.Color = xFFD4D4D4
+      Brush.Color = xFFDAD6CE
     end
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       Locked = True
       HitTest = False
       Padding.Left = 1.000000000000000000
@@ -5545,7 +5546,7 @@ object TStyleContainer
       Size.Width = 116.999992370605500000
       Size.Height = 131.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD2D2D2
+      Stroke.Color = xFFD9D4CB
       object TLayout
         StyleName = 'content'
         Align = Client
@@ -5555,7 +5556,7 @@ object TStyleContainer
         Size.PlatformDefault = False
         object TRectangle
           StyleName = 'selection'
-          Fill.Color = x330969DA
+          Fill.Color = x333B6EA8
           HitTest = False
           Size.Width = 50.000000000000000000
           Size.Height = 50.000000000000000000
@@ -5564,7 +5565,7 @@ object TStyleContainer
         end
         object TRectangle
           StyleName = 'focusedselection'
-          Fill.Color = x330969DA
+          Fill.Color = x333B6EA8
           HitTest = False
           Size.Width = 50.000000000000000000
           Size.Height = 50.000000000000000000
@@ -5629,7 +5630,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -5654,7 +5655,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFEAEFF4
+          Color = xFFF0EDE9
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -5662,7 +5663,7 @@ object TStyleContainer
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFDADADA
+      Stroke.Color = xFFE0DCD4
     end
     object TText
       StyleName = 'text'
@@ -5699,7 +5700,7 @@ object TStyleContainer
       Size.Width = 81.000000000000000000
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
     end
   end
   object TLayout
@@ -5713,7 +5714,7 @@ object TStyleContainer
     TabOrder = 66
     object TBrushObject
       StyleName = 'AlternatingRowBackground'
-      Brush.Color = xFFD4D4D4
+      Brush.Color = xFFDAD6CE
     end
     object TLayout
       StyleName = 'background'
@@ -5842,12 +5843,12 @@ object TStyleContainer
       Size.Width = 82.000000000000000000
       Size.Height = 22.000000000000000000
       Size.PlatformDefault = False
-      TextSettings.FontColor = xFF828282
+      TextSettings.FontColor = xFF8C8578
       TextSettings.WordWrap = False
       TextSettings.HorzAlign = Leading
       ShadowVisible = False
       ActiveTrigger = Selected
-      ActiveColor = xFF0A3D75
+      ActiveColor = xFF213D5E
     end
   end
   object TLayout
@@ -5866,7 +5867,7 @@ object TStyleContainer
     object TRectangle
       StyleName = 'textborder'
       Align = Bottom
-      Fill.Color = x52005ACC
+      Fill.Color = x52356397
       HitTest = False
       Margins.Top = 2.000000000000000000
       Position.Y = 8.000000000000000000
@@ -5908,7 +5909,7 @@ object TStyleContainer
       Size.Width = 50.000000000000000000
       Size.Height = 50.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFF484848
+      Stroke.Color = xFF4C4944
       Stroke.Thickness = 4.000000000000000000
       Stroke.Dash = Dash
       XRadius = 11.000000953674320000
@@ -5923,7 +5924,7 @@ object TStyleContainer
         Size.Width = 30.000000000000000000
         Size.Height = 50.000000000000000000
         Size.PlatformDefault = False
-        TextSettings.FontColor = xFF484848
+        TextSettings.FontColor = xFF4C4944
       end
     end
     object TFloatKeyAnimation
@@ -5953,7 +5954,7 @@ object TStyleContainer
         915DC64321E0F54302000000919DBB439643F94302000000087CB043F833FB43
         01000000087CB043F087A4430100000008EC8343F087A4430300000000000000
         00000000}
-      Fill.Color = xFF484848
+      Fill.Color = xFF4C4944
       HitTest = False
       Size.Width = 50.000000000000000000
       Size.Height = 50.000003814697270000
@@ -5966,11 +5967,11 @@ object TStyleContainer
     Brush.Kind = Gradient
     Brush.Gradient.Points = <
       item
-        Color = xFFFFFFFF
+        Color = xFFF9F8F6
         Offset = 0.000000000000000000
       end
       item
-        Color = xFFDEDEDE
+        Color = xFFE3E0D9
         Offset = 1.000000000000000000
       end>
   end
@@ -5979,11 +5980,11 @@ object TStyleContainer
     Brush.Kind = Gradient
     Brush.Gradient.Points = <
       item
-        Color = xFFC5C5C5
+        Color = xFFCDC8BD
         Offset = 0.000000000000000000
       end
       item
-        Color = xFFF2F2F2
+        Color = xFFF2F0EB
         Offset = 1.000000000000000000
       end>
   end
@@ -5992,11 +5993,11 @@ object TStyleContainer
     Brush.Kind = Gradient
     Brush.Gradient.Points = <
       item
-        Color = xFFC1CCDA
+        Color = xFFD5D0C6
         Offset = 0.000000000000000000
       end
       item
-        Color = xFF8793B1
+        Color = xFF879BB1
         Offset = 1.000000000000000000
       end>
   end
@@ -6005,11 +6006,11 @@ object TStyleContainer
     Brush.Kind = Gradient
     Brush.Gradient.Points = <
       item
-        Color = xFFFFFFFF
+        Color = xFFF9F8F6
         Offset = 0.000000000000000000
       end
       item
-        Color = xFFDEDEDE
+        Color = xFFE3E0D9
         Offset = 1.000000000000000000
       end>
     Brush.Gradient.StartPosition.Y = 0.500000000000000000
@@ -6028,16 +6029,16 @@ object TStyleContainer
     TabOrder = 70
     object TBrushObject
       StyleName = 'AlternatingRowBackground'
-      Brush.Color = xFFE2E2E2
+      Brush.Color = xFFE7E4DD
     end
     object TBrushObject
       StyleName = 'linefill'
-      Brush.Color = xFFD5D5D5
+      Brush.Color = xFFDBD7CF
     end
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       Locked = True
       HitTest = False
       Padding.Left = 1.000000000000000000
@@ -6047,7 +6048,7 @@ object TStyleContainer
       Size.Width = 116.999992370605500000
       Size.Height = 131.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFDADADA
+      Stroke.Color = xFFE0DCD4
       object THeader
         StyleName = 'header'
         Sides = [Bottom]
@@ -6067,7 +6068,7 @@ object TStyleContainer
         Size.PlatformDefault = False
         object TRectangle
           StyleName = 'selection'
-          Fill.Color = x603DC9ED
+          Fill.Color = x606292C8
           HitTest = False
           Size.Width = 50.000000000000000000
           Size.Height = 50.000000000000000000
@@ -6143,7 +6144,7 @@ object TStyleContainer
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -6168,7 +6169,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = xFFEAEFF4
+          Color = xFFF0EDE9
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -6176,7 +6177,7 @@ object TStyleContainer
       Size.Width = 91.000000000000000000
       Size.Height = 24.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFDADADA
+      Stroke.Color = xFFE0DCD4
     end
     object TText
       StyleName = 'text'
@@ -6191,7 +6192,7 @@ object TStyleContainer
       Size.Height = 20.000000000000000000
       Size.PlatformDefault = False
       Text = 'button'
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
     end
   end
   object TLayout
@@ -6205,11 +6206,11 @@ object TStyleContainer
     TabOrder = 72
     object TBrushObject
       StyleName = 'foreground'
-      Brush.Color = xFF898989
+      Brush.Color = xFF938C7F
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803DC9ED
+      Brush.Color = x806292C8
     end
     object TLayout
       StyleName = 'content'
@@ -6260,7 +6261,7 @@ object TStyleContainer
             008A64440020D843010000000064644400D8D743010000000060644400D0D743
             01000000005C644400C8D7430100000000386444007CD7430100000000366444
             0080D74301000000000C6444002CD74303000000000C6444002CD743}
-          Fill.Color = xFFFFFFFF
+          Fill.Color = xFFF9F8F6
           Locked = True
           HitTest = False
           Size.Width = 7.000000000000000000
@@ -6270,15 +6271,15 @@ object TStyleContainer
           object TColorAnimation
             Duration = 0.001000000047497451
             PropertyName = 'Fill.Color'
-            StartValue = x00034E9E
-            StopValue = xFF111111
+            StartValue = x002A4E77
+            StopValue = xFF121110
             Trigger = 'IsChecked=true'
           end
           object TColorAnimation
             Duration = 0.001000000047497451
             PropertyName = 'Fill.Color'
-            StartValue = xFF111111
-            StopValue = x00034E9E
+            StartValue = xFF121110
+            StopValue = x002A4E77
             Trigger = 'IsChecked=false'
           end
         end
@@ -6305,7 +6306,7 @@ object TStyleContainer
         Data.Path = {
           0500000000000000000000000000803F010000000000803F0000803F01000000
           0000003F0000000001000000000000000000803F030000000000000000000000}
-        Fill.Color = xFF0969DA
+        Fill.Color = xFF3B6EA8
         HitTest = False
         Margins.Top = -9.000000000000000000
         Size.Width = 8.000000000000000000
@@ -6318,7 +6319,7 @@ object TStyleContainer
         Data.Path = {
           04000000000000000000000000000000010000000000803F0000000001000000
           0000003F0000803F030000000000000000000000}
-        Fill.Color = xFF0969DA
+        Fill.Color = xFF3B6EA8
         HitTest = False
         Margins.Top = 7.000000000000000000
         Size.Width = 8.000000000000000000
@@ -6340,7 +6341,7 @@ object TStyleContainer
       Size.Height = 12.000000000000000000
       Size.PlatformDefault = False
       Text = 'button'
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       TextSettings.WordWrap = False
     end
   end
@@ -6370,11 +6371,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFF73E1EF
+            Color = xFF8CAFD6
             Offset = 0.000000000000000000
           end
           item
-            Color = xFF00C7F8
+            Color = xFF4078B8
             Offset = 1.000000000000000000
           end>
         Locked = True
@@ -6525,7 +6526,7 @@ object TStyleContainer
     Visible = False
     object TRectangle
       Align = Client
-      Fill.Color = xFFF2F2F2
+      Fill.Color = xFFF2F0EB
       HitTest = False
       Margins.Left = -1.000000000000000000
       Margins.Top = -1.000000000000000000
@@ -6558,14 +6559,14 @@ object TStyleContainer
     TabOrder = 79
     object TRectangle
       Align = Client
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       HitTest = False
       Margins.Right = -8.000000000000000000
       Margins.Bottom = -8.000000000000000000
       Size.Width = 50.000000000000000000
       Size.Height = 50.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFCCCCCC
+      Stroke.Color = xFFD3CEC5
       object TShadowEffect
         Distance = 4.000000000000000000
         Direction = 45.000000000000000000
@@ -6597,14 +6598,14 @@ object TStyleContainer
     TabOrder = 80
     object TRectangle
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       HitTest = False
       Opacity = 0.000099999997473788
       Sides = [Top, Left, Right]
       Size.Width = 73.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFCCCCCC
+      Stroke.Color = xFFD3CEC5
       object TShadowEffect
         Distance = 4.000000000000000000
         Direction = 45.000000000000000000
@@ -6652,11 +6653,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFFFFFFFF
+            Color = xFFF9F8F6
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 0.500000000000000000
           end>
         HitTest = False
@@ -6664,12 +6665,12 @@ object TStyleContainer
         Size.Width = 25.000000000000000000
         Size.Height = 26.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD9D9D9
+        Stroke.Color = xFFDFDBD3
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
         object TEllipse
           Align = Center
-          Fill.Color = xFF0969DA
+          Fill.Color = xFF3B6EA8
           Locked = True
           HitTest = False
           Size.Width = 7.000000000000000000
@@ -6725,13 +6726,13 @@ object TStyleContainer
       Size.Width = 50.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       TextSettings.HorzAlign = Leading
       object TColorAnimation
         Duration = 0.200000002980232200
         PropertyName = 'Fill.Color'
-        StartValue = xFF898989
-        StopValue = xFF0969DA
+        StartValue = xFF938C7F
+        StopValue = xFF3B6EA8
         Trigger = 'IsMouseOver=true'
         TriggerInverse = 'IsMouseOver=false'
       end
@@ -6761,7 +6762,7 @@ object TStyleContainer
         Data.Path = {
           0400000000000000000000000000000001000000000000000000803F01000000
           0000803F0000003F030000000000000000000000}
-        Fill.Color = xFFD0D7DE
+        Fill.Color = xFFDDD9D1
         Locked = True
         HitTest = False
         Size.Width = 7.000000000000000000
@@ -6782,14 +6783,14 @@ object TStyleContainer
     TabOrder = 81
     object TRectangle
       Align = Contents
-      Fill.Color = xFFF6F8FA
+      Fill.Color = xFFF5F4F0
       HitTest = False
       Opacity = 0.000099999997473788
       Sides = [Top, Left, Right]
       Size.Width = 73.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFCCCCCC
+      Stroke.Color = xFFD3CEC5
       object TShadowEffect
         Distance = 4.000000000000000000
         Direction = 45.000000000000000000
@@ -6837,11 +6838,11 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = xFFFFFFFF
+            Color = xFFF9F8F6
             Offset = 0.000000000000000000
           end
           item
-            Color = xFFF0F3F6
+            Color = xFFF2F0EC
             Offset = 0.500000000000000000
           end>
         HitTest = False
@@ -6849,12 +6850,12 @@ object TStyleContainer
         Size.Width = 25.000000000000000000
         Size.Height = 26.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = xFFD9D9D9
+        Stroke.Color = xFFDFDBD3
         XRadius = 2.000000000000000000
         YRadius = 2.000000000000000000
         object TEllipse
           Align = Center
-          Fill.Color = xFF0969DA
+          Fill.Color = xFF3B6EA8
           Locked = True
           HitTest = False
           Size.Width = 7.000000000000000000
@@ -6908,13 +6909,13 @@ object TStyleContainer
       Size.Width = 50.000000000000000000
       Size.Height = 26.000000000000000000
       Size.PlatformDefault = False
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       TextSettings.HorzAlign = Leading
       object TColorAnimation
         Duration = 0.200000002980232200
         PropertyName = 'Fill.Color'
-        StartValue = xFF898989
-        StopValue = xFF0969DA
+        StartValue = xFF938C7F
+        StopValue = xFF3B6EA8
         Trigger = 'IsMouseOver=true'
         TriggerInverse = 'IsMouseOver=false'
       end
@@ -6944,7 +6945,7 @@ object TStyleContainer
         Data.Path = {
           0400000000000000000000000000000001000000000000000000803F01000000
           0000803F0000003F030000000000000000000000}
-        Fill.Color = xFFD0D7DE
+        Fill.Color = xFFDDD9D1
         Locked = True
         HitTest = False
         Size.Width = 7.000000000000000000
@@ -6978,7 +6979,7 @@ object TStyleContainer
       Size.Width = 44.000000000000000000
       Size.Height = 1.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFDBDBDB
+      Stroke.Color = xFFE1DDD5
     end
     object TLine
       Align = Top
@@ -6990,7 +6991,7 @@ object TStyleContainer
       Size.Width = 44.000000000000000000
       Size.Height = 1.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFECECEC
+      Stroke.Color = xFFEEEBE6
     end
   end
   object TImage
@@ -7776,7 +7777,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'spintopbutton'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Margins.Left = 1.000000000000000000
     Margins.Top = 1.000000000000000000
@@ -7787,7 +7788,7 @@ object TStyleContainer
     Size.Width = 16.000000000000000000
     Size.Height = 19.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
@@ -7799,7 +7800,7 @@ object TStyleContainer
         01000000650CB6439DE3944301000000D5FEB6439DE3944301000000D5FEB643
         0DD69543010000006098B7430DD695430100000074A0B743BBE0964301000000
         0DA3B843BBE09643010000000FA3B8432BD39743030000008088B4432BD39743}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 6.000000000000000000
@@ -7810,7 +7811,7 @@ object TStyleContainer
   end
   object TRectangle
     StyleName = 'spinbottombutton'
-    Fill.Color = xFFFFFFFF
+    Fill.Color = xFFF9F8F6
     HitTest = False
     Margins.Left = 1.000000000000000000
     Margins.Top = 1.000000000000000000
@@ -7821,7 +7822,7 @@ object TStyleContainer
     Size.Width = 16.000000000000000000
     Size.Height = 19.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = xFFD0D7DE
+    Stroke.Color = xFFDDD9D1
     Visible = False
     XRadius = 2.000000000000000000
     YRadius = 2.000000000000000000
@@ -7833,7 +7834,7 @@ object TStyleContainer
         01000000650CB6432BD3974301000000D5FEB6432BD3974301000000D5FEB643
         BBE09643010000006098B743BBE096430100000074A0B7430DD6954301000000
         0DA3B8430DD69543010000000FA3B8439DE39443030000008088B4439DE39443}
-      Fill.Color = xFF0969DA
+      Fill.Color = xFF3B6EA8
       Locked = True
       HitTest = False
       Size.Width = 6.000000000000000000
@@ -7852,13 +7853,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 50.000000000000000000
       Size.Height = 50.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
     end
     object TGridLayout
       Align = MostRight
@@ -7919,16 +7920,16 @@ object TStyleContainer
       Size.Width = 0.000000000000000000
       Size.Height = 46.000000000000000000
       Size.PlatformDefault = False
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       ShadowVisible = False
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803DC9ED
+      Brush.Color = x806292C8
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -7970,7 +7971,7 @@ object TStyleContainer
           000048420000964201000000000070410000DC42010000000000A0C00000B442
           010000000000F04100005C42010000000000A0C0000070410300000000000000
           00000000}
-        Fill.Color = xFF898989
+        Fill.Color = xFF938C7F
         Locked = True
         HitTest = False
         Margins.Left = 4.000000000000000000
@@ -7995,13 +7996,13 @@ object TStyleContainer
     object TRectangle
       StyleName = 'background'
       Align = Contents
-      Fill.Color = xFFFFFFFF
+      Fill.Color = xFFF9F8F6
       Locked = True
       HitTest = False
       Size.Width = 50.000000000000000000
       Size.Height = 50.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = xFFD5D5D5
+      Stroke.Color = xFFDBD7CF
     end
     object TButton
       StyleName = 'arrow'
@@ -8030,16 +8031,16 @@ object TStyleContainer
       Size.Width = 0.000000000000000000
       Size.Height = 46.000000000000000000
       Size.PlatformDefault = False
-      TextSettings.FontColor = xFF898989
+      TextSettings.FontColor = xFF938C7F
       ShadowVisible = False
     end
     object TBrushObject
       StyleName = 'selection'
-      Brush.Color = x803DC9ED
+      Brush.Color = x806292C8
     end
     object TGlowEffect
       Softness = 0.200000002980232200
-      GlowColor = xFF0969DA
+      GlowColor = xFF3B6EA8
       Opacity = 1.000000000000000000
       Trigger = 'IsFocused=true'
       Enabled = False
@@ -8081,7 +8082,7 @@ object TStyleContainer
           000048420000964201000000000070410000DC42010000000000A0C00000B442
           010000000000F04100005C42010000000000A0C0000070410300000000000000
           00000000}
-        Fill.Color = xFF898989
+        Fill.Color = xFF938C7F
         Locked = True
         HitTest = False
         Margins.Left = 4.000000000000000000

--- a/studio/PasclawLight.style
+++ b/studio/PasclawLight.style
@@ -260,7 +260,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = claWhite
+          Color = xFFF9F8F6
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -487,7 +487,7 @@ object TStyleContainer
     Size.Width = 101.000000000000000000
     Size.Height = 27.000000000000000000
     Size.PlatformDefault = False
-    Stroke.Color = claWhite
+    Stroke.Color = xFFF9F8F6
     Visible = False
     object TSizeGrip
       StyleName = 'sizegrip'
@@ -760,7 +760,7 @@ object TStyleContainer
       Size.Width = 131.000000000000000000
       Size.Height = 92.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = claGainsboro
+      Stroke.Color = xFFE2DED6
       XRadius = 4.000000000000000000
       YRadius = 4.000000000000000000
       object TRectangle
@@ -777,7 +777,7 @@ object TStyleContainer
         Size.Width = 129.000000000000000000
         Size.Height = 89.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = claWhite
+        Stroke.Color = xFFF9F8F6
         XRadius = 3.000000000000000000
         YRadius = 3.000000000000000000
       end
@@ -827,7 +827,7 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = claWhitesmoke
+            Color = xFFF3F2EE
             Offset = 0.000000000000000000
           end
           item
@@ -853,7 +853,7 @@ object TStyleContainer
               Offset = 0.000000000000000000
             end
             item
-              Color = claWhitesmoke
+              Color = xFFF3F2EE
               Offset = 1.000000000000000000
             end>
           HitTest = False
@@ -1027,7 +1027,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = claWhite
+          Color = xFFF9F8F6
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -1039,7 +1039,7 @@ object TStyleContainer
       object TColorAnimation
         Duration = 0.000000999999997475
         PropertyName = 'Fill.Color'
-        StartValue = claWhite
+        StartValue = xFFF9F8F6
         StopValue = xFFF3F2EE
         Trigger = 'IsSelected=false'
       end
@@ -1108,7 +1108,7 @@ object TStyleContainer
           Offset = 0.000000000000000000
         end
         item
-          Color = claWhite
+          Color = xFFF9F8F6
           Offset = 1.000000000000000000
         end>
       Locked = True
@@ -1121,7 +1121,7 @@ object TStyleContainer
       object TColorAnimation
         Duration = 0.000000999999997475
         PropertyName = 'Fill.Color'
-        StartValue = claWhite
+        StartValue = xFFF9F8F6
         StopValue = xFFF3F2EE
         Trigger = 'IsSelected=false'
       end
@@ -1414,7 +1414,7 @@ object TStyleContainer
           object TColorAnimation
             Duration = 0.100000001490116100
             PropertyName = 'Fill.Color'
-            StartValue = claWhite
+            StartValue = xFFF9F8F6
             StopValue = xFF3B6EA8
             Trigger = 'IsChecked=true'
           end
@@ -1422,7 +1422,7 @@ object TStyleContainer
             Duration = 0.100000001490116100
             PropertyName = 'Fill.Color'
             StartValue = xFF3B6EA8
-            StopValue = claWhite
+            StopValue = xFFF9F8F6
             Trigger = 'IsChecked=false'
           end
         end
@@ -1900,7 +1900,7 @@ object TStyleContainer
           Duration = 0.200000002980232200
           PropertyName = 'Fill.Color'
           StartValue = xFF938C7F
-          StopValue = claWhite
+          StopValue = xFFF9F8F6
           Trigger = 'IsSelected=true'
           TriggerInverse = 'IsSelected=False'
         end
@@ -1999,7 +1999,7 @@ object TStyleContainer
         Size.Width = 121.000000000000000000
         Size.Height = 8.000000000000000000
         Size.PlatformDefault = False
-        Stroke.Color = claWhite
+        Stroke.Color = xFFF9F8F6
       end
     end
     object TRectangle
@@ -2031,7 +2031,7 @@ object TStyleContainer
         Size.Width = 8.000000000000000000
         Size.Height = 5.000000953674316000
         Size.PlatformDefault = False
-        Stroke.Color = claWhite
+        Stroke.Color = xFFF9F8F6
       end
     end
     object TThumb
@@ -2092,7 +2092,7 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = claWhitesmoke
+            Color = xFFF3F2EE
             Offset = 0.000000000000000000
           end
           item
@@ -2596,7 +2596,7 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = claWhitesmoke
+            Color = xFFF3F2EE
             Offset = 0.000000000000000000
           end
           item
@@ -2671,7 +2671,7 @@ object TStyleContainer
         Duration = 0.200000002980232200
         PropertyName = 'Fill.Color'
         StartValue = xFF8C8578
-        StopValue = claWhite
+        StopValue = xFFF9F8F6
         Trigger = 'IsFocused=true'
         TriggerInverse = 'IsFocused=False'
       end
@@ -4502,7 +4502,7 @@ object TStyleContainer
       Size.Width = 79.000000000000000000
       Size.Height = 14.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = claGray
+      Stroke.Color = xFF8A8376
       XRadius = 3.000000000000000000
       YRadius = 3.000000000000000000
     end
@@ -4544,7 +4544,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = claWhitesmoke
+          Color = xFFF3F2EE
           Offset = 0.000000000000000000
         end
         item
@@ -4622,7 +4622,7 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = claWhitesmoke
+            Color = xFFF3F2EE
             Offset = 0.000000000000000000
           end
           item
@@ -5039,7 +5039,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = claWhite
+          Color = xFFF9F8F6
           Offset = 0.000000000000000000
         end
         item
@@ -5073,7 +5073,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = claWhite
+          Color = xFFF9F8F6
           Offset = 0.000000000000000000
         end
         item
@@ -5367,7 +5367,7 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = claWhitesmoke
+            Color = xFFF3F2EE
             Offset = 0.000000000000000000
           end
           item
@@ -5455,7 +5455,7 @@ object TStyleContainer
         Fill.Kind = Gradient
         Fill.Gradient.Points = <
           item
-            Color = claWhitesmoke
+            Color = xFFF3F2EE
             Offset = 0.000000000000000000
           end
           item
@@ -5651,7 +5651,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = claWhitesmoke
+          Color = xFFF3F2EE
           Offset = 0.000000000000000000
         end
         item
@@ -6165,7 +6165,7 @@ object TStyleContainer
       Fill.Kind = Gradient
       Fill.Gradient.Points = <
         item
-          Color = claWhitesmoke
+          Color = xFFF3F2EE
           Offset = 0.000000000000000000
         end
         item
@@ -6534,7 +6534,7 @@ object TStyleContainer
       Size.Width = 52.000000000000000000
       Size.Height = 51.000000000000000000
       Size.PlatformDefault = False
-      Stroke.Color = claWhite
+      Stroke.Color = xFFF9F8F6
     end
     object TLayout
       StyleName = 'content'


### PR DESCRIPTION
**Based on `main` directly.**

## The stretched arrow
The glyph's path bounds are **7.9 × 5.0** (aspect 1.58), but `Align = Right` plus 8px top/bottom margins forced the control to **8 × 10** — aspect 0.8. A wide triangle squashed into a tall box. Dark never showed it because its arrow's box (10 × 7) matches its path. Light's box is now 10 × 6 with `WrapMode` explicitly `Fit`, so aspect survives even if the box moves again.

## The palette
A census of the light book explains the eye strain exactly:

| | |
|---|---|
| `#FFFFFF` | **38 references** — pure white grounds |
| grey ramp | **chroma 0** — clinical neutrals |
| `#0969DA` | **60 references**, chroma **209** |

Maximum glare, no warmth to soften it, and an accent loud enough to pull the eye everywhere at once.

`scripts/retone-light.py` takes the approach from **FMXExpress/Cross-Platform-Retro-OS-Styles**, whose generator classifies each colour *"by chroma and lightness before mapping it to a role"* rather than editing values by hand, and whose Vellum style is built on *"low-arousal neutrals and processing fluency"*:

- **Neutrals → one warm hue**, saturated at the paper end, fading to near-neutral ink. Warmth belongs to the paper, not the text — my first ramp went the other way and turned mid greys olive and body ink brown.
- **No pure white.** The top of the range is *compressed*, not clamped — a flat cap mapped `#FFFFFF` and `#F6F8FA` onto one value and collapsed panel into background, losing the layering.
- **One accent hue**, saturation **capped** (a cap, not a scale — idempotent, and it leaves already-muted blues alone), folding in the stray cyans the stock style left behind.

Role colours: `bg F5F4F0 · panel F9F8F6 · panel-alt F2F0EC · border DBD7CF · ink 5C5851 · accent 3B6EA8`

## Two things worth calling out
**Idempotence was the hard part.** The transform now recognises its own gamut, with a tolerance that *widens as chroma falls* — at chroma 5 an 8-bit round trip moves the measured hue by eight degrees, so a tight test rejected the transform's own output and drifted on every run. `--check` verifies it, wired into `make lint-studio`.

**Two generators, one file.** `gen-studio-icons.py` also writes into the light book, so it now carries post-retone values. Otherwise the two fight over the same bytes and neither `--check` can ever pass — which is exactly what happened on the first run.

The Pascal light branches (`StyleChromeRect`, `ThemePaintColor/Stroke`, `ApplyTheme`) are retoned through the same function, so code-drawn surfaces can't sit cool against warm chrome.

`make lint-studio` green across all three checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_