### PR TITLE
Studio: only use the non-scrolling tool section when the fit is certain

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -21968,6 +21968,18 @@ var
 
     { Returns the vertical space this section actually consumes, so the
       caller can size the panel to its children instead of guessing. }
+    function IsPlainAscii(const Text: string): Boolean;
+    { Character count only models width for single-column ASCII. A tab has
+      no fixed width either, so it is refused with the rest. }
+    var
+      I: Integer;
+    begin
+      for I := 1 to Length(Text) do
+        if (Text[I] > #126) or (Text[I] = #9) then
+          Exit(False);
+      Result := True;
+    end;
+
     function AddToolDetailSection(Host: TFmxObject; const TitleText,
       DetailText: string): Single;
     { A TMemo is by far the most expensive control the transcript builds --
@@ -21998,9 +22010,20 @@ var
       SectionLabel.Text := TitleText;
       StyleLabel(SectionLabel, UI_MUTED, 10, True);
 
-      Lines := EstimateTextLines(DetailText, CharsPerLine);
+      { Decide against a DELIBERATELY narrow budget, and size from the same
+        pessimistic count. EstimateTextLines divides by an average character
+        width, so a line of wide glyphs wraps sooner than it predicts -- and
+        a label cannot scroll, so an optimistic guess hides output for good.
+        Three-quarters of the budget covers that spread, and non-ASCII text
+        is refused outright because one character can be two columns wide
+        (or more) and no character count models it.
+
+        Half the budget, not three quarters: modelled against a line of all
+        'W' -- about 1.6x the average glyph -- three quarters still came out
+        one line short, and one line short is one line lost. }
+      Lines := EstimateTextLines(DetailText, Max(18, CharsPerLine div 2));
       BodyHeight := Min(190, Max(58, Lines * SECTION_LINE_H + 24));
-      if Lines <= NO_SCROLL_LINES then
+      if (Lines <= NO_SCROLL_LINES) and IsPlainAscii(DetailText) then
       begin
         TextLabel := TLabel.Create(Host);
         TextLabel.Parent := Host;


### PR DESCRIPTION
Fixes the Codex finding on #504 (already merged). **Based on `main` directly.**

## The bug
The label-instead-of-memo optimisation chose its path from `EstimateTextLines`, which divides by an **average** character width — so a line of wide glyphs wraps sooner than it predicts. A `TMemo` absorbs that with a scroll bar; a `TLabel` cannot. An optimistic estimate therefore clips the tail of a tool result and puts it **permanently out of reach**. Silent data loss to save a control — not a trade worth making.

## The fix
The label is an optimisation, so it now has to *prove* it fits:

- **Estimate against half the character budget**, and size the label from that same pessimistic count. Being generous costs a little whitespace; being short costs output.
- **Non-ASCII takes the memo unconditionally** — one character can be two columns wide or more, and no character count models that.

## Why half, not three-quarters
I modelled it against a line of all `W` (≈1.6× the average glyph). Three-quarters *still came out a line short* — and one line short is one line lost:

```
case                          est/2 real@W  fits?  label?
all-W worst case (380ch)          8      7     OK   label
mixed prose (405ch)               9      7     OK   label
one long token (380ch)            8      7     OK   label
short json result                 1      1     OK   label
5-line json                       5      5     OK   label
typical 8-line output             8      8     OK   label
```

The speedup survives: short results — nearly all of them, and where the win came from — still take the label. A one-line JSON result estimates at one line even under the halved budget.

## Note on the approach
The right fix would be measuring rendered text height via `TTextLayout`. I checked, and this file has no text-measurement facility at all — and introducing one is complicated by #504's `BeginUpdate` batching, since a control's width isn't resolved until realign, so a measurement taken at build time would be against the wrong width. A provably-conservative estimate avoids that ordering problem entirely. If measurement becomes worthwhile later, it belongs in the transcript-virtualisation work where widths are known up front.

`make lint-studio` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_