### PR TITLE
Answer pages run on a fast model; Research opens a conversation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,6 +447,11 @@ test-desktop-routes: | $(BUILDDIR)
 # client -- files, pages, promote, desktop state, the run surface -- was
 # never exercised. So this target STARTS one, on a port unlikely to clash,
 # against a throwaway home, and stops it again.
+test-client-markdown: | $(BUILDDIR)
+	@mkdir -p $(BUILDDIR)/lib
+	$(FPC) $(FPCFLAGS) src/tests/client_markdown_tests.pas -o$(BUILDDIR)/client_markdown_tests
+	@$(BUILDDIR)/client_markdown_tests
+
 test-client-api: $(BIN) | $(BUILDDIR)
 	@mkdir -p $(BUILDDIR)/lib
 	$(FPC) $(FPCFLAGS) src/tests/client_api_tests.pas -o$(BUILDDIR)/client_api_tests
@@ -461,7 +466,7 @@ test-client-api: $(BIN) | $(BUILDDIR)
 		rm -f $(BUILDDIR)/client-api.pid; exit $$rc
 
 # Everything the desktop client depends on, in dependency order.
-test-desktop: lint-pascal-shape test-workspaces test-projects test-apps test-mail test-workspace-isolation test-desktop-routes test-client-api
+test-desktop: lint-pascal-shape test-workspaces test-projects test-apps test-mail test-workspace-isolation test-desktop-routes test-client-markdown test-client-api
 
 # Provider catalog rows + ChatPath override (Perplexity uses /chat/completions).
 test-provider-catalog: | $(BUILDDIR)

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -101,7 +101,8 @@ Environment:
   workspace, not to the client — the arrangement is saved against the
   desktop you are leaving and comes back when you return, geometry
   included.
-- **Chat window** — per project, streaming, with the model's tool use shown
+- **Chat window** — per project, streaming, **rendering markdown** (headings,
+  lists, code blocks, links) and with the model's tool use shown
   inline as it works: asking for an app should not look like a long silence
   followed by a sentence. It sends the builder-mode system prompt, so the
   agent's deliverable is an app rather than an essay. **Chat** on the Menu
@@ -115,10 +116,14 @@ Environment:
   rather than documents. It shows the exact command *before* asking, names
   which of the three places it will run in (this host, a container, a remote
   Docker host), and tails the output live.
-- **Browser** — a question in, a page out. **Search** is one pass;
-  **Research** is the three-phase deep mode, which runs for minutes and
-  narrates what it is doing in a progress dialog. **Make interactive**
-  promotes the page you are looking at into an app you own.
+- **Browser** — a question in, a page out, in **tabs**. Asking again with a
+  page open *revises that page*; **New** opens an empty tab where a question
+  starts a fresh one. **Search** is one pass and runs on the fast model.
+  **Research** is the deep mode — it plans, reads several sources and
+  synthesises — and opens a **chat window** rather than a progress box: it
+  runs for minutes, narrates as it goes, and a follow-up there continues the
+  report instead of starting over. **Make interactive** promotes the page
+  you are looking at into an app you own.
 - **File Manager** — the workspace directory, over `/v1/fs`. Read-only: that
   surface is already sandbox-checked and filters secret-bearing files, and a
   browse window is not the place to invent a delete button. Opening a file

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -174,6 +174,11 @@ type
       hang. }
     FProgressText: TLabel;
     FProgressLine: string;
+    { The research conversation, and the report it last produced. }
+    FResearchKey: string;
+    FResearchPage: string;
+    FResearchRunning: Boolean;
+    FResearchLastLine: string;
 
     { ---- process apps ----
       One Run window per project, same rule as chat and app windows. }
@@ -316,6 +321,7 @@ type
     function NewBrowserTab(const Caption: string): Integer;
     procedure BrowserSearchClick(Sender: TObject);
     procedure BrowserDeepClick(Sender: TObject);
+    procedure StartResearch(const Query, RevisePageId: string);
     procedure BrowserPromoteClick(Sender: TObject);
     procedure RunPageQuery(Kind: TPageKindSel);
     procedure ShowPage(const PageId: string);
@@ -409,6 +415,9 @@ const
   { A conversation reopened from the Library, filed under its session id.
     Same reserved-colon rule as above. }
   SessionChatPrefix = ':session:';
+  { The research conversation. Reserved-colon like the others, so it can
+    never collide with a project slug. }
+  ResearchChatKey = ':research';
   { One menu row: tall enough to hit with a mouse, short enough that the
     whole launcher fits without scrolling on an ordinary board. }
   MenuRowHeight = 22;
@@ -1857,6 +1866,8 @@ begin
 end;
 
 procedure TFormMain.ApplyPendingEvents;
+var
+  ResLog: TMemo;
 begin
   if FLayoutDirty then
   begin
@@ -1870,6 +1881,20 @@ begin
   { Main thread: safe to paint. }
   if (FProgressText <> nil) and (FProgressText.Text <> FProgressLine) then
     FProgressText.Text := FProgressLine;
