### PR TITLE
Drop the WebView2Loader.dll post-build copy

### DIFF
--- a/desktop/PasclawDesktop.dproj
+++ b/desktop/PasclawDesktop.dproj
@@ -253,7 +253,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
-        <PostBuildEvent>if exist "$(BDS)\Redist\win32\WebView2Loader.dll" (copy /Y "$(BDS)\Redist\win32\WebView2Loader.dll" "$(OUTPUTDIR)") else (echo WARNING: WebView2Loader.dll was not found at "$(BDS)\Redist\win32\WebView2Loader.dll" - TWebBrowser will fall back to the legacy IE engine)</PostBuildEvent>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
         <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
         <VerInfo_Locale>1033</VerInfo_Locale>
@@ -267,7 +266,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
-        <PostBuildEvent>if exist "$(BDS)\Redist\win64\WebView2Loader.dll" (copy /Y "$(BDS)\Redist\win64\WebView2Loader.dll" "$(OUTPUTDIR)") else (echo WARNING: WebView2Loader.dll was not found at "$(BDS)\Redist\win64\WebView2Loader.dll" - TWebBrowser will fall back to the legacy IE engine)</PostBuildEvent>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
         <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
         <VerInfo_Locale>1033</VerInfo_Locale>

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -42,20 +42,17 @@ to misrepresent the app the agent just wrote.
 *If available* is the operative half. WebView2 is only available when
 `WebView2Loader.dll` sits beside the exe; without it FMX falls back to the
 legacy engine **silently**, and the app looks broken for reasons nothing
-reports. A post-build event in the `.dproj` copies it for both Windows
-platforms:
+reports. So if the chat renders but an app window looks like 1998, that DLL
+is the first thing to check.
 
-```
-if exist "$(BDS)\Redist\win32\WebView2Loader.dll" (copy /Y "$(BDS)\Redist\win32\WebView2Loader.dll" "$(OUTPUTDIR)") else (echo WARNING: ...)
-```
-
-`$(BDS)` rather than a literal `C:\Program Files (x86)\Embarcadero\Studio\23.0`
-so it follows whichever RAD Studio is building, and `win32` / `win64` from the
-matching Redist directory — a 32-bit loader beside a 64-bit exe does not load.
-
-Guarded with `if exist` so a Delphi install without that redistributable
-cannot fail the build, and the `else` prints a warning rather than passing in
-silence, since silence is the failure mode this exists to prevent.
+The project does **not** copy it for you. A post-build event pulling it from
+`$(BDS)\Redist\win32|win64` was tried and removed: that directory does not
+carry `WebView2Loader.dll` on the RAD Studio installs we have looked at, so
+the step was a guaranteed no-op that read like a solved problem. Put a copy
+beside the exe yourself, from wherever your install actually keeps one —
+usually under the `WebView2` NuGet package pulled in by a project that uses
+it, and matching the platform: a 32-bit loader beside a 64-bit exe does not
+load.
 
 Shipping the app to a machine that has never run an Edge-based application
 also needs the **WebView2 Evergreen Runtime** installed there; the loader DLL


### PR DESCRIPTION
You told me the DLL is not in the Redist folder and to take the copy out of the project. It did not land — my amended commit on #539 was force-pushed *after* that PR had already merged the earlier version, so `main` still carries both `PostBuildEvent` entries. This is that removal, done properly, off `main`.

## What was wrong with it

```xml
<PostBuildEvent>if exist "$(BDS)\Redist\win32\WebView2Loader.dll" (copy /Y ... "$(OUTPUTDIR)") else (echo WARNING: ...)</PostBuildEvent>
```

`$(BDS)\Redist\win32|win64` does not carry `WebView2Loader.dll` on the installs this has been checked against. The `if exist` guard meant it never fired, so the step was a guaranteed no-op — while reading, in the `.dproj` and the README both, like the problem was handled.

That is worse than not having it. The failure mode this was meant to prevent is *silent*: without the loader beside the exe, FMX falls back to the legacy IE engine and the app just looks like 1998, with nothing reporting why. The next person to hit that will look at the post-build event, see it sitting there, and rule it out.

## What this does

- Removes both `<PostBuildEvent>` entries (Win32 and Win64) from `PasclawDesktop.dproj`. Two deleted lines, nothing else in that file touched.
- Rewrites the README section to say the copy is yours to make and where the DLL actually tends to live (the WebView2 NuGet package, not Redist), keeping the platform warning — a 32-bit loader beside a 64-bit exe does not load.
- Keeps the part worth keeping: *why* the DLL matters, and that the Evergreen Runtime is a separate thing the loader finds rather than provides.

No code change; nothing to test beyond `make test`, which is unaffected. The one failure there, `self_improving_skills_tests`, is pre-existing on `main`.

Targets `main` directly — not stacked on #541.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_