### PR TITLE
Fix Delphi compile errors in the app runner

### DIFF
--- a/src/pkg/projects/PasClaw.Apps.Runner.pas
+++ b/src/pkg/projects/PasClaw.Apps.Runner.pas
@@ -210,13 +210,16 @@ function PortInUse(Port: Integer): Boolean;
 var
   C: TIdTCPClient;
 begin
-  Result := False;
   C := TIdTCPClient.Create(nil);
   try
-    C.Host := '127.0.0.1';
-    C.Port := Port;
-    C.ConnectTimeout := 250;
+    { The property writes are inside the try so every path out of this
+      function assigns Result exactly once -- a leading Result := False
+      would be dead on both branches below, which Delphi reports as
+      H2077. }
     try
+      C.Host := '127.0.0.1';
+      C.Port := Port;
+      C.ConnectTimeout := 250;
       C.Connect;
       Result := True;      { someone answered -- taken }
       C.Disconnect;
@@ -811,8 +814,10 @@ begin
     command, on the same consent -- so it belongs in the plan. Showing
     only the run line would let a model-authored manifest hide arbitrary
     shell in `build` behind a benign-looking confirmation. }
+  { sLineBreak, not LineEnding: the latter is FPC-only and this unit is
+    compiled by Delphi too. }
   if Trim(Info.Build) <> '' then
-    Result := Trim(Info.Build) + LineEnding + Result;
+    Result := Trim(Info.Build) + sLineBreak + Result;
   (* The port isn't claimed until the app starts, so show a placeholder a
      person reads as one -- the raw brace token in a consent prompt looks
      like the command is broken. Paren-star: the token itself would close a


### PR DESCRIPTION
```
[dcc64 Hint]        PasClaw.Apps.Runner.pas(213): H2077 Value assigned to 'PortInUse' never used
[dcc64 Error]       PasClaw.Apps.Runner.pas(815): E2003 Undeclared identifier: 'LineEnding'
[dcc64 Warning]     PasClaw.Apps.Runner.pas(815): W1058 Implicit string cast with potential data loss from 'string' to 'ShortString'
[dcc64 Fatal Error] PasClaw.Gateway.Desktop.pas(97): F2063 Could not compile used unit 'PasClaw.Apps.Runner.pas'
```

## `LineEnding` (the fatal)

`LineEnding` is FPC-only; Delphi spells it `sLineBreak`. It came in with the recent change that puts an app manifest's `build` line into `PlannedCommand`, so the user sees every command before consenting rather than just `run`. Both compilers have `sLineBreak`, and on every platform in play it is the same bytes, so behaviour is unchanged.

The `W1058` on the same line was the compiler guessing at the undeclared name, and the `F2063` in `PasClaw.Gateway.Desktop` was the cascade from the failed unit — both clear with the one fix.

## `PortInUse` (the hint)

The function opened with `Result := False`, which both branches below overwrite — dead, hence H2077. Rather than just delete the initialiser, the property writes moved inside the `try`:

```pascal
C := TIdTCPClient.Create(nil);
try
  try
    C.Host := '127.0.0.1';
    C.Port := Port;
    C.ConnectTimeout := 250;
    C.Connect;
    Result := True;      { someone answered -- taken }
    C.Disconnect;
  except
    Result := False;     { refused -- free }
  end;
finally
  C.Free;
end;
```

Now every path out assigns `Result` exactly once, including one where a property setter raises — deleting the initialiser alone would have left that path returning garbage.

## Verification

`make all`, the full test suite and `make lint-pascal-shape` are unchanged and green. `apps_tests` covers `PlannedCommand`'s two-line output directly.

No Delphi in this environment, so the fixes are read from the diagnostics rather than confirmed by a compiler. One thing to expect next: the fatal stopped `dcc64` at line 815, so anything after it in the file is still unreported. I swept the rest of the package for other FPC-only identifiers and found none.

Unrelated but worth knowing, since it will surface eventually: vendored `onnxruntime.pas` uses `LineEnding` in `TORTTensor<T>.ToString`. It compiles today only because Delphi does not compile a generic method body until something instantiates it. Left alone deliberately — that unit is used verbatim from upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_