### PR TITLE
Closing the desktop waited for the gateway to say something

### DIFF
--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -428,6 +428,19 @@ type
     procedure QueueLogEntry(const Kind, Origin, Text_: string);
     procedure DrainLogLines;
     procedure StopLogWatch;
+    (* Stop the desktop event watcher.
+
+       Terminate alone does not do it, and this is why closing the app was
+       nearly impossible. The thread spends its life inside WatchEvents,
+       blocked on a read with no timeout; Terminated is only consulted
+       between reconnects, and the callback's Stop flag is only consulted
+       when a real event arrives. A keepalive does not count -- it is a
+       comment line and gets dropped before the callback sees it.
+
+       So on an idle board, which is most of the time, joining this thread
+       waits for something to happen on the gateway. Measured at 45 seconds
+       and still going, against a gateway that was perfectly healthy. *)
+    procedure StopEventWatch;
 
     { ---- hex viewer ---- }
     procedure OpenHex(const Path: string);
@@ -924,7 +937,9 @@ begin
         component as the form comes apart, which is after this runs.
      2. Stop the timers, or a tick lands mid-teardown and repaints windows
         that are going away.
-     3. Stop the watcher threads, which read through the client.
+     3. Stop the watcher threads, which read through the client -- and
+        stopping them means CUTTING them, not asking politely: both park
+        inside a blocking read that a flag cannot reach.
      4. Save, while the client still exists -- the layout lives on the
         gateway, so there is no writing it afterwards.
      5. Only then free anything. *)
@@ -937,12 +952,7 @@ begin
   if FRunTimer <> nil then FRunTimer.Enabled := False;
 
   { Stop the watchers before the client they read through goes away. }
-  if FEventThread <> nil then
-  begin
-    FEventThread.Terminate;
-    FEventThread.WaitFor;
-    FreeAndNil(FEventThread);
-  end;
+  StopEventWatch;
   StopLogWatch;
   (* And release the off-thread work, which is the other thing holding the
      client. Freeing it while a worker is mid-request is a use-after-free
@@ -960,9 +970,20 @@ begin
      because a desktop must close even when something has gone wrong. *)
   if FClient <> nil then FClient.CancelAll;
   WaitForAsync(5000);
-  { Save before the client goes: the layout is stored on the gateway, so
-    there is no writing it once the connection is gone -- which is why this
-    is the one save that waits. }
+  (* Save before the client goes: the layout is stored on the gateway, so
+     there is no writing it once the connection is gone -- which is why this
+     is the one save that waits.
+
+     On a SHORT clock, though. This is a blocking PUT, and the ordinary
+     thirty seconds is a sensible answer to "how long may a board call take"
+     and a terrible one to "how long may closing the window take" -- a
+     gateway that has stopped answering would hold the app open for half a
+     minute over a layout nobody is waiting for. Losing the arrangement is
+     the cheaper failure.
+
+     After CancelAll, deliberately: that cut only what was already on the
+     wire, so this opens a fresh connection and is not cancelled with them. *)
+  if FClient <> nil then FClient.TimeoutMs := 3000;
   try
     SaveDesktopStateNow;
   except
@@ -2717,6 +2738,8 @@ begin
 end;
 
 procedure TEventWatchThread.Execute;
+var
+  Naps: Integer;
 begin
   while not Terminated do
   begin
@@ -2728,7 +2751,14 @@ begin
       { a dead gateway is not an error worth a dialog -- retry quietly }
     end;
     if Terminated then Break;
-    Sleep(3000);
+    { Sliced, not one Sleep(3000): a Terminate arriving at the start of the
+      pause would otherwise still hold the joiner for three seconds, and
+      "closing takes a moment" is how a close button stops being trusted. }
+    for Naps := 1 to 30 do
+    begin
+      if Terminated then Break;
+      Sleep(100);
+    end;
   end;
 end;
 
