### PR TITLE
TNotificationCenter lives in System.Notification

### DIFF
--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -28,10 +28,16 @@ uses
   System.SysUtils, System.Types, System.UITypes, System.Classes,
   System.IOUtils, System.StrUtils, System.Generics.Collections,
   System.SyncObjs, System.IniFiles,
+  { TNotificationCenter is in System.Notification, not FMX.Notification.
+    It was FMX-only long ago and moved when VCL apps got it too; the old
+    name is gone, so naming it is a hard "unit not found" rather than
+    anything that degrades. The FMX platform layer still provides the
+    implementation underneath -- only the unit that declares it moved. }
+  System.Notification,
   FMX.Types, FMX.Controls, FMX.Forms, FMX.Graphics, FMX.Dialogs,
   FMX.StdCtrls, FMX.Layouts, FMX.ListBox, FMX.Edit, FMX.Memo, FMX.Styles,
   FMX.Objects, FMX.TreeView, FMX.WebBrowser, FMX.ScrollBox,
-  FMX.Controls.Presentation, FMX.TabControl, FMX.Notification,
+  FMX.Controls.Presentation, FMX.TabControl,
   FMX.RetroWindows, FMX.RetroSkins,
   PasClaw.Client.Api,
   PasClaw.Client.Markdown;


### PR DESCRIPTION
```
[dcc64 Fatal Error] uDesktopMain.pas(34): F2613 Unit 'FMX.Notification' not found.
```

`FMX.Notification` was `TNotificationCenter`'s home before XE8, and was removed when notifications were generalized so VCL apps could have them too. The class is in `System.Notification` now.

Naming the old unit is a hard `F2613` rather than anything that degrades, so the desktop did not compile at all.

The FMX platform layer still provides the implementation underneath — `FMX.Platform.Win` and friends register the notification service, and an FMX app already pulls those in through `FMX.Forms`. Only the unit that *declares* the class moved, so nothing else about the notification code changes: no API differences, and `Supported` / `CreateNotification` / `PresentNotification` are the same.

No `.dproj` change — the project file lists only its own sources, and `System.Notification` comes off the RTL search path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_