### PR TITLE
Draw the chat transcript with FMX controls, not a browser

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -34,8 +34,8 @@ Both vendored pieces come from
 
 ### WebView2 on Windows
 
-App windows, the Browser and the chat transcript are all `TWebBrowser`, and
-they ask for `TWindowsEngine.EdgeIfAvailable` — because the legacy engine is
+App windows and the Browser are `TWebBrowser`, and they ask for
+`TWindowsEngine.EdgeIfAvailable` — because the legacy engine is
 IE-era and renders a modern document (flexbox, grid, ES6, fetch) badly enough
 to misrepresent the app the agent just wrote.
 
@@ -130,10 +130,12 @@ Environment:
   workspace, not to the client — the arrangement is saved against the
   desktop you are leaving and comes back when you return, geometry
   included.
-- **Chat window** — per project, streaming, **rendering markdown** (headings,
-  lists, code blocks, links) and with the model's tool use shown
-  inline as it works: asking for an app should not look like a long silence
-  followed by a sentence. It sends the builder-mode system prompt, so the
+- **Chat window** — per project, streaming, with structure preserved
+  (headings, bullets, numbered lists, quotes and code blocks each get their
+  own control) and the model's tool use shown inline as it works: asking for
+  an app should not look like a long silence followed by a sentence. It is
+  built from ordinary FMX controls, **not** a `TWebBrowser` — see the design
+  note below. It sends the builder-mode system prompt, so the
   agent's deliverable is an app rather than an essay. **Chat** on the Menu
   opens the project-less one instead — no builder prompt, just a
   conversation. When a
@@ -196,6 +198,19 @@ desktop in the browser and this app opens with it.
   the current style like everything else, and they are the same furniture the
   agent's own questions will use when the period-native output work lands
   (§7 of the plan).
+- **The chat transcript is not a browser.** It was, and that is what made
+  the window a white square. A `TWebBrowser` is a native control that has to
+  be swapped for a bitmap to coexist with overlapping windows, and its Edge
+  engine initialises *asynchronously* — hand it a document in the same turn
+  you create it and the document is dropped. Under the legacy IE engine that
+  worked by accident, so the failure only appeared once WebView2 actually
+  engaged. It is a `TVertScrollBox` of labels now: no native control, no
+  snapshot, no engine, nothing to be blank. The markdown is parsed in
+  `PasClaw.Client.Markdown` (`MarkdownToBlocks`), where FPC compiles it and
+  `client_markdown_tests` asserts it, leaving this file with nothing but
+  "make a label, make a memo". PasClaw Studio's chat has no browser either.
+  The cost: an FMX `TLabel` has no rich text, so bold and links are
+  flattened to plain text rather than styled.
 - **The browser snapshot trick** is the demo's: `TWebBrowser` is a native
   control that paints above all FMX content, so an inactive window freezes
   its browser into a `TImage` and swaps the live control back on focus.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -216,7 +216,11 @@ desktop in the browser and this app opens with it.
   its browser into a `TImage` and swaps the live control back on focus.
 - **Windows report their own death** through `FreeNotification`, so closing
   one clears its dictionary entries rather than leaving a dangling pointer
-  for the next Restore to walk.
+  for the next Restore to walk. The `TWebBrowser`es do the same, and have
+  to: `FBrowsers` holds them without owning them, so a closed window used
+  to leave a freed pointer in the list. The activation handler only walked
+  that list when a window was activated, which made it look like stability;
+  the tick that asserts the live control walks it every 700 ms.
 - **Logic lives in the client library, not here.** Everything with a rule in
   it — what a run record means, how a directory listing is shaped, which
   page kinds exist — is in `PasClaw.Client.Api`, which FPC compiles and CI

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -612,6 +612,9 @@ type
 
     procedure Say(const Msg: string);
     function TrackWindow(AWindow: TRetroWindow): TRetroWindow;
+    { Register a browser and its snapshot, and arrange to be told when the
+      browser dies -- FBrowsers holds it without owning it. }
+    procedure TrackBrowser(ABrowser: TWebBrowser; ASnap: TImage);
     function ProjectByName(const Name: string; out Row: TProjectRow): Boolean;
   protected
     procedure Notification(AComponent: TComponent;
@@ -1055,6 +1058,26 @@ begin
     AWindow.FreeNotification(Self);
 end;
 
+(* The same contract for the browsers, and for the same reason.
+
+   FBrowsers is created with OwnsObjects False -- every TWebBrowser belongs
+   to the window it sits in, and closing that window frees it. Nothing was
+   telling this form about that, so the list kept the pointer and the next
+   walk over it read freed memory. Rare enough to look like stability while
+   the only walk was BrowserActiveChanged, which needs a window to be
+   activated first; EnsureLiveBrowsers walks the same list every 700 ms,
+   which turns "eventually" into "on the next tick after any close".
+
+   FreeNotification is what the windows already use. The browser reports its
+   own death and Notification below drops both entries. *)
+procedure TFormMain.TrackBrowser(ABrowser: TWebBrowser; ASnap: TImage);
+begin
+  if ABrowser = nil then Exit;
+  ABrowser.FreeNotification(Self);
+  FBrowsers.Add(ABrowser);
+  FSnapshots.AddOrSetValue(ABrowser, ASnap);
+end;
+
 procedure TFormMain.Notification(AComponent: TComponent;
   Operation: TOperation);
 var
@@ -1077,6 +1100,18 @@ begin
 
   { A window closing is a layout change like any other. }
   if AComponent is TRetroWindow then MarkLayoutDirty;
+
+  (* A browser dies with the window that owns it, and it dies FIRST -- a
+     window frees its children on the way out, so this arrives before the
+     branch that clears the window's own fields. Drop both entries here and
+     that ordering stops mattering: whichever comes first, nothing is left
+     in FBrowsers for the timer to walk into. *)
+  if AComponent is TWebBrowser then
+  begin
+    if FBrowsers <> nil then FBrowsers.Remove(TWebBrowser(AComponent));
+    if FSnapshots <> nil then FSnapshots.Remove(TWebBrowser(AComponent));
+    Exit;
+  end;
 
   if AComponent = FStylePicker then
   begin
@@ -1138,7 +1173,9 @@ begin
     FBrowserSearch := nil;
     FBrowserDeep := nil;
     FBrowserPromote := nil;
-    { The view is also in FBrowsers/FSnapshots; the loop below clears those. }
+    { The view is also in FBrowsers/FSnapshots. Its own notification clears
+      those -- it does not depend on this branch, and this branch must not
+      pretend to do it. }
     FBrowserView := nil;
     FBrowserNew := nil;
     FBrowserTabs := nil;
@@ -3297,7 +3334,9 @@ var
   Snap: TImage;
   W: TRetroWindow;
 begin
-  if FClosing or (FBrowsers = nil) then Exit;
+  if FClosing or (FSnapshots = nil) or (FBrowsers = nil) then Exit;
+  { Every entry here is live: TrackBrowser took a free notification, so a
+    browser leaves the list as it dies rather than being read after it. }
   for I := 0 to FBrowsers.Count - 1 do
   begin
     B := FBrowsers[I];
@@ -4602,8 +4641,7 @@ begin
   Browser.Parent := Host;
   Browser.Align := TAlignLayout.Client;
   Browser.URL := FClient.AppURL(Project);
-  FBrowsers.Add(Browser);
-  FSnapshots.AddOrSetValue(Browser, Snap);
+  TrackBrowser(Browser, Snap);
   MarkLayoutDirty;
 end;
 
@@ -5663,8 +5701,7 @@ begin
 {$ENDIF}
   FBrowserView.Parent := Host;
   FBrowserView.Align := TAlignLayout.Client;
-  FBrowsers.Add(FBrowserView);
-  FSnapshots.AddOrSetValue(FBrowserView, Snap);
+  TrackBrowser(FBrowserView, Snap);
   MarkLayoutDirty;
 
   NewBrowserTab('New tab');

--- a/desktop/uDesktopMain.pas
+++ b/desktop/uDesktopMain.pas
@@ -144,11 +144,16 @@ type
        shown while a turn is in flight and hidden once the finished turn
        joins the transcript. *)
     FChatTurns: TObjectDictionary<string, TStringList>;
-    FChatViews: TDictionary<string, TWebBrowser>;
+    { The transcript, as controls. No browser: see the note in OpenChat. }
+    FChatFlows: TDictionary<string, TVertScrollBox>;
     FChatInputs: TDictionary<string, TMemo>;
     FChatHistory: TDictionary<string, string>;
     FBrowsers: TObjectList<TWebBrowser>;
     FSnapshots: TDictionary<TWebBrowser, TImage>;