@@ -2740,6 +2770,8 @@ begin
 end;
 
 procedure TLogWatchThread.Execute;
+var
+  Naps: Integer;
 begin
   while not Terminated do
   begin
@@ -2749,7 +2781,11 @@ begin
       { same deal as events: a dead gateway is a retry, not a dialog }
     end;
     if Terminated then Break;
-    Sleep(3000);
+    for Naps := 1 to 30 do
+    begin
+      if Terminated then Break;
+      Sleep(100);
+    end;
   end;
 end;
 
@@ -2797,6 +2833,10 @@ begin
   FLogStop := False;
   if FLogThread = nil then
   begin
+    { Same rule as the event stream: arm before the thread exists. The Log
+      window is opened and closed repeatedly, so this one really does get
+      cancelled and restarted. }
+    FClient.BeginLogs;
     FLogThread := TLogWatchThread.Create(Self);
     FLogThread.Start;
   end;
@@ -2917,6 +2957,18 @@ begin
   finally
     Batch.Free;
   end;
+end;
+
+procedure TFormMain.StopEventWatch;
+begin
+  if FEventThread = nil then Exit;
+  FEventThread.Terminate;
+  { Cut the socket BEFORE joining, exactly as StopLogWatch does. The flag
+    set by Terminate cannot reach a thread parked in a read; only closing
+    the socket under it can. }
+  if FClient <> nil then FClient.CancelEvents;
+  FEventThread.WaitFor;
+  FreeAndNil(FEventThread);
 end;
 
 procedure TFormMain.StopLogWatch;
@@ -3222,6 +3274,9 @@ begin
   FEventTimer.OnTimer := EventTimerTick;
   FEventTimer.Enabled := True;
 
+  { Armed before the thread exists. Clearing the cancel latch from inside
+    the watcher would race a cancel that arrived first -- see BeginEvents. }
+  FClient.BeginEvents;
   FEventThread := TEventWatchThread.Create(Self);
   FEventThread.Start;
 end;

--- a/src/pkg/component/PasClaw.Client.Api.pas
+++ b/src/pkg/component/PasClaw.Client.Api.pas
@@ -258,6 +258,24 @@ type
        of its interface deliberately, and a cancel only needs Disconnect. *)
     FLive: TList;
     FLiveLock: TCriticalSection;
