### PR TITLE
Studio: stop rebuilding the transcript when nothing about it changed

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -3080,9 +3080,20 @@ begin
     SaveLocalSettings;
   TThread.ForceQueue(nil,
     procedure
+    var
+      PriorWidth: Single;
     begin
+      { Re-measure always; re-RENDER only if the column actually moved.
+        Since the cap stopped following the drawer, hiding it on any window
+        wider than the measure changes the margins and nothing else -- the
+        bubbles are already the right width. Rebuilding every one of them to
+        discover that is what made the toggle lag. }
+      PriorWidth := 0;
+      if FChatFlow <> nil then
+        PriorWidth := FChatFlow.Width;
       ApplyChatMeasure;
-      RenderChat;
+      if (FChatFlow <> nil) and (Abs(FChatFlow.Width - PriorWidth) > 0.5) then
+        RenderChat;
     end);
 end;
 
@@ -19871,6 +19882,7 @@ var
   TitleLabel: TLabel;
 begin
   FLoadingSessions := True;
+  FSessionList.BeginUpdate;
   try
     FSessionList.Clear;
     Filter := Trim(LowerCase(FSessionSearch.Text));
@@ -19953,6 +19965,7 @@ begin
     end;
     FSessionList.ItemIndex := SelectedIndex;
   finally
+    FSessionList.EndUpdate;
     FLoadingSessions := False;
   end;
 end;
@@ -21957,9 +21970,22 @@ var
       caller can size the panel to its children instead of guessing. }
     function AddToolDetailSection(Host: TFmxObject; const TitleText,
       DetailText: string): Single;
+    { A TMemo is by far the most expensive control the transcript builds --
+      model, presentation layer, two scroll bars and a caret each -- and an
+      expanded transcript wants three per tool call. Output short enough to
+      fit without scrolling gets a TLabel instead, which is most of them and
+      costs a fraction; anything long keeps the memo so it stays scrollable
+      and selectable. }
+    const
+      SECTION_LINE_H = 18;
+      NO_SCROLL_LINES = 9;      { fits inside the 190px memo cap }
     var
+      Body: TControl;
+      BodyHeight: Single;
+      Lines: Integer;
       Memo: TMemo;
       SectionLabel: TLabel;
+      TextLabel: TLabel;
     begin
       Result := 0;
       if Trim(DetailText) = '' then
@@ -21971,18 +21997,37 @@ var
       SectionLabel.HitTest := False;
       SectionLabel.Text := TitleText;
       StyleLabel(SectionLabel, UI_MUTED, 10, True);
-      Memo := TMemo.Create(Host);
-      Memo.Parent := Host;
-      Memo.Align := TAlignLayout.Top;
-      Memo.Height := Min(190, Max(58,
-        EstimateTextLines(DetailText, CharsPerLine) * 18 + 24));
-      Memo.ReadOnly := True;
-      Memo.WordWrap := True;
-      Memo.Lines.Text := DetailText;
-      SetControlMargins(Memo, 0, 2, 0, 8);
-      StyleTextControl(Memo, UI_TEXT, 11);
-      { label + memo + the 2/8 margins above and below the memo }
-      Result := SectionLabel.Height + Memo.Height + 10;
+
+      Lines := EstimateTextLines(DetailText, CharsPerLine);
+      BodyHeight := Min(190, Max(58, Lines * SECTION_LINE_H + 24));
+      if Lines <= NO_SCROLL_LINES then
+      begin
+        TextLabel := TLabel.Create(Host);
+        TextLabel.Parent := Host;
+        TextLabel.Align := TAlignLayout.Top;
+        TextLabel.Height := BodyHeight;
+        TextLabel.HitTest := False;
+        TextLabel.WordWrap := True;
+        TextLabel.Text := DetailText;
+        TextLabel.TextSettings.VertAlign := TTextAlign.Leading;
+        StyleLabel(TextLabel, UI_TEXT, 11, False);
+        Body := TextLabel;
+      end
+      else
+      begin
+        Memo := TMemo.Create(Host);
+        Memo.Parent := Host;
+        Memo.Align := TAlignLayout.Top;
+        Memo.Height := BodyHeight;
+        Memo.ReadOnly := True;
+        Memo.WordWrap := True;
+        Memo.Lines.Text := DetailText;
+        StyleTextControl(Memo, UI_TEXT, 11);
+        Body := Memo;
+      end;
+      SetControlMargins(Body, 0, 2, 0, 8);
+      { label + body + the 2/8 margins above and below the body }
+      Result := SectionLabel.Height + BodyHeight + 10;
     end;
 
     procedure RenderToolDetailBlocks;
@@ -22360,28 +22405,38 @@ begin
 
   if FChatFlow <> nil then
   begin