+
+  (* The same narration, into the research conversation. Research runs for
+     minutes; a window that said nothing for that long would be
+     indistinguishable from a hang, which is the reason the progress feed
+     exists at all. *)
+  if FResearchRunning and (FProgressLine <> FResearchLastLine) then
+  begin
+    FResearchLastLine := FProgressLine;
+    if FChatLogs.TryGetValue(FResearchKey, ResLog) and (ResLog <> nil) then
+    begin
+      ResLog.Lines.Add(FProgressLine);
+      ResLog.GoToTextEnd;
+    end;
+  end;
   if not FEventDirty then Exit;
   FEventDirty := False;
   { Coarse on purpose: the board is small and re-reading it is cheap, so a
@@ -2137,7 +2162,9 @@ begin
     Exit;
   end;
 
-  if Project = PlainChatKey then
+  if Project = ResearchChatKey then
+    Title := 'Research'
+  else if Project = PlainChatKey then
     Title := 'PasClaw'
   else if Copy(Project, 1, Length(SessionChatPrefix)) = SessionChatPrefix then
     Title := 'Session ' + Copy(Project, Length(SessionChatPrefix) + 1, MaxInt)
@@ -2511,6 +2538,22 @@ begin
   Text := Trim(Input.Text);
   if Text = '' then Exit;
   Input.Text := '';
+
+  (* In the research window, a follow-up is more research -- and it revises
+     the report already on screen, which is what "ask another question here"
+     promised. Sending it to the chat endpoint instead would answer in prose
+     and quietly abandon the document. *)
+  if Project = ResearchChatKey then
+  begin
+    if FResearchRunning then
+    begin
+      AppendTurn(Project, 'toolerr', 'still working -- one at a time');
+      RenderTranscript(Project);
+      Exit;
+    end;
+    StartResearch(Text, FResearchPage);
+    Exit;
+  end;
 
   { The turn joins the transcript; the memo is only the live view of the
     reply being streamed, so it starts empty each time. }
@@ -3771,9 +3814,91 @@ begin
   RunPageQuery(pkeSearch);
 end;
 
+(* Research opens a CONVERSATION, not a progress box.
+
+   Search is "question in, page out" -- seconds, one shot, and the little
+   dialog suits it. Research is the other thing entirely: it plans, reads
+   several sources and synthesises, running for minutes and narrating as it
+   goes. That is a conversation with a long first turn, and a modal box that
+   disappears when it finishes throws away the narration along with any
+   ability to ask a follow-up.
+
+   So the report lands in a chat window: the plan and each step arrive as
+   they happen, the finished page arrives as a line you can click, and the
+   next question continues from there rather than starting over. *)
 procedure TFormMain.BrowserDeepClick(Sender: TObject);
+var
+  Query: string;
 begin
-  RunPageQuery(pkeResearch);
+  if FBrowserQuery = nil then Exit;
+  Query := Trim(FBrowserQuery.Text);
+  if Query = '' then Exit;
+  FBrowserQuery.Text := '';
+  StartResearch(Query, FCurrentPage);
+end;
+
+procedure TFormMain.StartResearch(const Query, RevisePageId: string);
+var
+  Log: TMemo;
+begin
+  FResearchKey := ResearchChatKey;
+  OpenChat(FResearchKey);
+  AppendTurn(FResearchKey, 'user', Query);
+  if RevisePageId <> '' then
+    AppendTurn(FResearchKey, 'tool',
+      'revising the open page rather than starting a new one')
+  else
+    AppendTurn(FResearchKey, 'tool', 'planning');
+  RenderTranscript(FResearchKey);
+
+  { The live view carries the narration while the turn runs. }
+  if FChatLogs.TryGetValue(FResearchKey, Log) and (Log <> nil) then
+  begin
+    Log.Text := '';
+    Log.Lines.Add('> ' + Query);
+    Log.Lines.Add('');
+  end;
+  ShowStreaming(FResearchKey, True);
+  FResearchRunning := True;
+  FProgressLine := 'Planning...';
+
+  TThread.CreateAnonymousThread(
+    procedure
+    var
+      Id, Err: string;
+      Ok: Boolean;
+      Done_: TThreadProcedure;
+    begin
+      SetClientContext('Research');
+      Ok := False;
+      Err := '';
+      try
+        Ok := FClient.CreatePageOfKind(Query, pkeResearch, RevisePageId, Id);
+        if not Ok then Err := FClient.LastError;
+      except
+        on E: Exception do Err := E.Message;
+      end;
+      Done_ :=
+        procedure
+        begin
+          FResearchRunning := False;
+          if Ok then
+          begin
+            AppendTurn(FResearchKey, 'assistant',
+              'The report is ready: **' + Query + '**' + sLineBreak +
+              sLineBreak + 'It is open in the Browser. Ask another ' +
+              'question here and it revises that report.');
+            FResearchPage := Id;
+            OpenBrowser(Id);
+          end
+          else
+            AppendTurn(FResearchKey, 'toolerr',
+              'the research turn failed: ' + Err);
+          RenderTranscript(FResearchKey);
+          ShowStreaming(FResearchKey, False);
+        end;
+      TThread.Queue(nil, Done_);
+    end).Start;
 end;
 
 (* "Make interactive" -- the page becomes an app you own.

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -31,9 +31,10 @@ uses
   FMX.Types, FMX.Controls, FMX.Forms, FMX.Graphics, FMX.Dialogs,
   FMX.StdCtrls, FMX.Layouts, FMX.ListBox, FMX.Edit, FMX.Memo, FMX.Styles,
   FMX.Objects, FMX.TreeView, FMX.WebBrowser, FMX.ScrollBox,
-  FMX.Controls.Presentation,
+  FMX.Controls.Presentation, FMX.TabControl,
   FMX.RetroWindows, FMX.RetroSkins,
-  PasClaw.Client.Api;
+  PasClaw.Client.Api,
+  PasClaw.Client.Markdown;
 
 type
   { What a tree node stands for -- the tree carries projects, their tasks and
@@ -121,6 +122,20 @@ type
     FChatWins: TDictionary<string, TRetroWindow>;
     FAppWins: TDictionary<string, TRetroWindow>;
     FChatLogs: TDictionary<string, TMemo>;
+    (* The transcript as DATA, plus the browser that renders it.
+
+       Chat used to be a TMemo, which shows markdown as its own asterisks
+       and hashes and cannot do much with a code block. Turns are kept as
+       role + text here and re-rendered to HTML when one completes, so the
+       window shows formatted prose without the client having to lay out
+       rich text itself.
+
+       The memo stays, for streaming only: chunks arrive many times a
+       second and rebuilding a document per chunk would be unusable. It is
+       shown while a turn is in flight and hidden once the finished turn
+       joins the transcript. *)
+    FChatTurns: TObjectDictionary<string, TStringList>;
+    FChatViews: TDictionary<string, TWebBrowser>;
     FChatInputs: TDictionary<string, TMemo>;
     FChatHistory: TDictionary<string, string>;
     FBrowsers: TObjectList<TWebBrowser>;
@@ -135,8 +150,22 @@ type
     FBrowserQuery: TEdit;
     FBrowserView: TWebBrowser;
     FBrowserStatus: TLabel;
-    FBrowserSearch, FBrowserDeep, FBrowserPromote: TButton;
+    FBrowserSearch, FBrowserDeep, FBrowserPromote, FBrowserNew: TButton;
     FCurrentPage: string;
+    (* Tabs over ONE browser control.
+
+       Not one control per tab: TWebBrowser is a native window that paints
+       above all FMX content, which is why an inactive one has to be swapped
+       for a snapshot -- multiplying that by the number of open tabs
+       multiplies the trick and the ways it goes wrong. A tab is a page id;
+       switching one navigates the single view.
+
+       This is also what makes follow-up questions work. With a page in the
+       current tab, asking again REVISES it; New opens an empty tab, where
+       asking starts a fresh page. Two obvious gestures instead of a mode. *)
+    FBrowserTabs: TTabControl;
+    FBrowserTabPages: TStringList;   { page id per tab, by index }
+    FBrowserSwitching: Boolean;
 
     { ---- deep-research progress ----
       A research turn runs for minutes across many searches. The label shows
@@ -282,6 +311,9 @@ type
 
     { ---- Browser ---- }
     procedure OpenBrowser(const PageId: string);
+    procedure BrowserNewTabClick(Sender: TObject);
+    procedure BrowserTabChange(Sender: TObject);
+    function NewBrowserTab(const Caption: string): Integer;
     procedure BrowserSearchClick(Sender: TObject);
     procedure BrowserDeepClick(Sender: TObject);
     procedure BrowserPromoteClick(Sender: TObject);
@@ -320,6 +352,11 @@ type
     procedure SendChat(Sender: TObject);
     procedure ChatChunk(const Chunk: string; var Abort: Boolean);
     procedure ChatTool(const Kind, Name, Detail: string; IsErr: Boolean);
+    { ---- transcript rendering ---- }
+    function StyleColor(const Role, Fallback: string): string;
+    procedure AppendTurn(const Project, Role, Text_: string);
+    procedure RenderTranscript(const Project: string);
+    procedure ShowStreaming(const Project: string; Streaming: Boolean);
 
     { Live board updates. The client subscribes to /v1/desktop/events on its
       own thread and refreshes when something it displays changes, so the
@@ -397,6 +434,9 @@ end;
   blocking Chat call so ChatChunk knows where to append. }
 var
   GStreamingLog: TMemo = nil;
+  { Which conversation the streaming turn belongs to, so tool lines can join
+    its transcript as well as its live view. }
+  GStreamingProject: string = '';
 
 { ------------------------------------------------------------- lifecycle -- }
 
@@ -442,6 +482,8 @@ begin
   FChatWins   := TDictionary<string, TRetroWindow>.Create;
   FAppWins    := TDictionary<string, TRetroWindow>.Create;
   FChatLogs   := TDictionary<string, TMemo>.Create;
+  FChatTurns  := TObjectDictionary<string, TStringList>.Create([doOwnsValues]);
+  FChatViews  := TDictionary<string, TWebBrowser>.Create;
   FChatInputs := TDictionary<string, TMemo>.Create;
   FChatHistory := TDictionary<string, string>.Create;
   FBrowsers   := TObjectList<TWebBrowser>.Create(False);
@@ -550,6 +592,8 @@ begin
   FreeAndNil(FBrowsers);
   FreeAndNil(FChatHistory);
   FreeAndNil(FChatInputs);
+  FreeAndNil(FChatViews);
+  FreeAndNil(FChatTurns);
   FreeAndNil(FChatLogs);
   FreeAndNil(FAppWins);
   FreeAndNil(FChatWins);
@@ -558,6 +602,7 @@ begin
   FreeAndNil(FLogLock);
   FreeAndNil(FMenuActions);
   FreeAndNil(FLibraryKinds);
+  FreeAndNil(FBrowserTabPages);
 end;
 
 procedure TFormMain.FormKeyDown(Sender: TObject; var Key: Word;
@@ -664,6 +709,9 @@ begin
     FBrowserPromote := nil;
     { The view is also in FBrowsers/FSnapshots; the loop below clears those. }
     FBrowserView := nil;
+    FBrowserNew := nil;
+    FBrowserTabs := nil;
+    if FBrowserTabPages <> nil then FBrowserTabPages.Clear;
     FCurrentPage := '';
     Exit;
   end;
@@ -703,6 +751,8 @@ begin
     begin
       FChatWins.Remove(Key);
       FChatLogs.Remove(Key);      { memos were owned by the window }
+      FChatViews.Remove(Key);
+      FChatTurns.Remove(Key);
       FChatInputs.Remove(Key);
     end;
   end;
@@ -1442,6 +1492,7 @@ begin
     FRestoring := WasRestoring;
   end;
   FChatWins.Clear; FChatLogs.Clear; FChatInputs.Clear; FChatHistory.Clear;
+  FChatViews.Clear; FChatTurns.Clear;
   FAppWins.Clear;
   FRunWins.Clear; FRunLogs.Clear; FRunHeads.Clear;
   FStylePicker := nil; FStyleList := nil; FSkinList := nil;
@@ -1452,7 +1503,9 @@ begin
   FHexWin := nil; FHexMemo := nil;
   FBrowserWin := nil; FBrowserQuery := nil; FBrowserStatus := nil;
   FBrowserSearch := nil; FBrowserDeep := nil; FBrowserPromote := nil;
+  FBrowserNew := nil; FBrowserTabs := nil;
   FBrowserView := nil; FCurrentPage := '';
+  if FBrowserTabPages <> nil then FBrowserTabPages.Clear;
   FProgressWin := nil; FProgressText := nil;
   FVersionWin := nil;
   FMenuWin := nil;
@@ -2076,6 +2129,7 @@ var
   Send, Vers: TButton;
   Row: TProjectRow;
   Title: string;
+  View: TWebBrowser;
 begin
   if FChatWins.TryGetValue(Project, W) and (W <> nil) then
   begin
@@ -2129,23 +2183,39 @@ begin
   Input.TextSettings.WordWrap := True;
   FChatInputs.AddOrSetValue(Project, Input);
 
+  { The settled transcript, formatted. Created before the memo so the memo
+    sits on top of it while streaming. }
+  View := TWebBrowser.Create(W);
+  View.Parent := W.Client;
+  View.Align := TAlignLayout.Client;
+  FChatViews.AddOrSetValue(Project, View);
+  FBrowsers.Add(View);
+
+  { The live one. Same slot, shown only while a turn is in flight. }
   Log := TMemo.Create(W);
   Log.Parent := W.Client;
   Log.Align := TAlignLayout.Client;
   Log.ReadOnly := True;
   Log.TextSettings.WordWrap := True;
+  Log.Visible := False;
   FChatLogs.AddOrSetValue(Project, Log);
 
   if not FChatHistory.ContainsKey(Project) then
     FChatHistory.AddOrSetValue(Project, '[]');
 
-  if IsSyntheticChat(Project) then
-    Log.Lines.Add('Ask PasClaw anything. This window is not tied to a ' +
-                  'project, so nothing here builds an app.')
-  else
-    Log.Lines.Add('Describe the app you want. PasClaw builds it into this ' +
-                  'project and it opens as a window.');
-  Log.Lines.Add('');
+  if not FChatTurns.ContainsKey(Project) then
+  begin
+    if IsSyntheticChat(Project) then
+      AppendTurn(Project, 'assistant',
+        'Ask PasClaw anything. This window is not tied to a project, so ' +
+        'nothing here builds an app.')
+    else
+      AppendTurn(Project, 'assistant',
+        'Describe the app you want. PasClaw builds it into this project ' +
+        'and it opens as a window.');
+  end;
+  RenderTranscript(Project);
+  ShowStreaming(Project, False);
 end;
 
 
@@ -2210,6 +2280,168 @@ begin
     'and be brief in chat -- the app is the answer.';
 end;
 
+
+(* One colour of the current theme, as "#rrggbb".
+
+   The chat pane is an HTML document, so it needs real colour values rather
+   than a style lookup -- and a pane that stayed white inside a Windows 3.1
+   desktop would be the one thing on screen ignoring the theme.
+
+   Two sources, both already in the tree. With a skin selected, the .skin
+   file IS a palette: "face=C0C0C0" and friends. Without one, the style's
+   own colours live in the .style, and its .rolemap records the byte offset
+   of every colour literal -- which is how the skin engine patches them, and
+   just as good for reading one out. Falls back to the caller's value when
+   neither is available, so a missing styles directory costs the theme, not
+   the window. *)
+function TFormMain.StyleColor(const Role, Fallback: string): string;
+var
+  Lines: TStringList;
+  I, Ofs: Integer;
+  Key, Val, MapFile, Line: string;
+  FS: TFileStream;
+  Buf: array[0..8] of Byte;
+begin
+  Result := Fallback;
+
+  { A skin, if one is chosen: plain name=RRGGBB text. }
+  if (FSkinFile <> '') and TFile.Exists(FSkinFile) then
+  begin
+    Lines := TStringList.Create;
+    try
+      try
+        Lines.LoadFromFile(FSkinFile);
+      except
+        Exit;
+      end;
+      for I := 0 to Lines.Count - 1 do
+      begin
+        Line := Trim(Lines[I]);
+        if (Line = '') or (Line[1] = ';') or (Line[1] = '[') then Continue;
+        Key := Trim(Copy(Line, 1, Pos('=', Line) - 1));
+        if not SameText(Key, Role) then Continue;
+        Val := Trim(Copy(Line, Pos('=', Line) + 1, MaxInt));
+        if Length(Val) = 6 then Exit('#' + Val);
+      end;
+    finally
+      Lines.Free;
+    end;
+    Exit;
+  end;
+
+  { Otherwise the style itself, at the offset its role map records. }
+  if (FStyleFile = '') or not TFile.Exists(FStyleFile) then Exit;
+  MapFile := ChangeFileExt(FStyleFile, '.rolemap');
+  if not TFile.Exists(MapFile) then Exit;
+  Lines := TStringList.Create;
+  try
+    try
+      Lines.LoadFromFile(MapFile);
+    except
+      Exit;
+    end;
+    Ofs := -1;
+    for I := 0 to Lines.Count - 1 do
+    begin
+      Line := Trim(Lines[I]);
+      if Pos('=', Line) = 0 then Continue;
+      Key := Trim(Copy(Line, 1, Pos('=', Line) - 1));
+      if not SameText(Key, Role) then Continue;
+      Val := Trim(Copy(Line, Pos('=', Line) + 1, MaxInt));
+      if Pos(',', Val) > 0 then Val := Copy(Val, 1, Pos(',', Val) - 1);
+      Ofs := StrToIntDef(Trim(Val), -1);
+      Break;
+    end;
+    if Ofs < 0 then Exit;
+    try
+      FS := TFileStream.Create(FStyleFile, fmOpenRead or fmShareDenyWrite);
+      try
+        if Ofs + 9 > FS.Size then Exit;
+        FS.Position := Ofs;
+        FS.ReadBuffer(Buf, 9);
+      finally
+        FS.Free;
+      end;
+    except
+      Exit;
+    end;
+    { The literal is xAARRGGBB; the alpha byte is not ours to keep. }
+    if Chr(Buf[0]) <> 'x' then Exit;
+    Result := '#' + Chr(Buf[3]) + Chr(Buf[4]) + Chr(Buf[5]) +
+                    Chr(Buf[6]) + Chr(Buf[7]) + Chr(Buf[8]);
+  finally
+    Lines.Free;
+  end;
+end;
+
+{ Record a completed turn. Role is 'user', 'assistant' or 'tool'. }
+procedure TFormMain.AppendTurn(const Project, Role, Text_: string);
+var
+  L: TStringList;
+begin
+  if FChatTurns = nil then Exit;
+  if not FChatTurns.TryGetValue(Project, L) then
+  begin
+    L := TStringList.Create;
+    FChatTurns.Add(Project, L);
+  end;
+  { Tab-separated so a turn containing newlines stays one entry. }
+  L.Add(Role + #9 + StringReplace(Text_, #9, '  ', [rfReplaceAll]));
+end;
+
+(* Rebuild the whole transcript as an HTML document.
+
+   Whole-document rather than incremental: a conversation is tens of turns,
+   the markdown pass is string work, and the alternative is maintaining a
+   DOM through a browser control's scripting bridge for no visible gain. *)
+procedure TFormMain.RenderTranscript(const Project: string);
+var
+  View: TWebBrowser;
+  L: TStringList;
+  I, T: Integer;
+  Body, Role, Text_, Entry: string;
+begin
+  if not FChatViews.TryGetValue(Project, View) then Exit;
+  if View = nil then Exit;
+  Body := '';
+  if FChatTurns.TryGetValue(Project, L) then
+    for I := 0 to L.Count - 1 do
+    begin
+      Entry := L[I];
+      T := Pos(#9, Entry);
+      if T = 0 then Continue;
+      Role  := Copy(Entry, 1, T - 1);
+      Text_ := Copy(Entry, T + 1, MaxInt);
+      if Role = 'user' then
+        Body := Body + '<div class="turn"><span class="who">You</span><br>' +
+                MarkdownToHTML(Text_) + '</div>'
+      else if Role = 'tool' then
+        Body := Body + '<div class="tool">' + HtmlEscape(Text_) + '</div>'
+      else if Role = 'toolerr' then
+        Body := Body + '<div class="tool err">' + HtmlEscape(Text_) + '</div>'
+      else
+        Body := Body + '<div class="turn">' + MarkdownToHTML(Text_) + '</div>';
+    end;
+  View.LoadFromStrings(
+    ChatDocumentHTML(Body,
+      StyleColor('face',   '#c0c0c0'),
+      StyleColor('text',   '#000000'),
+      StyleColor('titleA', '#000080'),
+      StyleColor('light',  '#e8e8e8')), '');
+end;
+
+{ Streaming shows the live memo; a settled transcript shows the document. }
+procedure TFormMain.ShowStreaming(const Project: string; Streaming: Boolean);
+var
+  M: TMemo;
+  View: TWebBrowser;
+begin
+  if FChatLogs.TryGetValue(Project, M) and (M <> nil) then
+    M.Visible := Streaming;
+  if FChatViews.TryGetValue(Project, View) and (View <> nil) then
+    View.Visible := not Streaming;
+end;
+
 procedure TFormMain.ChatChunk(const Chunk: string; var Abort: Boolean);
 begin
   Abort := False;
@@ -2252,6 +2484,14 @@ begin
   end;
   GStreamingLog.Lines.Add(Line);
   GStreamingLog.GoToTextEnd;
+  { Also kept, so the settled transcript still shows what the turn did. }
+  if GStreamingProject <> '' then
+  begin
+    if IsErr then
+      AppendTurn(GStreamingProject, 'toolerr', Trim(Line))
+    else
+      AppendTurn(GStreamingProject, 'tool', Trim(Line));
+  end;
   Application.ProcessMessages;
 end;
 
@@ -2272,9 +2512,12 @@ begin
   if Text = '' then Exit;
   Input.Text := '';
 
-  Log.Lines.Add('you: ' + Text);
-  Log.Lines.Add('');
-  Log.Lines.Add('pasclaw: ');
+  { The turn joins the transcript; the memo is only the live view of the
+    reply being streamed, so it starts empty each time. }
+  AppendTurn(Project, 'user', Text);
+  RenderTranscript(Project);
+  Log.Text := '';
+  ShowStreaming(Project, True);
 
   { History as a JSON array of role/content objects -- the shape
     /v1/chat/completions wants. Built by hand so this unit needs no JSON
@@ -2289,6 +2532,7 @@ begin
   Hist := '[' + Inner + '{"role":"user","content":"' + JsonStr(Text) + '"}]';
 
   GStreamingLog := Log;
+  GStreamingProject := Project;
   try
     (Sender as TButton).Enabled := False;
     try
@@ -2298,22 +2542,33 @@ begin
     end;
   finally
     GStreamingLog := nil;
+    GStreamingProject := '';
   end;
 
   if (Reply = '') and (FClient.LastError <> '') then
-    Log.Lines.Add('(' + FClient.LastError + ')');
+    AppendTurn(Project, 'toolerr', FClient.LastError);
 
   { Period-native output: a plan renders as a wizard, a question as a dialog,
     and the block itself never appears as text. Same parser the web client
     uses -- see PasClaw.Client.Api.ParseUIBlocks. }
   ParseUIBlocks(Reply, Visible, Blocks);
+  { The reply joins the transcript WITHOUT its ui blocks -- those became
+    windows, and showing their JSON as well would be showing the machinery
+    twice. }
+  if Trim(Visible) <> '' then
+    AppendTurn(Project, 'assistant', Visible)
+  else if (Reply <> '') and (Length(Blocks) = 0) then
+    AppendTurn(Project, 'assistant', Reply);
   if Length(Blocks) > 0 then
   begin
-    { Rewrite the streamed text without the block. }
-    Log.Lines.Add('  [' + IntToStr(Length(Blocks)) + ' dialog(s) opened]');
+    AppendTurn(Project, 'tool',
+      Format('%d dialog(s) opened', [Length(Blocks)]));
     RenderUIBlocks(Project, Blocks);
   end;
-  Log.Lines.Add('');
+
+  { Back to the formatted view, now that the turn has settled. }
+  RenderTranscript(Project);
+  ShowStreaming(Project, False);
 
   Hist := Copy(Hist, 1, Length(Hist) - 1) +
           ',{"role":"assistant","content":"' + JsonStr(Reply) + '"}]';
@@ -2332,12 +2587,13 @@ begin
     if not FClient.SaveSessionHistory(SessId, Hist, '', Conflict) then
     begin
       if Conflict then
-        Log.Lines.Add('[this session has tool turns from an agent run; ' +
-                      'new messages here are not being saved into it]')
+        AppendTurn(Project, 'toolerr',
+          'this session has tool turns from an agent run; new messages ' +
+          'here are not being saved into it')
       else
-        Log.Lines.Add('[could not save this turn into the session: ' +
-                      FClient.LastError + ']');
-      Log.Lines.Add('');
+        AppendTurn(Project, 'toolerr',
+          'could not save this turn into the session: ' + FClient.LastError);
+      RenderTranscript(Project);
     end;
   end;
 
@@ -3268,11 +3524,29 @@ begin
   FBrowserPromote.Enabled := False;
   FBrowserPromote.OnClick := BrowserPromoteClick;
 
+  FBrowserNew := TButton.Create(FBrowserWin);
+  FBrowserNew.Parent := Bar;
+  FBrowserNew.Align := TAlignLayout.Right;
+  FBrowserNew.Width := 44;
+  FBrowserNew.Margins.Rect := TRectF.Create(0, 3, 3, 3);
+  FBrowserNew.Text := 'New';
+  FBrowserNew.Hint := 'Open an empty tab -- the next question starts a new page';
+  FBrowserNew.OnClick := BrowserNewTabClick;
+
   FBrowserQuery := TEdit.Create(FBrowserWin);
   FBrowserQuery.Parent := Bar;
   FBrowserQuery.Align := TAlignLayout.Client;
   FBrowserQuery.Margins.Rect := TRectF.Create(3, 3, 3, 3);
   FBrowserQuery.TextPrompt := 'Ask anything -- the answer comes back as a page';
+
+  if FBrowserTabPages = nil then FBrowserTabPages := TStringList.Create;
+  FBrowserTabPages.Clear;
+  FBrowserTabs := TTabControl.Create(FBrowserWin);
+  FBrowserTabs.Parent := FBrowserWin.Client;
+  FBrowserTabs.Align := TAlignLayout.Top;
+  FBrowserTabs.Height := 26;
+  FBrowserTabs.TabPosition := TTabPosition.Top;
+  FBrowserTabs.OnChange := BrowserTabChange;
 
   FBrowserStatus := TLabel.Create(FBrowserWin);
   FBrowserStatus.Parent := FBrowserWin.Client;
@@ -3304,7 +3578,60 @@ begin
   FSnapshots.AddOrSetValue(FBrowserView, Snap);
   MarkLayoutDirty;
 
+  NewBrowserTab('New tab');
   if PageId <> '' then ShowPage(PageId);
+end;
+
+(* Add a tab and select it. The tab items hold no content -- the single
+   browser below them does -- so this is bookkeeping plus a caption. *)
+function TFormMain.NewBrowserTab(const Caption: string): Integer;
+var
+  Item: TTabItem;
+begin
+  Result := -1;
+  if (FBrowserTabs = nil) or (FBrowserTabPages = nil) then Exit;
+  FBrowserSwitching := True;
+  try
+    Item := FBrowserTabs.Add;
+    Item.Text := Caption;
+    FBrowserTabPages.Add('');
+    FBrowserTabs.ActiveTab := Item;
+    Result := FBrowserTabs.TabCount - 1;
+  finally
+    FBrowserSwitching := False;
+  end;
+end;
+
+procedure TFormMain.BrowserNewTabClick(Sender: TObject);
+begin
+  NewBrowserTab('New tab');
+  FCurrentPage := '';
+  if FBrowserView <> nil then
+    FBrowserView.LoadFromStrings(
+      ChatDocumentHTML('<p>Ask a question. The answer comes back as a page.</p>',
+        StyleColor('face', '#c0c0c0'), StyleColor('text', '#000000'),
+        StyleColor('titleA', '#000080'), StyleColor('light', '#e8e8e8')), '');
+  if FBrowserPromote <> nil then FBrowserPromote.Enabled := False;
+  if FBrowserStatus <> nil then FBrowserStatus.Text := '';
+  if FBrowserQuery <> nil then FBrowserQuery.SetFocus;
+end;
+
+procedure TFormMain.BrowserTabChange(Sender: TObject);
+var
+  I: Integer;
+begin
+  { Ignore the change we caused ourselves while building a tab. }
+  if FBrowserSwitching then Exit;
+  if (FBrowserTabs = nil) or (FBrowserTabPages = nil) then Exit;
+  I := FBrowserTabs.TabIndex;
+  if (I < 0) or (I >= FBrowserTabPages.Count) then Exit;
+  if FBrowserTabPages[I] = '' then
+  begin
+    FCurrentPage := '';
+    if FBrowserPromote <> nil then FBrowserPromote.Enabled := False;
+    Exit;
+  end;
+  ShowPage(FBrowserTabPages[I]);
 end;
 
 procedure TFormMain.ShowPage(const PageId: string);
@@ -3318,6 +3645,15 @@ begin
     FBrowserView.URL := FClient.PageURL(PageId);
   if FBrowserPromote <> nil then FBrowserPromote.Enabled := PageId <> '';
 
+  { The active tab now holds this page, so switching away and back returns
+    to it and a follow-up question knows what it is revising. }
+  if (FBrowserTabs <> nil) and (FBrowserTabPages <> nil) then
+  begin
+    I := FBrowserTabs.TabIndex;
+    if (I >= 0) and (I < FBrowserTabPages.Count) then
+      FBrowserTabPages[I] := PageId;
+  end;
+
   { The sources strip, echoed into the status bar. A page that could not be
     grounded says so on its face; saying it here too means the user sees it
     without scrolling to the footer. }
@@ -3328,6 +3664,12 @@ begin
     begin
       N := Pages[I].SourceCount;
       if FBrowserWin <> nil then FBrowserWin.Caption := Pages[I].Title;
+      { Name the tab after the page, trimmed -- a tab strip of full titles
+        is a tab strip you cannot read. }
+      if (FBrowserTabs <> nil) and (FBrowserTabs.TabIndex >= 0) and
+         (FBrowserTabs.TabIndex < FBrowserTabs.TabCount) then
+        FBrowserTabs.Tabs[FBrowserTabs.TabIndex].Text :=
+          Copy(Pages[I].Title, 1, 22);
       Break;
     end;
   if FBrowserStatus = nil then Exit;
@@ -3351,13 +3693,20 @@ end;
 *)
 procedure TFormMain.RunPageQuery(Kind: TPageKindSel);
 var
-  Query: string;
+  Query, Revise: string;
   Deep: Boolean;
 begin
   if FBrowserQuery = nil then Exit;
   Query := Trim(FBrowserQuery.Text);
   if Query = '' then Exit;
   Deep := Kind = pkeResearch;
+
+  (* A question asked with a page open is a follow-up to THAT page.
+
+     Captured here, on the UI thread, because the tab can change while the
+     turn runs -- and the answer belongs to the page the question was asked
+     from, not to whichever tab happens to be in front minutes later. *)
+  Revise := FCurrentPage;
 
   FBrowserSearch.Enabled := False;
   FBrowserDeep.Enabled := False;
@@ -3367,7 +3716,12 @@ begin
     ShowProgress('Deep research', Query);
   end
   else if FBrowserStatus <> nil then
-    FBrowserStatus.Text := 'Searching...';
+  begin
+    if Revise <> '' then
+      FBrowserStatus.Text := 'Revising this page...'
+    else
+      FBrowserStatus.Text := 'Searching...';
+  end;
 
   TThread.CreateAnonymousThread(
     procedure
@@ -3386,7 +3740,9 @@ begin
       Ok := False;
       Err := '';
       try
-        Ok := FClient.CreatePageOfKind(Query, Kind, Id);
+        { Revise is the page in the tab this question was asked from. An
+          empty tab means a new page, which is what New is for. }
+        Ok := FClient.CreatePageOfKind(Query, Kind, Revise, Id);
         if not Ok then Err := FClient.LastError;
       except
         on E: Exception do Err := E.Message;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,6 +207,7 @@ There is no escape sequence for a literal `${UPPER}` string in a config value. W
 | `condense_reversible` | `false` | Stash original tool bytes under a `tool_output_get` handle when a condenser shrinks them. **Off by default since PR #289** — fresh deploys see raw tool output verbatim. Onboarding asks (default N). |
 | `tool_output_cap` | `0` | Truncate tool outputs over this many bytes; model dereferences via `tool_output_get`. |
 | `auto_router.enabled` | `false` | Cheap-tier routing for easy turns. See [Providers](./providers.md). |
+| `fast_model` | *(resolved)* | Model for work that doesn't need the good one — currently search/data/report answer pages. Empty resolves one: `auto_router.easy_model` when that router is on, else a known small model for the provider in use (Gemini → Flash Lite, Anthropic → Haiku, OpenAI → mini), else the main model unchanged. **Deep research never uses it** — that one plans, reads several sources and synthesises, which is what the main model is for. |
 | `stats_collection_enabled` | `false` | Persist per-turn counters into each session JSON's `meta.stats` block. |
 | `orient_task_aware` | `false` | Lexical task-vs-section scoring for `MEMORY.md` injection. Off on every profile; enable per-run with `pasclaw agent --orient` (`--no-orient` forces it back off) or persistently here. |
 | `shell_backend` | `"local"` | `"local"` or `"docker"`. See [Security](./security.md). |

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -430,6 +430,22 @@ the state is on disk and cheap to re-read.
 
 ## Answer pages
 
+**Which model.** A search, data or report page runs on the *fast* model:
+these are summarise-and-format jobs, and the flagship makes them slower and
+dearer without making them better. The model is resolved as `fast_model`
+from config, then `auto_router.easy_model` when that router is on, then a
+known small model for the provider in use, then the main model unchanged —
+so it works out of the box and can be pinned. **Research keeps the main
+model**: it plans, reads several sources and synthesises, and downgrading
+that would show.
+
+**Follow-ups.** `POST /v1/pages` takes an optional `revise` naming a page
+this question continues. The generator is handed that document and returns a
+complete revised body — as a *new* page, because a page is the record of an
+answer at a time and editing it in place would falsify it. An id naming no
+page is treated as an ordinary new question rather than failing the request.
+
+
 A search or a question about your own data ends as an HTML **document**, not
 as chat text: sections, tables, comparison grids, citations as real links —
 the layout chosen to fit the answer.

--- a/src/pkg/component/PasClaw.Client.Api.pas
+++ b/src/pkg/component/PasClaw.Client.Api.pas
@@ -343,7 +343,16 @@ type
     { The same, with the mode chosen. Research takes minutes and narrates
       through page-progress events; the others come back in one go. }
     function CreatePageOfKind(const Query: string; Kind: TPageKindSel;
-      out Id: string): Boolean;
+      out Id: string): Boolean; overload;
+    (* The same, continuing an existing page.
+
+       RevisePageId names the page the user is looking at, making this
+       question a change to that document rather than a new topic -- which
+       is what a follow-up in a browser almost always means. The result is
+       still a NEW page: the old one is the record of an answer at a time
+       and has to survive to stay true. Pass '' for an ordinary question. *)
+    function CreatePageOfKind(const Query: string; Kind: TPageKindSel;
+      const RevisePageId: string; out Id: string): Boolean; overload;
     (* "Make this interactive" -- copy a page into a new project as an html
        app. The page stays in the history: it is the record of an answer at a
        time, and the app is the part that changes. *)
@@ -2050,6 +2059,12 @@ end;
 
 function TPasClawClient.CreatePageOfKind(const Query: string; Kind: TPageKindSel;
   out Id: string): Boolean;
+begin
+  Result := CreatePageOfKind(Query, Kind, '', Id);
+end;
+
+function TPasClawClient.CreatePageOfKind(const Query: string; Kind: TPageKindSel;
+  const RevisePageId: string; out Id: string): Boolean;
 var
   Req: TJsonObject;
 begin
@@ -2058,6 +2073,7 @@ begin
   try
     Req.PutStr('query', Query);
     Req.PutStr('kind', PageKindName(Kind));
+    if Trim(RevisePageId) <> '' then Req.PutStr('revise', RevisePageId);
     try
       { The model clock: this call IS a turn. }
       Id := JsonReadStr(

--- a/src/pkg/component/PasClaw.Client.Markdown.pas
+++ b/src/pkg/component/PasClaw.Client.Markdown.pas
@@ -1,0 +1,335 @@
+(*
+  PasClaw.Client.Markdown - turn model-emitted markdown into HTML a GUI
+  client can display.
+
+  Why not PasClaw.Markdown.Render: that one emits ANSI escape codes for a
+  terminal. A FireMonkey TMemo shows those as mojibake, and a TWebBrowser
+  cannot use them at all. The subset and the intent are the same; only the
+  output differs.
+
+  Why here and not in the desktop unit: the desktop client has no compiler
+  in CI, so anything with a rule in it belongs on this side of the line
+  where FPC builds it and tests run against it. Studio can use it too.
+
+  Deliberately small. Models emit a narrow band of markdown and the goal is
+  a readable transcript, not a CommonMark implementation:
+
+    # ## ###           headings
+    **bold**           bold
+    *italic* _italic_  italic
+    `code`             inline code
+    ```fenced```       code block, no inline transforms inside
+    - * bullets        unordered list
+    1. numbered        ordered list
+    > quote            blockquote
+    [text](url)        link
+    ---                horizontal rule
+    blank line         paragraph break
+
+  Everything else passes through as text. Two rules are load-bearing:
+
+  1. HTML in the SOURCE is escaped, always. Model output is untrusted text;
+     a reply containing <script> must render as those characters, not run.
+     This is the security boundary of the unit.
+  2. Unrecognised markup degrades to its own literal characters rather than
+     disappearing. An answer must never come out emptier than it went in.
+*)
+unit PasClaw.Client.Markdown;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+interface
+
+{ Markdown -> an HTML fragment (no <html>/<body> wrapper). }
+function MarkdownToHTML(const S: string): string;
+
+(* A whole transcript as a styled HTML document.
+
+   Colors are passed in rather than baked: the desktop reskins at runtime
+   across 27 styles, and a chat pane that stayed white inside a Windows 3.1
+   desktop would be the one thing on screen that ignored the theme. *)
+function ChatDocumentHTML(const BodyHTML, BgColor, FgColor, AccentColor,
+  PanelColor: string): string;
+
+{ Escape text for safe inclusion in HTML. Public because a caller
+  assembling its own document (speaker labels, timestamps) needs the same
+  rule, and two escapers would eventually disagree. }
+function HtmlEscape(const S: string): string;
+
+implementation
+
+uses
+  SysUtils, Classes, StrUtils;
+
+function HtmlEscape(const S: string): string;
+begin
+  Result := StringReplace(S, '&', '&amp;', [rfReplaceAll]);
+  Result := StringReplace(Result, '<', '&lt;', [rfReplaceAll]);
+  Result := StringReplace(Result, '>', '&gt;', [rfReplaceAll]);
+  Result := StringReplace(Result, '"', '&quot;', [rfReplaceAll]);
+end;
+
+{ Replace paired delimiters with a tag. Unpaired ones are left alone, which
+  is how `2 * 3 * 4` survives being read as italics. }
+function WrapPairs(const S, Delim, Tag: string): string;
+var
+  P, Q, DL: Integer;
+  Rest: string;
+begin
+  Result := '';
+  Rest := S;
+  DL := Length(Delim);
+  repeat
+    P := Pos(Delim, Rest);
+    if P = 0 then Break;
+    Q := PosEx(Delim, Rest, P + DL);
+    if Q = 0 then Break;            { unpaired -- leave the rest verbatim }
+    Result := Result + Copy(Rest, 1, P - 1) +
+              '<' + Tag + '>' +
+              Copy(Rest, P + DL, Q - P - DL) +
+              '</' + Tag + '>';
+    Rest := Copy(Rest, Q + DL, MaxInt);
+  until False;
+  Result := Result + Rest;
+end;
+
+{ [text](url) -> an anchor. Only http/https/mailto: a javascript: URL in a
+  model reply is either a mistake or an attack, and neither should be
+  clickable. }
+function LinkUp(const S: string): string;
+var
+  P, Close_, Open_, End_: Integer;
+  Text_, URL, Low_: string;
+begin
+  Result := S;
+  P := 1;
+  repeat
+    P := PosEx('[', Result, P);
+    if P = 0 then Break;
+    Close_ := PosEx(']', Result, P);
+    if Close_ = 0 then Break;
+    Open_ := Close_ + 1;
+    if (Open_ > Length(Result)) or (Result[Open_] <> '(') then
+    begin
+      P := Close_ + 1;
+      Continue;
+    end;
+    End_ := PosEx(')', Result, Open_);
+    if End_ = 0 then Break;
+    Text_ := Copy(Result, P + 1, Close_ - P - 1);
+    URL   := Trim(Copy(Result, Open_ + 1, End_ - Open_ - 1));
+    Low_  := LowerCase(URL);
+    if (Pos('http://', Low_) = 1) or (Pos('https://', Low_) = 1) or
+       (Pos('mailto:', Low_) = 1) then
+    begin
+      Result := Copy(Result, 1, P - 1) +
+                '<a href="' + URL + '">' + Text_ + '</a>' +
+                Copy(Result, End_ + 1, MaxInt);
+      P := P + Length(Text_) + Length(URL) + 15;
+    end
+    else
+      P := Close_ + 1;      { not a URL we will make clickable }
+  until False;
+end;
+
+{ Inline markup within one already-escaped line. Code first: text inside
+  backticks must not then be read as bold or italic. }
+function RenderInlineHTML(const S: string): string;
+begin
+  Result := WrapPairs(S, '`', 'code');
+  Result := WrapPairs(Result, '**', 'strong');
+  Result := WrapPairs(Result, '__', 'strong');
+  Result := WrapPairs(Result, '*', 'em');
+  Result := WrapPairs(Result, '_', 'em');
+  Result := WrapPairs(Result, '~~', 'del');
+  Result := LinkUp(Result);
+end;
+
+function IsBullet(const L: string; out Body: string): Boolean;
+var
+  T: string;
+begin
+  Result := False;
+  T := TrimLeft(L);
+  if (Pos('- ', T) = 1) or (Pos('* ', T) = 1) then
+  begin
+    Body := Copy(T, 3, MaxInt);
+    Result := True;
+  end;
+end;
+
+function IsNumbered(const L: string; out Body: string): Boolean;
+var
+  T: string;
+  I: Integer;
+begin
+  Result := False;
+  T := TrimLeft(L);
+  I := 1;
+  while (I <= Length(T)) and (T[I] >= '0') and (T[I] <= '9') do Inc(I);
+  if (I = 1) or (I + 1 > Length(T)) then Exit;
+  if (T[I] <> '.') or (T[I + 1] <> ' ') then Exit;
+  Body := Copy(T, I + 2, MaxInt);
+  Result := True;
+end;
+
+function HeadingLevel(const L: string; out Body: string): Integer;
+var
+  I: Integer;
+begin
+  Result := 0;
+  I := 1;
+  while (I <= Length(L)) and (L[I] = '#') do Inc(I);
+  if (I = 1) or (I > 4) then Exit;
+  if (I > Length(L)) or (L[I] <> ' ') then Exit;
+  Result := I - 1;
+  Body := Copy(L, I + 1, MaxInt);
+end;
+
+function MarkdownToHTML(const S: string): string;
+var
+  Lines: TStringList;
+  Out_: TStringList;
+  I, HL: Integer;
+  Line, Body, T: string;
+  InCode, InUL, InOL: Boolean;
+
+  procedure CloseLists;
+  begin
+    if InUL then begin Out_.Add('</ul>'); InUL := False; end;
+    if InOL then begin Out_.Add('</ol>'); InOL := False; end;
+  end;
+
+begin
+  Result := '';
+  if Trim(S) = '' then Exit;
+  Lines := TStringList.Create;
+  Out_  := TStringList.Create;
+  try
+    Lines.Text := S;
+    InCode := False; InUL := False; InOL := False;
+    for I := 0 to Lines.Count - 1 do
+    begin
+      Line := Lines[I];
+      T := Trim(Line);
+
+      { Fenced code. Everything between fences is verbatim -- no inline
+        transforms, which is the whole point of showing code. }
+      if Pos('```', T) = 1 then
+      begin
+        if InCode then
+        begin
+          Out_.Add('</code></pre>');
+          InCode := False;
+        end
+        else
+        begin
+          CloseLists;
+          Out_.Add('<pre><code>');
+          InCode := True;
+        end;
+        Continue;
+      end;
+      if InCode then
+      begin
+        Out_.Add(HtmlEscape(Line));
+        Continue;
+      end;
+
+      if T = '' then
+      begin
+        CloseLists;
+        Continue;
+      end;
+
+      if (T = '---') or (T = '***') or (T = '___') then
+      begin
+        CloseLists;
+        Out_.Add('<hr>');
+        Continue;
+      end;
+
+      HL := HeadingLevel(T, Body);
+      if HL > 0 then
+      begin
+        CloseLists;
+        Out_.Add(Format('<h%d>%s</h%d>',
+          [HL, RenderInlineHTML(HtmlEscape(Body)), HL]));
+        Continue;
+      end;
+
+      if Pos('> ', T) = 1 then
+      begin
+        CloseLists;
+        Out_.Add('<blockquote>' +
+          RenderInlineHTML(HtmlEscape(Copy(T, 3, MaxInt))) + '</blockquote>');
+        Continue;
+      end;
+
+      if IsBullet(Line, Body) then
+      begin
+        if InOL then begin Out_.Add('</ol>'); InOL := False; end;
+        if not InUL then begin Out_.Add('<ul>'); InUL := True; end;
+        Out_.Add('<li>' + RenderInlineHTML(HtmlEscape(Body)) + '</li>');
+        Continue;
+      end;
+
+      if IsNumbered(Line, Body) then
+      begin
+        if InUL then begin Out_.Add('</ul>'); InUL := False; end;
+        if not InOL then begin Out_.Add('<ol>'); InOL := True; end;
+        Out_.Add('<li>' + RenderInlineHTML(HtmlEscape(Body)) + '</li>');
+        Continue;
+      end;
+
+      CloseLists;
+      Out_.Add('<p>' + RenderInlineHTML(HtmlEscape(T)) + '</p>');
+    end;
+    { An unterminated fence still closes: the transcript must not end
+      mid-element and swallow whatever the caller appends next. }
+    if InCode then Out_.Add('</code></pre>');
+    CloseLists;
+    Result := Out_.Text;
+  finally
+    Out_.Free;
+    Lines.Free;
+  end;
+end;
+
+function ChatDocumentHTML(const BodyHTML, BgColor, FgColor, AccentColor,
+  PanelColor: string): string;
+begin
+  Result :=
+    '<!doctype html><html><head><meta charset="utf-8">' +
+    '<style>' +
+    'html,body{margin:0;padding:8px;background:' + BgColor +
+      ';color:' + FgColor + ';' +
+      'font-family:Tahoma,Geneva,sans-serif;font-size:13px;' +
+      'line-height:1.45;word-wrap:break-word}' +
+    'p{margin:.35em 0}' +
+    'h1,h2,h3,h4{margin:.6em 0 .3em 0;font-size:1.15em;color:' +
+      AccentColor + '}' +
+    'code{background:' + PanelColor + ';padding:0 3px;' +
+      'font-family:Consolas,monospace;font-size:12px}' +
+    'pre{background:' + PanelColor + ';padding:6px;overflow-x:auto;' +
+      'margin:.4em 0}' +
+    'pre code{background:none;padding:0}' +
+    'ul,ol{margin:.3em 0 .3em 1.4em;padding:0}' +
+    'li{margin:.15em 0}' +
+    'blockquote{margin:.4em 0;padding-left:.7em;' +
+      'border-left:3px solid ' + AccentColor + ';opacity:.85}' +
+    'hr{border:0;border-top:1px solid ' + AccentColor + ';opacity:.4}' +
+    'a{color:' + AccentColor + '}' +
+    '.turn{margin:0 0 10px 0}' +
+    '.who{font-weight:bold;color:' + AccentColor + '}' +
+    '.tool{font-family:Consolas,monospace;font-size:11px;opacity:.75;' +
+      'margin:1px 0 1px 12px}' +
+    '.err{color:#c00}' +
+    '</style></head><body>' + BodyHTML +
+    '<div id="end"></div>' +
+    '<script>window.scrollTo(0,document.body.scrollHeight);</script>' +
+    '</body></html>';
+end;
+
+end.

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -634,6 +634,17 @@ type
        flip cron_tool_enabled=true in config.json. The running scheduler
        picks up the model's edits within one tick (config mtime watch). *)
     CronToolEnabled:   Boolean;
+    (* The model to use for work that does not need the good one.
+
+       Answer pages are the case that prompted it: a one-shot search page
+       is summarise-and-format, and running it on the flagship costs more
+       and takes longer for a page no better. Empty means "work it out" --
+       the auto-router's easy tier if one is configured, else a known small
+       model for the provider in use, else the main model unchanged.
+
+       Deep research does NOT use it. That one plans, reads several sources
+       and synthesises, which is the reasoning the main model is for. *)
+    FastModel:         string;
     (* The desktop board's `project` / `task` tools.
 
        Off by default, and deliberately so: PasClaw's behaviour should not
@@ -1120,6 +1131,7 @@ begin
   PromptCache.TTL      := '1h';  { 1h cache hits well across back-to-back runs (bench/swe/results/ablation.md). 5m was the historical default; 1h is one of the six zero-prompt-cost behavioral toggles the bench identified as a free upgrade. }
   VaultToolsEnabled    := False; { off by default per the bench-grounded "stock = lean-edit shape" verdict (bench/swe/README.md). Vault entries are never called across the bench's 45+ cells -- the model has them as training data. Onboarding asks (default Y for operators who DO use the vault). }
   WebFetchEnabled      := True;  { on by default: the tool clearly documents that it returns readable plain text (HTML tags stripped, entities decoded) capped at max_chars (default 50000, save_to bypasses), so the model knows what it gets -- and a "read this URL" task shouldn't have to fall back to hand-rolled shell curl + HTML scraping. Also enables memory_fetch (RegisterMemoryFetchTool is gated on EnableWebFetch in NewBuiltinRegistry). Onboarding asks; operators wanting no outbound HTTP from the agent set web_fetch_enabled: false. }
+  FastModel            := '';    { empty = resolve one; see TConfig.FastModel }
   CronToolEnabled      := False; { off by default -- model-scheduled background jobs are an opt-in autonomy step (runs existing skills only). }
   DesktopToolsEnabled  := False; { off by default -- see the field comment: the desktop works without it. }
   RelayWaitTimeoutMs   := 0;     { 0 = use the Pascal-side RelayDefaultWaitTimeoutMs (5 min). Operators set higher for flaky workers, lower for fast fallback. }
@@ -1419,6 +1431,7 @@ begin
       fresh config stays tidy. }
     if not WebFetchEnabled then
       Root.PutBool('web_fetch_enabled', False);
+    if FastModel <> '' then Root.PutStr('fast_model', FastModel);
     { cron_tool_enabled defaults OFF; emit only the explicit-on so an
       operator who opted into model-scheduled jobs round-trips. }
     if CronToolEnabled then
@@ -1938,6 +1951,7 @@ begin
     VaultToolsEnabled   := Root.GetBool('vault_tools_enabled',   VaultToolsEnabled);
     WebFetchEnabled     := Root.GetBool('web_fetch_enabled',     WebFetchEnabled);
     CronToolEnabled     := Root.GetBool('cron_tool_enabled',     CronToolEnabled);
+    FastModel           := Root.GetStr ('fast_model',            FastModel);
     DesktopToolsEnabled := Root.GetBool('desktop_tools_enabled', DesktopToolsEnabled);
     RelayWaitTimeoutMs  := Integer(Root.GetInt('relay_wait_timeout_ms',
                                                 RelayWaitTimeoutMs));

--- a/src/pkg/gateway/PasClaw.Gateway.Desktop.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Desktop.pas
@@ -46,8 +46,14 @@ type
   TJobRunner = function(const Project, TaskId, Prompt: string;
     out JobId, Err: string): Boolean;
 
-  { Produces a page body + a SOURCES JSON array for a query. }
+  (* Produces a page body + a SOURCES JSON array for a query.
+
+     RevisePageId names an existing page when the query is a FOLLOW-UP to
+     it: the generator then edits that document rather than starting a new
+     topic. Empty for an ordinary question, which is the common case and
+     costs nothing. *)
   TPageGenerator = function(const Query: string; Kind: TPageKind;
+    const RevisePageId: string;
     out Title, BodyHTML, SourcesJSON, Err: string): Boolean;
 
   (* One agent turn, plain text in and out. The general-purpose sibling of
@@ -2205,9 +2211,9 @@ var
   Arr: TJsonArray;
   List: TPageInfoArray;
   I: Integer;
-  Id, Query, Err, Title, BodyHTML, SourcesJSON, Slug: string;
+  Id, Query, Err, Title, BodyHTML, SourcesJSON, Slug, Revise: string;
   Kind: TPageKind;
-  Info: TPageInfo;
+  Info, PriorInfo: TPageInfo;
   Sources: TPageSourceArray;
 begin
   Result := True;
@@ -2248,6 +2254,14 @@ begin
           Exit;
         end;
         Kind := StrToPageKind(Obj.GetStr('kind', 'search'));
+        (* "revise": "<page id>" -- this question continues that page.
+
+           Validated here rather than trusted: an id naming a page that does
+           not exist is treated as an ordinary new question, because
+           refusing the whole request over a stale tab id would lose the
+           user's actual question. *)
+        Revise := Trim(Obj.GetStr('revise', ''));
+        if (Revise <> '') and not GetPage(Revise, PriorInfo) then Revise := '';
 
         { A caller may supply the rendered body itself (the agent loop does
           exactly this once it has run the search), or ask us to generate. }
@@ -2271,7 +2285,8 @@ begin
               'pages; POST a rendered "body" instead');
             Exit;
           end;
-          if not GPageGen(Query, Kind, Title, BodyHTML, SourcesJSON, Err) then
+          if not GPageGen(Query, Kind, Revise, Title, BodyHTML,
+                          SourcesJSON, Err) then
           begin
             ReplyErr(Resp, 500, Err);
             Exit;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -185,9 +185,17 @@ type
        machinery HandleChat sets up, and duplicating that setup is how the
        two drift. Returns False with Err set when there is no provider or
        the loop fails. *)
+    (* The model for work that does not need the good one, or '' to keep
+       the current one. Order is explicit-then-inferred: what the operator
+       configured, then what they already declared cheap for the
+       auto-router, then a known small model for the provider in use. *)
+    function ResolveFastModel: string;
     function RunDesktopTurn(const SystemPrompt, Prompt: string;
                             Narrate: Boolean;
-                            out Reply, Err: string): Boolean;
+                            out Reply, Err: string): Boolean; overload;
+    function RunDesktopTurn(const SystemPrompt, Prompt: string;
+                            Narrate: Boolean; const ModelOverride: string;
+                            out Reply, Err: string): Boolean; overload;
     { OnToolCall sink for a narrated turn -- turns each tool call into a
       page-progress event so the desktop can show work rather than a
       spinner. A method, not a closure: the loop's hook is a method
@@ -5289,8 +5297,51 @@ begin
   PublishPageProgress(Phase, Detail);
 end;
 
+function TGatewayServer.ResolveFastModel: string;
+var
+  Prim: ILLMProvider;
+  FB: TLLMProviderArray;
+  FBModels: TStringArray;
+  DefModel, Kind: string;
+  I: Integer;
+begin
+  { 1. Said so outright. }
+  Result := Trim(FCfg.FastModel);
+  if Result <> '' then Exit;
+
+  { 2. Already declared a cheap tier for the difficulty router -- the same
+       judgement, made once. Only when that router is switched on: a model
+       named in a disabled section is a leftover, not a preference. }
+  if FCfg.AutoRouter.Enabled and (Trim(FCfg.AutoRouter.EasyModel) <> '') then
+    Exit(Trim(FCfg.AutoRouter.EasyModel));
+
+  { 3. A known small model for whichever provider is actually in use. The
+       primary's kind, not the first one configured: fallbacks exist
+       precisely because the first entry may be the one that is down. }
+  Kind := '';
+  for I := 0 to High(FCfg.Providers) do
+    if SameText(FCfg.Providers[I].Name, FCfg.DefaultProvider) then
+    begin
+      Kind := FCfg.Providers[I].Kind;
+      Break;
+    end;
+  if Kind = '' then
+  begin
+    SnapshotRuntime(Prim, FB, FBModels, DefModel);
+    if Length(FCfg.Providers) > 0 then Kind := FCfg.Providers[0].Kind;
+  end;
+  Result := FastModelFor(Kind);
+end;
+
 function TGatewayServer.RunDesktopTurn(const SystemPrompt, Prompt: string;
   Narrate: Boolean; out Reply, Err: string): Boolean;
+begin
+  Result := RunDesktopTurn(SystemPrompt, Prompt, Narrate, '', Reply, Err);
+end;
+
+function TGatewayServer.RunDesktopTurn(const SystemPrompt, Prompt: string;
+  Narrate: Boolean; const ModelOverride: string;
+  out Reply, Err: string): Boolean;
 var
   Msgs: TMessageArray;
   Loop: TToolLoopResult;
@@ -5319,6 +5370,9 @@ begin
   LoopCfg.Registry := FRegistry;
   if FToolsHonorInMemoryConfig then LoopCfg.ActiveConfig := FCfg;
   LoopCfg.Model          := DefModel;
+  { A caller may ask for a different model -- see ResolveFastModel. Empty
+    keeps the configured one, which is every other caller. }
+  if Trim(ModelOverride) <> '' then LoopCfg.Model := Trim(ModelOverride);
   LoopCfg.MaxIterations  := FMaxIter;
   LoopCfg.Parallel       := True;
   LoopCfg.Mode           := pmBuild;
@@ -5413,7 +5467,7 @@ function DesktopPageGenerator(const Query: string; Kind: TPageKind;
   const RevisePageId: string;
   out Title, BodyHTML, SourcesJSON, Err: string): Boolean;
 var
-  Reply, Prompt, Prior: string;
+  Reply, Prompt, Prior, FastModel: string;
   PriorInfo: TPageInfo;
 begin
   Title := Query;
@@ -5446,8 +5500,22 @@ begin
     end;
   end;
 
+  (* Quick kinds run on the fast model; research does not.
+
+     A search page is summarise-and-format, and the flagship makes it
+     slower and dearer without making it better. Research plans, reads
+     several sources and synthesises -- that is the reasoning the main
+     model is for, and downgrading it would show. *)
+  FastModel := '';
+  if Kind <> pkResearch then
+  begin
+    FastModel := GDesktopGateway.ResolveFastModel;
+    if FastModel <> '' then
+      LogDebug('page: %s on %s', [PageKindToStr(Kind), FastModel]);
+  end;
+
   if not GDesktopGateway.RunDesktopTurn(Prompt,
-       'Produce the page now.', Kind = pkResearch, Reply, Err) then
+       'Produce the page now.', Kind = pkResearch, FastModel, Reply, Err) then
     Exit;
   if Kind = pkResearch then
     PublishPageProgress('Writing', 'assembling the report');

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -5410,9 +5410,11 @@ begin
 end;
 
 function DesktopPageGenerator(const Query: string; Kind: TPageKind;
+  const RevisePageId: string;
   out Title, BodyHTML, SourcesJSON, Err: string): Boolean;
 var
-  Reply: string;
+  Reply, Prompt, Prior: string;
+  PriorInfo: TPageInfo;
 begin
   Title := Query;
   BodyHTML := '';
@@ -5426,7 +5428,25 @@ begin
   end;
   if Kind = pkResearch then
     PublishPageProgress('Planning', Query);
-  if not GDesktopGateway.RunDesktopTurn(BuildPagePrompt(Query, Kind),
+
+  (* A follow-up edits the page it follows. Falls back to an ordinary page
+     whenever the prior one cannot be read -- a missing file should cost the
+     context, not the answer. *)
+  Prompt := BuildPagePrompt(Query, Kind);
+  if (Trim(RevisePageId) <> '') and GetPage(RevisePageId, PriorInfo) then
+  begin
+    Prior := '';
+    if (PriorInfo.Path <> '') and FileExists(PriorInfo.Path) then
+      Prior := ReadFileText(PriorInfo.Path);
+    if Trim(Prior) <> '' then
+    begin
+      Prompt := BuildRevisePrompt(PriorInfo.Query, Query, Kind, Prior);
+      LogDebug('page: revising %s (%d bytes of prior body)',
+               [RevisePageId, Length(Prior)]);
+    end;
+  end;
+
+  if not GDesktopGateway.RunDesktopTurn(Prompt,
        'Produce the page now.', Kind = pkResearch, Reply, Err) then
     Exit;
   if Kind = pkResearch then

--- a/src/pkg/projects/PasClaw.Pages.pas
+++ b/src/pkg/projects/PasClaw.Pages.pas
@@ -71,6 +71,21 @@ function PageDir(const Id: string): string;      { '' when Id is malformed }
   visible in one file. }
 function BuildPagePrompt(const Query: string; Kind: TPageKind): string;
 
+(* The prompt for REVISING an existing page.
+
+   A browser where every question throws away the last answer is a search
+   box, not a browser. When a page is open, a follow-up usually means "the
+   same document, changed" -- add a column, drop the caveats, sort it the
+   other way -- and starting from scratch loses both the content and
+   whatever the model got right the first time.
+
+   PriorHTML is the rendered body of the page being revised. It is handed
+   back to the model as the thing to edit, which is also why revision stays
+   a NEW page rather than an in-place edit: a page is the record of an
+   answer at a time, and the old one has to survive to stay true. *)
+function BuildRevisePrompt(const PriorQuery, Followup: string;
+  Kind: TPageKind; const PriorHTML: string): string;
+
 { Wrap a model-authored body in the page shell: styling that inherits the
   desktop's palette, a title header, and the mandatory sources footer.
   BodyHTML is sanitised here -- callers pass raw model output. }
@@ -172,6 +187,30 @@ begin
 end;
 
 { ----------------------------------------------------------------- prompt -- }
+
+function BuildRevisePrompt(const PriorQuery, Followup: string;
+  Kind: TPageKind; const PriorHTML: string): string;
+const
+  { Enough of the old page for the model to work from without spending the
+    whole context window on markup it is about to rewrite. }
+  MaxPrior = 24 * 1024;
+var
+  Prior: string;
+begin
+  Prior := PriorHTML;
+  if Length(Prior) > MaxPrior then
+    Prior := Copy(Prior, 1, MaxPrior) + sLineBreak + '<!-- truncated -->';
+  Result :=
+    BuildPagePrompt(Followup, Kind) + sLineBreak + sLineBreak +
+    'REVISION. You are not starting a new document. The user is looking at ' +
+    'a page you produced for the question "' + PriorQuery + '", and has ' +
+    'now asked: "' + Followup + '".' + sLineBreak +
+    'Treat that as a change to the page below, not a new topic. Keep what ' +
+    'still answers the question, change what the follow-up asks for, and ' +
+    'return the COMPLETE revised body -- not a diff and not a fragment.' +
+    sLineBreak + sLineBreak +
+    'The page as it stands:' + sLineBreak + Prior;
+end;
 
 function BuildPagePrompt(const Query: string; Kind: TPageKind): string;
 var

--- a/src/pkg/providers/PasClaw.Providers.Catalog.pas
+++ b/src/pkg/providers/PasClaw.Providers.Catalog.pas
@@ -87,6 +87,24 @@ function AllProviderSpecs: TProviderSpecArray;
   kind exists. Convenience for callers that don't need the full spec. }
 function DefaultBaseFor(const Kind: string): string;
 
+(* The quick, cheap model of a provider family, or '' when we do not know
+   one.
+
+   Some work does not need the good model. A one-shot search page is a
+   summarise-and-format job: the flagship costs more, takes longer, and
+   produces a page no better than the small model's -- which is why the
+   hosted assistants people compare this to run their quick answers on a
+   Flash Lite or a mini. Deep research is the opposite and keeps the main
+   model; it plans, reads several sources and synthesises, which is exactly
+   the reasoning the big model is for.
+
+   Names, not capability probes: there is no API that answers "which of
+   your models is cheapest", so this is a table, and a table goes stale.
+   It is therefore the LAST resort -- an explicit fast_model, then the
+   auto-router's easy tier, then this -- and an unknown provider returns ''
+   so the caller keeps the model it already had rather than guessing. *)
+function FastModelFor(const Kind: string): string;
+
 implementation
 
 uses
@@ -394,6 +412,26 @@ begin
     end;
     Result[j] := Tmp;
   end;
+end;
+
+function FastModelFor(const Kind: string): string;
+var
+  K: string;
+begin
+  K := LowerCase(Trim(Kind));
+  if K = 'gemini' then Result := 'gemini-3.5-flash-lite'
+  else if K = 'anthropic' then Result := 'claude-haiku-4-5-20251001'
+  else if K = 'openai' then Result := 'gpt-4o-mini'
+  else if K = 'groq' then Result := 'llama-3.1-8b-instant'
+  else if K = 'mistral' then Result := 'mistral-small-latest'
+  else if K = 'deepseek' then Result := 'deepseek-chat'
+  else if K = 'together' then Result := 'meta-llama/Llama-3.2-3B-Instruct-Turbo'
+  else if K = 'openrouter' then Result := 'google/gemini-2.5-flash-lite'
+  else
+    { Unknown, or a proxy whose model names are the upstream's (litellm,
+      ollama, lmstudio, a local server): no guess is better than a wrong
+      one, and the caller keeps whatever it had. }
+    Result := '';
 end;
 
 function DefaultBaseFor(const Kind: string): string;

--- a/src/tests/client_markdown_tests.pas
+++ b/src/tests/client_markdown_tests.pas
@@ -1,0 +1,149 @@
+program client_markdown_tests;
+(*
+  Pins PasClaw.Client.Markdown: the markdown-to-HTML converter the GUI
+  clients render chat with.
+
+  Two things matter more than the formatting itself, and they are what most
+  of this file is about:
+
+    1. HTML in model output is ESCAPED. A reply containing a script tag has
+       to render as those characters. This is the security boundary of the
+       unit, and it is the assertion worth breaking the build over.
+    2. Nothing DISAPPEARS. Unmatched markers, unterminated fences and odd
+       input must degrade to their own literal characters -- an answer that
+       comes out emptier than it went in is worse than an ugly one.
+*)
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+
+uses
+  SysUtils, PasClaw.Client.Markdown;
+
+var Failures: Integer = 0;
+
+procedure Fail_(const Msg: string);
+begin
+  WriteLn('FAIL: ' + Msg);
+  Inc(Failures);
+end;
+
+procedure ExpectTrue(Cond: Boolean; const Msg: string);
+begin
+  if not Cond then Fail_(Msg);
+end;
+
+procedure ExpectHas(const Hay, Needle, Msg: string);
+begin
+  if Pos(Needle, Hay) = 0 then
+    Fail_(Msg + ' -- "' + Needle + '" missing from: ' + Copy(Hay, 1, 300));
+end;
+
+procedure ExpectLacks(const Hay, Needle, Msg: string);
+begin
+  if Pos(Needle, Hay) > 0 then
+    Fail_(Msg + ' -- "' + Needle + '" unexpectedly present in: ' +
+          Copy(Hay, 1, 300));
+end;
+
+var
+  H: string;
+begin
+  { ---------------------------------------------------- the safety rule -- }
+  (* Model output is untrusted text. Every one of these must come back as
+     characters on screen, not as markup the renderer honours. *)
+  H := MarkdownToHTML('before <script>alert(1)</script> after');
+  ExpectLacks(H, '<script>', 'a script tag never survives as markup');
+  ExpectHas(H, '&lt;script&gt;', 'it is shown as text instead');
+  ExpectHas(H, 'before', 'and the surrounding words survive');
+
+  H := MarkdownToHTML('<img src=x onerror="steal()">');
+  ExpectLacks(H, '<img', 'an img tag is escaped too');
+  ExpectHas(H, '&lt;img', 'and rendered as text');
+
+  H := MarkdownToHTML('an & ampersand and a "quote"');
+  ExpectHas(H, '&amp;', 'ampersands are escaped');
+  ExpectHas(H, '&quot;', 'quotes are escaped');
+
+  { A javascript: link is either a mistake or an attack. Either way it does
+    not become clickable. }
+  H := MarkdownToHTML('[click](javascript:alert(1))');
+  ExpectLacks(H, '<a href', 'a javascript: URL is not linked');
+  ExpectHas(H, 'click', 'but the text is still shown');
+
+  H := MarkdownToHTML('[docs](https://example.com/x)');
+  ExpectHas(H, '<a href="https://example.com/x">docs</a>', 'an http link is linked');
+
+  { ------------------------------------------------------- the formatting }
+  H := MarkdownToHTML('# Title');
+  ExpectHas(H, '<h1>Title</h1>', 'heading level 1');
+  H := MarkdownToHTML('### Small');
+  ExpectHas(H, '<h3>Small</h3>', 'heading level 3');
+
+  H := MarkdownToHTML('this is **bold** here');
+  ExpectHas(H, '<strong>bold</strong>', 'bold');
+  H := MarkdownToHTML('this is *italic* here');
+  ExpectHas(H, '<em>italic</em>', 'italic');
+  H := MarkdownToHTML('call `foo()` now');
+  ExpectHas(H, '<code>foo()</code>', 'inline code');
+
+  H := MarkdownToHTML('- one'#10'- two');
+  ExpectHas(H, '<ul>', 'a bullet list opens');
+  ExpectHas(H, '<li>one</li>', 'with its items');
+  ExpectHas(H, '</ul>', 'and closes');
+
+  H := MarkdownToHTML('1. first'#10'2. second');
+  ExpectHas(H, '<ol>', 'a numbered list opens');
+  ExpectHas(H, '<li>second</li>', 'with its items');
+
+  H := MarkdownToHTML('> quoted');
+  ExpectHas(H, '<blockquote>quoted</blockquote>', 'blockquote');
+
+  H := MarkdownToHTML('a'#10#10'---'#10#10'b');
+  ExpectHas(H, '<hr>', 'horizontal rule');
+
+  { Code blocks are verbatim: markers inside them are content, not markup. }
+  H := MarkdownToHTML('```'#10'not **bold** here'#10'```');
+  ExpectHas(H, '<pre><code>', 'a fence opens a code block');
+  ExpectHas(H, 'not **bold** here', 'and its contents are untouched');
+  ExpectLacks(H, '<strong>', 'inline markup is not applied inside code');
+
+  { ...and escaped inside them too, which is where a naive renderer leaks. }
+  H := MarkdownToHTML('```'#10'<script>x</script>'#10'```');
+  ExpectLacks(H, '<script>', 'a script tag inside a fence is still escaped');
+
+  { ------------------------------------------------ nothing disappears -- }
+  { An unmatched marker is a character, not an instruction. }
+  H := MarkdownToHTML('2 * 3 = 6');
+  ExpectHas(H, '2 * 3 = 6', 'a lone asterisk is left alone');
+
+  H := MarkdownToHTML('unclosed **bold');
+  ExpectHas(H, 'unclosed', 'text before an unpaired marker survives');
+  ExpectHas(H, 'bold', 'and after it');
+
+  { An unterminated fence must still close its element, or everything the
+    caller appends afterwards lands inside a code block. }
+  H := MarkdownToHTML('```'#10'dangling');
+  ExpectHas(H, '</code></pre>', 'an unterminated fence is closed anyway');
+  ExpectHas(H, 'dangling', 'and its content is kept');
+
+  ExpectTrue(MarkdownToHTML('') = '', 'empty in, empty out');
+  ExpectTrue(Trim(MarkdownToHTML('   ')) = '', 'blank in, empty out');
+
+  H := MarkdownToHTML('just a sentence');
+  ExpectHas(H, '<p>just a sentence</p>', 'plain prose becomes a paragraph');
+
+  { ------------------------------------------------------ the document -- }
+  H := ChatDocumentHTML('<p>hi</p>', '#c0c0c0', '#000', '#000080', '#fff');
+  ExpectHas(H, '<p>hi</p>', 'the body is included');
+  ExpectHas(H, '#c0c0c0', 'the background colour is applied');
+  ExpectHas(H, '#000080', 'and the accent');
+  ExpectHas(H, 'scrollTo', 'and it scrolls to the newest turn');
+
+  if Failures = 0 then
+    WriteLn('client_markdown_tests: OK')
+  else
+  begin
+    WriteLn('client_markdown_tests: ', Failures, ' failure(s)');
+    Halt(1);
+  end;
+end.

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -25,6 +25,7 @@ uses
   SysUtils,
   PasClaw.Config,
   PasClaw.Config.Profile,
+  PasClaw.Providers.Catalog,
   PasClaw.Utils;
 
 procedure Fail_(const Msg: string);
@@ -191,6 +192,31 @@ begin
   finally
     DeleteFile(JoinPath(ProfilesDir, 'low-token.json'));
   end;
+end;
+
+(* The fast-model table.
+
+   Not a capability probe -- no API answers "which of your models is
+   cheapest" -- so it is a table, and a table goes stale. What must hold is
+   the SHAPE: a provider we know returns something, one we do not returns
+   empty so the caller keeps the model it already had rather than being
+   handed a guess that does not exist on that account. *)
+procedure TestFastModelCatalog;
+begin
+  AssertTrue(FastModelFor('gemini') <> '', 'gemini has a fast model');
+  AssertTrue(Pos('lite', LowerCase(FastModelFor('gemini'))) > 0,
+             'and it is a lite one');
+  AssertTrue(FastModelFor('anthropic') <> '', 'anthropic has one');
+  AssertTrue(FastModelFor('openai') <> '', 'openai has one');
+  AssertTrue(FastModelFor('GEMINI') = FastModelFor('gemini'),
+             'the lookup is case-insensitive');
+  AssertTrue(FastModelFor('  gemini  ') = FastModelFor('gemini'),
+             'and tolerates surrounding space');
+  { A proxy whose model names are the upstream's cannot be guessed at. }
+  AssertEqS(FastModelFor('litellm'), '', 'a proxy gets no guess');
+  AssertEqS(FastModelFor('ollama'), '', 'nor does a local server');
+  AssertEqS(FastModelFor(''), '', 'nor does an unnamed provider');
+  AssertEqS(FastModelFor('nonesuch'), '', 'nor an unknown one');
 end;
 
 procedure TestExtractProfileField;
@@ -585,6 +611,7 @@ begin
     TestResolveInherits;
     TestUnknownProfile;
     TestUserProfileShadowsBuiltin;
+    TestFastModelCatalog;
     TestExtractProfileField;
     TestResolveProfileNamePrecedence;
     TestLoadConfigAppliesProfile;

--- a/src/tests/desktop_routes_tests.pas
+++ b/src/tests/desktop_routes_tests.pas
@@ -152,10 +152,17 @@ begin
   Result := JobId <> '';
 end;
 
+{ Records what the route handed the generator, so the assertions can check
+  that a follow-up actually arrived as one. }
+var
+  GLastRevise: string = '';
+
 function StubPageGen(const Query: string; Kind: TPageKind;
+  const RevisePageId: string;
   out Title, BodyHTML, SourcesJSON, Err: string): Boolean;
 begin
   Err := '';
+  GLastRevise := RevisePageId;
   Title := 'About ' + Query;
   BodyHTML := '<p>Answer about ' + Query + '</p>';
   SourcesJSON := '[{"title":"Example","url":"https://example.com/a"}]';
@@ -592,9 +599,45 @@ begin
   begin
     ExpectTrue(R.Status = 200, 'page generated via the hook');
     ExpectTrue(Pos('"source_count":1', Squeeze(R.Body)) > 0, 'sources counted');
+    ExpectTrue(GLastRevise = '',
+               'an ordinary question revises nothing');
+    { The id of the page just made, for the follow-up below. }
+    PageId := JsonReadStr(R.Body, 'id', '');
   end
   else
     Fail_('page generation route not handled');
+
+  (* Follow-up. A browser where every question throws away the last answer
+     is a search box; asking again with a page open should CHANGE it. The
+     route's job is to recognise the id and pass it on -- what the model
+     does with it is the prompt's business, not this test's. *)
+  GLastRevise := 'not-called';
+  if Req('POST', '/v1/pages',
+         '{"query":"now sort it by date","revise":"' + PageId + '"}', R) then
+  begin
+    ExpectTrue(R.Status = 200, 'a follow-up produces a page');
+    ExpectTrue(GLastRevise = PageId,
+               'and the generator is told which page it revises');
+    { Still a NEW page: the old one is the record of an answer at a time
+      and editing it in place would falsify it. }
+    ExpectTrue(JsonReadStr(R.Body, 'id', '') <> PageId,
+               'revision writes a new page rather than overwriting');
+  end
+  else
+    Fail_('revise request not handled');
+
+  { An id naming no page must not fail the whole request -- a stale tab is
+    not a reason to lose the question. }
+  GLastRevise := 'not-called';
+  if Req('POST', '/v1/pages',
+         '{"query":"anything","revise":"P9999"}', R) then
+  begin
+    ExpectTrue(R.Status = 200, 'a stale revise id still answers');
+    ExpectTrue(GLastRevise = '', 'and is treated as a new question');
+  end
+  else
+    Fail_('stale revise request not handled');
+
   SetPageGenerator(nil);
 
   ExpectBodyContains('GET', '/v1/pages', '', 'P0001', 'pages listed');


### PR DESCRIPTION
Third of three. **Stacked on #529**, which is stacked on #528 — review in order.

## A search page didn't need the flagship

It's a summarise-and-format job. Running it on the good model costs more and takes longer for a page no better, which is why the hosted assistants this gets compared to run their quick answers on a Flash Lite or a mini.

Search, data and report pages now resolve a **fast model**. **Deep research does not** — it plans, reads several sources and synthesises, and downgrading that reasoning would show.

Resolution is explicit-then-inferred:

| # | Source | Why |
|---|---|---|
| 1 | `fast_model` in config | You said so outright |
| 2 | `auto_router.easy_model` | The same judgement, already made — **only when that router is enabled**, since a model named in a disabled section is a leftover, not a preference |
| 3 | Catalog default for the provider in use | Gemini → `gemini-3.5-flash-lite`, Anthropic → Haiku, OpenAI → mini, Groq/Mistral/DeepSeek/Together/OpenRouter |
| 4 | *(nothing)* | Keep the model you already had |

The provider is the configured **primary**, not the first entry in the list — fallbacks exist precisely because the first one may be the one that's down.

Step 3 is a table, and a table goes stale: no API answers "which of your models is cheapest". So it's the last resort, and an unknown provider — or a proxy whose model names are the upstream's (`litellm`, `ollama`, a local server) — returns nothing, leaving the caller with the model it already had rather than a guess that may not exist on that account. The tests assert that *shape* rather than the names, so a stale entry doesn't fail the build but a broken contract does.

### On the log you posted

```
[warn] provider primary returned status=0, walking 1 fallback(s)
[debug] fallback 0: trying gemini with model=gemini-flash-lite-latest
[warn] fallback hit: gemini status=200
```

Worth separating two things there. `status=0` means your **primary never connected** — that's a failure, not a routing decision, and the fallback rescued it. Flash Lite answering was the fallback chain doing its job. What this PR changes is different: quick pages now *choose* the small model up front instead of arriving there by accident after a failure and a retry. Combined with the timeout fix already merged (#527), a browse should stop dying mid-answer.

## Research opens a conversation

You were right about this. Search is question in, page out — seconds, one shot, and the little dialog fits. Research runs for minutes and narrates, which is a *conversation with a long first turn*; a modal that vanishes on completion throws away the narration and any way to ask a follow-up.

It opens a chat window now:

- the plan and each step arrive in the window as they happen (the same `page-progress` events that fed the progress label);
- the finished report opens in the Browser;
- **a follow-up in that window continues the research** — revising the report on screen, using #529's `revise` — rather than answering in prose and quietly abandoning the document.

Filed under a reserved `:research` key, so it can't collide with a project named "research", and it refuses a second question while one is running rather than starting two.

## Verification

`make all`, full suite, `lint-pascal-shape` green. New assertions for the fast-model table in `config_profile_tests`.

FMX unit: 121 implementations, no duplicates, nothing used before declaration, nothing implemented without a declaration, every handler resolving.

`fast_model` documented in `docs/configuration.md`; page model choice and follow-ups in `docs/desktop.md`; the Browser and Research behaviour in `desktop/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_