+    (* And the same for /v1/desktop/events, which needs it MORE, not less.
+
+       The reasoning that left this one out was that the event stream sends
+       a keepalive every ~15s, so a reader is never parked indefinitely. That
+       is true of the socket and false of the caller: a keepalive is a
+       comment line, and Consume drops comment lines BEFORE calling
+       FOnEvent -- so the Stop flag the callback sets is never consulted on
+       one. Stop is only read when a real `data:` event arrives, and an idle
+       board produces none.
+
+       So a client watching a healthy, quiet gateway blocks in Get until
+       something happens on the board. Measured: a join after Terminate was
+       still waiting 45 seconds later, against a gateway that was up and
+       sending keepalives the whole time. Not "fifteen seconds sometimes" --
+       indefinite, in the state the desktop spends most of its life in. *)
+    FEventHttp: TObject;
+    FEventLock: TCriticalSection;
+    FEventCancelled: Boolean;
     procedure TrackHttp(H: TObject);
     procedure UntrackHttp(H: TObject);
     procedure Trace(const Method, Path: string; Status, Millis: Integer;
@@ -484,6 +502,9 @@ type
     (* Cut the log subscription now, from any thread. Safe to call when
        none is running. Call this BEFORE joining the watcher thread. *)
     procedure CancelLogs;
+    { Arm the log stream for a new watch, clearing a previous cancel. Call it
+      on the thread that STARTS the watcher, before starting it. }
+    procedure BeginLogs;
     (* Cut every request currently in flight.
 
        For shutdown. A caller closing while a minutes-long call is out has
@@ -495,6 +516,15 @@ type
        request and runs normally, which is what lets a shutdown cancel its
        stragglers and still write one last thing. *)
     procedure CancelAll;
+    (* The same for the desktop event stream, and separately -- because this
+       one has to LATCH.
+
+       Terminate the thread first, then this, then join it. The flag alone
+       will not wake a reader parked in a zero-timeout Get. *)
+    procedure CancelEvents;
+    { Arm the event stream for a new watch, clearing a previous cancel. Call
+      it on the thread that STARTS the watcher, before starting it. }
+    procedure BeginEvents;
 
     { ---- raw bytes ---- }
     (* A bounded window of a file's bytes, for the hex viewer: a binary file
@@ -1030,6 +1060,7 @@ begin
   FLogLock := TCriticalSection.Create;
   FLiveLock := TCriticalSection.Create;
   FLive := TList.Create;
+  FEventLock := TCriticalSection.Create;
   FTimeoutMs := 30000;
   FModelTimeoutMs := 20 * 60 * 1000;   { deep research runs for minutes }
 end;
@@ -1058,10 +1089,12 @@ end;
 destructor TPasClawClient.Destroy;
 begin
   CancelLogs;
+  CancelEvents;
   CancelAll;
   FreeAndNil(FLogLock);
   FreeAndNil(FLive);
   FreeAndNil(FLiveLock);
+  FreeAndNil(FEventLock);
   inherited;
 end;
 
@@ -1099,32 +1132,32 @@ end;
 
 procedure TPasClawClient.CancelAll;
 var
-  Copy_: TList;
   I: Integer;
 begin
   if (FLiveLock = nil) or (FLive = nil) then Exit;
-  { Copied under the lock and disconnected outside it: Disconnect can block
-    briefly, and holding the lock across it would stall every request trying
-    to unregister itself -- the very threads this is trying to release. }
-  Copy_ := TList.Create;
+  (* Disconnected UNDER the lock, not from a copy taken out of it.
+
+     Copying the handles and releasing first looks kinder to the threads
+     trying to unregister -- and hands every one of them the chance to
+     finish, unregister and FREE its TIdHTTP before the loop below reaches
+     it. Disconnect would then be a method call on freed memory, which no
+     amount of try/except makes safe.
+
+     UntrackHttp takes this lock before its owner frees anything, so holding
+     it here is exactly what keeps these objects alive for the length of the
+     call. The threads it blocks are the ones that must wait. *)
+  FLiveLock.Acquire;
   try
-    FLiveLock.Acquire;
-    try
-      for I := 0 to FLive.Count - 1 do
-        Copy_.Add(FLive[I]);
-    finally
-      FLiveLock.Release;
-    end;
-    for I := 0 to Copy_.Count - 1 do
+    for I := 0 to FLive.Count - 1 do
       { Disconnecting from another thread is how Indy cancels a blocked
         read: the reader surfaces a socket error and unwinds. Swallowed
         because a race with normal completion is a no-op, not a problem. }
       try
-        TIdHTTP(Copy_[I]).Disconnect(False);
+        TIdHTTP(FLive[I]).Disconnect(False);
       except
       end;
   finally
-    Copy_.Free;
+    FLiveLock.Release;
   end;
 end;
 
@@ -1236,16 +1269,16 @@ var
 begin
   FLastError := '';
   Sink := TLogStream.Create(OnLine);
-  { A previous cancel must not silence errors on this one. }
-  FLogCancelled := False;
   Http := NewHttp(FToken, 0);
   try
     { Same deal as WatchEvents: an open, mostly-idle connection. }
     Http.ReadTimeout := 0;
     Http.Request.Accept := 'text/event-stream';
-    { Publish the handle so CancelLogs can reach it while we block below. }
+    { Test the latch and publish the handle in one critical section -- see
+      WatchEvents. BeginLogs clears the latch, before this thread exists. }
     FLogLock.Acquire;
     try
+      if FLogCancelled then Exit;
       FLogHttp := Http;
     finally
       FLogLock.Release;
@@ -1272,24 +1305,77 @@ begin
 end;
 
 procedure TPasClawClient.CancelLogs;
-var
-  H: TObject;
 begin
   if FLogLock = nil then Exit;
-  FLogCancelled := True;
+  { Latched, and disconnected under the lock -- for both reasons spelled out
+    on CancelEvents. This one had the same two holes; the Log window is
+    opened and closed often enough to hit them. }
   FLogLock.Acquire;
   try
-    H := FLogHttp;
+    FLogCancelled := True;
+    if FLogHttp = nil then Exit;
+    try
+      TIdHTTP(FLogHttp).Disconnect(False);
+    except
+    end;
   finally
     FLogLock.Release;
   end;
-  if H = nil then Exit;
-  { Disconnecting from another thread is how Indy cancels a blocked read:
-    the reader surfaces a socket error and unwinds. Swallowed because a
-    race with normal completion is a no-op, not a problem. }
+end;
+
+procedure TPasClawClient.BeginLogs;
+begin
+  if FLogLock = nil then Exit;
+  FLogLock.Acquire;
   try
-    TIdHTTP(H).Disconnect(False);
-  except
+    FLogCancelled := False;
+  finally
+    FLogLock.Release;
+  end;
+end;
+
+procedure TPasClawClient.CancelEvents;
+begin
+  if FEventLock = nil then Exit;
+  (* The whole thing under one lock, deliberately.
+
+     The handle cannot be copied out and used afterwards: if the stream ends
+     naturally in that gap, WatchEvents clears the field and frees the
+     TIdHTTP, and this would then call Disconnect on freed memory. An except
+     block does not make that safe -- it is not an exception, it is a method
+     call on an object that is gone.
+
+     WatchEvents' cleanup takes the same lock before it frees, so holding it
+     across the Disconnect is what keeps the object alive for the length of
+     the call. Disconnect can block briefly and the only thread it can block
+     is that cleanup, which is precisely the thread that must wait. *)
+  FEventLock.Acquire;
+  try
+    FEventCancelled := True;
+    if FEventHttp = nil then Exit;
+    { Disconnecting from another thread is how Indy cancels a blocked read:
+      the reader surfaces a socket error and unwinds. Swallowed because a
+      race with normal completion is a no-op, not a problem. }
+    try
+      TIdHTTP(FEventHttp).Disconnect(False);
+    except
+    end;
+  finally
+    FEventLock.Release;
+  end;
+end;
+
+procedure TPasClawClient.BeginEvents;
+begin
+  if FEventLock = nil then Exit;
+  { Cleared HERE rather than at the top of WatchEvents, which is the whole
+    point: the starter runs before the thread exists, so a cancel arriving
+    afterwards cannot be lost. }
+  FEventLock.Acquire;
+  try
+    FEventCancelled := False;
+  finally
+    FEventLock.Release;
   end;
 end;
 
@@ -1436,21 +1522,52 @@ begin
   FLastError := '';
   Sink := TEventStream.Create(OnEvent);
   Http := NewHttp(FToken, 0);
-  TrackHttp(Http);
   try
     { No read timeout: this connection is SUPPOSED to stay open and quiet.
-      The gateway sends a keepalive comment every ~15s, so a genuinely dead
-      socket still surfaces as a read error rather than hanging forever. }
+      Which means nothing here will ever end this call on its own -- see the
+      note on FEventHttp for why the keepalive does not, either. The handle
+      is published below so a caller can. }
     Http.ReadTimeout := 0;
     Http.Request.Accept := 'text/event-stream';
+    (* Test the latch and publish the handle in ONE critical section.
+
+       Two separate steps leave a window at exactly the wrong moment: a
+       Terminate + CancelEvents landing after the thread's loop check but
+       before the handle is published finds nothing to cut, and the worker
+       then blocks in a Get nobody can reach while the joiner is already
+       waiting. Closing hangs anyway, which is the bug.
+
+       So the cancel LATCHES rather than firing once, and this refuses to
+       start when the latch is set. BeginEvents clears it, on the thread
+       that starts the watcher, before the watcher exists. *)
+    FEventLock.Acquire;
+    try
+      if FEventCancelled then Exit;
+      FEventHttp := Http;
+    finally
+      FEventLock.Release;
+    end;
     try
       Http.Get(FBaseURL + '/v1/desktop/events', Sink);
     except
       on E: EAbort do ;      { caller asked to stop }
-      on E: Exception do FLastError := E.Message;
+      on E: Exception do
+        { A cancelled read is not a failure to report -- it is what was
+          asked for. }
+        if not FEventCancelled then FLastError := E.Message;
     end;
   finally
-    UntrackHttp(Http);
+    (* One owner per handle. This one is NOT in the general registry: two
+       mechanisms able to Disconnect the same socket, each under its own
+       lock, is how the "hold the lock across the disconnect" guarantee stops
+       composing -- CancelAll could be inside Disconnect while this is
+       freeing. CancelEvents owns the event stream; CancelAll owns the rest. *)
+    FEventLock.Acquire;
+    try
+      FEventHttp := nil;
+    finally
+      FEventLock.Release;
+    end;
     Http.Free;
     Sink.Free;
   end;

--- a/src/tests/cancelprobe.pas
+++ b/src/tests/cancelprobe.pas
@@ -1,0 +1,105 @@
+program cancelprobe;
+(*
+  Proves the desktop event-stream cancel reaches the socket.
+
+  This is the bug that made closing PasClaw Desktop nearly impossible.
+  WatchEvents blocks in an HTTP GET with no read timeout; Terminate sets a
+  flag the thread only checks between reconnects, and the callback's Stop
+  flag is only consulted when a real `data:` event arrives -- a keepalive is
+  a comment line and gets dropped before the callback sees it. So on an idle
+  board, joining that thread waits for something to happen on the gateway,
+  which may be never.
+
+  Measured before the fix: still waiting 45 seconds after Terminate, against
+  a gateway that was up and healthy the whole time. After: 101ms.
+
+  NOT part of `make test`, and deliberately so: it needs a LIVE gateway on a
+  real port, and the default suite runs in-process. Two commands:
+
+    PASCLAW_HOME=build/probe-home build/pasclaw gateway --port 8231 &
+    build/cancelprobe http://127.0.0.1:8231
+
+  Build it the way the other tests are built -- same FPC flags, see the
+  test-* targets in the Makefile.
+*)
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+{$H+}
+uses
+  {$IFDEF FPC}{$IFDEF UNIX}cthreads,{$ENDIF}{$ENDIF}
+  SysUtils, Classes, DateUtils,
+  PasClaw.Client.Api;
+
+type
+  TWatch = class(TThread)
+  private
+    FC: TPasClawClient;
+  protected
+    procedure Execute; override;
+  public
+    Returned: Boolean;
+    constructor Create(AC: TPasClawClient);
+    procedure OnEv(const Ev: TDesktopEvent; var Stop: Boolean);
+  end;
+
+constructor TWatch.Create(AC: TPasClawClient);
+begin
+  inherited Create(True);
+  FC := AC;
+  FreeOnTerminate := False;
+  Returned := False;
+end;
+
+procedure TWatch.OnEv(const Ev: TDesktopEvent; var Stop: Boolean);
+begin
+  Stop := Terminated;
+end;
+
+procedure TWatch.Execute;
+begin
+  FC.WatchEvents(OnEv);
+  Returned := True;
+end;
+
+var
+  C: TPasClawClient;
+  W: TWatch;
+  T0: TDateTime;
+  Ms: Integer;
+  Ver: string;
+begin
+  C := TPasClawClient.Create(ParamStr(1));
+  try
+    if not C.Ping(Ver) then
+    begin
+      WriteLn('no gateway at ', ParamStr(1));
+      Halt(2);
+    end;
+    W := TWatch.Create(C);
+    try
+      W.Start;
+      { Let the stream establish and park. }
+      Sleep(1500);
+      if W.Returned then
+      begin
+        WriteLn('FAIL: the watcher returned before it was cancelled');
+        Halt(1);
+      end;
+      T0 := Now;
+      W.Terminate;
+      C.CancelEvents;
+      W.WaitFor;
+      Ms := MilliSecondsBetween(Now, T0);
+      WriteLn('joined in ', Ms, 'ms');
+      if Ms > 2000 then
+      begin
+        WriteLn('FAIL: the join took ', Ms, 'ms -- cancel did not reach the socket');
+        Halt(1);
+      end;
+      WriteLn('OK');
+    finally
+      W.Free;
+    end;
+  finally
+    C.Free;
+  end;
+end.


### PR DESCRIPTION
`FormDestroy` joins the event-watcher thread, and that thread lives inside `WatchEvents`, blocked in an HTTP GET **with no read timeout**.

`Terminate` does not reach it. The flag is only consulted between reconnects, and the callback's `Stop` flag only when a real `data:` event arrives. **A keepalive does not count** — `Consume` drops comment lines *before* calling the callback, so the ~15s keepalive that was supposed to make this safe never wakes the reader. Joining that thread waits for something to happen on the board; on an idle desktop nothing does.

## Measured, not reasoned

Against a real gateway on a real port:

| | join after `Terminate` |
|---|---|
| before | **still waiting at 45s**, gateway up and healthy throughout |
| after | **100ms** |

`src/tests/cancelprobe.pas` is that measurement, with the two commands to run it at the top. Not in `make test` — it needs a live listener and the default suite runs in-process. I ran it both ways; the "before" number came from neutering the cancel to set its flag and skip the `Disconnect`, changing nothing else.

## Review findings — both legit, and both were in `CancelLogs` and `CancelAll` too

**A cancel has to latch.** `Terminate` + cancel landing after the thread's loop check but before it publishes its handle found nothing to cut, and the worker then blocked in a `Get` nobody could reach while the joiner was already waiting — the same hang through a narrower door. The cancel now sets a latch, the watcher **tests the latch and publishes its handle in one critical section**, and `BeginEvents` / `BeginLogs` clear it on the thread that *starts* the watcher, before the watcher exists. Clearing it from inside the watcher — which is what both did — is what created the window.

**Disconnect under the lock.** Copying the handle out and disconnecting after releasing hands the stream time to end naturally, clear the field and **free** the `TIdHTTP` first; `Disconnect` is then a method call on freed memory, which no `try/except` makes safe. The watcher's cleanup takes the same lock before it frees, so holding it across the `Disconnect` is exactly what keeps the object alive. `CancelAll` (merged with #536) had this over every handle at once — fixed here too.

Consequently the event stream is **no longer in the general handle registry**: two mechanisms able to disconnect one socket under two different locks is how "hold the lock across the disconnect" stops composing. One owner per handle.

## Two smaller things on the same path

- The retry pause between reconnects was one `Sleep(3000)`, so a `Terminate` at the start of it still held the joiner three seconds. Sliced into 100ms checks.
- The final layout save ran on the ordinary **30-second** clock. It gets 3 seconds — and runs *after* `CancelAll`, deliberately, since that cuts only what was already on the wire, so the save opens a fresh connection.

## Testing

Rebased onto `main` (now with #536). `make test` green apart from the same pre-existing `self_improving_skills_tests` failure; `make lint-pascal-shape` OK; structural checker clean; the live probe re-run after the restructure, still 100ms.

The FMX unit can't be compiled here — but everything that was actually broken is in the client library, and that part is measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U