+    { Temp files backing the generated documents -- one live file per key,
+      replaced as the document is re-rendered. See ShowHtml. }
+    FHtmlFiles: TDictionary<string, string>;
+    FHtmlSeq: Integer;
 
     { ---- File Manager ---- }
     { Bumped per navigation, so a listing that arrives after a later one
@@ -535,6 +540,15 @@ type
     function StyleColor(const Role, Fallback: string): string;
     procedure AppendTurn(const Project, Role, Text_: string);
     procedure RenderTranscript(const Project: string);
+    { One turn as controls, and the two blocks that are not labels. }
+    procedure AddTurnControls(Flow: TVertScrollBox; const Role, Text_: string);
+    procedure AddCodeBlock(Flow: TVertScrollBox; const Code: string);
+    procedure AddRule(Flow: TVertScrollBox);
+    { Generated HTML into a browser, through a temp file and .URL. See the
+      implementation for why not LoadFromStrings. }
+    function ShowHtml(B: TWebBrowser; const Key, Html: string): Boolean;
+    function SafeFileKey(const Key: string): string;
+    procedure DiscardHtmlFiles;
     procedure ShowStreaming(const Project: string; Streaming: Boolean);
 
     { Live board updates. The client subscribes to /v1/desktop/events on its
@@ -544,6 +558,9 @@ type
     procedure OnDesktopEvent(const Ev: TDesktopEvent; var Stop: Boolean);
     procedure ApplyPendingEvents;
     procedure EventTimerTick(Sender: TObject);
+    { Assert that the active window's browser is live, rather than trusting
+      the activation events to have left it that way. }
+    procedure EnsureLiveBrowsers;
 
     { ---- notifications ---- }
     (* Where the switch lives.
@@ -632,7 +649,6 @@ const
     whole launcher fits without scrolling on an ordinary board. }
   MenuRowHeight = 22;
   { Marks a chat transcript that is hidden because its turn is streaming. }
-  StreamingTag = 'streaming';
 
 { Conditional string. StrUtils has one; a local helper keeps this unit's
   uses clause to what it actually needs. Declared here, above every caller,
@@ -822,10 +838,11 @@ begin
   FAppWins    := TDictionary<string, TRetroWindow>.Create;
   FChatLogs   := TDictionary<string, TMemo>.Create;
   FChatTurns  := TObjectDictionary<string, TStringList>.Create([doOwnsValues]);
-  FChatViews  := TDictionary<string, TWebBrowser>.Create;
+  FChatFlows  := TDictionary<string, TVertScrollBox>.Create;
   FChatInputs := TDictionary<string, TMemo>.Create;
   FChatHistory := TDictionary<string, string>.Create;
   FBrowsers   := TObjectList<TWebBrowser>.Create(False);
+  FHtmlFiles  := TDictionary<string, string>.Create;
   FSnapshots  := TDictionary<TWebBrowser, TImage>.Create;
   FRunWins    := TDictionary<string, TRetroWindow>.Create;
   FRunLogs    := TDictionary<string, TMemo>.Create;
@@ -997,9 +1014,10 @@ begin
   FreeAndNil(FRunWins);
   FreeAndNil(FSnapshots);
   FreeAndNil(FBrowsers);
+  DiscardHtmlFiles;
   FreeAndNil(FChatHistory);
   FreeAndNil(FChatInputs);
-  FreeAndNil(FChatViews);
+  FreeAndNil(FChatFlows);
   FreeAndNil(FChatTurns);
   FreeAndNil(FChatLogs);
   FreeAndNil(FAppWins);
@@ -1172,7 +1190,7 @@ begin
     begin
       FChatWins.Remove(Key);
       FChatLogs.Remove(Key);      { memos were owned by the window }
-      FChatViews.Remove(Key);
+      FChatFlows.Remove(Key);
       FChatTurns.Remove(Key);
       FChatInputs.Remove(Key);
     end;
@@ -2165,7 +2183,7 @@ begin
     FRestoring := WasRestoring;
   end;
   FChatWins.Clear; FChatLogs.Clear; FChatInputs.Clear; FChatHistory.Clear;
-  FChatViews.Clear; FChatTurns.Clear;
+  FChatFlows.Clear; FChatTurns.Clear;
   FAppWins.Clear;
   FRunWins.Clear; FRunLogs.Clear; FRunHeads.Clear;
   FStylePicker := nil; FStyleList := nil; FSkinList := nil;
@@ -3256,9 +3274,48 @@ begin
   RefreshProjects;
 end;
 
+(* Repair the snapshot swap if it ever gets stuck.
+
+   The other thing a white square can be. BrowserActiveChanged freezes a
+   TWebBrowser into a TImage while its window is inactive, because a native
+   control paints above all FMX content -- and MakeScreenshot on a
+   composited WebView2 tends to come back blank, so a stuck snapshot IS a
+   white square over live content.
+
+   Being event-driven, it only ever fires when a window's Active flag
+   changes. A missed or mis-ordered event -- a snapshot taken as the window
+   was becoming active -- leaves the picture up with nothing to take it
+   down again, because the state it is waiting for has already happened.
+
+   So the invariant is asserted rather than merely maintained: the ACTIVE
+   window's browser is live, every tick. Cheap -- a handful of controls --
+   and it turns a permanent wedge into at most one frame of staleness. *)
+procedure TFormMain.EnsureLiveBrowsers;
+var
+  I: Integer;
+  B: TWebBrowser;
+  Snap: TImage;
+  W: TRetroWindow;
+begin
+  if FClosing or (FBrowsers = nil) then Exit;
+  for I := 0 to FBrowsers.Count - 1 do
+  begin
+    B := FBrowsers[I];
+    if (B = nil) or (B.Parent = nil) then Continue;
+    { Created as TWebBrowser.Create(W), so the owner IS its window. }
+    if not (B.Owner is TRetroWindow) then Continue;
+    W := TRetroWindow(B.Owner);
+    if not W.Active then Continue;
+    if FSnapshots.TryGetValue(B, Snap) and (Snap <> nil) and Snap.Visible then
+      Snap.Visible := False;
+    if not B.Visible then B.Visible := True;
+  end;
+end;
+
 procedure TFormMain.EventTimerTick(Sender: TObject);
 begin
   ApplyPendingEvents;
+  EnsureLiveBrowsers;
   { Log lines arrive on their own thread and are painted here, on the main
     one, for the same reason board events are. }
   DrainLogLines;
@@ -3537,9 +3594,7 @@ var
   Send, Vers: TButton;
   Row: TProjectRow;
   Title: string;
-  View: TWebBrowser;
-  ChatHost: TLayout;
-  ChatSnap: TImage;
+  Flow: TVertScrollBox;
 begin
   if FChatWins.TryGetValue(Project, W) and (W <> nil) then
   begin
@@ -3595,44 +3650,40 @@ begin
   Input.TextSettings.WordWrap := True;
   FChatInputs.AddOrSetValue(Project, Input);
 
-  (* Host + snapshot, the same arrangement the app and Browser windows use.
+  (* The transcript, in ORDINARY FMX CONTROLS.
 
-     TWebBrowser is a NATIVE control: it paints above all FMX content, so an
-     inactive window would keep showing its transcript on top of whatever
-     covers it. BrowserActiveChanged freezes it into a TImage when the
-     window loses focus -- but only for browsers it can find, which means
-     living inside a host layout under W.Client, being registered in
-     FSnapshots, and the window actually raising the event. Adding it to
-     FBrowsers alone did none of those. *)
-  W.OnActiveChanged := BrowserActiveChanged;
+     It was a TWebBrowser, and that is what made this window a white square.
+     A browser is a native control: it paints above all FMX content, so it
+     needs a snapshot-swap dance to coexist with overlapping windows, and
+     its engine initialises asynchronously -- hand it a document in the same
+     turn you create it and the document is simply dropped. Under the legacy
+     IE engine that worked by accident, because that one initialised
+     synchronously; the moment WebView2 actually engaged, the chat went
+     blank.
 
-  ChatHost := TLayout.Create(W);
-  ChatHost.Parent := W.Client;
-  ChatHost.Align := TAlignLayout.Client;
+     None of that machinery was buying anything. A conversation is a stack
+     of paragraphs, and a scroll box of labels renders it with no native
+     control, no snapshot, no engine, and no way to be blank. PasClaw Studio
+     reached the same conclusion -- its chat has no browser in it either.
 
-  ChatSnap := TImage.Create(W);
-  ChatSnap.Parent := ChatHost;
-  ChatSnap.Align := TAlignLayout.Client;
-  ChatSnap.WrapMode := TImageWrapMode.Stretch;
-  ChatSnap.Visible := False;
+     The cost is real and worth naming: an FMX TLabel has no rich text, so
+     bold and links are flattened (see FlattenInline) rather than styled.
+     Structure survives -- headings, bullets, quotes and code blocks are
+     each their own control -- and a readable transcript beats a beautifully
+     specified white rectangle. *)
+  Flow := TVertScrollBox.Create(W);
+  Flow.Parent := W.Client;
+  Flow.Align := TAlignLayout.Client;
+  FChatFlows.AddOrSetValue(Project, Flow);
 
-  { The settled transcript, formatted. }
-  View := TWebBrowser.Create(W);
-{$IFDEF MSWINDOWS}
-  { The transcript is a modern document too -- and the one place unicode in
-    the model's own words has to survive. Before Parent: see OpenApp. }
-  View.WindowsEngine := TWindowsEngine.EdgeIfAvailable;
-{$ENDIF}
-  View.Parent := ChatHost;
-  View.Align := TAlignLayout.Client;
-  FChatViews.AddOrSetValue(Project, View);
-  FBrowsers.Add(View);
-  FSnapshots.AddOrSetValue(View, ChatSnap);
-
-  { The live one. Same slot, shown only while a turn is in flight. }
+  { The live view for a turn in flight. Chunks arrive many times a second
+    and rebuilding the stack per chunk would be unusable, so streaming text
+    goes to one label at the bottom and joins the transcript when it
+    settles. }
   Log := TMemo.Create(W);
-  Log.Parent := ChatHost;
-  Log.Align := TAlignLayout.Client;
+  Log.Parent := W.Client;
+  Log.Align := TAlignLayout.Bottom;
+  Log.Height := 120;
   Log.ReadOnly := True;
   Log.TextSettings.WordWrap := True;
   Log.Visible := False;
@@ -3832,57 +3883,295 @@ end;
    Whole-document rather than incremental: a conversation is tens of turns,
    the markdown pass is string work, and the alternative is maintaining a
    DOM through a browser control's scripting bridge for no visible gain. *)
-procedure TFormMain.RenderTranscript(const Project: string);
+(* Put GENERATED html into a browser control.
+
+   Through a temporary file and .URL, not LoadFromStrings, and that swap is
+   the whole of this. The evidence is the split in this very file: every
+   place that assigns .URL renders -- app windows, answer pages -- and every
+   place that called LoadFromStrings came up a white square. Same windows,
+   same host layout, same snapshot machinery, same engine.
+
+   The difference is what the engine can defer. WebView2 initialises
+   ASYNCHRONOUSLY, and FMX's delegate holds a pending URL until the core is
+   ready; a string handed over before then has nothing to be held in and is
+   simply dropped. Under the legacy IE engine, which initialised
+   synchronously, the same call worked -- which is why this only started when
+   the WindowsEngine assignment was moved above Parent and Edge actually
+   engaged for the first time.
+
+   The file name carries a counter because navigating to the URL already
+   showing is not a navigation: without it the second render of a chat would
+   do nothing. The previous file is deleted as the next is written, so a
+   conversation leaves one file behind, not one per turn. *)
+function TFormMain.ShowHtml(B: TWebBrowser; const Key, Html: string): Boolean;
 var
-  View: TWebBrowser;
-  L: TStringList;
-  I, T: Integer;
-  Body, Role, Text_, Entry: string;
+  Dir, Path, Old, Enc: string;
 begin
-  if not FChatViews.TryGetValue(Project, View) then Exit;
-  if View = nil then Exit;
-  Body := '';
-  if FChatTurns.TryGetValue(Project, L) then
-    for I := 0 to L.Count - 1 do
-    begin
-      Entry := L[I];
-      T := Pos(#9, Entry);
-      if T = 0 then Continue;
-      Role  := Copy(Entry, 1, T - 1);
-      Text_ := Copy(Entry, T + 1, MaxInt);
-      if Role = 'user' then
-        Body := Body + '<div class="turn"><span class="who">You</span><br>' +
-                MarkdownToHTML(Text_) + '</div>'
-      else if Role = 'tool' then
-        Body := Body + '<div class="tool">' + HtmlEscape(Text_) + '</div>'
-      else if Role = 'toolerr' then
-        Body := Body + '<div class="tool err">' + HtmlEscape(Text_) + '</div>'
-      else
-        Body := Body + '<div class="turn">' + MarkdownToHTML(Text_) + '</div>';
+  Result := False;
+  if B = nil then Exit;
+  if FHtmlFiles = nil then FHtmlFiles := TDictionary<string, string>.Create;
+
+  Inc(FHtmlSeq);
+  Dir := TIOPath.GetTempPath;
+  Path := TIOPath.Combine(Dir,
+    'pasclaw-' + SafeFileKey(Key) + '-' + IntToStr(FHtmlSeq) + '.html');
+  try
+    TFile.WriteAllText(Path, Html, TEncoding.UTF8);
+  except
+    { A temp directory we cannot write is not a reason to fault; the window
+      stays blank and the Log window will have the trace. }
+    Exit;
+  end;
+
+  if FHtmlFiles.TryGetValue(Key, Old) and (Old <> '') and (Old <> Path) then
+    try
+      TFile.Delete(Old);
+    except
+      { a leftover temp file is not worth an exception }
     end;
-  View.LoadFromStrings(
-    ChatDocumentHTML(Body,
-      StyleColor('face',   '#c0c0c0'),
-      StyleColor('text',   '#000000'),
-      StyleColor('titleA', '#000080'),
-      StyleColor('light',  '#e8e8e8')), '');
+  FHtmlFiles.AddOrSetValue(Key, Path);
+
+  { file:/// plus forward slashes, with the characters a path may legally
+    contain and a URL may not. Windows temp paths live under a profile
+    directory, which routinely has a space in it. }
+  Enc := StringReplace(Path, '\', '/', [rfReplaceAll]);
+  Enc := StringReplace(Enc, '%', '%25', [rfReplaceAll]);
+  Enc := StringReplace(Enc, ' ', '%20', [rfReplaceAll]);
+  Enc := StringReplace(Enc, '#', '%23', [rfReplaceAll]);
+  Enc := StringReplace(Enc, '?', '%3F', [rfReplaceAll]);
+  if (Length(Enc) > 0) and (Enc[1] <> '/') then Enc := '/' + Enc;
+  B.URL := 'file://' + Enc;
+  Result := True;
 end;
 
-{ Streaming shows the live memo; a settled transcript shows the document. }
+{ Take the generated documents with us. They are in the system temp
+  directory, so leaving them is not a leak so much as litter -- but litter
+  with a conversation in it. }
+procedure TFormMain.DiscardHtmlFiles;
+var
+  Path: string;
+begin
+  if FHtmlFiles = nil then Exit;
+  for Path in FHtmlFiles.Values do
+    if Path <> '' then
+      try
+        TFile.Delete(Path);
+      except
+      end;
+  FreeAndNil(FHtmlFiles);
+end;
+
+{ A key that is safe as part of a file name. Project slugs already are, but
+  the synthetic chat keys start with a colon. }
+function TFormMain.SafeFileKey(const Key: string): string;
+var
+  I: Integer;
+  C: Char;
+begin
+  Result := '';
+  for I := 1 to Length(Key) do
+  begin
+    C := Key[I];
+    if CharInSet(C, ['a'..'z', 'A'..'Z', '0'..'9', '-', '_']) then
+      Result := Result + C
+    else
+      Result := Result + '-';
+  end;
+  if Result = '' then Result := 'chat';
+end;
+
+(* Build the transcript out of controls.
+
+   One control per BLOCK, not per turn: the parsing lives in
+   PasClaw.Client.Markdown where FPC compiles it and client_markdown_tests
+   asserts it, and everything left here is "make a label, make a memo".
+   That division is deliberate -- this file has no compiler in CI, so the
+   less judgement it carries the better.
+
+   Rebuilt wholesale on each settled turn. A conversation is tens of blocks,
+   not thousands, and a diffing renderer would be more code than it saves
+   and another thing to be subtly wrong. *)
+procedure TFormMain.RenderTranscript(const Project: string);
+var
+  Flow: TVertScrollBox;
+  L: TStringList;
+  I, T: Integer;
+  Role, Text_, Entry: string;
+begin
+  if not FChatFlows.TryGetValue(Project, Flow) then Exit;
+  if Flow = nil then Exit;
+
+  Flow.BeginUpdate;
+  try
+    while Flow.Content.ChildrenCount > 0 do
+      Flow.Content.Children[Flow.Content.ChildrenCount - 1].Free;
+
+    if FChatTurns.TryGetValue(Project, L) then
+      for I := 0 to L.Count - 1 do
+      begin
+        Entry := L[I];
+        T := Pos(#9, Entry);
+        if T = 0 then Continue;
+        Role  := Copy(Entry, 1, T - 1);
+        Text_ := Copy(Entry, T + 1, MaxInt);
+        AddTurnControls(Flow, Role, Text_);
+      end;
+  finally
+    Flow.EndUpdate;
+  end;
+  { The newest turn is the one you want to be looking at. }
+  Flow.ViewportPosition := PointF(0, Flow.Content.Height);
+end;
+
+(* '#RRGGBB' -> an OPAQUE TAlphaColor.
+
+   Explicit rather than StringToAlphaColor, which reads a six-digit value as
+   AARRGGBB -- alpha byte absent, therefore zero, therefore text that is
+   perfectly laid out and completely invisible. Which is the same bug as the
+   white square this window has just come out of, and would have been a
+   miserable one to find twice. *)
+function HexColor(const S: string; Fallback: TAlphaColor): TAlphaColor;
+var
+  V: Integer;
+  T: string;
+begin
+  T := Trim(S);
+  if (T <> '') and (T[1] = '#') then Delete(T, 1, 1);
+  if Length(T) <> 6 then Exit(Fallback);
+  if not TryStrToInt('$' + T, V) then Exit(Fallback);
+  Result := TAlphaColor($FF000000 or Cardinal(V));
+end;
+
+{ One turn: a speaker line, then a control per markdown block. }
+procedure TFormMain.AddTurnControls(Flow: TVertScrollBox;
+  const Role, Text_: string);
+var
+  Blocks: TMdBlocks;
+  I: Integer;
+  Who: string;
+
+  { Every control here is Align=Top inside the scroll box's content, so the
+    box stacks them and sizes itself. }
+  function NewLabel(const S: string; Size: Single; Bold: Boolean;
+    Indent: Single; const ColorRole, Fallback: string): TLabel;
+  begin
+    Result := TLabel.Create(Flow);
+    Result.Parent := Flow.Content;
+    Result.Align := TAlignLayout.Top;
+    Result.Margins.Rect := TRectF.Create(8 + Indent, 2, 8, 2);
+    Result.StyledSettings := [];
+    Result.AutoSize := True;
+    Result.TextSettings.WordWrap := True;
+    Result.TextSettings.Font.Size := Size;
+    if Bold then
+      Result.TextSettings.Font.Style := [TFontStyle.fsBold]
+    else
+      Result.TextSettings.Font.Style := [];
+    Result.TextSettings.FontColor :=
+      HexColor(StyleColor(ColorRole, Fallback), TAlphaColors.Black);
+    Result.Text := S;
+  end;
+
+begin
+  if Role = 'user' then Who := 'You'
+  else if Role = 'tool' then Who := ''
+  else if Role = 'toolerr' then Who := ''
+  else Who := 'PasClaw';
+
+  { Tool lines are machinery, not conversation: small, indented, no
+    speaker. An error among them is the same shape in the accent colour, so
+    it reads as part of the same stream rather than a separate event. }
+  if Role = 'tool' then
+  begin
+    NewLabel(Text_, 11, False, 14, 'text', '#000000').Opacity := 0.65;
+    Exit;
+  end;
+  if Role = 'toolerr' then
+  begin
+    NewLabel(Text_, 11, False, 14, 'titleA', '#000080');
+    Exit;
+  end;
+
+  NewLabel(Who, 11, True, 0, 'titleA', '#000080');
+
+  Blocks := MarkdownToBlocks(Text_);
+  { Prose with no markdown in it still has to appear. }
+  if Length(Blocks) = 0 then
+  begin
+    if Trim(Text_) <> '' then
+      NewLabel(Trim(Text_), 12, False, 0, 'text', '#000000');
+    Exit;
+  end;
+
+  for I := 0 to High(Blocks) do
+    case Blocks[I].Kind of
+      mbHeading:
+        NewLabel(Blocks[I].Text, 16 - (Blocks[I].Level * 1.5), True, 0,
+                 'text', '#000000');
+      mbBullet:
+        NewLabel('  ' + #$2022 + '  ' + Blocks[I].Text, 12, False, 8,
+                 'text', '#000000');
+      mbNumber:
+        NewLabel('  ' + IntToStr(Blocks[I].Level) + '.  ' + Blocks[I].Text,
+                 12, False, 8, 'text', '#000000');
+      mbQuote:
+        NewLabel('|  ' + Blocks[I].Text, 12, False, 8,
+                 'text', '#000000').Opacity := 0.8;
+      mbRule:
+        AddRule(Flow);
+      mbCode:
+        AddCodeBlock(Flow, Blocks[I].Text);
+      else
+        NewLabel(Blocks[I].Text, 12, False, 0, 'text', '#000000');
+    end;
+end;
+
+{ A code block: monospace, in a panel, and NOT a label -- a fenced block is
+  the one place the exact characters and their line breaks are the content,
+  so it gets a control that will not reflow them. }
+procedure TFormMain.AddCodeBlock(Flow: TVertScrollBox; const Code: string);
+var
+  M: TMemo;
+  Lines: Integer;
+  I: Integer;
+begin
+  Lines := 1;
+  for I := 1 to Length(Code) do
+    if Code[I] = #10 then Inc(Lines);
+  if Lines > 24 then Lines := 24;
+
+  M := TMemo.Create(Flow);
+  M.Parent := Flow.Content;
+  M.Align := TAlignLayout.Top;
+  M.Margins.Rect := TRectF.Create(16, 4, 8, 4);
+  M.ReadOnly := True;
+  M.TextSettings.WordWrap := False;
+  M.TextSettings.Font.Family := 'Courier New';
+  M.TextSettings.Font.Size := 11;
+  { Sized to its content rather than scrolled: a code block inside a
+    scrolling transcript that scrolls on its own is a trap for the wheel. }
+  M.Height := 8 + (Lines * 15);
+  M.Text := Code;
+end;
+
+procedure TFormMain.AddRule(Flow: TVertScrollBox);
+var
+  Ln: TLine;
+begin
+  Ln := TLine.Create(Flow);
+  Ln.Parent := Flow.Content;
+  Ln.Align := TAlignLayout.Top;
+  Ln.LineType := TLineType.Top;
+  Ln.Height := 6;
+  Ln.Margins.Rect := TRectF.Create(8, 4, 8, 4);
+end;
+
 procedure TFormMain.ShowStreaming(const Project: string; Streaming: Boolean);
 var
   M: TMemo;
-  View: TWebBrowser;
 begin
   if FChatLogs.TryGetValue(Project, M) and (M <> nil) then
     M.Visible := Streaming;
-  if FChatViews.TryGetValue(Project, View) and (View <> nil) then
-  begin
-    View.Visible := not Streaming;
-    { Marked so the focus handler does not un-hide the transcript over the
-      live memo when the window is clicked mid-turn. }
-    if Streaming then View.TagString := StreamingTag else View.TagString := '';
-  end;
 end;
 
 procedure TFormMain.ChatChunk(const Chunk: string; var Abort: Boolean);
@@ -4064,22 +4353,33 @@ begin
     { Pin what this turn produced to the turn that produced it, so scrolling
       back through the conversation is scrolling back through versions. }
     AddArtifactCard(Project);
+    { Into the TRANSCRIPT, not the streaming memo. That memo is hidden the
+      moment the turn settles, so these notices -- the ones that say what
+      just happened to your app -- were written where nobody could read
+      them. }
     if App.Servable then
     begin
-      Log.Lines.Add('>> "' + App.Name + '" is ready. Opening it.');
+      AppendTurn(Project, 'tool', '"' + App.Name + '" is ready. Opening it.');
+      RenderTranscript(Project);
       OpenApp(Project);
     end
     else
     begin
       { python/fpc/delphi: a program, not a document. It gets the Run window
         rather than a browser view, and nothing starts without consent. }
-      Log.Lines.Add(Format('>> "%s" is a %s app -- opening its Run window.',
-                           [App.Name, App.Kind]));
+      AppendTurn(Project, 'tool',
+        Format('"%s" is a %s app -- opening its Run window.',
+               [App.Name, App.Kind]));
+      RenderTranscript(Project);
       OpenRun(Project);
     end;
   end
   else if ProjectByName(Project, Row) and Row.HasApp then
-    Log.Lines.Add('>> The app was written but has no runnable entry yet.');
+  begin
+    AppendTurn(Project, 'tool',
+      'The app was written but has no runnable entry yet.');
+    RenderTranscript(Project);
+  end;
 end;
 
 { ------------------------------------------------------------------- app -- }
@@ -4107,9 +4407,7 @@ begin
     if W.Active then
     begin
       Snap.Visible := False;
-      { A chat window streaming a reply is showing its memo; restoring the
-        transcript here would paint it over the live text. }
-      B.Visible := B.TagString <> StreamingTag;
+      B.Visible := True;
     end
     else
     begin
@@ -5407,10 +5705,10 @@ procedure TFormMain.ShowBlankTab;
 begin
   FCurrentPage := '';
   if FBrowserView <> nil then
-    FBrowserView.LoadFromStrings(
+    ShowHtml(FBrowserView, 'browser',
       ChatDocumentHTML('<p>Ask a question. The answer comes back as a page.</p>',
         StyleColor('face', '#c0c0c0'), StyleColor('text', '#000000'),
-        StyleColor('titleA', '#000080'), StyleColor('light', '#e8e8e8')), '');
+        StyleColor('titleA', '#000080'), StyleColor('light', '#e8e8e8')));
   if FBrowserPromote <> nil then FBrowserPromote.Enabled := False;
   if FBrowserStatus <> nil then FBrowserStatus.Text := '';
   if FBrowserWin <> nil then FBrowserWin.Caption := 'Browser';
@@ -5545,18 +5843,21 @@ begin
         { Say what happened IN the tab, rather than leaving the last document
           standing as if it were this one. The tab keeps its path, so
           reselecting it -- or fixing the file -- tries again. }
-        FBrowserView.LoadFromStrings(
+        ShowHtml(FBrowserView, 'browser',
           ChatDocumentHTML('<p><b>' + HtmlEscape(Name) +
             '</b> could not be read.</p><p>' + HtmlEscape(Err) + '</p><p>' +
             HtmlEscape(Path) + '</p>',
             StyleColor('face', '#c0c0c0'), StyleColor('text', '#000000'),
-            StyleColor('titleA', '#000080'), StyleColor('light', '#e8e8e8')), '');
+            StyleColor('titleA', '#000080'), StyleColor('light', '#e8e8e8')));
         if FBrowserStatus <> nil then
           FBrowserStatus.Text := Path + '  [unreadable]';
         Exit;
       end;
 
-      FBrowserView.LoadFromStrings(Body, Path);
+      { The base URL LoadFromStrings took is gone, and was already inert:
+        WebView2 loads a string into an opaque origin, so a document's
+        relative images and stylesheets never resolved under Edge anyway. }
+      ShowHtml(FBrowserView, 'browser', Body);
       if FBrowserStatus <> nil then
       begin
         if Truncated then FBrowserStatus.Text := Path + '  [truncated]'

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -809,6 +809,46 @@ idempotence lives — is testable without a mail server.
 
 The FireMonkey client needs Delphi and is not part of `make`.
 
+## The chat transcript is not a browser (FireMonkey client)
+
+It was, and that is what made the window a white square. A `TWebBrowser` is
+a native control: it paints above all FMX content, so it needs a
+snapshot-swap to coexist with overlapping windows, and its Edge engine
+initialises **asynchronously** — hand it a document in the same turn you
+create it and the document is dropped. Under the legacy IE engine that
+worked by accident, which is why the failure only appeared once the
+`WindowsEngine` ordering was fixed and WebView2 actually engaged.
+
+The transcript is a `TVertScrollBox` of ordinary controls now — one per
+markdown block, not one per turn:
+
+| Block | Control |
+|---|---|
+| heading | a bold label, sized by level |
+| paragraph | a wrapped label (consecutive prose lines join, so a hard-wrapped reply is not a column of one-liners) |
+| bullet / numbered | an indented label carrying its own marker |
+| quote | an indented, dimmed label |
+| code fence | a read-only monospace `TMemo`, sized to its content — a fence is the one place the exact characters and line breaks *are* the content |
+| rule | a `TLine` |
+
+No native control, no snapshot, no engine, nothing that can be blank. The
+parsing lives in `PasClaw.Client.Markdown` (`MarkdownToBlocks`,
+`FlattenInline`) where FPC compiles it and `client_markdown_tests` asserts
+it; the FMX side is left with "make a label, make a memo", which matters in
+a file that has no compiler in CI.
+
+The cost, stated plainly: an FMX `TLabel` has no rich text, so **bold and
+links are flattened** — `**bold**` loses its asterisks and `[text](url)`
+becomes `text (url)`, because dropping where something points is worse than
+showing it. Structure survives; typography does not. PasClaw Studio's chat
+reached the same trade.
+
+Streaming still uses a memo, but it now sits *below* the transcript instead
+of replacing it: with both as ordinary controls they can coexist, so the
+settled conversation stays readable while the next reply arrives.
+
+---
+
 ## Off the UI thread (FireMonkey client)
 
 Every call into `TPasClawClient` is a blocking HTTP round trip, and most of

--- a/src/pkg/component/PasClaw.Client.Markdown.pas
+++ b/src/pkg/component/PasClaw.Client.Markdown.pas
@@ -57,6 +57,43 @@ function ChatDocumentHTML(const BodyHTML, BgColor, FgColor, AccentColor,
   rule, and two escapers would eventually disagree. }
 function HtmlEscape(const S: string): string;
 
+(* ---- the same markdown, for a caller with no browser ----
+
+   A FireMonkey client can render a transcript with ordinary controls
+   instead of a TWebBrowser, and for a chat window it should: a browser is a
+   native control that paints above all FMX content, so it needs a
+   snapshot-swap dance to coexist with overlapping windows, and its engine
+   initialises asynchronously -- hand it a document too early and you get a
+   white square. A stack of labels has neither problem. It is also what
+   PasClaw Studio does.
+
+   So: the same parser, emitting BLOCKS rather than markup, and the caller
+   builds one control per block. The line between the two is drawn here on
+   purpose -- everything with a rule in it stays on this side, where FPC
+   compiles it and the tests run; the client is left with nothing but
+   "make a label, make a memo".
+
+   Inline markers are flattened rather than dropped: **bold** loses its
+   asterisks, `code` its backticks, and [text](url) becomes "text (url)"
+   because an FMX TLabel has no rich text and a bare strip would throw the
+   destination away. Code blocks are handed over verbatim -- a fenced block
+   is the one place the source characters ARE the content. *)
+type
+  TMdBlockKind = (mbParagraph, mbHeading, mbBullet, mbNumber, mbCode,
+                  mbQuote, mbRule);
+  TMdBlock = record
+    Kind:  TMdBlockKind;
+    Level: Integer;   { 1..3 for a heading; the ordinal for a numbered item }
+    Text:  string;    { inline markers already flattened, except in code }
+  end;
+  TMdBlocks = array of TMdBlock;
+
+function MarkdownToBlocks(const S: string): TMdBlocks;
+
+{ Flatten inline markdown to plain text. Public for the same reason
+  HtmlEscape is: a caller labelling its own rows needs the identical rule. }
+function FlattenInline(const S: string): string;
+
 implementation
 
 uses
@@ -251,6 +288,263 @@ begin
   if (I > Length(L)) or (L[I] <> ' ') then Exit;
   Result := I - 1;
   Body := Copy(L, I + 1, MaxInt);
+end;
+
+
+{ ------------------------------------------------ blocks, for FMX clients -- }
+
+function IsAllDigits(const S: string): Boolean;
+var
+  I: Integer;
+begin
+  Result := S <> '';
+  for I := 1 to Length(S) do
+    if (S[I] < '0') or (S[I] > '9') then Exit(False);
+end;
+
+(* Inline markers, flattened.
+
+   Order matters: links first, so the brackets are gone before emphasis
+   runs and cannot be mistaken for anything; then code spans, whose
+   contents must not have emphasis applied inside them; then the emphasis
+   markers themselves.
+
+   A marker with no partner is left alone rather than eaten -- an answer
+   must never come out emptier than it went in, which is the same rule the
+   HTML side keeps. *)
+function FlattenInline(const S: string): string;
+
+  (* `code` -> code, and ** / __ / * / _ around a run -> the run.
+
+     Three conditions, and each one is a case that actually turns up in
+     model output rather than a nicety:
+
+       the opening marker is followed by content, not a space
+       the closing marker is preceded by content, not a space
+       neither is on the other side of a newline
+
+     Without the first two, "2 * 3 * 4" is a pair of markers around " 3 "
+     and comes out as "2  3  4" -- arithmetic silently rewritten. Without
+     the third, one stray asterisk in a paragraph pairs with another three
+     lines later and eats everything between them. *)
+  function Unwrap(const Src, Marker: string): string;
+  var
+    P, Q, ML: Integer;
+    Inner: string;
+  begin
+    Result := Src;
+    ML := Length(Marker);
+    P := 1;
+    while True do
+    begin
+      P := PosEx(Marker, Result, P);
+      if P = 0 then Break;
+      if (P + ML > Length(Result)) or (Result[P + ML] = ' ') then
+      begin
+        P := P + ML;
+        Continue;
+      end;
+      { Scan on for a closing marker that is not preceded by a space. }
+      Q := P + ML;
+      repeat
+        Q := PosEx(Marker, Result, Q);
+        if Q = 0 then Break;
+        if Result[Q - 1] <> ' ' then Break;
+        Q := Q + ML;
+      until False;
+      if Q = 0 then Break;
+      Inner := Copy(Result, P + ML, Q - P - ML);
+      if (Pos(#10, Inner) > 0) or (Pos(#13, Inner) > 0) then
+      begin
+        P := P + ML;
+        Continue;
+      end;
+      Delete(Result, Q, ML);
+      Delete(Result, P, ML);
+      P := Q - ML;
+    end;
+  end;
+
+var
+  P, Close_, Open_, End_: Integer;
+  Text_, Url: string;
+begin
+  Result := S;
+
+  { [text](url) -> text (url). The destination is kept: a label cannot be
+    clickable, and silently dropping where something points is worse than
+    showing it. }
+  P := 1;
+  while True do
+  begin
+    P := PosEx('[', Result, P);
+    if P = 0 then Break;
+    Close_ := PosEx(']', Result, P + 1);
+    if (Close_ = 0) or (Close_ + 1 > Length(Result)) or
+       (Result[Close_ + 1] <> '(') then
+    begin
+      Inc(P);
+      Continue;
+    end;
+    Open_ := Close_ + 1;
+    End_ := PosEx(')', Result, Open_ + 1);
+    if End_ = 0 then
+    begin
+      Inc(P);
+      Continue;
+    end;
+    Text_ := Copy(Result, P + 1, Close_ - P - 1);
+    Url   := Copy(Result, Open_ + 1, End_ - Open_ - 1);
+    { An image is the same shape with a bang in front; drop only the bang. }
+    if (P > 1) and (Result[P - 1] = '!') then
+    begin
+      Delete(Result, P - 1, 1);
+      Dec(P);
+      Dec(Close_); Dec(Open_); Dec(End_);
+    end;
+    if Trim(Url) = '' then
+      Text_ := Text_
+    else if Trim(Text_) = '' then
+      Text_ := Url
+    else
+      Text_ := Text_ + ' (' + Url + ')';
+    Delete(Result, P, End_ - P + 1);
+    Insert(Text_, Result, P);
+    P := P + Length(Text_);
+  end;
+
+  Result := Unwrap(Result, '`');
+  Result := Unwrap(Result, '**');
+  Result := Unwrap(Result, '__');
+  Result := Unwrap(Result, '*');
+  Result := Unwrap(Result, '_');
+end;
+
+function MarkdownToBlocks(const S: string): TMdBlocks;
+var
+  Lines: TStringList;
+  I, N, HL, Dot: Integer;
+  Line, T, Para, Code: string;
+  InCode: Boolean;
+
+  procedure Emit(K: TMdBlockKind; const Text_: string; Lvl: Integer);
+  begin
+    N := Length(Result);
+    SetLength(Result, N + 1);
+    Result[N].Kind := K;
+    Result[N].Level := Lvl;
+    Result[N].Text := Text_;
+  end;
+
+  { Consecutive prose lines are one paragraph, so a model that hard-wraps
+    does not become a column of one-line labels. }
+  procedure FlushPara;
+  begin
+    if Trim(Para) = '' then
+    begin
+      Para := '';
+      Exit;
+    end;
+    Emit(mbParagraph, FlattenInline(Trim(Para)), 0);
+    Para := '';
+  end;
+
+begin
+  SetLength(Result, 0);
+  if Trim(S) = '' then Exit;
+  Lines := TStringList.Create;
+  try
+    Lines.Text := S;
+    InCode := False;
+    Para := '';
+    Code := '';
+    for I := 0 to Lines.Count - 1 do
+    begin
+      Line := Lines[I];
+      T := Trim(Line);
+
+      { Fenced code: verbatim, and no inline flattening inside it. }
+      if Copy(T, 1, 3) = '```' then
+      begin
+        if InCode then
+        begin
+          Emit(mbCode, Code, 0);
+          Code := '';
+          InCode := False;
+        end
+        else
+        begin
+          FlushPara;
+          InCode := True;
+        end;
+        Continue;
+      end;
+      if InCode then
+      begin
+        if Code <> '' then Code := Code + sLineBreak;
+        Code := Code + Line;
+        Continue;
+      end;
+
+      if T = '' then
+      begin
+        FlushPara;
+        Continue;
+      end;
+
+      if (T = '---') or (T = '***') or (T = '___') then
+      begin
+        FlushPara;
+        Emit(mbRule, '', 0);
+        Continue;
+      end;
+
+      if Copy(T, 1, 1) = '#' then
+      begin
+        HL := 0;
+        while (HL < Length(T)) and (T[HL + 1] = '#') do Inc(HL);
+        if (HL >= 1) and (HL <= 6) and (Copy(T, HL + 1, 1) = ' ') then
+        begin
+          FlushPara;
+          if HL > 3 then HL := 3;
+          Emit(mbHeading, FlattenInline(Trim(Copy(T, HL + 2, MaxInt))), HL);
+          Continue;
+        end;
+      end;
+
+      if Copy(T, 1, 2) = '> ' then
+      begin
+        FlushPara;
+        Emit(mbQuote, FlattenInline(Trim(Copy(T, 3, MaxInt))), 0);
+        Continue;
+      end;
+
+      if (Copy(T, 1, 2) = '- ') or (Copy(T, 1, 2) = '* ') then
+      begin
+        FlushPara;
+        Emit(mbBullet, FlattenInline(Trim(Copy(T, 3, MaxInt))), 0);
+        Continue;
+      end;
+
+      { "1. text" -- a digit run, a dot, a space. }
+      Dot := Pos('. ', T);
+      if (Dot > 1) and (Dot <= 4) and IsAllDigits(Copy(T, 1, Dot - 1)) then
+      begin
+        FlushPara;
+        Emit(mbNumber, FlattenInline(Trim(Copy(T, Dot + 2, MaxInt))),
+             StrToIntDef(Copy(T, 1, Dot - 1), 0));
+        Continue;
+      end;
+
+      if Para <> '' then Para := Para + ' ';
+      Para := Para + T;
+    end;
+    { An unterminated fence must not swallow the answer. }
+    if InCode and (Trim(Code) <> '') then Emit(mbCode, Code, 0);
+    FlushPara;
+  finally
+    Lines.Free;
+  end;
 end;
 
 function MarkdownToHTML(const S: string): string;

--- a/src/pkg/component/PasClaw.Client.Markdown.pas
+++ b/src/pkg/component/PasClaw.Client.Markdown.pas
@@ -304,15 +304,63 @@ end;
 
 (* Inline markers, flattened.
 
-   Order matters: links first, so the brackets are gone before emphasis
-   runs and cannot be mistaken for anything; then code spans, whose
-   contents must not have emphasis applied inside them; then the emphasis
-   markers themselves.
+   Order matters, and it is the reverse of the obvious one: code spans
+   first, then links, then emphasis.
+
+   Stripping a code span's backticks and moving on is not enough, because
+   the emphasis passes then run over what was inside it: `__init__` loses
+   its backticks, and the `__` pass eats the rest, leaving "init". Same for
+   a link destination -- https://x.test/a_b_c comes out as .../abc. Both
+   are literal text that happens to contain a marker character, which is
+   exactly what a code span and a URL are for.
+
+   So the protected pieces are PARKED first -- lifted out and replaced with
+   a placeholder no marker can match -- and put back after the last
+   emphasis pass has run. The HTML renderer protects the same two spans;
+   this is that rule, in the form this function can express it.
 
    A marker with no partner is left alone rather than eaten -- an answer
    must never come out emptier than it went in, which is the same rule the
    HTML side keeps. *)
 function FlattenInline(const S: string): string;
+const
+  { Control characters: a placeholder has to be something no model writes
+    and no emphasis pass can see a marker in. }
+  ParkOpen  = #1;
+  ParkClose = #2;
+var
+  Parked: array of string;
+
+  function Park(const Value: string): string;
+  begin
+    SetLength(Parked, Length(Parked) + 1);
+    Parked[High(Parked)] := Value;
+    Result := ParkOpen + IntToStr(High(Parked)) + ParkClose;
+  end;
+
+  function Unpark(const Src: string): string;
+  var
+    P, Q, Idx: Integer;
+  begin
+    Result := Src;
+    P := 1;
+    while True do
+    begin
+      P := PosEx(ParkOpen, Result, P);
+      if P = 0 then Break;
+      Q := PosEx(ParkClose, Result, P + 1);
+      if Q = 0 then Break;
+      Idx := StrToIntDef(Copy(Result, P + 1, Q - P - 1), -1);
+      if (Idx < 0) or (Idx > High(Parked)) then
+      begin
+        Inc(P);
+        Continue;
+      end;
+      Delete(Result, P, Q - P + 1);
+      Insert(Parked[Idx], Result, P);
+      P := P + Length(Parked[Idx]);
+    end;
+  end;
 
   (* `code` -> code, and ** / __ / * / _ around a run -> the run.
 
@@ -326,8 +374,12 @@ function FlattenInline(const S: string): string;
      Without the first two, "2 * 3 * 4" is a pair of markers around " 3 "
      and comes out as "2  3  4" -- arithmetic silently rewritten. Without
      the third, one stray asterisk in a paragraph pairs with another three
-     lines later and eats everything between them. *)
-  function Unwrap(const Src, Marker: string): string;
+     lines later and eats everything between them.
+
+     Protect parks the run instead of merely unwrapping it, so the code
+     span shares the pairing rules exactly rather than reimplementing
+     them. *)
+  function Unwrap(const Src, Marker: string; Protect: Boolean): string;
   var
     P, Q, ML: Integer;
     Inner: string;
@@ -359,9 +411,20 @@ function FlattenInline(const S: string): string;
         P := P + ML;
         Continue;
       end;
-      Delete(Result, Q, ML);
-      Delete(Result, P, ML);
-      P := Q - ML;
+      if Protect then
+      begin
+        { marker, run, marker -- all three out, the run back as a token }
+        Delete(Result, P, Q + ML - P);
+        Inner := Park(Inner);
+        Insert(Inner, Result, P);
+        P := P + Length(Inner);
+      end
+      else
+      begin
+        Delete(Result, Q, ML);
+        Delete(Result, P, ML);
+        P := Q - ML;
+      end;
     end;
   end;
 
@@ -369,11 +432,18 @@ var
   P, Close_, Open_, End_: Integer;
   Text_, Url: string;
 begin
+  SetLength(Parked, 0);
   Result := S;
+
+  { Code spans go first and go whole: what is inside one is literal, and
+    every pass after this must see a token rather than its characters. }
+  Result := Unwrap(Result, '`', True);
 
   { [text](url) -> text (url). The destination is kept: a label cannot be
     clickable, and silently dropping where something points is worse than
-    showing it. }
+    showing it. The destination is parked, the link text is not -- an
+    underscore in a URL is part of the address, an asterisk around the
+    words is still emphasis. }
   P := 1;
   while True do
   begin
@@ -405,19 +475,20 @@ begin
     if Trim(Url) = '' then
       Text_ := Text_
     else if Trim(Text_) = '' then
-      Text_ := Url
+      Text_ := Park(Url)
     else
-      Text_ := Text_ + ' (' + Url + ')';
+      Text_ := Text_ + ' (' + Park(Url) + ')';
     Delete(Result, P, End_ - P + 1);
     Insert(Text_, Result, P);
     P := P + Length(Text_);
   end;
 
-  Result := Unwrap(Result, '`');
-  Result := Unwrap(Result, '**');
-  Result := Unwrap(Result, '__');
-  Result := Unwrap(Result, '*');
-  Result := Unwrap(Result, '_');
+  Result := Unwrap(Result, '**', False);
+  Result := Unwrap(Result, '__', False);
+  Result := Unwrap(Result, '*', False);
+  Result := Unwrap(Result, '_', False);
+
+  Result := Unpark(Result);
 end;
 
 function MarkdownToBlocks(const S: string): TMdBlocks;
@@ -425,7 +496,7 @@ var
   Lines: TStringList;
   I, N, HL, Dot: Integer;
   Line, T, Para, Code: string;
-  InCode: Boolean;
+  InCode, CodeAny: Boolean;
 
   procedure Emit(K: TMdBlockKind; const Text_: string; Lvl: Integer);
   begin
@@ -456,6 +527,7 @@ begin
   try
     Lines.Text := S;
     InCode := False;
+    CodeAny := False;
     Para := '';
     Code := '';
     for I := 0 to Lines.Count - 1 do
@@ -470,19 +542,27 @@ begin
         begin
           Emit(mbCode, Code, 0);
           Code := '';
+          CodeAny := False;
           InCode := False;
         end
         else
         begin
           FlushPara;
+          Code := '';
+          CodeAny := False;
           InCode := True;
         end;
         Continue;
       end;
       if InCode then
       begin
-        if Code <> '' then Code := Code + sLineBreak;
+        { CodeAny, not Code <> '': the two mean different things the moment
+          the first line inside the fence is blank. Testing the accumulated
+          text would treat that line as "nothing here yet" and swallow it,
+          and a fence is the one place leading whitespace is content. }
+        if CodeAny then Code := Code + sLineBreak;
         Code := Code + Line;
+        CodeAny := True;
         Continue;
       end;
 

--- a/src/tests/client_markdown_tests.pas
+++ b/src/tests/client_markdown_tests.pas
@@ -251,6 +251,31 @@ begin
   ExpectStr(FlattenInline('a * b'#10'c * d'), 'a * b'#10'c * d',
             'and a pair spanning a newline is not either');
 
+  (* What is inside a code span and inside a URL is LITERAL, and both are
+     full of characters that look like emphasis markers. Stripping the
+     backticks and moving on left the later passes free to eat what they
+     had been protecting: `__init__` came out as "init". *)
+  ExpectStr(FlattenInline('call `__init__` first'), 'call __init__ first',
+            'a code span survives the emphasis passes intact');
+  ExpectStr(FlattenInline('`a * b * c`'), 'a * b * c',
+            'asterisks inside code are characters, not markers');
+  ExpectStr(FlattenInline('see [docs](https://x.test/a_b_c)'),
+            'see docs (https://x.test/a_b_c)',
+            'and underscores in a URL are part of the address');
+  ExpectStr(FlattenInline('[**docs**](https://x.test/a)'),
+            'docs (https://x.test/a)',
+            'the link TEXT is still flattened -- only the URL is protected');
+  ExpectStr(FlattenInline('`code` and **bold**'), 'code and bold',
+            'the ordinary case is unchanged by the parking');
+
+  { A fence hands over its lines verbatim, and a blank first line is one of
+    them. Using "nothing accumulated yet" to mean "no line seen yet" ate
+    exactly the leading whitespace the block promised to keep. }
+  Blocks := MarkdownToBlocks('```'#10#10'  indented'#10'```');
+  ExpectTrue(Length(Blocks) = 1, 'the fence is one block');
+  ExpectStr(Blocks[0].Text, #10'  indented',
+            'and its leading blank line survives');
+
   { The fail-safe rule the HTML side keeps, kept here too. }
   Blocks := MarkdownToBlocks('before'#10'```'#10'never closed');
   ExpectTrue(Length(Blocks) = 2, 'an unterminated fence still yields blocks');

--- a/src/tests/client_markdown_tests.pas
+++ b/src/tests/client_markdown_tests.pas
@@ -32,6 +32,12 @@ begin
   if not Cond then Fail_(Msg);
 end;
 
+procedure ExpectStr(const Got, Want, Msg: string);
+begin
+  if Got <> Want then
+    Fail_(Msg + ' -- got "' + Got + '", want "' + Want + '"');
+end;
+
 procedure ExpectHas(const Hay, Needle, Msg: string);
 begin
   if Pos(Needle, Hay) = 0 then
@@ -47,6 +53,7 @@ end;
 
 var
   H: string;
+  Blocks: TMdBlocks;
 begin
   { ---------------------------------------------------- the safety rule -- }
   (* Model output is untrusted text. Every one of these must come back as
@@ -164,6 +171,94 @@ begin
   ExpectHas(H, '#c0c0c0', 'the background colour is applied');
   ExpectHas(H, '#000080', 'and the accent');
   ExpectHas(H, 'scrollTo', 'and it scrolls to the newest turn');
+
+  (* A COMPLETE, STANDALONE document, and the reason that matters changed.
+
+     It used to reach the browser through LoadFromStrings, where an
+     unterminated or headless fragment would still mostly render. It is
+     written to a file and navigated to now -- see ShowHtml in the FMX
+     client, and the white chat window that made it necessary -- and a file
+     is parsed as a file: no doctype at the front and the charset is a guess,
+     no </html> and a truncated write looks like a whole page.
+
+     So this pins the frame, not just the body. If a chat window ever comes
+     up blank again, these assertions passing is what says the content was
+     fine and the delivery was not. *)
+  ExpectTrue(Pos('<!doctype html>', LowerCase(H)) = 1,
+             'the document opens with a doctype, at the very start');
+  ExpectHas(LowerCase(H), 'charset="utf-8"',
+            'and declares utf-8 rather than leaving it to be sniffed');
+  ExpectHas(LowerCase(H), '</html>', 'and is terminated');
+
+  { Unicode in the model's own words has to survive the whole way out. }
+  H := ChatDocumentHTML(MarkdownToHTML('an em dash -- really a ' + #$2014 +
+                                       ' and a ' + #$00E9),
+                        '#c0c0c0', '#000', '#000080', '#fff');
+  ExpectHas(H, #$2014, 'an em dash survives into the document');
+  ExpectHas(H, #$00E9, 'and an accented letter');
+
+  (* ---- the same markdown, as BLOCKS ----
+
+     The chat window renders with ordinary FMX controls rather than a
+     TWebBrowser -- a browser is a native control that has to be swapped for
+     a snapshot to coexist with overlapping windows, and its engine
+     initialises asynchronously, which is how the chat became a white
+     square. A stack of labels has neither problem.
+
+     Which puts the parsing here, where FPC compiles it and this runs. The
+     client is left with "make a label, make a memo", and everything with a
+     rule in it is asserted below. *)
+  Blocks := MarkdownToBlocks('# Title'#10#10'Some **bold** prose.'#10 +
+    'Wrapped onto two lines.'#10#10'- one'#10'- two'#10#10'1. first'#10 +
+    '2. second'#10#10'> quoted'#10#10'---'#10#10'```'#10'x := 1;'#10'```');
+
+  ExpectTrue(Length(Blocks) = 9,
+             'nine blocks out of that document');
+  ExpectTrue(Blocks[0].Kind = mbHeading, 'the heading is a heading');
+  ExpectTrue(Blocks[0].Level = 1, 'at level one');
+  ExpectStr(Blocks[0].Text, 'Title', 'with its hashes gone');
+
+  { Consecutive prose lines are ONE paragraph -- a model that hard-wraps
+    must not become a column of one-line labels. }
+  ExpectTrue(Blocks[1].Kind = mbParagraph, 'the prose is a paragraph');
+  ExpectStr(Blocks[1].Text, 'Some bold prose. Wrapped onto two lines.',
+            'joined, with the emphasis markers flattened');
+
+  ExpectTrue(Blocks[2].Kind = mbBullet, 'a bullet');
+  ExpectStr(Blocks[2].Text, 'one', 'with its dash gone');
+  ExpectTrue(Blocks[4].Kind = mbNumber, 'a numbered item');
+  ExpectTrue(Blocks[4].Level = 1, 'carrying its own number');
+  ExpectStr(Blocks[5].Text, 'second', 'and the second');
+  ExpectTrue(Blocks[6].Kind = mbQuote, 'a quote');
+  ExpectTrue(Blocks[7].Kind = mbRule, 'a rule');
+  ExpectTrue(Blocks[8].Kind = mbCode, 'and a code block');
+  ExpectStr(Blocks[8].Text, 'x := 1;',
+            'handed over VERBATIM -- a fence is the one place the source ' +
+            'characters are the content');
+
+  { Inline flattening, on its own. A label has no rich text, so the markers
+    come off -- but a link's destination is kept, because dropping where
+    something points is worse than showing it. }
+  ExpectStr(FlattenInline('a **bold** and `code` word'),
+            'a bold and code word', 'emphasis and code markers come off');
+  ExpectStr(FlattenInline('see [the docs](https://x.test/a)'),
+            'see the docs (https://x.test/a)',
+            'a link keeps its destination');
+  ExpectStr(FlattenInline('an ![image](p.png) inline'),
+            'an image (p.png) inline', 'an image loses only its bang');
+  ExpectStr(FlattenInline('2 * 3 * 4'), '2 * 3 * 4',
+            'a lone asterisk in prose is not emphasis');
+  ExpectStr(FlattenInline('a * b'#10'c * d'), 'a * b'#10'c * d',
+            'and a pair spanning a newline is not either');
+
+  { The fail-safe rule the HTML side keeps, kept here too. }
+  Blocks := MarkdownToBlocks('before'#10'```'#10'never closed');
+  ExpectTrue(Length(Blocks) = 2, 'an unterminated fence still yields blocks');
+  ExpectTrue(Blocks[1].Kind = mbCode, 'the run becomes code');
+  ExpectStr(Blocks[1].Text, 'never closed',
+            'and the text inside it survives rather than vanishing');
+
+  ExpectTrue(Length(MarkdownToBlocks('   ')) = 0, 'blank in, nothing out');
 
   if Failures = 0 then
     WriteLn('client_markdown_tests: OK')


### PR DESCRIPTION
The chat window came up as a white square. It was not the snapshot `TImage` and not a stale control left behind — it was that the transcript was a `TWebBrowser` being handed its document through `LoadFromStrings`.

## Why it was blank

WebView2 initialises **asynchronously**. FMX's Edge delegate queues an `.URL` assignment and replays it once the core is ready, but `LoadFromStrings` maps to `NavigateToString`, which is **dropped outright** if the core has not come up — and it never has, in the same turn the control is created.

That is the asymmetry in the old code, and it is what pinned the diagnosis: every site that set `.URL` (Browser window, file view, app windows) rendered fine; every site that called `LoadFromStrings` (only the chat) was blank. Same windows, same snapshot code, same engine. The chat *document* was never at fault — a probe produced a complete, well-formed 1177-byte page with the charset tag and unicode intact.

Under the legacy IE engine `LoadFromStrings` happened to work synchronously, so this only surfaced once #533's `WindowsEngine`-before-`Parent` ordering made `EdgeIfAvailable` actually engage.

## What replaces it

The transcript stops being a browser. It is a `TVertScrollBox` of ordinary FMX controls — the way PasClaw Studio's chat has always done it. No native control, no snapshot bitmap, no engine, nothing left that can be blank.

The parsing lives in the shared library rather than the FMX unit:

```pascal
TMdBlockKind = (mbParagraph, mbHeading, mbBullet, mbNumber, mbCode, mbQuote, mbRule);

function MarkdownToBlocks(const S: string): TMdBlocks;
function FlattenInline(const S: string): string;
```

FPC compiles `PasClaw.Client.Markdown` and `client_markdown_tests` asserts it, which leaves `uDesktopMain` with nothing harder than "make a label, make a memo" — the split this project keeps to because no CI here has Delphi.

| Block | Control |
|---|---|
| heading 1–3 | `TLabel`, sized 18/15/13, bold |
| bullet / numbered | `TLabel` indented, `• ` or `n. ` prefix |
| quote | `TLabel` indented, dimmed |
| code fence | read-only monospace `TMemo`, height from line count, capped at 24 lines |
| rule | `TLine` |
| paragraph | `TLabel`, wrapped |

Emphasis unwrapping requires the marker to sit against a non-space on the inside, so `2 * 3 * 4` survives as itself instead of collapsing to `2  3  4`. My own test caught that one.

## Also in here

- **`HexColor` replaces `StringToAlphaColor`** for the palette. FMX reads a 6-digit `#RRGGBB` as `AARRGGBB` — alpha `0` — so every label would have been invisible. That was the second, independent way this window could have come up empty.
- **End-of-turn notices** ("app updated", "no app produced") move out of the hidden streaming memo and into the transcript, where they can be seen.
- **`EnsureLiveBrowsers`** runs off the event timer, so the Browser and App windows assert their own live control rather than trusting an activation event to have fired.
- **`ShowHtml` stays**, and stays on `.URL`, for the Browser window that still needs a real document.

The streaming memo is kept as a hidden, toggleable raw view. The transcript rebuilds wholesale from `FChatTurns`, so there is no incremental-append state to get out of step.

## Cost

An FMX `TLabel` has no rich text, so **bold and links flatten to plain text** rather than being styled. Structure is preserved; inline styling is not. Documented in both `docs/desktop.md` and `desktop/README.md`.

## Verification

- `make test-client-markdown` → **OK** (~30 new assertions on `MarkdownToBlocks` / `FlattenInline`)
- `make lint-pascal-shape` → **OK**
- `make test` → one failure, `self_improving_skills_tests` ("FAIL: error mentions unsafe"), which **fails identically on stock `main`** — confirmed by `git stash`. Not from this change.
- The FMX unit itself has not been through a compiler; there is no Delphi in CI.

Targets `main` directly — not stacked on any open PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_