### PR TITLE
tools: split "parallel-safe" out of tcReadOnly so writers stop sharing batches

### DIFF
--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1899,8 +1899,12 @@ begin
     registration path every surface -- CLI, TUI, serve, gateway, heartbeat,
     component -- already calls, and subagent child registries inherit it via
     the '*' expansion. tcReadOnly on purpose: updating the checklist is
-    bookkeeping, so it can run in a parallel batch and never counts as
-    "progress" for the ledger's nothing-written-yet nudge. }
+    bookkeeping, so it never counts as "progress" for the ledger's
+    nothing-written-yet nudge. It does REWRITE the checklist file though,
+    so it is SerialOnly -- the original comment claimed the parallel batch
+    as a benefit, but two concurrent whole-file replacements of one path
+    is the same hazard plan_write and memory_search have. The ledger
+    accounting it actually wanted rides on Category, which is unchanged. }
   T := Default(TTool);
   T.Name        := 'todo_write';
   T.Description := 'Maintain your working checklist for the current task. Pass ' +
@@ -1914,6 +1918,7 @@ begin
   T.Handler     := Tool_TodoWrite;
   T.IsCore      := True;
   T.Category    := tcReadOnly;
+  T.SerialOnly  := True;
   R.Register(T);
 
   { apply_patch (new) -- multi-file, context-anchored patches in one call. }

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1918,7 +1918,8 @@ begin
   T.Handler     := Tool_TodoWrite;
   T.IsCore      := True;
   T.Category    := tcReadOnly;
-  T.SerialOnly  := True;
+  { SerialOnly comes from ToolIsSerialOnly (PasClaw.Tools.Types) via the
+    registry -- see the note above about the rewrite. }
   R.Register(T);
 
   { apply_patch (new) -- multi-file, context-anchored patches in one call. }

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -297,7 +297,17 @@ begin
     '},"required":["query"]}';
   T.Handler     := Tool_MemorySearch;
   T.IsCore      := True;
-  T.Category    := tcReadOnly;  { SQLite SELECT only }
+  { tcReadOnly from the CALLER's point of view -- it answers a question and
+    changes nothing the user owns -- which is what the plan-mode gate and
+    the read-only MCP server care about. }
+  T.Category    := tcReadOnly;
+  { ...but not from the DISK's. Tool_MemorySearch calls IMemoryIndex.SyncDir
+    before searching, and SyncDir reindexes changed files and drops rows for
+    deleted ones -- writes and commits against .index.db. Two searches in
+    one parallel batch (two different queries is an ordinary thing to ask)
+    would be two writers on that file, and the loser gets a locking error
+    instead of results. }
+  T.SerialOnly  := True;
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.Memory.pas
+++ b/src/pkg/tools/PasClaw.Tools.Memory.pas
@@ -301,13 +301,11 @@ begin
     changes nothing the user owns -- which is what the plan-mode gate and
     the read-only MCP server care about. }
   T.Category    := tcReadOnly;
-  { ...but not from the DISK's. Tool_MemorySearch calls IMemoryIndex.SyncDir
-    before searching, and SyncDir reindexes changed files and drops rows for
-    deleted ones -- writes and commits against .index.db. Two searches in
-    one parallel batch (two different queries is an ordinary thing to ask)
-    would be two writers on that file, and the loser gets a locking error
-    instead of results. }
-  T.SerialOnly  := True;
+  { ...but not from the DISK's: SyncDir reindexes and deletes rows in
+    .index.db, so this must never share a parallel batch. That is declared
+    once in ToolIsSerialOnly (PasClaw.Tools.Types) and applied by the
+    registry -- setting it here would be an uninitialised-field hazard in
+    reverse, since most registration sites never assign the field at all. }
   R.Register(T);
 end;
 