-    while FChatFlow.ChildrenCount > 0 do
-      FChatFlow.Children[0].Free;
-    ChatFlowHeight := 0;
-    ApplyChatMeasure;   { the one authority on the flow's width + margins }
-    if FTurns.Count = 0 then
-      AddTranscriptCard(0, 1, 'assistant',
-        'Connect to PasClaw, choose or create a session, then describe the code change you want.', '')
-    else
-      for I := 0 to FTurns.Count - 1 do
-      begin
-        Turn := FTurns[I];
-        AddTranscriptCard(I, FTurns.Count, Turn.Role, Turn.Text,
-          Turn.ToolDetails);
-      end;
+    { One realign for the whole rebuild instead of one per control. A long
+      session with expanded tool cards creates thousands of controls, and
+      without this every single Free and Create realigns the flow. }
+    FChatFlow.BeginUpdate;
+    try
+      { Free from the END: removing index 0 shifts the entire children list
+        down on every iteration, which turns clearing a long transcript into
+        quadratic work before a single new control is built. }
+      while FChatFlow.ChildrenCount > 0 do
+        FChatFlow.Children[FChatFlow.ChildrenCount - 1].Free;
+      ChatFlowHeight := 0;
+      ApplyChatMeasure;   { the one authority on the flow's width + margins }
+      if FTurns.Count = 0 then
+        AddTranscriptCard(0, 1, 'assistant',
+          'Connect to PasClaw, choose or create a session, then describe the code change you want.', '')
+      else
+        for I := 0 to FTurns.Count - 1 do
+        begin
+          Turn := FTurns[I];
+          AddTranscriptCard(I, FTurns.Count, Turn.Role, Turn.Text,
+            Turn.ToolDetails);
+        end;
+      if FChatScroll <> nil then
+        FChatFlow.Height := Max(FChatScroll.Height, ChatFlowHeight + 8)
+      else
+        FChatFlow.Height := ChatFlowHeight + 8;
+    finally
+      FChatFlow.EndUpdate;
+    end;
     if FChatScroll <> nil then
-    begin
-      FChatFlow.Height := Max(FChatScroll.Height, ChatFlowHeight + 8);
       FChatScroll.ViewportPosition := PointF(0,
         Max(0, FChatFlow.Height - FChatScroll.Height));
-    end
-    else
-      FChatFlow.Height := ChatFlowHeight + 8;
   end
   else if FChatList <> nil then
   begin

--- a/studio/PasclawLight.style
+++ b/studio/PasclawLight.style
@@ -3147,7 +3147,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3163,7 +3163,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3368,7 +3368,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3384,7 +3384,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3682,7 +3682,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3698,7 +3698,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -3760,7 +3760,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -3776,7 +3776,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4459,7 +4459,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -4475,7 +4475,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True
@@ -4780,7 +4780,7 @@ object TStyleContainer
       HitTest = False
       Locked = True
       Opacity = 0.000000000000000000
-      Stroke.Color = xFF0969DA
+      Stroke.Color = xFF3B6EA8
       Stroke.Thickness = 1.500000000000000000
       XRadius = 6.000000000000000000
       YRadius = 6.000000000000000000
@@ -4796,7 +4796,7 @@ object TStyleContainer
     object TPath
       StyleName = 'icon'
       Align = Center
-      Fill.Color = xFF4A5563
+      Fill.Color = xFF5C5851
       Fill.Kind = Solid
       HitTest = False
       Locked = True


### PR DESCRIPTION
**Based on `main` directly.**

## The drawer toggle
It is **not** refreshing sessions — it runs a full `RenderChat`, freeing and rebuilding every bubble. Three separate costs, all avoidable:

1. **It shouldn't rebuild at all.** Since the cap stopped following the drawer (#500), hiding it on any window wider than the measure changes the *margins* and nothing else — the bubbles are already the right width. The toggle now re-measures always but re-renders only if the column actually moved, which on a normal window is never.
2. **Quadratic clear.** `while ChildrenCount > 0 do Children[0].Free` shifts the entire children list down on every iteration. It frees from the end now.
3. **No `BeginUpdate`.** Every `Free` and every `Create` realigned the flow — thousands of realigns for a long session. One realign now wraps the whole rebuild.

## The tool toggle
The dominant cost is the control itself. A `TMemo` carries a model, a presentation layer, two scroll bars and a caret, and an expanded transcript wants **three per tool call**. Output short enough to fit without scrolling (nine lines — the existing 190px height cap) now uses a `TLabel`, which is most sections; longer output keeps the memo so it stays scrollable and selectable.

`RenderSessionList` gets the same batching, since it rebuilds on every refresh and every theme switch.

## Also: main couldn't lint
`make lint-studio` fails on current `main`, before this change. #502 and #503 both write `PasclawLight.style`, and #503 was branched before #502 landed — so the merge kept the six new icon styles with their **pre-retone** colours while retoning everything around them. Regenerating restores the invariant.

That's the generated-file hazard biting from a new angle: previously two *generators* fighting over one file, now two *branches*. Worth knowing when queuing PRs that touch the style books.

`make lint-studio` green again (lint + DFM validation + 28 icons/book + custom-list guard + retone check).

**Not measured on a running app** — these are structural wins (fewer rebuilds, fewer realigns, lighter controls) rather than profiled ones. If the tool toggle is still slow on a very long session, the next step is virtualising the transcript so only visible turns build controls, which is a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_