### PR TITLE
Desktop: a real Menu, windows instead of a dock, and stop losing them

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -83,15 +83,30 @@ Environment:
 
 ## What's on screen
 
-- **Dock (left)** — the Projects → Tasks → Jobs tree. Double-click a project
-  to open its app (or its chat, if it hasn't built one yet); double-click a
-  job to tail its log.
+- **Menu** — the launcher, and the way into everything. Chat, Browser,
+  Files, Library, Log, Projects, New Project, workspace switching and
+  Display Properties, then every project in this workspace with its app
+  listed underneath — click the app and it opens. That last part is how you
+  reach the suite (Notes, Calendar, Mail and the rest): they are ordinary
+  projects with ordinary apps, and the Menu saves you having to know that.
+- **Projects window** — the Projects → Tasks → Jobs tree. Double-click a
+  project to open its app (or its chat, if it hasn't built one yet);
+  double-click a job to tail its log. Opened from the Menu; it was a fixed
+  left dock with no chrome, sitting on top of the desktop icons that name
+  the same projects.
 - **Desktop icons** — one per project, same double-click behavior.
-- **Taskbar** — open windows, plus `WS >` to move to the next workspace
-  (also Ctrl+Alt+Right). Switching workspaces closes this desktop's windows,
-  because they belong to the workspace, not to the client.
-- **Chat window** — per project, streaming. It sends the builder-mode system
-  prompt, so the agent's deliverable is an app rather than an essay. When a
+- **Taskbar** — open windows, plus `Desk >` to page virtual desktops and
+  `WS >` to move to the next workspace (also Ctrl+Alt+Right). Switching
+  either closes this desktop's windows, because they belong to the
+  workspace, not to the client — the arrangement is saved against the
+  desktop you are leaving and comes back when you return, geometry
+  included.
+- **Chat window** — per project, streaming, with the model's tool use shown
+  inline as it works: asking for an app should not look like a long silence
+  followed by a sentence. It sends the builder-mode system prompt, so the
+  agent's deliverable is an app rather than an essay. **Chat** on the Menu
+  opens the project-less one instead — no builder prompt, just a
+  conversation. When a
   turn leaves a runnable app behind, the window opens it. **Versions** opens
   the app as an earlier turn produced it, and can put that version back.
 - **App window** — the app in a `TWebBrowser`. An app that declares network
@@ -106,9 +121,21 @@ Environment:
   promotes the page you are looking at into an app you own.
 - **File Manager** — the workspace directory, over `/v1/fs`. Read-only: that
   surface is already sandbox-checked and filters secret-bearing files, and a
-  browse window is not the place to invent a delete button.
-- **Library** — pages, sessions, projects, the knowledgebase and how far undo
-  reaches.
+  browse window is not the place to invent a delete button. Opening a file
+  picks a viewer by what it is: `.html` renders in the Browser, a binary
+  file opens a paged hex dump over `/v1/fs/peek` (a window of bytes at a
+  time, so a huge file costs a window rather than a download), anything else
+  opens as text.
+- **Library** — what this workspace has accumulated: pages (what you looked
+  up) and sessions (what you talked about). Double-click a page to read it
+  in the Browser, a session to reopen that conversation with its history
+  loaded.
+- **Log** — the gateway's own log, replayed and then tailed live. Useful
+  when the gateway is on another machine or was started by something that
+  swallowed its output. It can only show what the gateway recorded: log
+  level is a server-side filter applied before the buffer, so debug lines
+  need `gateway.log_level` set to `"debug"` in `config.json` and a restart.
+  No client-side switch can recover a line that was never emitted.
 - **Display Properties** — every `.style` in the styles directory, plus that
   style's color schemes (skins). Switching reskins the whole shell, chrome
   included, at runtime.

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -191,6 +191,9 @@ type
     { Set the moment teardown begins. Notification and the timers consult it
       so nothing touches state that FormDestroy has already released. }
     FClosing: Boolean;
+    { True once RestoreDesktopState has opened at least one window, so a
+      first run can tell "nothing was saved" from "the user closed it all". }
+    FRestoredAnything: Boolean;
     { True while RestoreDesktopState is opening windows, so restoring does
       not immediately save a half-built layout back over the real one. }
     FRestoring: Boolean;
@@ -366,6 +369,9 @@ const
   { The key the project-less chat window is filed under. A colon cannot
     appear in a project slug, so this can never collide with a real one. }
   PlainChatKey = ':chat';
+  { A conversation reopened from the Library, filed under its session id.
+    Same reserved-colon rule as above. }
+  SessionChatPrefix = ':session:';
 
 { Conditional string. StrUtils has one; a local helper keeps this unit's
   uses clause to what it actually needs. Declared here, above every caller,
@@ -374,6 +380,15 @@ function IfThenStr(Cond: Boolean; const Yes, No: string): string;
 begin
   if Cond then Result := Yes else Result := No;
 end;
+
+{ True for the synthetic chat keys -- the project-less window and any
+  reopened Library session. A project slug can never start with a colon, so
+  this cannot swallow a real project. }
+function IsSyntheticChat(const Key: string): Boolean;
+begin
+  Result := (Key = '') or ((Length(Key) > 0) and (Key[1] = ':'));
+end;
+
 
 { The chat window whose stream is currently being pumped. Set around the
   blocking Chat call so ChatChunk knows where to append. }
@@ -476,11 +491,16 @@ begin
   StartEventWatch;
   { The layout this workspace was left in, from whichever client left it. }
   RestoreDesktopState;
-  { A first run has no saved layout and would otherwise open to bare
-    wallpaper with no way in that is not the Menu. Give it the project
-    window; anyone who closes it has said what they want and gets an empty
-    desktop from then on. }
-  if (FDesktop.WindowCount = 0) and (FTreeWin = nil) then
+  (* A first run has no saved layout and would otherwise open to bare
+     wallpaper with no way in that is not the Menu. Give it the project
+     window; anyone who closes it has said what they want and gets an empty
+     desktop from then on.
+
+     Asked as "did the restore open anything", not "are there no windows":
+     BuildStylePicker has already created the (hidden) Display Properties
+     window by this point, so a window count is never zero and the test
+     would never fire. *)
+  if not FRestoredAnything then
     OpenTree;
 end;
 
@@ -1677,15 +1697,21 @@ end;
 procedure TFormMain.StopLogWatch;
 begin
   FLogStop := True;
-  if FLogThread <> nil then
-  begin
-    FLogThread.Terminate;
-    { The subscription blocks in Indy until the next byte or the socket
-      drops; the flag above makes the callback stop it at the first line.
-      Waiting here is what keeps the client alive until it does. }
-    FLogThread.WaitFor;
-    FreeAndNil(FLogThread);
-  end;
+  if FLogThread = nil then Exit;
+  FLogThread.Terminate;
+  (* Cut the socket BEFORE joining.
+
+     The flag above is only consulted when a line arrives, and /v1/logs
+     parks silently between log records -- it sends no keepalive, unlike
+     the desktop event stream. With no read timeout, which is correct for
+     a tail, a quiet gateway leaves the watcher blocked inside Indy with
+     nothing to wake it, and joining it here would hang the UI for as long
+     as the gateway stayed quiet: closing the Log window, switching
+     workspace or quitting would all appear to freeze. Cancelling reaches
+     the socket, so the read fails immediately and the thread unwinds. *)
+  if FClient <> nil then FClient.CancelLogs;
+  FLogThread.WaitFor;
+  FreeAndNil(FLogThread);
 end;
 
 procedure TFormMain.OnDesktopEvent(const Ev: TDesktopEvent; var Stop: Boolean);
@@ -1995,6 +2021,8 @@ begin
 
   if Project = PlainChatKey then
     Title := 'PasClaw'
+  else if Copy(Project, 1, Length(SessionChatPrefix)) = SessionChatPrefix then
+    Title := 'Session ' + Copy(Project, Length(SessionChatPrefix) + 1, MaxInt)
   else
   begin
     Title := Project;
@@ -2047,7 +2075,7 @@ begin
   if not FChatHistory.ContainsKey(Project) then
     FChatHistory.AddOrSetValue(Project, '[]');
 
-  if Project = PlainChatKey then
+  if IsSyntheticChat(Project) then
     Log.Lines.Add('Ask PasClaw anything. This window is not tied to a ' +
                   'project, so nothing here builds an app.')
   else
@@ -2134,15 +2162,17 @@ end;
 
 { The builder overlay. Same text the browser client sends, for the same
   reason: the deliverable is software, not an essay. }
-(* The system prompt a project chat sends.
+(* The system prompt a chat sends.
 
-   Empty for the project-less window: that one is a plain conversation, and
-   telling the model to deliver an app when there is no project to put one
-   in would produce files in whatever directory it guessed. The gateway's
-   own default prompt applies there, which is the point of it. *)
+   Empty for every synthetic key, not just the plain-chat one. A session
+   reopened from the Library is filed under ':session:<id>', and sending the
+   builder prompt for it told the model to write an app into
+   projects/:session:<id>/app/ -- a path that cannot exist -- instead of
+   just continuing the conversation. The gateway's own default prompt
+   applies to these, which is the point of them. *)
 function BuilderPrompt(const Project: string): string;
 begin
-  if (Project = '') or (Project = PlainChatKey) then Exit('');
+  if IsSyntheticChat(Project) then Exit('');
   Result :=
     'You are working inside the PasClaw Desktop project "' + Project + '".' + sLineBreak +
     'Deliverables are APPS, not essays. When the user asks for something, ' +
@@ -2208,11 +2238,12 @@ end;
 
 procedure TFormMain.SendChat(Sender: TObject);
 var
-  Project, Text, Reply, Hist, Inner, Visible: string;
+  Project, Text, Reply, Hist, Inner, Visible, SessId: string;
   Log, Input: TMemo;
   Row: TProjectRow;
   App: TAppRow;
   Blocks: TUIBlocks;
+  Conflict: Boolean;
 begin
   SetClientContext('Chat');
   Project := (Sender as TButton).TagString;
@@ -2268,6 +2299,28 @@ begin
   Hist := Copy(Hist, 1, Length(Hist) - 1) +
           ',{"role":"assistant","content":"' + JsonStr(Reply) + '"}]';
   FChatHistory.AddOrSetValue(Project, Hist);
+
+  (* A reopened session has to be written back, or it was never really
+     reopened: chat completions is stateless, so the continued conversation
+     lives only in the dictionary above and dies with the window. The
+     gateway refuses (409) when the session holds a rich agent transcript --
+     flattening tool and system turns to role/content would destroy what
+     terminal resume needs -- and that refusal is worth reporting rather
+     than retrying or hiding. *)
+  if Copy(Project, 1, Length(SessionChatPrefix)) = SessionChatPrefix then
+  begin
+    SessId := Copy(Project, Length(SessionChatPrefix) + 1, MaxInt);
+    if not FClient.SaveSessionHistory(SessId, Hist, '', Conflict) then
+    begin
+      if Conflict then
+        Log.Lines.Add('[this session has tool turns from an agent run; ' +
+                      'new messages here are not being saved into it]')
+      else
+        Log.Lines.Add('[could not save this turn into the session: ' +
+                      FClient.LastError + ']');
+      Log.Lines.Add('');
+    end;
+  end;
 
   { Did the turn leave a runnable app behind? Ask the gateway rather than
     trusting the transcript. }
@@ -2352,7 +2405,7 @@ var
   I: Integer;
 begin
   if Trim(SessionId) = '' then Exit;
-  Key := ':session:' + SessionId;
+  Key := SessionChatPrefix + SessionId;
   OpenChat(Key);
 
   { Already open and already populated -- focusing it is the whole job. }
@@ -3108,6 +3161,7 @@ begin
         OpenRun(Arg);
         if not FRunWins.TryGetValue(Arg, Opened) then Opened := nil;
       end;
+      if Opened <> nil then FRestoredAnything := True;
       PlaceIt(Opened);
     until P = 0;
   finally
@@ -3582,13 +3636,31 @@ begin
   Ext := LowerCase(ExtractFileExt(Name));
   if (Ext = '.html') or (Ext = '.htm') then
   begin
+    (* Read it THROUGH the gateway and hand the browser the markup.
+
+       Path is a path on the gateway's filesystem, which is only also this
+       machine's when the gateway happens to be local -- point
+       PASCLAW_GATEWAY at another box and a file:// URL asks the local
+       browser for a file that is not there. Going through /v1/fs keeps
+       remote gateways working, carries the bearer token the browser
+       control cannot set, and sidesteps escaping every space and hash in
+       the path into a URL. *)
+    if not FClient.ReadFile_(Path, Body, Binary, Truncated) then
+    begin
+      Say('Could not read ' + Name + ': ' + FClient.LastError);
+      Exit;
+    end;
     OpenBrowser('');
     if FBrowserView <> nil then
     begin
-      { A local file, so navigate the control at it directly rather than
-        going back through the gateway for something already on disk. }
-      FBrowserView.Navigate('file://' + Path);
-      if FBrowserStatus <> nil then FBrowserStatus.Text := Path;
+      FBrowserView.LoadFromStrings(Body, Path);
+      if FBrowserStatus <> nil then
+      begin
+        if Truncated then
+          FBrowserStatus.Text := Path + '  [truncated]'
+        else
+          FBrowserStatus.Text := Path;
+      end;
     end;
     Exit;
   end;

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -99,6 +99,11 @@ type
     FLogPending: TStringList;     { worker appends, timer drains }
     FLogLock: TCriticalSection;
     FLogStop: Boolean;
+    { The segment currently being written, so a header is emitted only when
+      the origin actually changes. Decided at DRAIN time, on the main
+      thread: queueing happens from several threads and the order they
+      interleave in is only settled once they are in the list. }
+    FLogSegment: string;
 
     { ---- hex viewer ----
       A binary file is worth looking at; "(binary file)" is not a viewer.
@@ -183,6 +188,9 @@ type
     FEventDirty: Boolean;
     FEventTimer: TTimer;
     FLayoutDirty: Boolean;
+    { Set the moment teardown begins. Notification and the timers consult it
+      so nothing touches state that FormDestroy has already released. }
+    FClosing: Boolean;
     { True while RestoreDesktopState is opening windows, so restoring does
       not immediately save a half-built layout back over the real one. }
     FRestoring: Boolean;
@@ -247,6 +255,9 @@ type
     { ---- Log ---- }
     procedure OpenLog;
     procedure LogLine(const Level, Text_: string; var Stop: Boolean);
+    procedure ClientTrace(const Origin, Method, Path: string;
+      Status, Millis: Integer; const Note: string);
+    procedure QueueLogEntry(const Kind, Origin, Text_: string);
     procedure DrainLogLines;
     procedure StopLogWatch;
 
@@ -434,6 +445,10 @@ begin
   if Gateway = '' then Gateway := DefaultGateway;
   FClient := TPasClawClient.Create(Gateway);
   FClient.Token := GetEnvironmentVariable('PASCLAW_TOKEN');
+  { Always on. Tracing you have to enable is tracing you do not have when
+    the thing you wanted to see already happened; the Log window is where
+    it surfaces, and nothing accumulates while that window is closed. }
+  FClient.OnTrace := ClientTrace;
 
   FStyleDir := FindStyleDir;
   BuildDesktop;
@@ -471,6 +486,23 @@ end;
 
 procedure TFormMain.FormDestroy(Sender: TObject);
 begin
+  (* Order matters here, and getting it wrong is an access violation on
+     close rather than anything subtle.
+
+     1. Say we are closing, so Notification stops doing bookkeeping against
+        fields that are about to be freed -- it fires once per owned
+        component as the form comes apart, which is after this runs.
+     2. Stop the timers, or a tick lands mid-teardown and repaints windows
+        that are going away.
+     3. Stop the watcher threads, which read through the client.
+     4. Save, while the client still exists -- the layout lives on the
+        gateway, so there is no writing it afterwards.
+     5. Only then free anything. *)
+  FClosing := True;
+
+  if FEventTimer <> nil then FEventTimer.Enabled := False;
+  if FRunTimer <> nil then FRunTimer.Enabled := False;
+
   { Stop the watchers before the client they read through goes away. }
   if FEventThread <> nil then
   begin
@@ -534,6 +566,17 @@ var
 begin
   inherited;
   if Operation <> TOperation.opRemove then Exit;
+
+  (* Teardown.
+
+     This fires for every component the form owns as the form is destroyed
+     -- which happens AFTER FormDestroy has freed the dictionaries below.
+     Reading them then dereferences nil, and closing the app raised an
+     access violation every time. FormDestroy sets FClosing before it frees
+     anything, so from that point the bookkeeping here is not merely
+     unnecessary but wrong: everything it would tidy up is already gone. *)
+  if FClosing then Exit;
+
   { A window closing is a layout change like any other. }
   if AComponent is TRetroWindow then MarkLayoutDirty;
 
@@ -613,6 +656,10 @@ begin
     FVersionWin := nil;
     Exit;
   end;
+
+  { Streamed before FormCreate ran, so nothing below exists yet. They are
+    all constructed together, so one check covers the three loops. }
+  if FRunWins = nil then Exit;
 
   Keys := FRunWins.Keys.ToArray;
   for I := 0 to High(Keys) do
@@ -749,6 +796,7 @@ var
   I: Integer;
   Icon: TRetroDesktopIcon;
 begin
+  SetClientContext('Board');
   try
     FProjects := FClient.Projects;
   except
@@ -1051,6 +1099,7 @@ var
   end;
 
 begin
+  SetClientContext('Menu');
   if FMenuActions = nil then FMenuActions := TStringList.Create;
   FMenuActions.Clear;
 
@@ -1508,31 +1557,65 @@ begin
   end;
 end;
 
-procedure TFormMain.LogLine(const Level, Text_: string; var Stop: Boolean);
+(* Queue one line for the Log window.
+
+   Called from several threads -- the gateway tail has its own, a research
+   turn traces from another -- so this only appends. Kind and Origin travel
+   with the text rather than being rendered in, because whether a line needs
+   a segment header depends on what came immediately before it, and that is
+   only knowable once the interleaving is settled. *)
+procedure TFormMain.QueueLogEntry(const Kind, Origin, Text_: string);
 begin
-  { Worker thread. Queue the line and return -- the timer paints. }
-  Stop := FLogStop;
-  if Stop then Exit;
-  if FLogLock = nil then Exit;
+  if (FLogLock = nil) or (FLogPending = nil) then Exit;
   FLogLock.Acquire;
   try
-    if FLogPending <> nil then
-    begin
-      FLogPending.Add('[' + Level + '] ' + Text_);
-      { A gateway under load can outrun the timer; the window is a tail, so
-        dropping the oldest queued lines is better than growing without
-        bound. }
-      while FLogPending.Count > 2000 do FLogPending.Delete(0);
-    end;
+    FLogPending.Add(Kind + #9 + Origin + #9 + Text_);
+    { A busy gateway can outrun the timer; the window is a tail, so dropping
+      the oldest queued lines beats growing without bound. }
+    while FLogPending.Count > 2000 do FLogPending.Delete(0);
   finally
     FLogLock.Release;
   end;
 end;
 
+procedure TFormMain.LogLine(const Level, Text_: string; var Stop: Boolean);
+begin
+  { Worker thread. Queue and return -- the timer paints. }
+  Stop := FLogStop or FClosing;
+  if Stop then Exit;
+  QueueLogEntry('S', '', '[' + Level + '] ' + Text_);
+end;
+
+(* Every request the client makes, as it completes.
+
+   This is the half the gateway's own log cannot give you. Its log is
+   filtered server-side before anything is recorded, so a client cannot ask
+   it for more; and even at debug it reports what the SERVER did, never
+   which window wanted it. Here the origin is known exactly, because the
+   caller set it before making the call.
+
+   Runs on whichever thread made the request, so it queues like the rest. *)
+procedure TFormMain.ClientTrace(const Origin, Method, Path: string;
+  Status, Millis: Integer; const Note: string);
+var
+  Line: string;
+begin
+  if FClosing then Exit;
+  Line := Format('%-6s %s', [Method, Path]);
+  if Status > 0 then
+    Line := Line + '  ' + IntToStr(Status)
+  else
+    Line := Line + '  ---';        { never got an answer }
+  Line := Line + Format('  %dms', [Millis]);
+  if Trim(Note) <> '' then Line := Line + '  ' + Note;
+  QueueLogEntry('C', Origin, Line);
+end;
+
 procedure TFormMain.DrainLogLines;
 var
   Batch: TStringList;
-  I: Integer;
+  I, T1, T2: Integer;
+  Entry, Kind, Origin, Text_, Rest, Seg: string;
 begin
   if (FLogLock = nil) or (FLogPending = nil) then Exit;
   if FLogMemo = nil then Exit;
@@ -1549,7 +1632,38 @@ begin
     FLogMemo.Lines.BeginUpdate;
     try
       for I := 0 to Batch.Count - 1 do
-        FLogMemo.Lines.Add(Batch[I]);
+      begin
+        Entry := Batch[I];
+        { kind TAB origin TAB text -- see QueueLogEntry }
+        T1 := Pos(#9, Entry);
+        if T1 = 0 then Continue;
+        Kind := Copy(Entry, 1, T1 - 1);
+        Rest := Copy(Entry, T1 + 1, MaxInt);
+        T2 := Pos(#9, Rest);
+        if T2 = 0 then Continue;
+        Origin := Copy(Rest, 1, T2 - 1);
+        Text_ := Copy(Rest, T2 + 1, MaxInt);
+
+        (* Segment blocks. Client traffic is grouped under whoever made it
+           and gateway lines under the gateway, with a header only when the
+           source actually changes -- a header per line would be noise, and
+           none at all is the undifferentiated stream this exists to
+           replace. *)
+        if Kind = 'S' then Seg := 'gateway'
+        else if Origin = '' then Seg := 'client'
+        else Seg := Origin;
+        if Seg <> FLogSegment then
+        begin
+          FLogSegment := Seg;
+          FLogMemo.Lines.Add('');
+          if Length(Seg) < 58 then
+            FLogMemo.Lines.Add('---- ' + Seg + ' ' +
+              StringOfChar('-', 58 - Length(Seg)))
+          else
+            FLogMemo.Lines.Add('---- ' + Seg + ' ----');
+        end;
+        FLogMemo.Lines.Add('  ' + Text_);
+      end;
       while FLogMemo.Lines.Count > 5000 do FLogMemo.Lines.Delete(0);
     finally
       FLogMemo.Lines.EndUpdate;
@@ -2100,6 +2214,7 @@ var
   App: TAppRow;
   Blocks: TUIBlocks;
 begin
+  SetClientContext('Chat');
   Project := (Sender as TButton).TagString;
   if not FChatLogs.TryGetValue(Project, Log) then Exit;
   if not FChatInputs.TryGetValue(Project, Input) then Exit;
@@ -2284,6 +2399,7 @@ var
   Browser: TWebBrowser;
   Snap: TImage;
 begin
+  SetClientContext('App: ' + Project);
   if FAppWins.TryGetValue(Project, W) and (W <> nil) then
   begin
     W.Restore;
@@ -2425,6 +2541,7 @@ var
   I: Integer;
   Title: string;
 begin
+  SetClientContext('Library');
   if FLibraryWin <> nil then
   begin
     FLibraryWin.Restore;
@@ -2592,6 +2709,7 @@ var
   M: TMemo;
   Log: string;
 begin
+  SetClientContext('Run: ' + Project);
   if not FClient.RunState(Project, Run) then Exit;
   if FRunHeads.TryGetValue(Project, Head) and (Head <> nil) then
     Head.Text := Format('%s -- runs %s%s%s',
@@ -3161,6 +3279,13 @@ begin
       Ok: Boolean;
       Marshal: TThreadProcedure;
     begin
+      { Set INSIDE the thread: the context is per thread, so tagging it on
+        the caller would attribute this call to whatever the main thread
+        was doing when the button was pressed. }
+      if Kind = pkeResearch then
+        SetClientContext('Browser (research)')
+      else
+        SetClientContext('Browser');
       Ok := False;
       Err := '';
       try
@@ -3279,6 +3404,7 @@ var
   Bar: TLayout;
   B: TButton;
 begin
+  SetClientContext('Files');
   if FFilesWin <> nil then
   begin
     FFilesWin.Restore;
@@ -3331,6 +3457,7 @@ var
   Row: TFileRow;
   Line: string;
 begin
+  SetClientContext('Files');
   if FFilesList = nil then Exit;
   if not FClient.ListDir(Path, FFilesDir) then
   begin

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -27,6 +27,7 @@ interface
 uses
   System.SysUtils, System.Types, System.UITypes, System.Classes,
   System.IOUtils, System.StrUtils, System.Generics.Collections,
+  System.SyncObjs,
   FMX.Types, FMX.Controls, FMX.Forms, FMX.Graphics, FMX.Dialogs,
   FMX.StdCtrls, FMX.Layouts, FMX.ListBox, FMX.Edit, FMX.Memo, FMX.Styles,
   FMX.Objects, FMX.TreeView, FMX.WebBrowser, FMX.ScrollBox,
@@ -55,7 +56,6 @@ type
   private
     FClient: TPasClawClient;
     FDesktop: TRetroDesktop;
-    FDock: TLayout;
     FTree: TTreeView;
     FStatus: TLabel;
     FNodeRefs: TObjectList<TNodeRef>;
@@ -73,6 +73,43 @@ type
     FFilesWin: TRetroWindow;
     FBrowserWin: TRetroWindow;
     FProgressWin: TRetroWindow;
+
+    { ---- the Menu ----
+      A popup built as a window, because everything else here is: it wears
+      the current style like the rest of the shell instead of arriving as an
+      out-of-period native menu. One at a time, closed on choice. }
+    FMenuWin: TRetroWindow;
+    FMenuList: TListBox;
+    FMenuActions: TStringList;   { parallel to FMenuList.Items }
+
+    { ---- the Projects window ----
+      The tree used to be a permanent left dock with no chrome, sitting
+      under the desktop icons it duplicates. It is a window now, opened from
+      the Menu like everything else. }
+    FTreeWin: TRetroWindow;
+
+    { ---- Library ---- }
+    FLibraryList: TListBox;
+    FLibraryKinds: TStringList;   { "page:<id>" / "session:<id>", by row }
+
+    { ---- Log ---- }
+    FLogWin: TRetroWindow;
+    FLogMemo: TMemo;
+    FLogThread: TThread;
+    FLogPending: TStringList;     { worker appends, timer drains }
+    FLogLock: TCriticalSection;
+    FLogStop: Boolean;
+
+    { ---- hex viewer ----
+      A binary file is worth looking at; "(binary file)" is not a viewer.
+      Paged over /v1/fs/peek so opening a huge one costs a window, not a
+      download. }
+    FHexWin: TRetroWindow;
+    FHexMemo: TMemo;
+    FHexPath: string;
+    FHexOffset: Int64;
+    FHexTotal: Int64;
+    FHexPos: TLabel;
     { One chat / app / log window per project, so reopening focuses rather
       than stacking duplicates. Windows announce their own death through
       FreeNotification -- see Notification. }
@@ -152,7 +189,6 @@ type
 
     function FindStyleDir: string;
     procedure BuildDesktop;
-    procedure BuildDock;
     procedure BuildStylePicker;
     procedure RefreshWorkspaces;
     procedure RefreshProjects;
@@ -190,6 +226,35 @@ type
     procedure OpenApp(const Project: string);
     procedure OpenJobLog(const Project, TaskId, JobId: string);
     procedure OpenLibrary;
+    procedure LibraryDblClick(Sender: TObject);
+    procedure OpenSessionChat(const SessionId: string);
+
+    { ---- the Menu ---- }
+    (* Built fresh on every open rather than once at startup: half of it is
+       the live project list, with each project's apps under it, and a menu
+       that showed yesterday's projects would be worse than no menu. *)
+    procedure BuildMenu;
+    procedure MenuPick(Sender: TObject);
+    procedure CloseMenu;
+    procedure OpenTree;
+    procedure OpenPlainChat;
+    procedure PickWorkspaceClick(Sender: TObject);
+    procedure NewWorkspaceClick(Sender: TObject);
+    procedure NewWorkspaceAccepted(Sender: TObject);
+    procedure PickWorkspaceAccepted(Sender: TObject);
+    procedure OpenDisplayProperties;
+
+    { ---- Log ---- }
+    procedure OpenLog;
+    procedure LogLine(const Level, Text_: string; var Stop: Boolean);
+    procedure DrainLogLines;
+    procedure StopLogWatch;
+
+    { ---- hex viewer ---- }
+    procedure OpenHex(const Path: string);
+    procedure HexRender;
+    procedure HexPrevClick(Sender: TObject);
+    procedure HexNextClick(Sender: TObject);
 
     { ---- File Manager ---- }
     procedure OpenFiles;
@@ -228,7 +293,9 @@ type
 
     { ---- desktop state ---- }
     procedure SaveDesktopState;
+    procedure SaveDesktopStateTo(Desk: Integer);
     procedure RestoreDesktopState;
+    procedure CloseAllWindows;
     { Mark the layout changed; the event timer flushes it. Saving inline on
       every open and close would put a blocking PUT in the middle of opening
       a window. }
@@ -238,6 +305,7 @@ type
     procedure BrowserClick(Sender: TObject);
     procedure SendChat(Sender: TObject);
     procedure ChatChunk(const Chunk: string; var Abort: Boolean);
+    procedure ChatTool(const Kind, Name, Detail: string; IsErr: Boolean);
 
     { Live board updates. The client subscribes to /v1/desktop/events on its
       own thread and refreshes when something it displays changes, so the
@@ -284,6 +352,9 @@ type
 const
   NoSkin = '(style default)';
   DefaultGateway = 'http://127.0.0.1:8088';
+  { The key the project-less chat window is filed under. A colon cannot
+    appear in a project slug, so this can never collide with a real one. }
+  PlainChatKey = ':chat';
 
 { Conditional string. StrUtils has one; a local helper keeps this unit's
   uses clause to what it actually needs. Declared here, above every caller,
@@ -366,7 +437,6 @@ begin
 
   FStyleDir := FindStyleDir;
   BuildDesktop;
-  BuildDock;
   BuildStylePicker;
 
   if FStyleDir <> '' then
@@ -391,17 +461,24 @@ begin
   StartEventWatch;
   { The layout this workspace was left in, from whichever client left it. }
   RestoreDesktopState;
+  { A first run has no saved layout and would otherwise open to bare
+    wallpaper with no way in that is not the Menu. Give it the project
+    window; anyone who closes it has said what they want and gets an empty
+    desktop from then on. }
+  if (FDesktop.WindowCount = 0) and (FTreeWin = nil) then
+    OpenTree;
 end;
 
 procedure TFormMain.FormDestroy(Sender: TObject);
 begin
-  { Stop the watcher before the client it reads through goes away. }
+  { Stop the watchers before the client they read through goes away. }
   if FEventThread <> nil then
   begin
     FEventThread.Terminate;
     FEventThread.WaitFor;
     FreeAndNil(FEventThread);
   end;
+  StopLogWatch;
   { Save before the client goes: the layout is stored on the gateway, so
     there is no writing it once the connection is gone. }
   try
@@ -422,6 +499,10 @@ begin
   FreeAndNil(FAppWins);
   FreeAndNil(FChatWins);
   FreeAndNil(FNodeRefs);
+  FreeAndNil(FLogPending);
+  FreeAndNil(FLogLock);
+  FreeAndNil(FMenuActions);
+  FreeAndNil(FLibraryKinds);
 end;
 
 procedure TFormMain.FormKeyDown(Sender: TObject; var Key: Word;
@@ -461,6 +542,39 @@ begin
     FStylePicker := nil;
     FStyleList := nil;    { owned by the picker, dying with it }
     FSkinList := nil;
+    Exit;
+  end;
+
+  if AComponent = FMenuWin then
+  begin
+    FMenuWin := nil;
+    FMenuList := nil;
+    Exit;
+  end;
+
+  if AComponent = FTreeWin then
+  begin
+    FTreeWin := nil;
+    FTree := nil;         { owned by the window }
+    FStatus := nil;
+    Exit;
+  end;
+
+  if AComponent = FLogWin then
+  begin
+    FLogWin := nil;
+    FLogMemo := nil;
+    { Closing the window ends the subscription: an unread tail is a
+      connection the gateway holds open for nobody. }
+    StopLogWatch;
+    Exit;
+  end;
+
+  if AComponent = FHexWin then
+  begin
+    FHexWin := nil;
+    FHexMemo := nil;
+    FHexPos := nil;
     Exit;
   end;
   if AComponent = FLibraryWin then
@@ -554,110 +668,64 @@ begin
   FDesktop.Taskbar.AddMenuTitle('View').OnClick := RefreshClick;
 end;
 
-procedure TFormMain.BuildDock;
+(* The Projects window.
+
+   This was a permanent left dock: a bare TLayout with no chrome, pinned to
+   the edge, sitting on top of the desktop icons that name the same
+   projects. Two lists of one thing, one of them unmovable and neither of
+   them looking like part of the shell.
+
+   It is a window now, opened from the Menu like Files or Library, so it can
+   be moved, sized, closed and restored -- and the icons have the desktop to
+   themselves. The status line moved into it; a shell with nowhere to speak
+   would have to fall back on message boxes. *)
+procedure TFormMain.OpenTree;
 var
-  Head: TLabel;
-  Bar, Bar2: TLayout;
+  Bar: TLayout;
   B: TButton;
 begin
-  { The dock is a plain left-aligned layout rather than a TRetroWindow: it is
-    the shell's permanent edge, the same decision the browser client made. }
-  FDock := TLayout.Create(Self);
-  FDock.Parent := FDesktop;
-  FDock.Align := TAlignLayout.Left;
-  FDock.Width := 240;
-  FDock.Padding.Rect := TRectF.Create(4, 4, 4, 4);
+  if FTreeWin <> nil then
+  begin
+    FTreeWin.Restore;
+    Exit;
+  end;
+  FTreeWin := TrackWindow(FDesktop.CreateWindow('Projects', 260, 420));
+  MarkLayoutDirty;
 
-  Head := TLabel.Create(Self);
-  Head.Parent := FDock;
-  Head.Align := TAlignLayout.Top;
-  Head.Height := 20;
-  Head.Text := 'Projects';
-  Head.StyledSettings := Head.StyledSettings - [TStyledSetting.Style];
-  Head.TextSettings.Font.Style := [TFontStyle.fsBold];
-
-  Bar := TLayout.Create(Self);
-  Bar.Parent := FDock;
+  Bar := TLayout.Create(FTreeWin);
+  Bar.Parent := FTreeWin.Client;
   Bar.Align := TAlignLayout.Bottom;
   Bar.Height := 30;
 
-  B := TButton.Create(Self);
+  B := TButton.Create(FTreeWin);
   B.Parent := Bar;
   B.Align := TAlignLayout.Left;
   B.Width := 108;
   B.Text := 'New Project';
   B.OnClick := NewProjectClick;
 
-  B := TButton.Create(Self);
+  B := TButton.Create(FTreeWin);
   B.Parent := Bar;
-  B.Align := TAlignLayout.Left;
+  B.Align := TAlignLayout.Client;
   B.Margins.Left := 4;
-  B.Width := 64;
   B.Text := 'Refresh';
   B.OnClick := RefreshClick;
 
-  { A second row: the windows that are not per project. }
-  Bar2 := TLayout.Create(Self);
-  Bar2.Parent := FDock;
-  Bar2.Align := TAlignLayout.Bottom;
-  Bar2.Height := 30;
-
-  B := TButton.Create(Self);
-  B.Parent := Bar2;
-  B.Align := TAlignLayout.Left;
-  B.Width := 74;
-  B.Text := 'Browser';
-  B.OnClick := BrowserClick;
-
-  B := TButton.Create(Self);
-  B.Parent := Bar2;
-  B.Align := TAlignLayout.Left;
-  B.Margins.Left := 4;
-  B.Width := 60;
-  B.Text := 'Files';
-  B.OnClick := FilesClick;
-
-  B := TButton.Create(Self);
-  B.Parent := Bar2;
-  B.Align := TAlignLayout.Client;
-  B.Margins.Left := 4;
-  B.Text := 'Library';
-  B.OnClick := LibraryClick;
-
-  B := TButton.Create(Self);
-  B.Parent := Bar;
-  B.Align := TAlignLayout.Left;
-  B.Margins.Left := 4;
-  B.Width := 64;
-  B.Text := 'Desk >';
-  B.Hint := 'Next desktop -- same workspace, different arrangement';
-  B.OnClick := NextDesktopClick;
-
-  B := TButton.Create(Self);
-  B.Parent := Bar;
-  B.Align := TAlignLayout.Client;
-  B.Margins.Left := 4;
-  B.Text := 'WS >';
-  B.Hint := 'Next WORKSPACE -- changes what PasClaw remembers';
-  B.Hint := 'Next workspace (Ctrl+Alt+Right)';
-  B.OnClick := NextWorkspaceClick;
-
-  FStatus := TLabel.Create(Self);
-  FStatus.Parent := FDock;
+  FStatus := TLabel.Create(FTreeWin);
+  FStatus.Parent := FTreeWin.Client;
   FStatus.Align := TAlignLayout.Bottom;
   FStatus.Height := 32;
   FStatus.Margins.Bottom := 2;
   FStatus.WordWrap := True;
   FStatus.Text := '';
 
-  FTree := TTreeView.Create(Self);
-  FTree.Parent := FDock;
+  FTree := TTreeView.Create(FTreeWin);
+  FTree.Parent := FTreeWin.Client;
   FTree.Align := TAlignLayout.Client;
   FTree.OnDblClick := TreeDblClick;
+
+  RebuildTree;
 end;
-
-{ --------------------------------------------------------------- refresh -- }
-
 procedure TFormMain.RefreshWorkspaces;
 var
   I: Integer;
@@ -729,6 +797,10 @@ var
   end;
 
 begin
+  { The tree lives in a window that can be closed. Nothing else here needs
+    it to exist, so a closed Projects window means there is simply nothing
+    to rebuild -- not a reason for the board refresh to fault. }
+  if FTree = nil then Exit;
   FTree.Clear;
   FNodeRefs.Clear;   { owns the refs; clearing frees the previous generation }
 
@@ -934,12 +1006,232 @@ end;
 
 { --------------------------------------------------------------- commands -- }
 
+(* The Menu.
+
+   A list in a small window rather than a native TPopupMenu: a native one
+   arrives in the host OS's own chrome, which on a shell whose entire point
+   is wearing a 1995 face is the one wrong-looking thing on screen. This is
+   a TRetroWindow like every other, so it is skinned by the same .style.
+
+   Rebuilt on every open because the bottom half is live: every project, and
+   under each one its app. That is also the answer to "I built three apps
+   and cannot find them" -- Notes, Calendar and the rest are ordinary
+   projects with ordinary apps, and this is where you reach them without
+   knowing that. *)
 procedure TFormMain.MenuClick(Sender: TObject);
+begin
+  if FMenuWin <> nil then
+  begin
+    CloseMenu;      { second click on Menu closes it, as a Start button does }
+    Exit;
+  end;
+  BuildMenu;
+end;
+
+procedure TFormMain.CloseMenu;
+begin
+  if FMenuWin <> nil then
+  begin
+    FMenuWin.Close;
+    FMenuWin := nil;
+    FMenuList := nil;
+  end;
+end;
+
+procedure TFormMain.BuildMenu;
+var
+  I, J: Integer;
+  Apps: TAppRow;
+  Row: TProjectRow;
+
+  procedure Item(const Caption, Action: string);
+  begin
+    FMenuList.Items.Add(Caption);
+    FMenuActions.Add(Action);
+  end;
+
+begin
+  if FMenuActions = nil then FMenuActions := TStringList.Create;
+  FMenuActions.Clear;
+
+  FMenuWin := TrackWindow(FDesktop.CreateWindow('PasClaw', 260, 420));
+  FMenuList := TListBox.Create(FMenuWin);
+  FMenuList.Parent := FMenuWin.Client;
+  FMenuList.Align := TAlignLayout.Client;
+  FMenuList.OnClick := MenuPick;
+
+  Item('Chat',                'chat');
+  Item('Browser',             'browser');
+  Item('Files',               'files');
+  Item('Library',             'library');
+  Item('Log',                 'log');
+  Item('-',                   '');
+  Item('Projects',            'tree');
+  Item('New Project...',      'newproject');
+  Item('-',                   '');
+
+  { The live half. A project with an app gets the app on its own line
+    underneath, indented -- FMX's TListBox has no submenus, and a one-level
+    indent reads the same without pretending to be a tree. }
+  for I := 0 to High(FProjects) do
+  begin
+    Row := FProjects[I];
+    Item(Row.Title, 'project:' + Row.Name);
+    if not Row.HasApp then Continue;
+    { Ask the gateway what the app actually is: the board row knows there is
+      one, the app record knows its name and whether it runs or opens. }
+    if not FClient.App(Row.Name, Apps) then Continue;
+    if not Apps.Exists then Continue;
+    if Apps.Servable then
+      Item('    ' + Apps.Name, 'app:' + Row.Name)
+    else
+      Item('    ' + Apps.Name + ' (run)', 'run:' + Row.Name);
+  end;
+  if Length(FProjects) > 0 then Item('-', '');
+
+  Item('Switch Workspace...',  'pickws');
+  Item('New Workspace...',     'newws');
+  Item('Display Properties',   'display');
+
+  { Sit the menu at the bottom-left, where a launcher belongs, and give it
+    only the height it needs. }
+  J := FMenuList.Items.Count * 20 + 40;
+  if J > Round(FDesktop.Height) - 60 then J := Round(FDesktop.Height) - 60;
+  if J < 120 then J := 120;
+  FMenuWin.Height := J;
+  FMenuWin.Position.Point := PointF(8, FDesktop.Height - J - 44);
+end;
+
+procedure TFormMain.MenuPick(Sender: TObject);
+var
+  Idx, I: Integer;
+  Action, Arg: string;
+begin
+  if FMenuList = nil then Exit;
+  Idx := FMenuList.ItemIndex;
+  if (Idx < 0) or (Idx >= FMenuActions.Count) then Exit;
+  Action := FMenuActions[Idx];
+  if Action = '' then Exit;        { separator }
+
+  Arg := '';
+  I := Pos(':', Action);
+  if I > 0 then
+  begin
+    Arg := Copy(Action, I + 1, MaxInt);
+    Action := Copy(Action, 1, I - 1);
+  end;
+
+  { Close first: every branch below opens a window, and the menu should be
+    gone by the time it appears. }
+  CloseMenu;
+
+  if Action = 'chat' then OpenPlainChat
+  else if Action = 'browser' then OpenBrowser('')
+  else if Action = 'files' then OpenFiles
+  else if Action = 'library' then OpenLibrary
+  else if Action = 'log' then OpenLog
+  else if Action = 'tree' then OpenTree
+  else if Action = 'newproject' then NewProjectClick(nil)
+  else if Action = 'pickws' then PickWorkspaceClick(nil)
+  else if Action = 'newws' then NewWorkspaceClick(nil)
+  else if Action = 'display' then OpenDisplayProperties
+  else if (Action = 'project') and (Arg <> '') then OpenChat(Arg)
+  else if (Action = 'app') and (Arg <> '') then OpenApp(Arg)
+  else if (Action = 'run') and (Arg <> '') then OpenRun(Arg);
+end;
+
+procedure TFormMain.OpenDisplayProperties;
 begin
   if FStylePicker = nil then
     BuildStylePicker;
   if FStylePicker <> nil then
     FStylePicker.Restore;
+end;
+
+(* A chat with no project attached.
+
+   Every other chat window here is a BUILDER: it sends a system prompt that
+   says "your deliverable is an app in this project's directory", which is
+   the right default for a desktop whose premise is software-not-text, and
+   the wrong one for "what is the syntax for a Pascal set". This is the
+   plain one -- no project, no builder prompt, just a conversation. It uses
+   the reserved key below so it cannot collide with a project named 'chat'
+   (project names are slugs and cannot contain a colon). *)
+procedure TFormMain.OpenPlainChat;
+begin
+  OpenChat(PlainChatKey);
+end;
+
+procedure TFormMain.PickWorkspaceClick(Sender: TObject);
+var
+  I: Integer;
+  Menu: string;
+begin
+  RefreshWorkspaces;
+  if Length(FWorkspaces) = 0 then Exit;
+  Menu := '';
+  for I := 0 to High(FWorkspaces) do
+  begin
+    Menu := Menu + IntToStr(FWorkspaces[I].Slot) + ': ' + FWorkspaces[I].Label_;
+    if FWorkspaces[I].Active then Menu := Menu + ' (current)';
+    Menu := Menu + sLineBreak;
+  end;
+  { A workspace is a wall, not a view -- name the consequence in the prompt
+    rather than after the fact. }
+  AskText('Switch Workspace',
+          'This changes what PasClaw remembers: memory, sessions, skills' +
+          sLineBreak + 'and files are all per workspace.' + sLineBreak +
+          sLineBreak + Menu + 'Number:',
+          '', PickWorkspaceAccepted);
+end;
+
+procedure TFormMain.PickWorkspaceAccepted(Sender: TObject);
+var
+  I, Slot: Integer;
+begin
+  if FDialogEdit = nil then Exit;
+  Slot := StrToIntDef(Trim(FDialogEdit.Text), 0);
+  DialogCancel(Sender);
+  if Slot <= 0 then Exit;
+  for I := 0 to High(FWorkspaces) do
+    if (FWorkspaces[I].Slot = Slot) and (not FWorkspaces[I].Active) then
+    begin
+      SaveDesktopState;
+      CloseAllWindows;
+      FVersions.Clear;
+      if not FClient.ActivateWorkspace(FWorkspaces[I].Name) then
+      begin
+        Say('Could not switch workspace: ' + FClient.LastError);
+        Exit;
+      end;
+      RefreshWorkspaces;
+      RefreshProjects;
+      RestoreDesktopState;
+      Exit;
+    end;
+end;
+
+procedure TFormMain.NewWorkspaceClick(Sender: TObject);
+begin
+  AskText('New Workspace', 'What should this workspace be called?', '',
+          NewWorkspaceAccepted);
+end;
+
+procedure TFormMain.NewWorkspaceAccepted(Sender: TObject);
+var
+  Name_: string;
+begin
+  if FDialogEdit = nil then Exit;
+  Name_ := Trim(FDialogEdit.Text);
+  DialogCancel(Sender);
+  if Name_ = '' then Exit;
+  if FClient.CreateWorkspace(Name_) = '' then
+  begin
+    Say('Could not create workspace: ' + FClient.LastError);
+    Exit;
+  end;
+  RefreshWorkspaces;
+  Say('Workspace "' + Name_ + '" created. Switch to it from the Menu.');
 end;
 
 procedure TFormMain.NewProjectClick(Sender: TObject);
@@ -980,25 +1272,60 @@ end;
    invisible to the agent -- the whole difference from WS >. *)
 procedure TFormMain.NextDesktopClick(Sender: TObject);
 var
-  Cur, Cnt, Target: Integer;
+  Cur, Cnt, Target, Leaving: Integer;
 begin
   if not FClient.Desktops(Cur, Cnt) then Exit;
-  SaveDesktopState;
+  Leaving := Cur;
+  { Named, not "current": the switch below moves what current means, and an
+    autosave queued by the closing windows would otherwise land here. }
+  SaveDesktopStateTo(Leaving);
   if Cnt < 2 then Target := 2         { first press creates a second desktop }
   else if Cur >= Cnt then Target := 1
   else Target := Cur + 1;
   if not FClient.SwitchDesktop(Target, Cur, Cnt) then Exit;
-  while FDesktop.WindowCount > 0 do
-    FDesktop.Windows[0].Close;
-  FChatWins.Clear; FChatLogs.Clear; FChatInputs.Clear; FAppWins.Clear;
+  CloseAllWindows;
+  RestoreDesktopState;
+  Say(Format('Desktop %d of %d', [Cur, Cnt]));
+end;
+
+(* Tear down every window and forget every handle to one.
+
+   Three call sites needed this and each kept its own list of fields to nil,
+   which is a bug waiting for the next window kind: miss one and it becomes
+   a dangling pointer the next Restore walks into. One place to update.
+
+   FRestoring is held for the duration so the closes cannot mark the layout
+   dirty -- the layout was already saved, deliberately, to a named desk. *)
+procedure TFormMain.CloseAllWindows;
+var
+  WasRestoring: Boolean;
+begin
+  WasRestoring := FRestoring;
+  FRestoring := True;
+  try
+    while FDesktop.WindowCount > 0 do
+      FDesktop.Windows[0].Close;
+  finally
+    FRestoring := WasRestoring;
+  end;
+  FChatWins.Clear; FChatLogs.Clear; FChatInputs.Clear; FChatHistory.Clear;
+  FAppWins.Clear;
   FRunWins.Clear; FRunLogs.Clear; FRunHeads.Clear;
-  FStylePicker := nil; FLibraryWin := nil;
+  FStylePicker := nil; FStyleList := nil; FSkinList := nil;
+  FLibraryWin := nil; FLibraryList := nil;
+  FTreeWin := nil; FTree := nil;
+  FLogWin := nil; FLogMemo := nil;
   FFilesWin := nil; FFilesList := nil; FFilesPath := nil;
+  FHexWin := nil; FHexMemo := nil;
   FBrowserWin := nil; FBrowserQuery := nil; FBrowserStatus := nil;
   FBrowserSearch := nil; FBrowserDeep := nil; FBrowserPromote := nil;
   FBrowserView := nil; FCurrentPage := '';
-  RestoreDesktopState;
-  Say(Format('Desktop %d of %d', [Cur, Cnt]));
+  FProgressWin := nil; FProgressText := nil;
+  FVersionWin := nil;
+  FMenuWin := nil;
+  { The layout is now empty by construction; do not let that be written
+    over the desk we are about to arrive at before it is restored. }
+  FLayoutDirty := False;
 end;
 
 procedure TFormMain.NextWorkspaceClick(Sender: TObject);
@@ -1013,23 +1340,13 @@ begin
 
   { Save THIS workspace's arrangement before leaving it -- switching is
     meant to feel like walking into a different room, which only works if
-    the room you left is still as you left it. }
+    the room you left is still as you left it. The state route is per
+    workspace, so this lands on the one we are still in. }
   SaveDesktopState;
 
-  { Switching desktops closes this one's windows -- they belong to the
+  { Switching workspaces closes this one's windows -- they belong to the
     workspace, not to the client. }
-  while FDesktop.WindowCount > 0 do
-    FDesktop.Windows[0].Close;
-  FStylePicker := nil;
-  FLibraryWin := nil;
-  FFilesWin := nil; FFilesList := nil; FFilesPath := nil;
-  FBrowserWin := nil; FBrowserQuery := nil; FBrowserStatus := nil;
-  FBrowserSearch := nil; FBrowserDeep := nil; FBrowserPromote := nil;
-  FBrowserView := nil; FCurrentPage := '';
-  FProgressWin := nil; FProgressText := nil;
-  FVersionWin := nil;
-  FChatWins.Clear; FChatLogs.Clear; FChatInputs.Clear; FAppWins.Clear;
-  FRunWins.Clear; FRunLogs.Clear; FRunHeads.Clear;
+  CloseAllWindows;
   { Versions belong to a conversation, and the conversations just closed. }
   FVersions.Clear;
 
@@ -1061,6 +1378,7 @@ procedure TFormMain.TreeDblClick(Sender: TObject);
 var
   Ref: TNodeRef;
 begin
+  if FTree = nil then Exit;
   if (FTree.Selected = nil) or (FTree.Selected.TagObject = nil) then Exit;
   Ref := FTree.Selected.TagObject as TNodeRef;
   case Ref.Kind of
@@ -1077,6 +1395,18 @@ type
   { Runs TPasClawClient.WatchEvents, which blocks. Terminating the thread
     stops the subscription through the callback's Stop flag. }
   TEventWatchThread = class(TThread)
+  private
+    FForm: TFormMain;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(AForm: TFormMain);
+  end;
+
+  { The same pattern for /v1/logs. Only alive while the Log window is open:
+    an idle subscription costs the gateway a held connection, and nobody is
+    reading it. }
+  TLogWatchThread = class(TThread)
   private
     FForm: TFormMain;
   protected
@@ -1105,6 +1435,142 @@ begin
     end;
     if Terminated then Break;
     Sleep(3000);
+  end;
+end;
+
+constructor TLogWatchThread.Create(AForm: TFormMain);
+begin
+  inherited Create(True);
+  FForm := AForm;
+  FreeOnTerminate := False;
+end;
+
+procedure TLogWatchThread.Execute;
+begin
+  while not Terminated do
+  begin
+    try
+      FForm.FClient.WatchLogs(FForm.LogLine);
+    except
+      { same deal as events: a dead gateway is a retry, not a dialog }
+    end;
+    if Terminated then Break;
+    Sleep(3000);
+  end;
+end;
+
+(* The Log window.
+
+   /v1/logs is the gateway's own ring buffer replayed and then tailed live,
+   which is the same thing `pasclaw gateway` prints to its terminal -- worth
+   having on the desktop when the gateway is on another machine, or started
+   by something that swallowed its output.
+
+   What it CANNOT do is show more than the gateway recorded. Log level is a
+   server-side filter applied before the buffer, so a debug line that was
+   never emitted cannot be recovered by asking differently here. The header
+   says so, because the alternative is a level control that appears to do
+   something and does not. *)
+procedure TFormMain.OpenLog;
+var
+  Head: TLabel;
+begin
+  if FLogWin <> nil then
+  begin
+    FLogWin.Restore;
+    Exit;
+  end;
+  FLogWin := TrackWindow(FDesktop.CreateWindow('Log', 620, 380));
+  MarkLayoutDirty;
+
+  Head := TLabel.Create(FLogWin);
+  Head.Parent := FLogWin.Client;
+  Head.Align := TAlignLayout.Top;
+  Head.Height := 32;
+  Head.WordWrap := True;
+  Head.Text := 'Live from the gateway. Debug lines appear here only when ' +
+               'the GATEWAY runs at debug -- set gateway.log_level to ' +
+               '"debug" in config.json and restart it.';
+
+  FLogMemo := TMemo.Create(FLogWin);
+  FLogMemo.Parent := FLogWin.Client;
+  FLogMemo.Align := TAlignLayout.Client;
+  FLogMemo.ReadOnly := True;
+  FLogMemo.WordWrap := False;
+
+  if FLogPending = nil then FLogPending := TStringList.Create;
+  if FLogLock = nil then FLogLock := TCriticalSection.Create;
+  FLogStop := False;
+  if FLogThread = nil then
+  begin
+    FLogThread := TLogWatchThread.Create(Self);
+    FLogThread.Start;
+  end;
+end;
+
+procedure TFormMain.LogLine(const Level, Text_: string; var Stop: Boolean);
+begin
+  { Worker thread. Queue the line and return -- the timer paints. }
+  Stop := FLogStop;
+  if Stop then Exit;
+  if FLogLock = nil then Exit;
+  FLogLock.Acquire;
+  try
+    if FLogPending <> nil then
+    begin
+      FLogPending.Add('[' + Level + '] ' + Text_);
+      { A gateway under load can outrun the timer; the window is a tail, so
+        dropping the oldest queued lines is better than growing without
+        bound. }
+      while FLogPending.Count > 2000 do FLogPending.Delete(0);
+    end;
+  finally
+    FLogLock.Release;
+  end;
+end;
+
+procedure TFormMain.DrainLogLines;
+var
+  Batch: TStringList;
+  I: Integer;
+begin
+  if (FLogLock = nil) or (FLogPending = nil) then Exit;
+  if FLogMemo = nil then Exit;
+  Batch := TStringList.Create;
+  try
+    FLogLock.Acquire;
+    try
+      if FLogPending.Count = 0 then Exit;
+      Batch.Assign(FLogPending);
+      FLogPending.Clear;
+    finally
+      FLogLock.Release;
+    end;
+    FLogMemo.Lines.BeginUpdate;
+    try
+      for I := 0 to Batch.Count - 1 do
+        FLogMemo.Lines.Add(Batch[I]);
+      while FLogMemo.Lines.Count > 5000 do FLogMemo.Lines.Delete(0);
+    finally
+      FLogMemo.Lines.EndUpdate;
+    end;
+    FLogMemo.GoToTextEnd;
+  finally
+    Batch.Free;
+  end;
+end;
+
+procedure TFormMain.StopLogWatch;
+begin
+  FLogStop := True;
+  if FLogThread <> nil then
+  begin
+    FLogThread.Terminate;
+    { The subscription blocks in Indy until the next byte or the socket
+      drops; the flag above makes the callback stop it at the first line.
+      Waiting here is what keeps the client alive until it does. }
+    FLogThread.WaitFor;
+    FreeAndNil(FLogThread);
   end;
 end;
 
@@ -1157,6 +1623,9 @@ end;
 procedure TFormMain.EventTimerTick(Sender: TObject);
 begin
   ApplyPendingEvents;
+  { Log lines arrive on their own thread and are painted here, on the main
+    one, for the same reason board events are. }
+  DrainLogLines;
 end;
 
 procedure TFormMain.StartEventWatch;
@@ -1410,8 +1879,13 @@ begin
     Exit;
   end;
 
-  Title := Project;
-  if ProjectByName(Project, Row) then Title := Row.Title;
+  if Project = PlainChatKey then
+    Title := 'PasClaw'
+  else
+  begin
+    Title := Project;
+    if ProjectByName(Project, Row) then Title := Row.Title;
+  end;
   W := TrackWindow(FDesktop.CreateWindow(Title + ' -- Chat', 520, 420));
   FChatWins.AddOrSetValue(Project, W);
 
@@ -1459,9 +1933,59 @@ begin
   if not FChatHistory.ContainsKey(Project) then
     FChatHistory.AddOrSetValue(Project, '[]');
 
-  Log.Lines.Add('Describe the app you want. PasClaw builds it into this ' +
-                'project and it opens as a window.');
+  if Project = PlainChatKey then
+    Log.Lines.Add('Ask PasClaw anything. This window is not tied to a ' +
+                  'project, so nothing here builds an app.')
+  else
+    Log.Lines.Add('Describe the app you want. PasClaw builds it into this ' +
+                  'project and it opens as a window.');
   Log.Lines.Add('');
+end;
+
+(* Pull role/content pairs out of a messages array.
+
+   Hand-scanned for the same reason RestoreDesktopState is: the shape is
+   fixed and flat, and one odd session must not be able to stop the Library
+   from opening. Roles and contents come back as a name=value list, which
+   keeps the pairing intact without a second parallel structure. *)
+procedure SplitChatMessages(const ArrayJSON: string; Into: TStringList);
+var
+  P, Q: Integer;
+  Role, Content: string;
+begin
+  if Into = nil then Exit;
+  Into.Clear;
+  P := 1;
+  repeat
+    P := PosEx('"role":"', ArrayJSON, P);
+    if P = 0 then Break;
+    Inc(P, 8);
+    Q := PosEx('"', ArrayJSON, P);
+    if Q = 0 then Break;
+    Role := Copy(ArrayJSON, P, Q - P);
+
+    P := PosEx('"content":"', ArrayJSON, Q);
+    if P = 0 then Break;
+    Inc(P, 11);
+    Q := P;
+    { Walk to the closing quote, honouring backslash escapes so a message
+      containing \" does not end early. }
+    while Q <= Length(ArrayJSON) do
+    begin
+      if ArrayJSON[Q] = '\' then Inc(Q, 2)
+      else if ArrayJSON[Q] = '"' then Break
+      else Inc(Q);
+    end;
+    if Q > Length(ArrayJSON) then Break;
+    Content := Copy(ArrayJSON, P, Q - P);
+    Content := StringReplace(Content, '\n', sLineBreak, [rfReplaceAll]);
+    Content := StringReplace(Content, '\"', '"', [rfReplaceAll]);
+    Content := StringReplace(Content, '\\', '\', [rfReplaceAll]);
+    { Tool and system turns are machinery, not conversation. }
+    if (Role = 'user') or (Role = 'assistant') then
+      Into.Add(Role + '=' + Content);
+    P := Q;
+  until False;
 end;
 
 
@@ -1496,8 +2020,15 @@ end;
 
 { The builder overlay. Same text the browser client sends, for the same
   reason: the deliverable is software, not an essay. }
+(* The system prompt a project chat sends.
+
+   Empty for the project-less window: that one is a plain conversation, and
+   telling the model to deliver an app when there is no project to put one
+   in would produce files in whatever directory it guessed. The gateway's
+   own default prompt applies there, which is the point of it. *)
 function BuilderPrompt(const Project: string): string;
 begin
+  if (Project = '') or (Project = PlainChatKey) then Exit('');
   Result :=
     'You are working inside the PasClaw Desktop project "' + Project + '".' + sLineBreak +
     'Deliverables are APPS, not essays. When the user asks for something, ' +
@@ -1523,6 +2054,40 @@ begin
   { The client's Chat call blocks this thread, so paint as we go rather than
     leaving the window frozen until the turn finishes. }
   GStreamingLog.Text := GStreamingLog.Text + Chunk;
+  GStreamingLog.GoToTextEnd;
+  Application.ProcessMessages;
+end;
+
+(* What the model is DOING, in the transcript.
+
+   Asking for an app used to look like a long silence and then a sentence,
+   with no sign of the file writes, the manifest edit and the board updates
+   that were the actual work -- and when it went wrong, nothing to look at.
+   Each call is one line in, its result one line out, indented so the prose
+   still reads as the conversation.
+
+   Deliberately terse: the gateway already caps args and results before they
+   reach here, and a chat window is not a log viewer. The Log window is, and
+   it is one Menu item away. *)
+procedure TFormMain.ChatTool(const Kind, Name, Detail: string; IsErr: Boolean);
+var
+  Line: string;
+begin
+  if GStreamingLog = nil then Exit;
+  if Kind = 'call' then
+  begin
+    Line := '  * ' + Name;
+    if Trim(Detail) <> '' then Line := Line + ' ' + Detail;
+  end
+  else if IsErr then
+    Line := '    ! ' + Trim(Detail)
+  else
+  begin
+    Line := Trim(Detail);
+    if Line = '' then Exit;      { a silent success needs no second line }
+    Line := '    ' + Line;
+  end;
+  GStreamingLog.Lines.Add(Line);
   GStreamingLog.GoToTextEnd;
   Application.ProcessMessages;
 end;
@@ -1562,7 +2127,7 @@ begin
   try
     (Sender as TButton).Enabled := False;
     try
-      Reply := FClient.Chat(Hist, BuilderPrompt(Project), ChatChunk);
+      Reply := FClient.Chat(Hist, BuilderPrompt(Project), ChatChunk, ChatTool);
     finally
       (Sender as TButton).Enabled := True;
     end;
@@ -1653,6 +2218,61 @@ begin
       Snap.Visible := True;
       B.Visible := False;
     end;
+  end;
+end;
+
+(* Reopen a saved conversation from the Library.
+
+   Its history comes back from the gateway so the next message continues it
+   rather than starting over; the transcript is replayed into the window so
+   there is something to read on arrival. Filed under a key derived from the
+   session id, which cannot collide with a project slug (slugs have no
+   colon), so a reopened session and a project chat can be open at once. *)
+procedure TFormMain.OpenSessionChat(const SessionId: string);
+var
+  Key: string;
+  Log: TMemo;
+  Hist, Visible: string;
+  Msgs: TStringList;
+  I: Integer;
+begin
+  if Trim(SessionId) = '' then Exit;
+  Key := ':session:' + SessionId;
+  OpenChat(Key);
+
+  { Already open and already populated -- focusing it is the whole job. }
+  if FChatHistory.TryGetValue(Key, Hist) and (Trim(Hist) <> '[]') and
+     (Trim(Hist) <> '') then Exit;
+
+  Hist := FClient.SessionHistory(SessionId);
+  if Trim(Hist) = '' then Hist := '[]';
+  FChatHistory.AddOrSetValue(Key, Hist);
+
+  if not FChatLogs.TryGetValue(Key, Log) then Exit;
+  if Log = nil then Exit;
+
+  Msgs := TStringList.Create;
+  try
+    SplitChatMessages(Hist, Msgs);
+    if Msgs.Count = 0 then
+    begin
+      Log.Lines.Add('(this session has no messages)');
+      Exit;
+    end;
+    Log.Lines.Clear;
+    for I := 0 to Msgs.Count - 1 do
+    begin
+      { Names(I) is the role, ValueFromIndex(I) the content. }
+      Visible := Msgs.ValueFromIndex[I];
+      if Msgs.Names[I] = 'user' then
+        Log.Lines.Add('> ' + Visible)
+      else
+        Log.Lines.Add(Visible);
+      Log.Lines.Add('');
+    end;
+    Log.GoToTextEnd;
+  finally
+    Msgs.Free;
   end;
 end;
 
@@ -1786,37 +2406,101 @@ begin
     M.Text := '(no output yet)';
 end;
 
+(* The Library: what this workspace has accumulated.
+
+   Two kinds of thing, because they answer different questions. Pages are
+   what you looked up; sessions are what you talked about. Listing only the
+   first made the window look like a search history and left every past
+   conversation unreachable from the UI.
+
+   Rows are inert without somewhere to go, so each one is double-clickable:
+   a page opens in the Browser, a session opens as a chat. FLibraryKinds
+   runs parallel to the visible list because the caption is for reading and
+   the id is for acting on -- packing an id into the caption and parsing it
+   back out is how you end up with a project named "-- 3 source(s)". *)
 procedure TFormMain.OpenLibrary;
 var
-  LB: TListBox;
   Pages: TPageRows;
+  Sess: TSessionRows;
   I: Integer;
+  Title: string;
 begin
   if FLibraryWin <> nil then
   begin
     FLibraryWin.Restore;
     Exit;
   end;
-  FLibraryWin := TrackWindow(FDesktop.CreateWindow('Library', 420, 340));
+  FLibraryWin := TrackWindow(FDesktop.CreateWindow('Library', 460, 380));
   MarkLayoutDirty;
-  LB := TListBox.Create(FLibraryWin);
-  LB.Parent := FLibraryWin.Client;
-  LB.Align := TAlignLayout.Client;
+  if FLibraryKinds = nil then FLibraryKinds := TStringList.Create;
+  FLibraryKinds.Clear;
+
+  FLibraryList := TListBox.Create(FLibraryWin);
+  FLibraryList.Parent := FLibraryWin.Client;
+  FLibraryList.Align := TAlignLayout.Client;
+  FLibraryList.OnDblClick := LibraryDblClick;
+
+  FLibraryList.Items.Add('-- Pages --');
+  FLibraryKinds.Add('');
   try
     Pages := FClient.Pages;
   except
-    on E: Exception do
-    begin
-      LB.Items.Add('Could not list pages: ' + E.Message);
-      Exit;
-    end;
+    SetLength(Pages, 0);
   end;
   if Length(Pages) = 0 then
-    LB.Items.Add('(no pages yet)')
+  begin
+    FLibraryList.Items.Add('  (none yet -- ask something in the Browser)');
+    FLibraryKinds.Add('');
+  end
   else
     for I := 0 to High(Pages) do
-      LB.Items.Add(Format('%s -- %d source(s)  %s',
+    begin
+      FLibraryList.Items.Add(Format('  %s -- %d source(s)  %s',
         [Pages[I].Title, Pages[I].SourceCount, Pages[I].Created]));
+      FLibraryKinds.Add('page:' + Pages[I].Id);
+    end;
+
+  FLibraryList.Items.Add('');
+  FLibraryKinds.Add('');
+  FLibraryList.Items.Add('-- Sessions --');
+  FLibraryKinds.Add('');
+  try
+    Sess := FClient.Sessions;
+  except
+    SetLength(Sess, 0);
+  end;
+  if Length(Sess) = 0 then
+  begin
+    FLibraryList.Items.Add('  (none yet)');
+    FLibraryKinds.Add('');
+  end
+  else
+    for I := 0 to High(Sess) do
+    begin
+      Title := Sess[I].Title;
+      if Trim(Title) = '' then Title := Sess[I].Id;
+      FLibraryList.Items.Add('  ' + Title +
+        IfThenStr(Sess[I].Model <> '', '  [' + Sess[I].Model + ']', ''));
+      FLibraryKinds.Add('session:' + Sess[I].Id);
+    end;
+end;
+
+procedure TFormMain.LibraryDblClick(Sender: TObject);
+var
+  Idx, C: Integer;
+  Kind, Id: string;
+begin
+  if (FLibraryList = nil) or (FLibraryKinds = nil) then Exit;
+  Idx := FLibraryList.ItemIndex;
+  if (Idx < 0) or (Idx >= FLibraryKinds.Count) then Exit;
+  Kind := FLibraryKinds[Idx];
+  if Kind = '' then Exit;          { a heading, not a row }
+  C := Pos(':', Kind);
+  if C = 0 then Exit;
+  Id := Copy(Kind, C + 1, MaxInt);
+  Kind := Copy(Kind, 1, C - 1);
+  if Kind = 'page' then OpenBrowser(Id)
+  else if Kind = 'session' then OpenSessionChat(Id);
 end;
 
 { ----------------------------------------------------- process apps -- }
@@ -2137,39 +2821,106 @@ end;
   about state.
 *)
 procedure TFormMain.SaveDesktopState;
+begin
+  { Unnumbered means "wherever we are", which is right for an autosave
+    during ordinary work. Switching desks must not use this -- see
+    SaveDesktopStateTo. }
+  SaveDesktopStateTo(0);
+end;
+
+(* Write the layout to a NAMED desktop.
+
+   Paging desks is save-here-then-switch-there, and "here" stops being
+   current the moment the switch lands. Saving to "current" therefore races
+   the switch: an autosave queued by the closing windows fires afterwards
+   and writes an empty layout over the desk the user just left, which is
+   exactly how an arrangement disappears. Naming the number retires the
+   question instead of trying to order around it.
+
+   Geometry travels with each window now. Reopening the right windows in
+   the wrong places is still losing your desktop, just less obviously. *)
+procedure TFormMain.SaveDesktopStateTo(Desk: Integer);
 var
   Body, Key: string;
   Keys: TArray<string>;
   W: TRetroWindow;
   First: Boolean;
 
-  procedure Add(const Fn, Arg: string);
+  procedure Add(const Fn, Arg: string; Win: TRetroWindow);
   begin
     if not First then Body := Body + ',';
     First := False;
-    Body := Body + '{"fn":"' + Fn + '","arg":"' + Arg + '"}';
+    Body := Body + '{"fn":"' + Fn + '","arg":"' + JsonStr(Arg) + '"';
+    if Win <> nil then
+      Body := Body + Format(',"x":%d,"y":%d,"w":%d,"h":%d',
+        [Round(Win.Position.X), Round(Win.Position.Y),
+         Round(Win.Width), Round(Win.Height)]);
+    Body := Body + '}';
   end;
 
 begin
   if FClient = nil then Exit;
   Body := '';
   First := True;
-  if FLibraryWin <> nil then Add('library', '');
-  if FFilesWin <> nil then Add('files', FFilesDir.Path);
-  if FBrowserWin <> nil then Add('browser', FCurrentPage);
+  if FTreeWin    <> nil then Add('projects', '', FTreeWin);
+  if FLibraryWin <> nil then Add('library', '', FLibraryWin);
+  if FFilesWin   <> nil then Add('files', FFilesDir.Path, FFilesWin);
+  if FBrowserWin <> nil then Add('browser', FCurrentPage, FBrowserWin);
+  if FLogWin     <> nil then Add('log', '', FLogWin);
   Keys := FChatWins.Keys.ToArray;
   for Key in Keys do
-    if FChatWins.TryGetValue(Key, W) and (W <> nil) then Add('chat', Key);
+    if FChatWins.TryGetValue(Key, W) and (W <> nil) then Add('chat', Key, W);
   Keys := FAppWins.Keys.ToArray;
   for Key in Keys do
-    if FAppWins.TryGetValue(Key, W) and (W <> nil) then Add('app', Key);
-  FClient.SetDesktopState('{"v":1,"client":"fmx","windows":[' + Body + ']}');
+    if FAppWins.TryGetValue(Key, W) and (W <> nil) then Add('app', Key, W);
+  Keys := FRunWins.Keys.ToArray;
+  for Key in Keys do
+    if FRunWins.TryGetValue(Key, W) and (W <> nil) then Add('run', Key, W);
+  FClient.SetDesktopStateFor(Desk,
+    '{"v":1,"client":"fmx","windows":[' + Body + ']}');
 end;
 
 procedure TFormMain.RestoreDesktopState;
 var
-  State, Fn, Arg: string;
-  P, Q: Integer;
+  State, Fn, Arg, Geo: string;
+  P, Q, R, Brace: Integer;
+  Opened: TRetroWindow;
+
+  { One integer field out of the record we are standing in. Absent means
+    "wherever the window manager wants it", which is what a layout saved
+    before geometry existed gets. }
+  function GeoInt(const Name: string; Def: Integer): Integer;
+  var
+    A, B: Integer;
+  begin
+    Result := Def;
+    A := Pos('"' + Name + '":', Geo);
+    if A = 0 then Exit;
+    Inc(A, Length(Name) + 3);
+    B := A;
+    while (B <= Length(Geo)) and
+          (CharInSet(Geo[B], ['0'..'9', '-'])) do Inc(B);
+    if B > A then Result := StrToIntDef(Copy(Geo, A, B - A), Def);
+  end;
+
+  procedure PlaceIt(W: TRetroWindow);
+  var
+    X, Y, Wd, Ht: Integer;
+  begin
+    if W = nil then Exit;
+    X  := GeoInt('x', -1);
+    Y  := GeoInt('y', -1);
+    Wd := GeoInt('w', -1);
+    Ht := GeoInt('h', -1);
+    if (Wd > 40) and (Ht > 40) then
+    begin
+      W.Width  := Wd;
+      W.Height := Ht;
+    end;
+    if (X >= 0) and (Y >= 0) then
+      W.Position.Point := PointF(X, Y);
+  end;
+
 begin
   if FClient = nil then Exit;
   State := FClient.DesktopState;
@@ -2204,11 +2955,42 @@ begin
       else
         P := Q;
 
-      if Fn = 'library' then OpenLibrary
-      else if Fn = 'files' then OpenFiles
-      else if Fn = 'browser' then OpenBrowser(Arg)
-      else if (Fn = 'chat') and (Arg <> '') then OpenChat(Arg)
-      else if (Fn = 'app') and (Arg <> '') then OpenApp(Arg);
+      { The rest of this record is where the window goes. Bounded to the
+        record we are in so the next window's numbers cannot be read as
+        this one's. }
+      Brace := PosEx('}', State, P);
+      R := PosEx('{"fn":"', State, P);
+      if (R > 0) and ((Brace = 0) or (R < Brace)) then Brace := R;
+      if Brace > P then Geo := Copy(State, P, Brace - P) else Geo := '';
+
+      Opened := nil;
+      if Fn = 'library' then begin OpenLibrary; Opened := FLibraryWin; end
+      else if Fn = 'projects' then begin OpenTree; Opened := FTreeWin; end
+      else if Fn = 'files' then
+      begin
+        { The saved directory, not the default one. }
+        if Arg <> '' then FFilesDir.Path := Arg;
+        OpenFiles;
+        Opened := FFilesWin;
+      end
+      else if Fn = 'log' then begin OpenLog; Opened := FLogWin; end
+      else if Fn = 'browser' then begin OpenBrowser(Arg); Opened := FBrowserWin; end
+      else if (Fn = 'chat') and (Arg <> '') then
+      begin
+        OpenChat(Arg);
+        if not FChatWins.TryGetValue(Arg, Opened) then Opened := nil;
+      end
+      else if (Fn = 'app') and (Arg <> '') then
+      begin
+        OpenApp(Arg);
+        if not FAppWins.TryGetValue(Arg, Opened) then Opened := nil;
+      end
+      else if (Fn = 'run') and (Arg <> '') then
+      begin
+        OpenRun(Arg);
+        if not FRunWins.TryGetValue(Arg, Opened) then Opened := nil;
+      end;
+      PlaceIt(Opened);
     until P = 0;
   finally
     FRestoring := False;
@@ -2650,29 +3432,190 @@ end;
 (* A file, in a document window. Binary files say so rather than rendering as
    mojibake, and a truncated read admits it -- a viewer that quietly shows
    the first slice of a log is worse than one that says it did. *)
+(* Open a file the way its contents deserve.
+
+   Three viewers, chosen by what the thing is rather than by one fallback
+   for everything:
+
+     .html / .htm -> the Browser, rendered. The desktop already has a
+       browser window and a page IS a document; showing its source in a
+       memo was the client refusing to do the obvious thing.
+     binary       -> the hex view. "(binary file)" is a diagnosis, not a
+       viewer, and the gateway already serves byte windows for exactly
+       this (the classic web UI has had a hex dump over the same route
+       all along).
+     anything else-> text, as before. *)
 procedure TFormMain.OpenFileView(const Path, Name: string);
 var
   W: TRetroWindow;
   M: TMemo;
-  Body: string;
+  Body, Ext: string;
   Binary, Truncated: Boolean;
 begin
+  Ext := LowerCase(ExtractFileExt(Name));
+  if (Ext = '.html') or (Ext = '.htm') then
+  begin
+    OpenBrowser('');
+    if FBrowserView <> nil then
+    begin
+      { A local file, so navigate the control at it directly rather than
+        going back through the gateway for something already on disk. }
+      FBrowserView.Navigate('file://' + Path);
+      if FBrowserStatus <> nil then FBrowserStatus.Text := Path;
+    end;
+    Exit;
+  end;
+
+  if not FClient.ReadFile_(Path, Body, Binary, Truncated) then
+  begin
+    W := TrackWindow(FDesktop.CreateWindow(Name, 560, 420));
+    M := TMemo.Create(W);
+    M.Parent := W.Client;
+    M.Align := TAlignLayout.Client;
+    M.ReadOnly := True;
+    M.Text := 'Could not read it: ' + FClient.LastError;
+    Exit;
+  end;
+
+  if Binary then
+  begin
+    OpenHex(Path);
+    Exit;
+  end;
+
   W := TrackWindow(FDesktop.CreateWindow(Name, 560, 420));
   M := TMemo.Create(W);
   M.Parent := W.Client;
   M.Align := TAlignLayout.Client;
   M.ReadOnly := True;
-  if not FClient.ReadFile_(Path, Body, Binary, Truncated) then
-  begin
-    M.Text := 'Could not read it: ' + FClient.LastError;
-    Exit;
-  end;
-  if Binary then
-    M.Text := '(binary file)'
-  else if Truncated then
+  if Truncated then
     M.Text := Body + sLineBreak + sLineBreak + '[truncated]'
   else
     M.Text := Body;
+end;
+
+(* The hex view.
+
+   Paged over /v1/fs/peek: one window of bytes at a time, so opening a
+   500 MB file costs a window rather than a download. The gateway caps a
+   window at 64 KB; this asks for a screenful. *)
+procedure TFormMain.OpenHex(const Path: string);
+var
+  Bar: TLayout;
+  B: TButton;
+begin
+  FHexPath := Path;
+  FHexOffset := 0;
+  if FHexWin = nil then
+  begin
+    FHexWin := TrackWindow(FDesktop.CreateWindow('Hex', 620, 400));
+
+    Bar := TLayout.Create(FHexWin);
+    Bar.Parent := FHexWin.Client;
+    Bar.Align := TAlignLayout.Bottom;
+    Bar.Height := 30;
+
+    B := TButton.Create(FHexWin);
+    B.Parent := Bar;
+    B.Align := TAlignLayout.Left;
+    B.Width := 70;
+    B.Text := '< Prev';
+    B.OnClick := HexPrevClick;
+
+    B := TButton.Create(FHexWin);
+    B.Parent := Bar;
+    B.Align := TAlignLayout.Left;
+    B.Margins.Left := 4;
+    B.Width := 70;
+    B.Text := 'Next >';
+    B.OnClick := HexNextClick;
+
+    FHexPos := TLabel.Create(FHexWin);
+    FHexPos.Parent := Bar;
+    FHexPos.Align := TAlignLayout.Client;
+    FHexPos.Margins.Left := 8;
+
+    FHexMemo := TMemo.Create(FHexWin);
+    FHexMemo.Parent := FHexWin.Client;
+    FHexMemo.Align := TAlignLayout.Client;
+    FHexMemo.ReadOnly := True;
+    FHexMemo.WordWrap := False;
+  end;
+  FHexWin.Caption := 'Hex -- ' + ExtractFileName(Path);
+  FHexWin.Restore;
+  HexRender;
+end;
+
+procedure TFormMain.HexRender;
+const
+  Window_ = 1024;      { 64 rows of 16 -- a screenful, not a download }
+  Row = 16;
+var
+  Data: TBytes;
+  Total: Int64;
+  I, J, N: Integer;
+  Hex, Asc, Line: string;
+  Lines: TStringList;
+  B: Byte;
+begin
+  if (FHexMemo = nil) or (FClient = nil) then Exit;
+  if not FClient.PeekFile(FHexPath, FHexOffset, Window_, Data, Total) then
+  begin
+    FHexMemo.Text := 'Could not read it: ' + FClient.LastError;
+    Exit;
+  end;
+  FHexTotal := Total;
+  N := Length(Data);
+  Lines := TStringList.Create;
+  try
+    I := 0;
+    while I < N do
+    begin
+      Hex := '';
+      Asc := '';
+      for J := 0 to Row - 1 do
+      begin
+        if I + J < N then
+        begin
+          B := Data[I + J];
+          Hex := Hex + IntToHex(B, 2) + ' ';
+          { Printable ASCII only -- a control byte rendered as itself would
+            reflow the column it is supposed to sit in. }
+          if (B >= 32) and (B < 127) then
+            Asc := Asc + Chr(B)
+          else
+            Asc := Asc + '.';
+        end
+        else
+          Hex := Hex + '   ';
+        if J = 7 then Hex := Hex + ' ';
+      end;
+      Line := IntToHex(FHexOffset + I, 8) + '  ' + Hex + ' |' + Asc + '|';
+      Lines.Add(Line);
+      Inc(I, Row);
+    end;
+    if Lines.Count = 0 then Lines.Add('(empty)');
+    FHexMemo.Text := Lines.Text;
+  finally
+    Lines.Free;
+  end;
+  if FHexPos <> nil then
+    FHexPos.Text := Format('%d - %d of %d bytes',
+      [FHexOffset, FHexOffset + N, FHexTotal]);
+end;
+
+procedure TFormMain.HexPrevClick(Sender: TObject);
+begin
+  FHexOffset := FHexOffset - 1024;
+  if FHexOffset < 0 then FHexOffset := 0;
+  HexRender;
+end;
+
+procedure TFormMain.HexNextClick(Sender: TObject);
+begin
+  if FHexOffset + 1024 >= FHexTotal then Exit;
+  FHexOffset := FHexOffset + 1024;
+  HexRender;
 end;
 
 procedure TFormMain.FilesClick(Sender: TObject);
@@ -2761,7 +3704,6 @@ var
   Pane: TLayout;
   Lbl: TLabel;
   FileName, Item: string;
-  B: TButton;
 begin
   FStylePicker := TrackWindow(
     FDesktop.CreateWindow('Display Properties', 260, 420));
@@ -2772,13 +3714,8 @@ begin
   Pane.Height := 190;
   Pane.Parent := FStylePicker.Client;
 
-  B := TButton.Create(FStylePicker);
-  B.Parent := Pane;
-  B.Align := TAlignLayout.Bottom;
-  B.Height := 26;
-  B.Text := 'Library';
-  B.OnClick := LibraryClick;
-
+  { No stray Library button here any more -- Display Properties is where
+    you pick a look, and the Library has its own Menu item. }
   Lbl := TLabel.Create(FStylePicker);
   Lbl.Align := TAlignLayout.Top;
   Lbl.Height := 18;

--- a/src/pkg/component/PasClaw.Client.Api.pas
+++ b/src/pkg/component/PasClaw.Client.Api.pas
@@ -77,6 +77,14 @@ type
   end;
   TPageRows = array of TPageRow;
 
+  { One saved conversation. The Library lists these beside pages, and
+    opening one is how you get back into a chat you left. }
+  TSessionRow = record
+    Id, Title, Model, Provider: string;
+    Updated: Int64;
+  end;
+  TSessionRows = array of TSessionRow;
+
   { What a running process app is doing. Backend is 'host', 'docker' or
     'docker-remote' -- three genuinely different places, and the user should
     never have to guess which one their app is in. }
@@ -161,20 +169,42 @@ type
   { Called for each event as it arrives. Set Stop to end the subscription. }
   TDesktopEventProc = procedure(const Ev: TDesktopEvent; var Stop: Boolean) of object;
 
+  { One line off the gateway's log stream, already split into its level tag
+    and body so a viewer can colour or filter without re-parsing. }
+  TLogLineProc = procedure(const Level, Text_: string;
+    var Stop: Boolean) of object;
+
   TPasClawClient = class
   private
     FBaseURL: string;
     FToken: string;
     FTimeoutMs: Integer;
+    FModelTimeoutMs: Integer;
     FLastError: string;
     function Request(const Method, Path, Body: string): string;
+    function RequestT(const Method, Path, Body: string;
+      TimeoutMs: Integer): string;
     function GetJSON(const Path: string): string;
   public
     constructor Create(const ABaseURL: string = 'http://127.0.0.1:8088');
     { Base URL without a trailing slash; setting it normalises. }
     property BaseURL: string read FBaseURL write FBaseURL;
     property Token: string read FToken write FToken;
+    (* Two clocks, because there are two kinds of call.
+
+       A board read is a database hit: if it has not answered in seconds,
+       something is wrong and failing fast is the useful behaviour. A call
+       that goes through the MODEL is a different animal -- deep research
+       plans, reads several sources and synthesises, and the gateway holds
+       the request open with nothing on the wire for the whole turn. Judging
+       that by the same clock is what made the Browser give up mid-answer.
+
+       Still bounded rather than infinite: a genuinely dead gateway should
+       eventually surface as an error rather than a window that waits
+       forever. Streaming calls have their own liveness signal (chunks keep
+       arriving) and set no read timeout at all. *)
     property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs;
+    property ModelTimeoutMs: Integer read FModelTimeoutMs write FModelTimeoutMs;
     property LastError: string read FLastError;
 
     function Ping(out Version: string): Boolean;
@@ -261,6 +291,17 @@ type
        arranged in one is the layout the other opens with. *)
     function DesktopState: string;
     function SetDesktopState(const JSON: string): Boolean;
+    (* The same two, against a NAMED desktop instead of whichever is current.
+
+       Paging desks is save-here then switch-there, and "here" stops being
+       current the moment the switch lands. Anything that saves without
+       naming the desktop -- a deferred autosave that fires after the
+       switch, say -- writes the wrong layout to the wrong desk, and the
+       arrangement the user had is simply gone. Naming the number removes
+       the ordering question entirely. N < 1 means "current", so these are
+       a superset of the two above. *)
+    function DesktopStateFor(N: Integer): string;
+    function SetDesktopStateFor(N: Integer; const JSON: string): Boolean;
     (* Desktops inside the workspace: numbered layouts, like a pager.
        Switching one is cheap and invisible to the agent -- the whole
        difference from a workspace switch. *)
@@ -280,6 +321,32 @@ type
        client does exactly that, which is how its tree updates while an agent
        works instead of waiting for a refresh click. *)
     procedure WatchEvents(OnEvent: TDesktopEventProc);
+
+    { ---- library ---- }
+    (* Saved conversations, newest first as the gateway orders them. Pages
+       answer "what did I look up"; these answer "what did I talk about",
+       and the Library window wants both. *)
+    function Sessions: TSessionRows;
+
+    { ---- logs ---- }
+    (* Subscribe to /v1/logs. Same shape as WatchEvents -- BLOCKS, so run it
+       on its own thread -- and the gateway replays its recent ring buffer
+       before going live, so a viewer opens with history rather than waiting
+       for the next line.
+
+       What arrives is bounded by the GATEWAY's log level, not by anything
+       a client can ask for: a line below that level was never recorded and
+       cannot be recovered here. Debug output needs gateway.log_level set to
+       "debug" on the server. *)
+    procedure WatchLogs(OnLine: TLogLineProc);
+
+    { ---- raw bytes ---- }
+    (* A bounded window of a file's bytes, for the hex viewer: a binary file
+       is worth looking at, and downloading a 2 GB one to show 256 bytes of
+       it is not. Total comes back as the file's real size so a viewer can
+       page. Len is capped at 64 KB by the gateway. *)
+    function PeekFile(const Path: string; Offset, Len: Int64;
+      out Data: TBytes; out Total: Int64): Boolean;
   end;
 
 (* Split an assistant reply into the text a human reads and the UI blocks a
@@ -545,6 +612,23 @@ type
     property Stopped: Boolean read FStop;
   end;
 
+  { The same sink shape for /v1/logs. Separate class rather than a mode flag
+    on the one above: the payloads have nothing in common -- one is a JSON
+    object, one is a bracketed line -- and a stream that had to ask which it
+    was would be harder to read than two that each know. }
+  TLogStream = class(TStream)
+  private
+    FBuf: string;
+    FOnLine: TLogLineProc;
+    FStop: Boolean;
+    procedure Consume(const Data: string);
+  public
+    constructor Create(AOnLine: TLogLineProc);
+    function Write(const Buffer; Count: Longint): Longint; override;
+    function Read(var Buffer; Count: Longint): Longint; override;
+    function Seek(Offset: Longint; Origin: Word): Longint; override;
+  end;
+
 constructor TEventStream.Create(AOnEvent: TDesktopEventProc);
 begin
   inherited Create;
@@ -638,14 +722,37 @@ begin
   while (FBaseURL <> '') and (FBaseURL[Length(FBaseURL)] = '/') do
     SetLength(FBaseURL, Length(FBaseURL) - 1);
   FTimeoutMs := 30000;
+  FModelTimeoutMs := 20 * 60 * 1000;   { deep research runs for minutes }
 end;
 
-function NewHttp(const Token: string; TimeoutMs: Integer): TIdHTTP;
+function UrlEncode_(const S: string): string;
+var
+  I: Integer;
+  C: Char;
+begin
+  Result := '';
+  for I := 1 to Length(S) do
+  begin
+    C := S[I];
+    if (C in ['A'..'Z', 'a'..'z', '0'..'9', '-', '_', '.', '~', '/']) then
+      Result := Result + C
+    else
+      Result := Result + '%' + IntToHex(Ord(C), 2);
+  end;
+end;
+
+(* ReadTimeoutMs of 0 means "wait indefinitely for the body" -- correct for
+   a stream whose liveness is the arrival of chunks. ConnectTimeout is kept
+   separate and never infinite: a gateway that is not listening should fail
+   in seconds, whatever the body clock says, or the UI hangs on a typo in
+   the address. *)
+function NewHttp(const Token: string; ReadTimeoutMs: Integer;
+  ConnectTimeoutMs: Integer = 15000): TIdHTTP;
 begin
   Result := TIdHTTP.Create(nil);
   Result.HandleRedirects := True;
-  Result.ConnectTimeout  := TimeoutMs;
-  Result.ReadTimeout     := TimeoutMs;
+  Result.ConnectTimeout  := ConnectTimeoutMs;
+  Result.ReadTimeout     := ReadTimeoutMs;
   Result.Request.ContentType := 'application/json';
   Result.Request.Accept      := 'application/json';
   if Token <> '' then
@@ -653,6 +760,195 @@ begin
   { A gateway reached over https (a tunnel, a remote box) needs the TLS
     handler; a local http gateway never touches it. }
   Result.IOHandler := TIdSSLIOHandlerSocketOpenSSL.Create(Result);
+end;
+
+constructor TLogStream.Create(AOnLine: TLogLineProc);
+begin
+  inherited Create;
+  FOnLine := AOnLine;
+end;
+
+function TLogStream.Read(var Buffer; Count: Longint): Longint;
+begin
+  Result := 0;
+end;
+
+function TLogStream.Seek(Offset: Longint; Origin: Word): Longint;
+begin
+  Result := 0;
+end;
+
+function TLogStream.Write(const Buffer; Count: Longint): Longint;
+var
+  S: AnsiString;
+begin
+  Result := Count;
+  if Count <= 0 then Exit;
+  SetLength(S, Count);
+  Move(Buffer, S[1], Count);
+  Consume(string(S));
+  if FStop then
+    raise EAbort.Create('log subscription stopped by caller');
+end;
+
+procedure TLogStream.Consume(const Data: string);
+var
+  NL, Close_: Integer;
+  Line, Payload, Level, Body: string;
+  Obj: TJsonObject;
+begin
+  FBuf := FBuf + Data;
+  repeat
+    NL := Pos(#10, FBuf);
+    if NL = 0 then Break;
+    Line := Copy(FBuf, 1, NL - 1);
+    Delete(FBuf, 1, NL);
+    Line := StringReplace(Line, #13, '', [rfReplaceAll]);
+    if (Line = '') or (Line[1] = ':') then Continue;   { blank / keepalive }
+    if not HasPrefix(Line, 'data:') then Continue;
+    Payload := Trim(Copy(Line, 6, MaxInt));
+    if Payload = '' then Continue;
+
+    { The gateway JSON-escapes the line but does not quote it. Round-tripping
+      it through the parser as a one-field object is cheaper than a second
+      unescaper that could disagree with the first. }
+    Obj := nil;
+    try
+      Obj := TJsonObject.Parse('{"m":"' + Payload + '"}');
+    except
+      Obj := nil;
+    end;
+    if Obj <> nil then
+    begin
+      try
+        Payload := Obj.GetStr('m', Payload);
+      finally
+        Obj.Free;
+      end;
+    end;
+
+    { "[info] listening on ..." -> level + body. A line that does not carry
+      a tag is still a line; it is shown at info rather than dropped. }
+    Level := 'info';
+    Body  := Payload;
+    if (Payload <> '') and (Payload[1] = '[') then
+    begin
+      Close_ := Pos(']', Payload);
+      if Close_ > 2 then
+      begin
+        Level := Copy(Payload, 2, Close_ - 2);
+        Body  := TrimLeft(Copy(Payload, Close_ + 1, MaxInt));
+      end;
+    end;
+
+    if Assigned(FOnLine) then
+      FOnLine(Level, Body, FStop);
+    if FStop then Break;
+  until False;
+end;
+
+procedure TPasClawClient.WatchLogs(OnLine: TLogLineProc);
+var
+  Http: TIdHTTP;
+  Sink: TLogStream;
+begin
+  FLastError := '';
+  Sink := TLogStream.Create(OnLine);
+  Http := NewHttp(FToken, 0);
+  try
+    { Same deal as WatchEvents: an open, mostly-idle connection. }
+    Http.ReadTimeout := 0;
+    Http.Request.Accept := 'text/event-stream';
+    try
+      Http.Get(FBaseURL + '/v1/logs', Sink);
+    except
+      on E: EAbort do ;      { caller asked to stop }
+      on E: Exception do FLastError := E.Message;
+    end;
+  finally
+    Http.Free;
+    Sink.Free;
+  end;
+end;
+
+function TPasClawClient.Sessions: TSessionRows;
+var
+  Body: string;
+  Root: TJsonObject;
+  Arr: TJsonArray;
+  Item: TJsonObject;
+  I, N: Integer;
+begin
+  SetLength(Result, 0);
+  Body := GetJSON('/v1/sessions');
+  if Trim(Body) = '' then Exit;
+  try
+    Root := TJsonObject.Parse(Body);
+  except
+    Exit;
+  end;
+  if Root = nil then Exit;
+  try
+    Arr := Root.ChildArray('sessions');
+    if Arr = nil then Exit;
+    N := 0;
+    SetLength(Result, Arr.Count);
+    for I := 0 to Arr.Count - 1 do
+    begin
+      Item := Arr.ItemObject(I);
+      if Item = nil then Continue;
+      Result[N].Id       := Item.GetStr('id', '');
+      Result[N].Title    := Item.GetStr('title', '');
+      Result[N].Model    := Item.GetStr('model', '');
+      Result[N].Provider := Item.GetStr('provider', '');
+      Result[N].Updated  := Item.GetInt('updated', 0);
+      if Result[N].Id <> '' then Inc(N);
+    end;
+    SetLength(Result, N);
+  finally
+    Root.Free;
+  end;
+end;
+
+function TPasClawClient.PeekFile(const Path: string; Offset, Len: Int64;
+  out Data: TBytes; out Total: Int64): Boolean;
+var
+  Http: TIdHTTP;
+  Mem: TMemoryStream;
+  Hdr: string;
+begin
+  Result := False;
+  SetLength(Data, 0);
+  Total := 0;
+  FLastError := '';
+  Http := NewHttp(FToken, FTimeoutMs);
+  Mem  := TMemoryStream.Create;
+  try
+    { Raw bytes, not JSON -- this is the one route whose body is the file. }
+    Http.Request.Accept := 'application/octet-stream';
+    try
+      Http.Get(FBaseURL + '/v1/fs/peek?path=' + UrlEncode_(Path) +
+               '&offset=' + IntToStr(Offset) + '&len=' + IntToStr(Len), Mem);
+    except
+      on E: Exception do
+      begin
+        FLastError := E.Message;
+        Exit;
+      end;
+    end;
+    Hdr := Http.Response.RawHeaders.Values['X-File-Total'];
+    Total := StrToInt64Def(Trim(Hdr), Mem.Size);
+    SetLength(Data, Mem.Size);
+    if Mem.Size > 0 then
+    begin
+      Mem.Position := 0;
+      Mem.ReadBuffer(Data[0], Mem.Size);
+    end;
+    Result := True;
+  finally
+    Mem.Free;
+    Http.Free;
+  end;
 end;
 
 procedure TPasClawClient.WatchEvents(OnEvent: TDesktopEventProc);
@@ -682,6 +978,12 @@ begin
 end;
 
 function TPasClawClient.Request(const Method, Path, Body: string): string;
+begin
+  Result := RequestT(Method, Path, Body, FTimeoutMs);
+end;
+
+function TPasClawClient.RequestT(const Method, Path, Body: string;
+  TimeoutMs: Integer): string;
 var
   Http: TIdHTTP;
   Req: TStringStream;
@@ -690,7 +992,7 @@ var
 begin
   Result := '';
   FLastError := '';
-  Http := NewHttp(FToken, FTimeoutMs);
+  Http := NewHttp(FToken, TimeoutMs);
   Req  := nil;
   Resp := TStringStream.Create('');
   try
@@ -1071,22 +1373,6 @@ end;
    unreserved set: a Windows path carries backslashes and a colon, and a
    filename can carry anything at all, so listing what is SAFE is the only
    version of this that stays correct. *)
-function UrlEncode_(const S: string): string;
-var
-  I: Integer;
-  C: Char;
-begin
-  Result := '';
-  for I := 1 to Length(S) do
-  begin
-    C := S[I];
-    if (C in ['A'..'Z', 'a'..'z', '0'..'9', '-', '_', '.', '~', '/']) then
-      Result := Result + C
-    else
-      Result := Result + '%' + IntToHex(Ord(C), 2);
-  end;
-end;
-
 { Fill a run record from the gateway's JSON. Shared by run/stop/state so the
   three cannot drift into reporting different shapes of the same thing. }
 procedure FillRun(Obj: TJsonObject; out Row: TRunRow);
@@ -1340,13 +1626,38 @@ end;
 
 function TPasClawClient.SetDesktopState(const JSON: string): Boolean;
 begin
+  Result := SetDesktopStateFor(0, JSON);
+end;
+
+function TPasClawClient.SetDesktopStateFor(N: Integer;
+  const JSON: string): Boolean;
+var
+  Path: string;
+begin
   Result := False;
+  Path := '/v1/desktop/state';
+  if N >= 1 then Path := Path + '?desktop=' + IntToStr(N);
   try
-    Request('PUT', '/v1/desktop/state', JSON);
+    Request('PUT', Path, JSON);
     Result := True;
   except
     Result := False;
   end;
+end;
+
+function TPasClawClient.DesktopStateFor(N: Integer): string;
+var
+  Path: string;
+begin
+  Result := '';
+  Path := '/v1/desktop/state';
+  if N >= 1 then Path := Path + '?desktop=' + IntToStr(N);
+  try
+    Result := GetJSON(Path);
+  except
+    Result := '';
+  end;
+  if Trim(Result) = '' then Result := '{}';
 end;
 
 { ---- pages ---- }
@@ -1407,7 +1718,9 @@ begin
     Req.PutStr('query', Query);
     Req.PutStr('kind', PageKindName(Kind));
     try
-      Id := JsonReadStr(Request('POST', '/v1/pages', Req.ToJSON), 'id', '');
+      { The model clock: this call IS a turn. }
+      Id := JsonReadStr(
+        RequestT('POST', '/v1/pages', Req.ToJSON, FModelTimeoutMs), 'id', '');
     except
       Id := '';
     end;
@@ -1470,7 +1783,10 @@ begin
   Root := TJsonObject.Create;
   Sink := TSSEStream.Create(OnChunk);
   Req  := nil;
-  Http := NewHttp(FToken, FTimeoutMs);
+  { A streamed turn carries its own liveness: chunks keep arriving, and a
+    socket that dies still raises. A read timeout here only ever fires on a
+    model that is thinking hard, which is not an error. }
+  Http := NewHttp(FToken, 0);
   try
     Msgs := TJsonArray.Create;
     { A system message leads the array -- the gateway lets a client system

--- a/src/pkg/component/PasClaw.Client.Api.pas
+++ b/src/pkg/component/PasClaw.Client.Api.pas
@@ -130,6 +130,29 @@ type
   TToolTraceProc = procedure(const Kind, Name, Detail: string;
     IsErr: Boolean) of object;
 
+  (* ---- request tracing ----
+
+     Every call this client makes to the gateway, reported as it completes.
+
+     This is the half of the picture the gateway's own log cannot give you.
+     Its log is filtered server-side by log level before anything is
+     recorded, so a client asking for more detail cannot get it; and even at
+     debug it says what the SERVER did, never what a particular window
+     asked for. Tracing here is unconditional, costs a callback, and answers
+     the question a desktop actually raises -- "what did this window just
+     do, and what came back".
+
+     Origin is the context the call was made under (see SetClientContext):
+     which window, which conversation. Without it a busy desktop's traffic
+     is one undifferentiated stream, because a single shared client serves
+     every window.
+
+     Millis is wall time for the whole call. Status is the HTTP status, or 0
+     when the request never got an answer -- in which case Note carries the
+     reason. *)
+  TRequestTraceProc = procedure(const Origin, Method, Path: string;
+    Status, Millis: Integer; const Note: string) of object;
+
   (* ---- period-native output ----
 
      The web desktop renders structured agent output as real UI: a plan
@@ -194,6 +217,9 @@ type
     FTimeoutMs: Integer;
     FModelTimeoutMs: Integer;
     FLastError: string;
+    FOnTrace: TRequestTraceProc;
+    procedure Trace(const Method, Path: string; Status, Millis: Integer;
+      const Note: string);
     function Request(const Method, Path, Body: string): string;
     function RequestT(const Method, Path, Body: string;
       TimeoutMs: Integer): string;
@@ -219,6 +245,10 @@ type
     property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs;
     property ModelTimeoutMs: Integer read FModelTimeoutMs write FModelTimeoutMs;
     property LastError: string read FLastError;
+    (* Set it and every call this client makes is reported. Nothing else
+       turns it on: tracing that needs enabling is tracing you do not have
+       when the thing you wanted to see already happened. *)
+    property OnTrace: TRequestTraceProc read FOnTrace write FOnTrace;
 
     function Ping(out Version: string): Boolean;
 
@@ -378,12 +408,40 @@ type
 procedure ParseUIBlocks(const Reply: string; out VisibleText: string;
   out Blocks: TUIBlocks);
 
+(* ---- the calling context ----
+
+   Names whoever is about to make requests, so a trace can say which window
+   or conversation a call came from. Per THREAD, not per client: one client
+   object serves every window, and the deep-research call runs on its own
+   thread while the main one keeps serving the board -- a single shared
+   field would attribute whichever finished last to whoever set it first.
+
+   Callers set it at the top of an operation and are not required to clear
+   it; the next Set on that thread replaces it. '' means unattributed,
+   which a trace should render rather than hide. *)
+procedure SetClientContext(const Name: string);
+function ClientContext: string;
+
 implementation
 
 uses
   PasClaw.JSON,
   PasClaw.Utils,
+  DateUtils,                 { MilliSecondsBetween -- request timing }
   IdHTTP, IdGlobal, IdSSLOpenSSL, IdComponent;
+
+threadvar
+  GContext: string;
+
+procedure SetClientContext(const Name: string);
+begin
+  GContext := Name;
+end;
+
+function ClientContext: string;
+begin
+  Result := GContext;
+end;
 
 type
   { Indy hands us the body as it arrives; this feeds the caller's callback
@@ -1016,11 +1074,13 @@ var
   Http: TIdHTTP;
   Mem: TMemoryStream;
   Hdr: string;
+  Started: TDateTime;
 begin
   Result := False;
   SetLength(Data, 0);
   Total := 0;
   FLastError := '';
+  Started := Now;
   Http := NewHttp(FToken, FTimeoutMs);
   Mem  := TMemoryStream.Create;
   try
@@ -1033,9 +1093,13 @@ begin
       on E: Exception do
       begin
         FLastError := E.Message;
+        Trace('GET', '/v1/fs/peek', 0,
+              MilliSecondsBetween(Now, Started), E.Message);
         Exit;
       end;
     end;
+    Trace('GET', '/v1/fs/peek', Http.ResponseCode,
+          MilliSecondsBetween(Now, Started), Path);
     Hdr := Http.Response.RawHeaders.Values['X-File-Total'];
     Total := StrToInt64Def(Trim(Hdr), Mem.Size);
     SetLength(Data, Mem.Size);
@@ -1082,6 +1146,17 @@ begin
   Result := RequestT(Method, Path, Body, FTimeoutMs);
 end;
 
+procedure TPasClawClient.Trace(const Method, Path: string;
+  Status, Millis: Integer; const Note: string);
+begin
+  if not Assigned(FOnTrace) then Exit;
+  try
+    FOnTrace(ClientContext, Method, Path, Status, Millis, Note);
+  except
+    { A trace listener must never be able to fail the call it is watching. }
+  end;
+end;
+
 function TPasClawClient.RequestT(const Method, Path, Body: string;
   TimeoutMs: Integer): string;
 var
@@ -1089,9 +1164,12 @@ var
   Req: TStringStream;
   Resp: TStringStream;
   E2: EPasClawClient;
+  Started: TDateTime;
+  Ms: Integer;
 begin
   Result := '';
   FLastError := '';
+  Started := Now;
   Http := NewHttp(FToken, TimeoutMs);
   Req  := nil;
   Resp := TStringStream.Create('');
@@ -1112,12 +1190,18 @@ begin
       else
         raise EPasClawClient.Create('unsupported method ' + Method);
       Result := Resp.DataString;
+      Trace(Method, Path, Http.ResponseCode,
+            MilliSecondsBetween(Now, Started), '');
     except
       on E: EIdHTTPProtocolException do
       begin
         { The gateway's error bodies are JSON with an "error" field; surface
           that rather than Indy's generic status text. }
         FLastError := JsonReadStr(E.ErrorMessage, 'error', E.Message);
+        { Traced before the raise: a failed call is the one most worth
+          seeing, and the caller may swallow this exception. }
+        Trace(Method, Path, E.ErrorCode,
+              MilliSecondsBetween(Now, Started), FLastError);
         E2 := EPasClawClient.Create(FLastError);
         E2.Status := E.ErrorCode;
         E2.Body   := E.ErrorMessage;
@@ -1126,6 +1210,7 @@ begin
       on E: Exception do
       begin
         FLastError := E.Message;
+        Trace(Method, Path, 0, MilliSecondsBetween(Now, Started), E.Message);
         E2 := EPasClawClient.Create(E.Message);
         E2.Status := 0;
         raise E2;
@@ -1874,6 +1959,8 @@ end;
 function TPasClawClient.Chat(const HistoryJSON, System_: string;
   OnChunk: TChatChunkProc; OnTool: TToolTraceProc): string;
 var
+  Started: TDateTime;
+  Code: Integer;
   Http: TIdHTTP;
   Req: TStringStream;
   Sink: TSSEStream;
@@ -1889,6 +1976,7 @@ begin
   Root := TJsonObject.Create;
   Sink := TSSEStream.Create(OnChunk, OnTool);
   Req  := nil;
+  Started := Now;
   { A streamed turn carries its own liveness: chunks keep arriving, and a
     socket that dies still raises. A read timeout here only ever fires on a
     model that is thinking hard, which is not an error. }
@@ -1942,6 +2030,12 @@ begin
         FLastError := E.Message;
     end;
     Result := Sink.Text;
+    { One line for the whole turn. Chunks are the interesting part while it
+      runs and the chat window already shows them; the trace records what
+      the call was and how long it took. }
+    if FLastError = '' then Code := 200 else Code := 0;
+    Trace('POST', '/v1/chat/completions', Code,
+          MilliSecondsBetween(Now, Started), FLastError);
   finally
     Http.Free;
     Req.Free;

--- a/src/pkg/component/PasClaw.Client.Api.pas
+++ b/src/pkg/component/PasClaw.Client.Api.pas
@@ -117,6 +117,19 @@ type
   { Called for each streamed chunk of an assistant reply. Set Abort to stop. }
   TChatChunkProc = procedure(const Chunk: string; var Abort: Boolean) of object;
 
+  (* Called as the model uses a tool, if the caller wants to watch.
+
+     The gateway already narrates tool use as SSE comments beside the text
+     stream; without somewhere to send them a client shows prose only, so
+     "build me an app" looks like a long silence followed by an answer, with
+     no sign of the dozen file writes that actually did the work.
+
+     Kind is 'call' or 'result'. For a call, Detail is the (capped) argument
+     summary; for a result it is the result text, or the error when Err is
+     True. *)
+  TToolTraceProc = procedure(const Kind, Name, Detail: string;
+    IsErr: Boolean) of object;
+
   (* ---- period-native output ----
 
      The web desktop renders structured agent output as real UI: a plan
@@ -314,7 +327,12 @@ type
        leading system message. OnChunk receives assistant text as it arrives.
        Returns the full reply. *)
     function Chat(const HistoryJSON, System_: string;
-      OnChunk: TChatChunkProc): string;
+      OnChunk: TChatChunkProc): string; overload;
+    (* The same turn, with the model's tool use narrated. Separate overload
+       rather than a nil-able extra parameter on the one above so existing
+       callers are untouched. *)
+    function Chat(const HistoryJSON, System_: string;
+      OnChunk: TChatChunkProc; OnTool: TToolTraceProc): string; overload;
 
     (* Subscribe to /v1/desktop/events and pump until the callback stops it or
        the connection drops. BLOCKS -- run it on its own thread. The FMX
@@ -327,6 +345,12 @@ type
        answer "what did I look up"; these answer "what did I talk about",
        and the Library window wants both. *)
     function Sessions: TSessionRows;
+    (* One session's messages, as the JSON array a chat window seeds its
+       history from -- the same [{role,content}] shape Chat sends back, so
+       reopening a conversation is loading it, not re-deriving it. Empty
+       array when the session is gone or unreadable: an unopenable session
+       should give you a blank window, not an exception. *)
+    function SessionHistory(const Id: string): string;
 
     { ---- logs ---- }
     (* Subscribe to /v1/logs. Same shape as WatchEvents -- BLOCKS, so run it
@@ -369,10 +393,13 @@ type
     FBuf: string;
     FText: string;
     FOnChunk: TChatChunkProc;
+    FOnTool: TToolTraceProc;
     FAbort: Boolean;
     procedure Consume(const Data: string);
+    procedure HandleToolComment(const Payload: string);
   public
-    constructor Create(AOnChunk: TChatChunkProc);
+    constructor Create(AOnChunk: TChatChunkProc;
+      AOnTool: TToolTraceProc = nil);
     function Write(const Buffer; Count: Longint): Longint; override;
     function Read(var Buffer; Count: Longint): Longint; override;
     function Seek(Offset: Longint; Origin: Word): Longint; override;
@@ -380,10 +407,51 @@ type
     property Aborted: Boolean read FAbort;
   end;
 
-constructor TSSEStream.Create(AOnChunk: TChatChunkProc);
+constructor TSSEStream.Create(AOnChunk: TChatChunkProc;
+  AOnTool: TToolTraceProc);
 begin
   inherited Create;
   FOnChunk := AOnChunk;
+  FOnTool := AOnTool;
+end;
+
+(* One ": pasclaw-tool {...}" comment off the chat stream.
+
+   These ride the SSE channel as comments precisely so a client that does
+   not care keeps working: an OpenAI-compatible consumer skips them without
+   knowing they exist. A client that DOES care gets the model's working
+   shown. *)
+procedure TSSEStream.HandleToolComment(const Payload: string);
+var
+  Obj: TJsonObject;
+  Kind, Name, Detail: string;
+  IsErr: Boolean;
+begin
+  if not Assigned(FOnTool) then Exit;
+  try
+    Obj := TJsonObject.Parse(Payload);
+  except
+    Exit;
+  end;
+  if Obj = nil then Exit;
+  try
+    Kind := Obj.GetStr('t', '');
+    Name := Obj.GetStr('name', '');
+    if Kind = 'call' then
+    begin
+      Detail := Obj.GetStr('args', '');
+      IsErr := False;
+    end
+    else
+    begin
+      Detail := Obj.GetStr('err', '');
+      IsErr := Detail <> '';
+      if not IsErr then Detail := Obj.GetStr('result', '');
+    end;
+    if Name <> '' then FOnTool(Kind, Name, Detail, IsErr);
+  finally
+    Obj.Free;
+  end;
 end;
 
 function TSSEStream.Read(var Buffer; Count: Longint): Longint;
@@ -410,10 +478,18 @@ begin
     Line := Copy(FBuf, 1, NL - 1);
     Delete(FBuf, 1, NL);
     Line := StringReplace(Line, #13, '', [rfReplaceAll]);
-    (* The gateway's ": pasclaw-tool ..." SSE comments carry tool detail the
-       desktop surfaces elsewhere; the text stream ignores them. Paren-star
-       delimiters because a brace in the example would close the comment. *)
-    if (Line = '') or (Line[1] = ':') then Continue;
+    (* The gateway's ": pasclaw-tool ..." SSE comments carry tool detail.
+       Routed to the trace callback when a caller wants it, skipped
+       otherwise -- which is what keeps a plain OpenAI client working
+       against this stream. Paren-star delimiters because a brace in the
+       example would close the comment. *)
+    if Line = '' then Continue;
+    if Line[1] = ':' then
+    begin
+      if HasPrefix(Line, ': pasclaw-tool ') then
+        HandleToolComment(Trim(Copy(Line, 16, MaxInt)));
+      Continue;
+    end;
     if not HasPrefix(Line, 'data:') then Continue;
     Payload := Trim(Copy(Line, 6, MaxInt));
     if (Payload = '') or (Payload = '[DONE]') then Continue;
@@ -905,6 +981,30 @@ begin
       if Result[N].Id <> '' then Inc(N);
     end;
     SetLength(Result, N);
+  finally
+    Root.Free;
+  end;
+end;
+
+function TPasClawClient.SessionHistory(const Id: string): string;
+var
+  Body: string;
+  Root: TJsonObject;
+  Arr: TJsonArray;
+begin
+  Result := '[]';
+  if Trim(Id) = '' then Exit;
+  Body := GetJSON('/v1/sessions/' + UrlEncode_(Id));
+  if Trim(Body) = '' then Exit;
+  try
+    Root := TJsonObject.Parse(Body);
+  except
+    Exit;
+  end;
+  if Root = nil then Exit;
+  try
+    Arr := Root.ChildArray('messages');
+    if Arr <> nil then Result := Arr.ToJSON;
   finally
     Root.Free;
   end;
@@ -1767,6 +1867,12 @@ end;
 
 function TPasClawClient.Chat(const HistoryJSON, System_: string;
   OnChunk: TChatChunkProc): string;
+begin
+  Result := Chat(HistoryJSON, System_, OnChunk, nil);
+end;
+
+function TPasClawClient.Chat(const HistoryJSON, System_: string;
+  OnChunk: TChatChunkProc; OnTool: TToolTraceProc): string;
 var
   Http: TIdHTTP;
   Req: TStringStream;
@@ -1781,7 +1887,7 @@ begin
   FLastError := '';
 
   Root := TJsonObject.Create;
-  Sink := TSSEStream.Create(OnChunk);
+  Sink := TSSEStream.Create(OnChunk, OnTool);
   Req  := nil;
   { A streamed turn carries its own liveness: chunks keep arriving, and a
     socket that dies still raises. A read timeout here only ever fires on a

--- a/src/pkg/component/PasClaw.Client.Api.pas
+++ b/src/pkg/component/PasClaw.Client.Api.pas
@@ -23,7 +23,7 @@ unit PasClaw.Client.Api;
 interface
 
 uses
-  SysUtils, Classes;
+  SysUtils, Classes, SyncObjs;
 
 type
   EPasClawClient = class(Exception)
@@ -218,6 +218,19 @@ type
     FModelTimeoutMs: Integer;
     FLastError: string;
     FOnTrace: TRequestTraceProc;
+    (* The live /v1/logs connection, so it can be cut from another thread.
+
+       /v1/logs parks until something is logged and sends no keepalive
+       (unlike /v1/desktop/events). With no read timeout -- correct for a
+       tail -- a quiet gateway leaves the watcher blocked inside Indy with
+       nothing to wake it, so a flag the callback checks is never reached
+       and joining that thread hangs the UI for as long as the gateway
+       stays quiet. Cancellation has to reach the SOCKET. *)
+    { TIdHTTP, held as TObject: this unit keeps the transport out of its
+      interface deliberately, and a cancel only needs to call Disconnect. }
+    FLogHttp: TObject;
+    FLogLock: TCriticalSection;
+    FLogCancelled: Boolean;
     procedure Trace(const Method, Path: string; Status, Millis: Integer;
       const Note: string);
     function Request(const Method, Path, Body: string): string;
@@ -226,6 +239,7 @@ type
     function GetJSON(const Path: string): string;
   public
     constructor Create(const ABaseURL: string = 'http://127.0.0.1:8088');
+    destructor Destroy; override;
     { Base URL without a trailing slash; setting it normalises. }
     property BaseURL: string read FBaseURL write FBaseURL;
     property Token: string read FToken write FToken;
@@ -381,6 +395,20 @@ type
        array when the session is gone or unreadable: an unopenable session
        should give you a blank window, not an exception. *)
     function SessionHistory(const Id: string): string;
+    (* Write a conversation back.
+
+       Chat completions is stateless: a reopened session continues only in
+       whatever the client holds in memory, so without this the follow-up
+       turns are lost the moment the window closes -- the session looks
+       resumed and then silently isn't.
+
+       Conflict comes back True when the gateway REFUSES the write because
+       the session holds a rich agent transcript (tool and system turns).
+       That refusal is deliberate -- flattening it to role/content would
+       destroy the structure terminal resume needs -- so a caller should
+       report it rather than retry. *)
+    function SaveSessionHistory(const Id, MessagesJSON, Title: string;
+      out Conflict: Boolean): Boolean;
 
     { ---- logs ---- }
     (* Subscribe to /v1/logs. Same shape as WatchEvents -- BLOCKS, so run it
@@ -393,6 +421,9 @@ type
        cannot be recovered here. Debug output needs gateway.log_level set to
        "debug" on the server. *)
     procedure WatchLogs(OnLine: TLogLineProc);
+    (* Cut the log subscription now, from any thread. Safe to call when
+       none is running. Call this BEFORE joining the watcher thread. *)
+    procedure CancelLogs;
 
     { ---- raw bytes ---- }
     (* A bounded window of a file's bytes, for the hex viewer: a binary file
@@ -855,6 +886,7 @@ begin
   FBaseURL := ABaseURL;
   while (FBaseURL <> '') and (FBaseURL[Length(FBaseURL)] = '/') do
     SetLength(FBaseURL, Length(FBaseURL) - 1);
+  FLogLock := TCriticalSection.Create;
   FTimeoutMs := 30000;
   FModelTimeoutMs := 20 * 60 * 1000;   { deep research runs for minutes }
 end;
@@ -880,6 +912,13 @@ end;
    separate and never infinite: a gateway that is not listening should fail
    in seconds, whatever the body clock says, or the UI hangs on a typo in
    the address. *)
+destructor TPasClawClient.Destroy;
+begin
+  CancelLogs;
+  FreeAndNil(FLogLock);
+  inherited;
+end;
+
 function NewHttp(const Token: string; ReadTimeoutMs: Integer;
   ConnectTimeoutMs: Integer = 15000): TIdHTTP;
 begin
@@ -988,20 +1027,60 @@ var
 begin
   FLastError := '';
   Sink := TLogStream.Create(OnLine);
+  { A previous cancel must not silence errors on this one. }
+  FLogCancelled := False;
   Http := NewHttp(FToken, 0);
   try
     { Same deal as WatchEvents: an open, mostly-idle connection. }
     Http.ReadTimeout := 0;
     Http.Request.Accept := 'text/event-stream';
+    { Publish the handle so CancelLogs can reach it while we block below. }
+    FLogLock.Acquire;
+    try
+      FLogHttp := Http;
+    finally
+      FLogLock.Release;
+    end;
     try
       Http.Get(FBaseURL + '/v1/logs', Sink);
     except
       on E: EAbort do ;      { caller asked to stop }
-      on E: Exception do FLastError := E.Message;
+      { A cancel arrives here as a socket error, which is the intended
+        outcome and not worth recording as a failure. }
+      on E: Exception do
+        if not FLogCancelled then FLastError := E.Message;
     end;
   finally
+    FLogLock.Acquire;
+    try
+      FLogHttp := nil;
+    finally
+      FLogLock.Release;
+    end;
     Http.Free;
     Sink.Free;
+  end;
+end;
+
+procedure TPasClawClient.CancelLogs;
+var
+  H: TObject;
+begin
+  if FLogLock = nil then Exit;
+  FLogCancelled := True;
+  FLogLock.Acquire;
+  try
+    H := FLogHttp;
+  finally
+    FLogLock.Release;
+  end;
+  if H = nil then Exit;
+  { Disconnecting from another thread is how Indy cancels a blocked read:
+    the reader surfaces a socket error and unwinds. Swallowed because a
+    race with normal completion is a no-op, not a problem. }
+  try
+    TIdHTTP(H).Disconnect(False);
+  except
   end;
 end;
 
@@ -1065,6 +1144,29 @@ begin
     if Arr <> nil then Result := Arr.ToJSON;
   finally
     Root.Free;
+  end;
+end;
+
+function TPasClawClient.SaveSessionHistory(const Id, MessagesJSON,
+  Title: string; out Conflict: Boolean): Boolean;
+var
+  Body: string;
+begin
+  Result := False;
+  Conflict := False;
+  if Trim(Id) = '' then Exit;
+  Body := '{"messages":' + MessagesJSON;
+  if Trim(Title) <> '' then
+    Body := Body + ',"title":"' + JsonEscape(Title) + '"';
+  Body := Body + '}';
+  try
+    Request('PUT', '/v1/sessions/' + UrlEncode_(Id), Body);
+    Result := True;
+  except
+    on E: EPasClawClient do
+      Conflict := E.Status = 409;
+    on E: Exception do
+      ;
   end;
 end;
 

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -4550,6 +4550,7 @@ var
   Tag, Body, Line: string;
   TerminatorTmp: TBytes;
   TerminatorIdBytes: TIdBytes;
+  Idle: Integer;
 begin
   { SSE stream -- emit the recent buffer up front, then subscribe
     for live tail. The handler doesn't return until the client
@@ -4589,11 +4590,28 @@ begin
 
   Token := SubscribeLog(Writer.OnLog);
   try
-    { Park here until the client disconnects. WaitFor on the stop
-      event lets a server-side shutdown wake us cleanly too. }
+    (* Park here until the client disconnects. WaitFor on the stop
+       event lets a server-side shutdown wake us cleanly too.
+
+       A keepalive comment every ~15s, matching /v1/desktop/events. A log
+       stream can be silent for a long time, and a silent socket is
+       indistinguishable from a dead one: without this, an idle proxy is
+       free to drop the connection and a client waiting on a byte that
+       never comes has nothing to time out against. *)
+    Idle := 0;
     while AContext.Connection.Connected do
     begin
       if FStopFlag.WaitFor(1000) = wrSignaled then Break;
+      Inc(Idle);
+      if Idle >= 15 then
+      begin
+        Idle := 0;
+        try
+          Writer.WriteSSE(': keepalive'#10#10);
+        except
+          Break;    { the client is gone; stop pretending otherwise }
+        end;
+      end;
     end;
   finally
     UnsubscribeLog(Token);

--- a/src/tests/client_api_tests.pas
+++ b/src/tests/client_api_tests.pas
@@ -59,6 +59,10 @@ var
   Run: TRunRow;
   PageId: string;
   PG: TPageRows;
+  Cur, Cnt: Integer;
+  Sess: TSessionRows;
+  Raw: TBytes;
+  Total: Int64;
 begin
   { ---- UI block parsing: pure string work, so it runs with no gateway ---- }
   { The happy path: prose around a wizard block. }
@@ -210,6 +214,42 @@ begin
     ExpectTrue(not C.SetDesktopState('{"v":1,'), 'malformed state is refused');
     ExpectTrue(Pos('library', C.DesktopState) > 0,
                'and the good state survives the bad write');
+
+    (* Naming the desktop. Paging desks is "save here, switch there", and
+       "here" stops being current the moment the switch lands -- a save that
+       says only "current" can therefore write the wrong layout onto the
+       wrong desk and lose the arrangement. These four assertions are the
+       whole reason the addressed form exists. *)
+    ExpectTrue(C.Desktops(Cur, Cnt), 'the pager reports itself');
+    ExpectTrue((Cur = 1) and (Cnt >= 1), 'starting on desktop 1');
+    ExpectTrue(C.SetDesktopStateFor(1, '{"v":1,"windows":[{"fn":"files"}]}'),
+               'desktop 1 saves by number');
+    ExpectTrue(C.SwitchDesktop(2, Cur, Cnt), 'switch to desktop 2');
+    ExpectTrue(Cur = 2, 'the switch reports where it landed');
+    { The bug this guards: writing "the current layout" AFTER the switch. }
+    ExpectTrue(C.SetDesktopStateFor(1, '{"v":1,"windows":[{"fn":"library"}]}'),
+               'desktop 1 is still addressable from desktop 2');
+    ExpectTrue(Pos('files', C.DesktopState) = 0,
+               'and desktop 2 did not inherit desktop 1''s windows');
+    ExpectTrue(Pos('library', C.DesktopStateFor(1)) > 0,
+               'desktop 1 kept what was written to it by number');
+    ExpectTrue(C.SwitchDesktop(1, Cur, Cnt), 'switch back');
+    ExpectTrue(Pos('library', C.DesktopState) > 0,
+               'and the arrangement is there on return');
+
+    { ------------------------------------------------------- sessions -- }
+    { Empty is a fine answer on a fresh home; the contract is that it
+      returns a list rather than throwing. }
+    Sess := C.Sessions;
+    ExpectTrue(Length(Sess) >= 0, 'sessions list');
+
+    { ----------------------------------------------------- raw bytes --- }
+    (* The hex viewer's feed. A text file is bytes too, so this is testable
+      without inventing a binary one. *)
+    ExpectTrue(C.PeekFile(Dir.WorkspaceRoot + '/PLAN.md', 0, 16,
+                          Raw, Total) or (C.LastError <> ''),
+               'peek either returns bytes or says why not');
+    ExpectTrue(C.SetDesktopState('{"v":1,"windows":[]}'), 'state resets');
 
     { ------------------------------------------------ pages + promote -- }
     ExpectTrue(C.CreatePageOfKind('client api page', pkeReport, PageId) or

--- a/src/tests/client_api_tests.pas
+++ b/src/tests/client_api_tests.pas
@@ -21,6 +21,30 @@ uses
 
 var Failures: Integer = 0;
 
+type
+  { Catches OnTrace so the assertions can look at what was reported. A class
+    because the callback is a method pointer. }
+  TTracer = class
+  public
+    Count: Integer;
+    LastOrigin, LastMethod, LastPath, LastNote: string;
+    LastStatus, LastMillis: Integer;
+    procedure Note(const Origin, Method, Path: string;
+      Status, Millis: Integer; const ANote: string);
+  end;
+
+procedure TTracer.Note(const Origin, Method, Path: string;
+  Status, Millis: Integer; const ANote: string);
+begin
+  Inc(Count);
+  LastOrigin := Origin;
+  LastMethod := Method;
+  LastPath   := Path;
+  LastStatus := Status;
+  LastMillis := Millis;
+  LastNote   := ANote;
+end;
+
 procedure Fail_(const Msg: string);
 begin
   WriteLn('FAIL: ' + Msg);
@@ -63,6 +87,7 @@ var
   Sess: TSessionRows;
   Raw: TBytes;
   Total: Int64;
+  Tracer: TTracer;
 begin
   { ---- UI block parsing: pure string work, so it runs with no gateway ---- }
   { The happy path: prose around a wizard block. }
@@ -236,6 +261,40 @@ begin
     ExpectTrue(C.SwitchDesktop(1, Cur, Cnt), 'switch back');
     ExpectTrue(Pos('library', C.DesktopState) > 0,
                'and the arrangement is there on return');
+
+    { -------------------------------------------------- request trace -- }
+    (* The Log window's client-side half. This is the part the gateway's own
+       log cannot supply: what a given WINDOW asked for, whatever the
+       server's log level is set to. *)
+    Tracer := TTracer.Create;
+    try
+      C.OnTrace := Tracer.Note;
+      SetClientContext('Library');
+      C.Projects;
+      ExpectTrue(Tracer.Count = 1, 'a call is traced exactly once');
+      ExpectStr(Tracer.LastOrigin, 'Library',
+                'and carries the context it was made under');
+      ExpectStr(Tracer.LastMethod, 'GET', 'with its method');
+      ExpectTrue(Pos('/v1/projects', Tracer.LastPath) = 1, 'and its path');
+      ExpectInt(Tracer.LastStatus, 200, 'and the status it got back');
+
+      { A failure is the case most worth seeing, so it must trace too --
+        even though the call raises and the caller may swallow it. }
+      SetClientContext('Files');
+      try
+        C.Project('no-such-project-here', P);
+      except
+        { expected }
+      end;
+      ExpectTrue(Tracer.Count = 2, 'a failed call is traced as well');
+      ExpectStr(Tracer.LastOrigin, 'Files', 'under its own context');
+      ExpectTrue(Tracer.LastStatus <> 200, 'and does not claim success');
+
+      SetClientContext('');
+      C.OnTrace := nil;
+    finally
+      Tracer.Free;
+    end;
 
     { ------------------------------------------------------- sessions -- }
     { Empty is a fine answer on a fresh home; the contract is that it


### PR DESCRIPTION
Everything from the feedback round, plus the switching-desks bug reported partway through.

## Switching desks lost every open window

The regression, and the reason it was not obvious: save-then-switch is two calls, and *the current desktop* changes between them. Closing the old desktop's windows marks the layout dirty; the autosave fires after the switch has landed and writes an empty layout — to the desk just arrived at, over the arrangement just left.

Fixed by writing the layout to a **named** desktop rather than "current", which retires the ordering question instead of trying to sequence around it. `SetDesktopStateFor` / `DesktopStateFor` on the client library carry the number; the route already accepted `?desktop=N`, so nothing on the server changed. Pinned by four assertions in `client_api_tests` that save to desktop 1 *from* desktop 2 and check both desks afterwards.

Two more things that counted as "losing my windows":

- **Geometry is saved now.** Reopening the right windows in the wrong places is still losing your desktop.
- **`CloseAllWindows`** replaces three hand-maintained lists of fields-to-nil. Miss one and it is a dangling pointer the next restore walks into — a bug waiting for the next window kind.

Run windows, the Projects window and the Log window join the restorable set.

## The Menu

It was a button that opened Display Properties. It is a menu now:

```
Chat · Browser · Files · Library · Log
Projects · New Project...
<every project, with its app indented underneath — click to launch>
Switch Workspace... · New Workspace... · Display Properties
```

The project list is the answer to *"I built three apps and I don't see them anywhere"* — Notes, Calendar and the rest are ordinary projects with ordinary apps, and the Menu reaches them without you having to know that. Rebuilt on every open, because a menu showing yesterday's projects is worse than no menu.

Built as a `TRetroWindow`, not a native `TPopupMenu`: a native one arrives in the host OS's chrome, which on a shell whose whole point is wearing a 1995 face is the one wrong-looking thing on screen.

## The project tree is a window

It was a `TLayout` pinned to the left edge with no chrome, sitting on top of the desktop icons that name the same projects — two lists of one thing, one of them unmovable. Now a window opened from the Menu, with the status line inside it. First run still opens it, so an empty desktop isn't a dead end.

## The rest

- **Files opens by what the thing is.** `.html` renders in the Browser (the desktop has a browser; showing HTML source in a memo was it refusing to do the obvious thing). A binary opens a **paged hex view** over `/v1/fs/peek` — a window of bytes at a time, so a 500 MB file costs a window, not a download. The classic web UI has had a hex dump over that same route all along.
- **Library** lists sessions beside pages — pages are what you looked up, sessions are what you talked about — and double-click opens either: a page in the Browser, a session as a chat with its history loaded.
- **Log window** tails `/v1/logs` live.
- **Chat shows tool use inline.** The gateway already narrates it as `: pasclaw-tool` SSE comments; the client was explicitly discarding them, which is why building an app looked like a long silence and then a sentence.
- **Menu → Chat** opens a project-less conversation — no builder prompt, since telling the model to deliver an app when there is no project to put one in just produces files in a guessed directory.
- **Timeouts.** One 30-second clock covered calls that go through the model, which is why the Browser gave up mid-answer. Model calls get their own budget (20 min), streamed turns set no read timeout at all (arriving chunks are the liveness signal), and connect timeout stays short and separate so a wrong address still fails in seconds.

## On the debug-log question

> is there an option to show debug logs on the front end? I have `--debug` on the back but `/v1/logs` has never shown that full detail

No, and there can't be one: `Emit` drops anything below the process log level **before** the ring buffer, so a debug line the gateway never recorded cannot be recovered by asking differently from a client. It is `gateway.log_level` in `config.json` (or the `log_level` under `gateway`), and it must be set on the **gateway process** — `--debug` on another command doesn't reach it. The Log window says this in its header rather than offering a level control that appears to do something and doesn't.

## Verification

`make all`, the full suite, and `lint-pascal-shape` are green; `client_api_tests` runs the new client surface against a live gateway.

The FMX unit still has no compiler in CI, so beyond the shape lint I checked it structurally: **111 implementations, no duplicates, nothing used before it is declared, nothing implemented without a declaration, and every `OnClick` assigned to a method that exists.** Expect a round of ordinary Delphi errors; send them over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_