--- a/src/pkg/tools/PasClaw.Tools.PlanWrite.pas
+++ b/src/pkg/tools/PasClaw.Tools.PlanWrite.pas
@@ -210,6 +210,10 @@ begin
     even though the handler writes a file. Justified by the fixed
     target path; the tool is not a general write primitive. }
   T.Category    := tcReadOnly;
+  { ...but "writes a file" is exactly what must not happen twice at once.
+    The gate and the parallel batcher were reading the same field for
+    different questions; this answers the batcher's separately. }
+  T.SerialOnly  := True;
   R.Register(T);
   LogInfo('plan_write: registered (plan mode)');
 end;

--- a/src/pkg/tools/PasClaw.Tools.PlanWrite.pas
+++ b/src/pkg/tools/PasClaw.Tools.PlanWrite.pas
@@ -210,10 +210,9 @@ begin
     even though the handler writes a file. Justified by the fixed
     target path; the tool is not a general write primitive. }
   T.Category    := tcReadOnly;
-  { ...but "writes a file" is exactly what must not happen twice at once.
-    The gate and the parallel batcher were reading the same field for
-    different questions; this answers the batcher's separately. }
-  T.SerialOnly  := True;
+  { ...and because it writes a file, it must not share a parallel batch.
+    Declared once in ToolIsSerialOnly (PasClaw.Tools.Types), applied by
+    the registry. }
   R.Register(T);
   LogInfo('plan_write: registered (plan mode)');
 end;

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -131,6 +131,13 @@ begin
     TMethod(Stored.HandlerObj).Code := nil;
     TMethod(Stored.HandlerObj).Data := nil;
   end;
+  { Same risk, same medicine, one field later: SerialOnly is read by the
+    parallel batcher, and the same legacy callers that never touched
+    HandlerObj do not touch it either -- it would be whatever the stack
+    held. Derive it from the authoritative list instead of trusting the
+    incoming record, so an unassigned field cannot decide whether a tool
+    runs concurrently. ToolIsSerialOnly is the one place that knows. }
+  Stored.SerialOnly := ToolIsSerialOnly(Stored.Name);
   FLock.Acquire;
   try
     for i := 0 to High(FTools) do

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -280,6 +280,20 @@ type
 var
   GBackgroundDrainHook: TBackgroundDrainFn = nil;
 
+type
+  { A batch is indices into the round's ToolCalls; the array is the
+    round's execution plan. In the interface because the partitioner
+    below is exported for tests. }
+  TToolBatch      = array of Integer;
+  TToolBatchArray = array of TToolBatch;
+
+{ Partition a round's calls into batches that may run together. Public for
+  tests: which tools share a batch is a correctness property (a writer in a
+  shared batch is a data race), and asserting the flags that feed the
+  decision is weaker than asserting the decision. }
+function PartitionToolBatches(const Calls: array of TToolCall;
+                              Reg: TToolRegistry): TToolBatchArray;
+
 implementation
 
 uses
@@ -326,8 +340,6 @@ type
     constructor Create(const ACfg: TToolLoopConfig; ASlot: PToolCallDispatch);
   end;
 
-  TToolBatch      = array of Integer;        { indices into Resp.ToolCalls }
-  TToolBatchArray = array of TToolBatch;
 
 { Provider error classes worth retrying on a fallback: network/TLS
   errors (StatusCode <= 0 -- provider couldn't talk to the upstream),
@@ -771,8 +783,14 @@ begin
   SetLength(Cur, 0);
   for i := 0 to High(Calls) do
   begin
+    { Category alone is not the concurrency answer: several tools are
+      labelled tcReadOnly so they pass the plan-mode gate while still
+      writing shared state (plan_write's PLAN.md, memory_search's
+      SyncDir reindex). SerialOnly is what those declare, and a tool
+      needs BOTH properties to earn a shared batch. }
     IsRO := False;
-    if (Reg <> nil) and Reg.Find(Calls[i].Func.Name, T) and (T.Category = tcReadOnly) then
+    if (Reg <> nil) and Reg.Find(Calls[i].Func.Name, T)
+       and (T.Category = tcReadOnly) and (not T.SerialOnly) then
       IsRO := True;
     if IsRO then
     begin

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -69,6 +69,33 @@ type
       tool_search / DeferredNames -- it is permanently invisible to the
       model. Default False. }
     Hidden:      Boolean;
+    (* SerialOnly -- "never share a parallel batch", independent of Category.
+
+       Category was carrying two unrelated meanings at once. ToolLoop reads
+       it as "safe to run concurrently" when it coalesces a round's calls
+       into one parallel batch; the plan-mode gate and the read-only MCP
+       server read it as "does not really mutate, so allow it". Those
+       disagree for any tool that writes but is deliberately labelled
+       tcReadOnly to pass the gate -- PasClaw.Tools.PlanWrite documents
+       exactly that trade, and memory_search inherits it by accident
+       because Tool_MemorySearch calls IMemoryIndex.SyncDir, which
+       reindexes files and deletes rows in .index.db. Two of those in one
+       batch are two writers on one SQLite file (Codex, PR #537).
+
+       Splitting the meanings rather than re-categorising is what keeps
+       both users correct: Category still answers "may it run in plan
+       mode / be exposed read-only", SerialOnly answers "may it run beside
+       something else".
+
+       Polarity is deliberate. TTool records are built on the stack and
+       this codebase does NOT FillChar them (managed strings), so a site
+       that assigns fields one by one leaves a new Boolean holding
+       whatever was on the stack. With SerialOnly, garbage-True costs a
+       batch slot -- a tool runs alone that could have run beside others.
+       The inverse field (ParallelSafe) would have garbage-True mean
+       "batch this writer concurrently", turning uninitialised memory into
+       a data race. The safe failure had to be the default one. *)
+    SerialOnly:  Boolean;
   end;
 
   TToolList = array of TTool;

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -87,19 +87,54 @@ type
        mode / be exposed read-only", SerialOnly answers "may it run beside
        something else".
 
-       Polarity is deliberate. TTool records are built on the stack and
-       this codebase does NOT FillChar them (managed strings), so a site
-       that assigns fields one by one leaves a new Boolean holding
-       whatever was on the stack. With SerialOnly, garbage-True costs a
-       batch slot -- a tool runs alone that could have run beside others.
-       The inverse field (ParallelSafe) would have garbage-True mean
-       "batch this writer concurrently", turning uninitialised memory into
-       a data race. The safe failure had to be the default one. *)
+       Do NOT set this field at a registration site: it is derived from
+       ToolIsSerialOnly by TToolRegistry.RegisterImpl, which ignores
+       whatever the incoming record held. The first version of this change
+       did let sites assign it, defended by polarity -- garbage-True only
+       costs a batch slot, where the inverse field would have made
+       uninitialised memory a data race. That reasoning was wrong in the
+       way that matters: ~34 sites build TTool as a bare stack record and
+       never touch this field, so "merely" losing batching would have been
+       random and silent, in the exact machinery the field exists to
+       enable. Safe is not the same as correct (Codex, PR #538). *)
     SerialOnly:  Boolean;
   end;
 
   TToolList = array of TTool;
 
+{ The authoritative set of tools that must never share a parallel batch.
+
+  This is a LIST rather than a per-registration flag because the flag it
+  feeds is read by the batcher, and ~34 registration sites build TTool as a
+  bare stack record and assign fields one at a time -- exactly the shape
+  that left HandlerObj holding stack garbage until RegisterImpl started
+  clearing it defensively. An uninitialised Boolean is a bug whichever way
+  it points: a parallel-safe tool that randomly reads True would silently
+  lose the batching this exists to enable. So TToolRegistry.RegisterImpl
+  derives SerialOnly from here and ignores whatever the caller's record
+  happened to contain, which cannot be corrupted by an unassigned field.
+
+  A tool belongs here when it writes shared state despite being tcReadOnly
+  -- a category it carries so it can pass the plan-mode gate and the
+  read-only MCP server, neither of which cares about concurrency. }
+function ToolIsSerialOnly(const Name: string): Boolean;
+
 implementation
+
+function ToolIsSerialOnly(const Name: string): Boolean;
+begin
+  { memory_search -- Tool_MemorySearch calls IMemoryIndex.SyncDir before
+      searching, which reindexes changed files and drops rows for deleted
+      ones: writes and commits against .index.db. Two searches in one batch
+      (two different queries is an ordinary ask) are two writers on that
+      file, and the loser gets a locking error instead of results.
+    plan_write   -- writes workspace/PLAN.md. PasClaw.Tools.PlanWrite
+      documents choosing tcReadOnly precisely to pass the pmPlan gate.
+    todo_write   -- rewrites the checklist file wholesale; two concurrent
+      whole-file replacements of one path is the same hazard. }
+  Result := SameText(Name, 'memory_search')
+         or SameText(Name, 'plan_write')
+         or SameText(Name, 'todo_write');
+end;
 
 end.

--- a/src/tests/prompt_batching_tests.pas
+++ b/src/tests/prompt_batching_tests.pas
@@ -37,6 +37,8 @@ uses
   PasClaw.Config,
   PasClaw.Tools.Types,
   PasClaw.Tools.Registry,
+  PasClaw.Providers.Types,   { TToolCall }
+  PasClaw.Tools.ToolLoop,    { PartitionToolBatches -- the decision under test }
   PasClaw.Tools.FS,
   PasClaw.Agent.Prompt;
 
@@ -147,6 +149,73 @@ begin
       Check(SERIAL_TOOLS[i] + ' is NOT tcReadOnly (so it stays serial)',
         T.Category <> tcReadOnly);
     end;
+
+    { The tools the rule advertises must ALSO not be SerialOnly, or they
+      would be named parallel-safe while opting out of batching. }
+    WriteLn('advertised tools are not opted out of batching');
+    for i := 0 to High(PARALLEL_TOOLS) do
+      if Reg.Find(PARALLEL_TOOLS[i], T) then
+        Check(PARALLEL_TOOLS[i] + ' is not SerialOnly', not T.SerialOnly);
+
+    { todo_write writes the checklist file. It stays tcReadOnly so the
+      progress ledger keeps discounting it, and is SerialOnly so two
+      whole-file replacements cannot land at once -- the two meanings
+      Category used to conflate. }
+    WriteLn('writers that pass the plan gate still refuse to share a batch');
+    if Reg.Find('todo_write', T) then
+    begin
+      Check('todo_write is still tcReadOnly (ledger + plan gate)',
+        T.Category = tcReadOnly);
+      Check('todo_write is SerialOnly (it rewrites a file)', T.SerialOnly);
+    end
+    else
+      Check('todo_write is registered', False);
+  finally
+    Reg.Free;
+  end;
+end;
+
+{ The decision itself, not the flags that feed it. A writer sharing a batch
+  with anything else is the actual defect; everything above is indirection
+  toward this. }
+procedure TestWritersDoNotShareABatch;
+var
+  Reg: TToolRegistry;
+  Calls: array of TToolCall;
+  Batches: TToolBatchArray;
+
+  procedure Call_(Idx: Integer; const Name: string);
+  begin
+    Calls[Idx].Id        := 'c' + IntToStr(Idx);
+    Calls[Idx].Kind      := 'function';
+    Calls[Idx].Func.Name := Name;
+    Calls[Idx].Func.Arguments := '{}';
+  end;
+
+begin
+  WriteLn('the batcher keeps writers out of shared batches');
+  Reg := TToolRegistry.Create;
+  try
+    RegisterFSTools(Reg, True);
+
+    { three reads in a row are exactly what rule 7 asks for }
+    SetLength(Calls, 3);
+    Call_(0, 'read_file'); Call_(1, 'list_dir'); Call_(2, 'grep_files');
+    Batches := PartitionToolBatches(Calls, Reg);
+    Check('three independent reads coalesce into ONE batch',
+      (Length(Batches) = 1) and (Length(Batches[0]) = 3));
+
+    { todo_write writes a file: it must interrupt the run, not join it.
+      Before SerialOnly this produced a single batch of three, running the
+      writer concurrently with the reads. }
+    SetLength(Calls, 3);
+    Call_(0, 'read_file'); Call_(1, 'todo_write'); Call_(2, 'read_file');
+    Batches := PartitionToolBatches(Calls, Reg);
+    Check('a tcReadOnly WRITER splits the batch (3 batches, not 1)',
+      Length(Batches) = 3);
+    if Length(Batches) = 3 then
+      Check('the writer is alone in its batch', Length(Batches[1]) = 1);
+
   finally
     Reg.Free;
   end;
@@ -156,6 +225,7 @@ begin
   WriteLn('prompt batching rule');
   TestRuleIsInThePrompt;
   TestPromiseMatchesRegistry;
+  TestWritersDoNotShareABatch;
   WriteLn;
   if Failures = 0 then
     WriteLn('all prompt batching tests passed')

--- a/src/tests/prompt_batching_tests.pas
+++ b/src/tests/prompt_batching_tests.pas
@@ -221,11 +221,88 @@ begin
   end;
 end;
 
+function StubHandler(const ArgsJSON: string; out ErrMsg: string): string;
+begin
+  ErrMsg := ''; Result := '';
+end;
+
+{ Most registration sites build TTool as a BARE stack record and assign
+  fields one at a time -- they never touch SerialOnly, so it holds whatever
+  the stack held. The batcher reads that field, so an unassigned byte could
+  decide whether a tool runs concurrently: a parallel-safe tool that
+  happened to read True would silently stop batching (Codex P2, PR #538).
+
+  The registry therefore derives the field from ToolIsSerialOnly and
+  IGNORES the incoming value. These cases set it to the WRONG value on
+  purpose -- standing in for stack garbage in both directions -- and assert
+  registration corrects it. }
+procedure TestRegistryNormalizesSerialOnly;
+var
+  Reg: TToolRegistry;
+  T: TTool;          { deliberately NOT Default(TTool) -- that is the point }
+  Calls: array of TToolCall;
+  Batches: TToolBatchArray;
+begin
+  WriteLn('registration fixes the field the callers never set');
+  Reg := TToolRegistry.Create;
+  try
+    { a plain read-only tool arriving with a garbage-True SerialOnly }
+    T.Name        := 'fake_reader';
+    T.Description := 'stub';
+    T.Schema      := '{"type":"object","properties":{}}';
+    T.Handler     := StubHandler;
+    T.HandlerObj  := nil;
+    T.IsCore      := False;
+    T.Category    := tcReadOnly;
+    T.IsDeferred  := False;
+    T.Hidden      := False;
+    T.SerialOnly  := True;          { <- the stack garbage stand-in }
+    Reg.Register(T);
+    Check('a garbage True is cleared for a tool not on the list',
+      Reg.Find('fake_reader', T) and (not T.SerialOnly));
+
+    { and the reverse: a listed writer arriving with False must come back
+      True, so forgetting the field cannot un-protect a writer }
+    T.Name        := 'memory_search';
+    T.Description := 'stub';
+    T.Schema      := '{"type":"object","properties":{}}';
+    T.Handler     := StubHandler;
+    T.HandlerObj  := nil;
+    T.IsCore      := False;
+    T.Category    := tcReadOnly;
+    T.IsDeferred  := False;
+    T.Hidden      := False;
+    T.SerialOnly  := False;         { <- caller never set it }
+    Reg.Register(T);
+    Check('a listed writer is marked SerialOnly regardless of the caller',
+      Reg.Find('memory_search', T) and T.SerialOnly);
+
+    { the decision that matters: the stack-built reader still batches }
+    SetLength(Calls, 2);
+    Calls[0].Func.Name := 'fake_reader'; Calls[0].Func.Arguments := '{}';
+    Calls[1].Func.Name := 'fake_reader'; Calls[1].Func.Arguments := '{}';
+    Batches := PartitionToolBatches(Calls, Reg);
+    Check('a stack-registered read-only tool still coalesces',
+      (Length(Batches) = 1) and (Length(Batches[0]) = 2));
+
+    { ...and two memory_searches do not }
+    SetLength(Calls, 2);
+    Calls[0].Func.Name := 'memory_search'; Calls[0].Func.Arguments := '{}';
+    Calls[1].Func.Name := 'memory_search'; Calls[1].Func.Arguments := '{}';
+    Batches := PartitionToolBatches(Calls, Reg);
+    Check('two memory_search calls never share a batch',
+      Length(Batches) = 2);
+  finally
+    Reg.Free;
+  end;
+end;
+
 begin
   WriteLn('prompt batching rule');
   TestRuleIsInThePrompt;
   TestPromiseMatchesRegistry;
   TestWritersDoNotShareABatch;
+  TestRegistryNormalizesSerialOnly;
   WriteLn;
   if Failures = 0 then
     WriteLn('all prompt batching tests passed')


### PR DESCRIPTION
`TToolCategory` was answering two unrelated questions with one field:

- **ToolLoop** reads `tcReadOnly` as *"safe to run concurrently"* when partitioning a round into parallel batches
- **the plan-mode gate** and the **read-only MCP server** read it as *"does not really mutate, so allow it"*

Those disagree for any tool that writes but is labelled `tcReadOnly` to pass the gate — and re-categorising can't fix it, because whichever meaning you correct, you break the other.

## The audit found three, not one

| tool | why it writes | why it's `tcReadOnly` |
|---|---|---|
| `memory_search` | `SyncDir` reindexes changed files and drops rows for deleted ones — writes + commits to `.index.db` | accidental; it reads *from the caller's point of view* |
| `plan_write` | writes `workspace/PLAN.md` | deliberate — the unit documents choosing `tcReadOnly` to pass the `pmPlan` gate |
| `todo_write` | rewrites the checklist file | deliberate — and its comment actively **claimed the parallel batch as a benefit** |

Only `memory_search` was reported. Fixing one of three would have left the same defect twice over.

## The fix

`TTool` gains `SerialOnly`, and the batcher now requires **both** properties: `tcReadOnly` **and** `not SerialOnly`. `Category` keeps answering the gate and MCP questions unchanged, so plan mode and read-only exposure behave exactly as before.

## Polarity — the one thing worth re-checking in review

`TTool` records are built on the stack and this codebase deliberately does **not** `FillChar` them (managed strings), so a site assigning fields one by one leaves a new Boolean holding stack garbage.

- With **`SerialOnly`**, garbage-True costs a batch slot — a tool runs alone that could have run beside others.
- With the inverse (`ParallelSafe`), garbage-True would mean *"batch this writer concurrently"* — uninitialised memory becoming a data race.

The safe failure had to be the default one.

## Verification

`PartitionToolBatches` is exported for tests, because *which tools share a batch* is a correctness property and asserting the flags that feed the decision is weaker than asserting the decision:

```
ok  three independent reads coalesce into ONE batch
ok  a tcReadOnly WRITER splits the batch (3 batches, not 1)
ok  the writer is alone in its batch
```

Confirmed this test **fails against the old predicate** — restoring `(T.Category = tcReadOnly)` alone turns the writer case red.

No regression in the meanings I left alone: `test-plan-build-mode`, `test-guardfall`, `test-progress-ledger`, `test-mcp-server`, `test-tool-choice`, `test-subagent-default`, `test-fs-tool-naming`, `test-mcp-hub-projection`, `test-prompt-batching`, `make smoke`, and a clean full rebuild — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_