### PR TITLE
studio: declare the missing FWorkflowOutputDirEdit field

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -343,6 +343,7 @@ type
     FWorkflowNodeIdEdit: TEdit;
     FWorkflowNodePositions: TDictionary<string, TPointF>;
     FWorkflowNodesList: TListBox;
+    FWorkflowOutputDirEdit: TEdit;
     FWorkflowOutputsMemo: TMemo;
     FWorkflowPickerCombo: TComboBox;
     FWorkflowReplicateResultsList: TListBox;


### PR DESCRIPTION
Fixes the Delphi build break on main:

```
[dcc64 Error] MasterDetail.pas(6990): E2003 Undeclared identifier: 'FWorkflowOutputDirEdit'
```

The #512/#513 merge kept the output-folder edit's construction (workflow toolbar) and its save/load uses (`WorkflowBuildSpec` / spec load), but the field declaration itself was lost. One line: declare `FWorkflowOutputDirEdit: TEdit;` alongside its workflow siblings in the form class.

FPC cannot compile `studio/` (FMX), so only a Delphi build catches this class of break. A scan of the file for other used-but-undeclared `F`-prefixed fields found none — this was the only casualty. `make lint-studio` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_