### PR TITLE
studio: the comment explaining the comment rule broke the build

### DIFF
--- a/scripts/lint-studio.py
+++ b/scripts/lint-studio.py
@@ -48,12 +48,14 @@ def scan(src):
             i += 1
             continue
         if c == "(" and i + 1 < n and src[i + 1] == "*":
-            i += 2
-            while i + 1 < n and not (src[i] == "*" and src[i + 1] == ")"):
-                if src[i] == "\n":
+            start, j, body = line, i + 2, []
+            while j + 1 < n and not (src[j] == "*" and src[j + 1] == ")"):
+                if src[j] == "\n":
                     line += 1
-                i += 1
-            i += 2
+                body.append(src[j])
+                j += 1
+            yield (start, PAREN, "".join(body))
+            i = j + 2
             continue
         if c == "/" and i + 1 < n and src[i + 1] == "/":
             while i < n and src[i] != "\n":
@@ -99,7 +101,26 @@ def main(path):
                 findings.append(
                     (ln, "brace-comment contains '{': it ended at the "
                          "example's own '}' and the rest parses as code "
-                         "-- use (* *)"))
+                         "-- use a paren-star comment"))
+            continue
+
+        if kind == PAREN:
+            # NB: read `text`, not `body` -- `body` is bound only in the
+            # BRACE branch above, so using it here silently tests the
+            # PREVIOUS brace comment and the rule never fires.
+            paren_body = text.strip()
+            # Paren-star comments do not nest either, so the same reasoning
+            # applies: the body stopped at the first close, and an opener
+            # still inside it means the comment already ended there. This is
+            # not hypothetical -- the comment ADDED to explain the brace rule
+            # named both delimiters literally and broke the build itself
+            # (E2070 'form' / E2052 unterminated string). Describe the
+            # delimiters in words inside a comment of the same kind.
+            if "(*" in paren_body:
+                findings.append(
+                    (ln, "paren-star comment contains an inner '(*': it "
+                         "ended at the first close and the rest parses as "
+                         "code -- name the delimiters in words"))
             continue
 
         line = text.strip()

--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -11578,9 +11578,11 @@ function TMasterDetailForm.WorkflowFindModelArray(
    result.results produced an empty list and no complaint. Probe every shape
    at both levels instead of betting on one.
 
-   NOTE the (* *) form: this text shows a brace pair, and Delphi's { }
-   comments do NOT nest -- a { } version ends at the example's own '}' and
-   spills the rest into the compiler as code. *)
+   Why the paren-star comment form: this text shows a brace pair, and brace
+   comments do NOT nest, so a brace version ends at the example's own
+   closing brace and spills the rest into the compiler as code. Paren-star
+   does not nest either -- naming these delimiters literally inside a
+   comment of the same kind is what broke the build last time. *)
 const
   ROW_KEYS: array[0..2] of string = ('models', 'results', 'data');
 var


### PR DESCRIPTION
Fixes the dcc64 break on main:

```
[dcc64 Error] MasterDetail.pas(11581): E2070 Unknown directive: 'form'
[dcc64 Error] MasterDetail.pas(11581): E2052 Unterminated string
[dcc64 Error] MasterDetail.pas(11582): E2038 Illegal character in input file: '}'
[dcc64 Error] MasterDetail.pas(11734): E2250 There is no overloaded version of 'Queue' ...
```

## Cause

#519 converted two brace comments to the paren-star form — and its explanatory NOTE **named both delimiters literally**. Paren-star comments don't nest either, so that comment ended at the inner close:

- the prose after it parsed as code → `E2070 'form'`
- the apostrophe in *"Delphi's"* opened a string that never closed → `E2052`
- the real terminator became stray input → `E2038`

The `E2250` on `TThread.Queue` is **cascade damage** from the same corruption — I checked that anonymous method and it's well-formed and unchanged, so it should clear with the comment. (Inferred, not compiled: FMX can't build here.)

The NOTE now names the delimiters in words rather than writing them.

## Why the gate missed it

`scan()` consumed paren-star comments **without yielding them**, so the rule added in #519 only ever saw brace comments. It now yields them and applies identical reasoning: the body stops at the first close, so an opener still inside proves the comment ended early.

Writing that rule surfaced a second defect worth recording. My first version of the paren branch read `body` — a name bound only in the *brace* branch — so it silently tested the **previous brace comment** and never fired. Python doesn't error on a stale loop variable; the gate just reported clean. That's how I caught it: the rule passed a file I knew was broken. It reads `text` now.

## Verified against the real files, not by inspection

```
#518-merge file  -> 2 brace findings   (rule still fires, no regression)
#519-merge file  -> 1 paren finding    (this build break, now caught)
fixed file       -> 0 findings
```

## Gates
`make lint-studio` green · `make smoke` green · begin/end balance unchanged vs HEAD.

Standing note: this is the fourth Studio break this session that only a Delphi build could catch. A dcc64 step in CI would retire the category — happy to wire it up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_