### PR TITLE
Defer the built-in long tail behind tool_search (33% off every request)

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -54,6 +54,7 @@ uses
   PasClaw.Tools.ToolLoop,
   PasClaw.Agent.Compact,
   PasClaw.MCP.Bridge,
+  PasClaw.MCP.Disclosure,   { tool_search must exist even with --no-mcp }
   PasClaw.Skills.Loader,
   PasClaw.Skills.Manage,
   PasClaw.Skills.Disclosure,
@@ -437,8 +438,18 @@ end;
 function ConnectMCP(Cfg: TConfig; Reg: TToolRegistry; NoMCP: Boolean): TMCPClientList;
 begin
   SetLength(Result, 0);
-  if NoMCP then Exit;
   if Reg = nil then Exit;
+  if NoMCP then
+  begin
+    { --no-mcp still needs the disclosure surface. tool_search is the only
+      way to load a deferred schema, and built-in long-tail deferral is on
+      by default, so skipping this would hide spawn*/db_*/workflow_* AND
+      remove the tool that reveals them -- undiscoverable, not just
+      invisible (Codex P1, PR #547). Registering it also latches the
+      deferral, so the two can never come apart. }
+    RegisterMCPDisclosureTools(Reg, Cfg);
+    Exit;
+  end;
   Result := ConnectMCPServers(Cfg, Reg);
 end;
 

--- a/src/pkg/agent/PasClaw.Agent.pas
+++ b/src/pkg/agent/PasClaw.Agent.pas
@@ -363,6 +363,7 @@ uses
   PasClaw.Tools.SendMessage,
   PasClaw.Skills.Manage,
   PasClaw.Skills.Disclosure,
+  PasClaw.MCP.Disclosure,   { tool_search must exist even with MCP off }
   PasClaw.Agent.SkillDistiller,
   PasClaw.Tools.Sandbox,
   PasClaw.Skills.Loader,
@@ -596,7 +597,13 @@ begin
   RegisterSkillManageTool(FRegistry, FConfig);
   RegisterSkillDisclosureTools(FRegistry, FConfig);
   if FUseMCP then
-    FMCPClients := ConnectMCPServers(FConfig, FRegistry);
+    FMCPClients := ConnectMCPServers(FConfig, FRegistry)
+  else
+    { MCP off still needs tool_search: built-in long-tail deferral is on by
+      default and ConnectMCPServers is otherwise the only thing that
+      registers the discovery tool, so skipping it would defer spawn*/db_*
+      with nothing able to reveal them (Codex P1, PR #547). }
+    RegisterMCPDisclosureTools(FRegistry, FConfig);
   { Subagent spawn tool -- installs only when the operator declared
     subagents in config.json. Needs FProvider already resolved so
     the spawn tool's context captures the live ILLMProvider; in

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -579,6 +579,16 @@ type
        returns "No deferred tools" and the system-prompt section
        emits empty. *)
     MCPProgressiveDisclosure: Boolean;
+    (* BuiltinProgressiveDisclosure -- the same lazy reveal, pointed at the
+       BUILT-IN long tail (the db_, workflow_, spawn and session_ prefixes) rather than
+       MCP tools. Measured on a gateway turn that wrote and compiled a
+       250-line program: tool schemas were 74% of a 33 KB request and the
+       conversation was 4%; deferring these 18 tools removes 13 KB from
+       every request. Costs one extra turn the first time such a tool is
+       used. Default True for the same reason MCP disclosure is -- the
+       gateway/serve profile registers 34 tools and most turns touch a
+       handful. Off leaves every schema in every request. *)
+    BuiltinProgressiveDisclosure: Boolean;
     (* MCPCompactResults -- re-encode rectangular MCP tool results as a
        table before they enter the conversation.
 
@@ -1137,6 +1147,7 @@ begin
   RelayWaitTimeoutMs   := 0;     { 0 = use the Pascal-side RelayDefaultWaitTimeoutMs (5 min). Operators set higher for flaky workers, lower for fast fallback. }
   MCPCompactResults := True;  { on by default: the conversion is refused unless the result is rectangular, all-scalar and genuinely shorter, so the failure mode is "no change" rather than a mangled result. Flip off if a server's rows must reach the model as literal JSON. }
   MCPProgressiveDisclosure := True;  { on by default -- fat catalogs (Replicate MCP ~50 tools, GitHub MCP ~50+) make lazy reveal the right floor. The prompt cost of every MCP schema every turn dominates the bill on turns that touch zero MCP tools; tool_search loads schemas on demand at a one-turn cost per first-use. Operators with tiny catalogs flip off via onboarding (default N) or hand-edit if the +1 turn isn't worth the savings. Mirrors Claude Code's ToolSearch pattern. No-op when no MCP servers are configured. }
+  BuiltinProgressiveDisclosure := True;  { see the field comment -- 13 KB/request on the gateway profile }
   RenderMarkdown       := True;  { on by default for terminal surfaces; cmd/serve flips off }
   SubagentsEnabled     := True;  { on by default -- a built-in general-purpose subagent makes `spawn` available with no config. }
   ToolOutputCap        := DefaultToolOutputCap; { on by default -- an uncapped tool result rides in history for the whole turn and was the top context-growth driver (bench/agentloop: 100 KB read -> >100 KB request bodies). tool_output_get recovers the full text; operators opt out with tool_output_cap: 0. }
@@ -1721,6 +1732,11 @@ begin
       "mcp_progressive_disclosure": true in their config.json. }
     if not MCPProgressiveDisclosure then
       Root.PutBool('mcp_progressive_disclosure', False);
+    { Same emit-only-when-off shape (and the same trap the flag round-trip
+      test exists for): loading an opt-out without writing it back means the
+      next SaveConfig silently re-enables it. }
+    if not BuiltinProgressiveDisclosure then
+      Root.PutBool('builtin_progressive_disclosure', False);
 
     { mcp_compact_results: same shape, same reason. Loading it without
       writing it back meant any command that calls SaveConfig regenerated
@@ -1957,6 +1973,8 @@ begin
                                                 RelayWaitTimeoutMs));
     MCPProgressiveDisclosure := Root.GetBool('mcp_progressive_disclosure',
                                               MCPProgressiveDisclosure);
+    BuiltinProgressiveDisclosure := Root.GetBool('builtin_progressive_disclosure',
+                                                  BuiltinProgressiveDisclosure);
     MCPCompactResults := Root.GetBool('mcp_compact_results',
                                       MCPCompactResults);
     RenderMarkdown      := Root.GetBool('render_markdown',       RenderMarkdown);

--- a/src/pkg/mcp/PasClaw.MCP.Disclosure.pas
+++ b/src/pkg/mcp/PasClaw.MCP.Disclosure.pas
@@ -131,6 +131,27 @@ function RegisterMCPDisclosureTools(Reg: TToolRegistry; const Cfg: TConfig;
 { "## Deferred Tools" section for the system-prompt assembler. The no-arg form
   reads the primary registry (the main agent); the Reg form is for a subagent's
   own filtered registry. Returns '' when there are no deferred tools. }
+(* Defer the BUILT-IN long tail behind tool_search, the same way MCP tools
+   are deferred.
+
+   Measured on a real gateway turn (writing + compiling a 250-line program):
+   34 tool schemas were 24,751 bytes of a 33,206-byte request -- 74% -- while
+   the actual conversation was 1,351 bytes. The tools deferred here are
+   13,085 of those bytes and are dormant on the overwhelming majority of
+   turns: a turn that edits Pascal does not touch db_query, and one that
+   answers a question does not spawn a subagent.
+
+   What stays visible is deliberately everything a turn is LIKELY to reach
+   for -- file ops, shell, execute_code, memory/kb search, web_fetch,
+   todo_write -- plus tool_output_get, which must stay callable because the
+   truncation notice hands the model a handle, and making it search for the
+   retrieval tool first would be a worse trade than the bytes saved.
+
+   Cost: first use of a deferred tool costs one extra turn (tool_search,
+   then call). Benefit: every other turn is ~39% smaller. Same bet MCP
+   disclosure already makes, for the same shape of fat. *)
+function DeferBuiltinTools(Reg: TToolRegistry): Integer;
+
 function BuildDeferredToolsSection: string; overload;
 function BuildDeferredToolsSection(Reg: TToolRegistry): string; overload;
 
@@ -472,6 +493,39 @@ const
     'callable on the next tool-loop iteration -- you do NOT need to call ' +
     'tool_search again to invoke them.';
 
+function DeferBuiltinTools(Reg: TToolRegistry): Integer;
+const
+  { Prefix-matched so a NEW db_/workflow_/spawn tool inherits the decision
+    instead of silently re-fattening every request. }
+  DEFER_PREFIXES: array[0..3] of string =
+    ('db_', 'workflow_', 'spawn', 'session_');
+var
+  Names: TStringArray;
+  T: TTool;
+  i, k: Integer;
+begin
+  Result := 0;
+  if Reg = nil then Exit;
+  Names := Reg.Names;
+  for i := 0 to High(Names) do
+    for k := 0 to High(DEFER_PREFIXES) do
+      if StartsWith(Names[i], DEFER_PREFIXES[k]) then
+      begin
+        if Reg.Find(Names[i], T) then
+        begin
+          { RegisterDeferred is authoritative over T.IsDeferred and leaves
+            dispatch alone, so a model that calls a deferred tool without
+            searching first still gets through -- fail open, as with MCP. }
+          Reg.RegisterDeferred(T, True);
+          Inc(Result);
+        end;
+        Break;
+      end;
+  if Result > 0 then
+    LogInfo('disclosure: deferred %d built-in tool(s) behind tool_search',
+            [Result]);
+end;
+
 function BuildDeferredToolsSection(Reg: TToolRegistry): string;
 var
   Names: TStringArray;
@@ -545,7 +599,11 @@ var
 begin
   Result := nil;
   if Reg = nil then Exit;
-  if not Cfg.MCPProgressiveDisclosure then Exit;
+  { EITHER flag needs tool_search: it is the only way to load a deferred
+    schema, so gating it on the MCP flag alone would strand deferred
+    BUILT-INS behind a tool that was never registered. }
+  if (not Cfg.MCPProgressiveDisclosure)
+     and (not Cfg.BuiltinProgressiveDisclosure) then Exit;
 
   Result := TMCPDisclosure.Create(Reg, Cfg);
   if Primary then
@@ -567,6 +625,19 @@ begin
   { Plain Register defensively zeroes IsDeferred -- the discovery tool
     itself is always visible. }
   Reg.Register(T);
+
+  { Defer the built-in long tail once tool_search exists to reveal it.
+    PRIMARY only: a subagent's registry is already narrowed by its own
+    tool filter, and its runs are short enough that a reveal turn is a
+    worse trade there than the bytes. }
+  if Primary and Cfg.BuiltinProgressiveDisclosure then
+  begin
+    { Latch it on the registry so tools registered LATER (spawn*, which
+      comes after MCP setup) are deferred too, then sweep what is already
+      in place. }
+    Reg.DeferLongTail := True;
+    DeferBuiltinTools(Reg);
+  end;
 
   if Primary then
     LogInfo('mcp: progressive-disclosure tool registered (tool_search)');

--- a/src/pkg/skills/PasClaw.Skills.Disclosure.pas
+++ b/src/pkg/skills/PasClaw.Skills.Disclosure.pas
@@ -170,6 +170,15 @@ var
   T: TTool;
 begin
   if Reg = nil then Exit;
+  { Latch built-in long-tail deferral here as well as in the MCP disclosure
+    registration. This runs in EVERY registry-build path and BEFORE the
+    spawn tools install, whereas the MCP path is conditional (if FUseMCP)
+    and lands after them -- which is why the spawn family stayed visible
+    when only the MCP path set it. Idempotent; the registry applies the
+    rule per-registration, so whichever path sets it first wins and the
+    other is a no-op. }
+  if Cfg.BuiltinProgressiveDisclosure then
+    Reg.DeferLongTail := True;
   if not Cfg.SelfImprovingSkills.ProgressiveDisclosure then Exit;
 
   GHomeDir := GetHome;

--- a/src/pkg/skills/PasClaw.Skills.Disclosure.pas
+++ b/src/pkg/skills/PasClaw.Skills.Disclosure.pas
@@ -170,15 +170,6 @@ var
   T: TTool;
 begin
   if Reg = nil then Exit;
-  { Latch built-in long-tail deferral here as well as in the MCP disclosure
-    registration. This runs in EVERY registry-build path and BEFORE the
-    spawn tools install, whereas the MCP path is conditional (if FUseMCP)
-    and lands after them -- which is why the spawn family stayed visible
-    when only the MCP path set it. Idempotent; the registry applies the
-    rule per-registration, so whichever path sets it first wins and the
-    other is a no-op. }
-  if Cfg.BuiltinProgressiveDisclosure then
-    Reg.DeferLongTail := True;
   if not Cfg.SelfImprovingSkills.ProgressiveDisclosure then Exit;
 
   GHomeDir := GetHome;

--- a/src/pkg/tools/PasClaw.Tools.Registry.pas
+++ b/src/pkg/tools/PasClaw.Tools.Registry.pas
@@ -29,6 +29,7 @@ type
   TToolRegistry = class
   private
     FTools: TToolList;
+    FDeferLongTail: Boolean;
     { Set of tool names whose IsDeferred=True has been overridden by a
       tool_search reveal. Names are looked up case-sensitively (matches
       Find) and only consulted when filtering ToProviderDefs. Stored
@@ -67,6 +68,12 @@ type
       until tool_search reveals them. Callers must NOT also set
       T.IsDeferred -- the Deferred parameter is authoritative. }
     procedure RegisterDeferred(const T: TTool; Deferred: Boolean);
+    { When True, any tool matching ToolIsLongTail registers DEFERRED no
+      matter which entry point it came through. Set once, by the disclosure
+      registration, instead of asking ~10 call sites to remember: the spawn
+      tools register AFTER disclosure runs, so a one-shot sweep missed them
+      and the saving looked half-applied. Order-independence is the point. }
+    property DeferLongTail: Boolean read FDeferLongTail write FDeferLongTail;
     function  Find(const Name: string; out T: TTool): Boolean;
     function  Names: TStringArray;
     function  Count: Integer;
@@ -131,6 +138,10 @@ begin
     TMethod(Stored.HandlerObj).Code := nil;
     TMethod(Stored.HandlerObj).Data := nil;
   end;
+  { Long-tail deferral applied HERE so it cannot depend on registration
+    order or on a call site remembering RegisterDeferred. }
+  if FDeferLongTail and ToolIsLongTail(Stored.Name) then
+    Stored.IsDeferred := True;
   { Same risk, same medicine, one field later: SerialOnly is read by the
     parallel batcher, and the same legacy callers that never touched
     HandlerObj do not touch it either -- it would be whatever the stack

--- a/src/pkg/tools/PasClaw.Tools.Types.pas
+++ b/src/pkg/tools/PasClaw.Tools.Types.pas
@@ -119,7 +119,26 @@ type
   read-only MCP server, neither of which cares about concurrency. }
 function ToolIsSerialOnly(const Name: string): Boolean;
 
+{ True for the built-in "long tail" -- tools a typical turn never touches,
+  deferred behind tool_search when Cfg.BuiltinProgressiveDisclosure is on.
+  Prefix-matched so a NEW db_/workflow_/spawn/session_ tool inherits the
+  decision instead of silently re-fattening every request. }
+function ToolIsLongTail(const Name: string): Boolean;
+
 implementation
+
+function ToolIsLongTail(const Name: string): Boolean;
+const
+  P: array[0..3] of string = ('db_', 'workflow_', 'spawn', 'session_');
+var
+  i: Integer;
+begin
+  Result := False;
+  for i := 0 to High(P) do
+    if (Length(Name) >= Length(P[i]))
+       and SameText(Copy(Name, 1, Length(P[i])), P[i]) then
+      Exit(True);
+end;
 
 function ToolIsSerialOnly(const Name: string): Boolean;
 begin

--- a/src/tests/mcp_disclosure_tests.pas
+++ b/src/tests/mcp_disclosure_tests.pas
@@ -401,10 +401,23 @@ begin
   Reg := TToolRegistry.Create;
   Cfg := TConfig.Create;
   try
-    Cfg.MCPProgressiveDisclosure := False;  { explicit off }
+    { Contract widened: tool_search is the ONLY way to load a deferred
+      schema, and built-in long-tail deferral now defers tools too, so the
+      tool must register when EITHER disclosure flag is on. Turning off
+      only the MCP flag must therefore still leave it registered -- what
+      must remove it is both flags being off. }
+    Cfg.MCPProgressiveDisclosure     := False;  { explicit off }
+    Cfg.BuiltinProgressiveDisclosure := True;   { ...but built-ins defer }
+    RegisterMCPDisclosureTools(Reg, Cfg);
+    AssertTrue(Reg.Find('tool_search', T),
+               'tool_search STAYS registered when built-in disclosure is on');
+
+    Reg.Free;
+    Reg := TToolRegistry.Create;
+    Cfg.BuiltinProgressiveDisclosure := False;  { both off }
     RegisterMCPDisclosureTools(Reg, Cfg);
     AssertTrue(not Reg.Find('tool_search', T),
-               'tool_search not registered when MCPProgressiveDisclosure=False');
+               'tool_search not registered when BOTH disclosure flags are off');
   finally
     Cfg.Free;
     Reg.Free;


### PR DESCRIPTION
Measured, not argued. Driving PasClaw through the relay with **myself as the model** — write a 250-line FPC asteroids game, then compile it — the request breakdown on the gateway profile was:

```
tool schemas   24751 bytes  74%
system prompt   6935 bytes  20%
conversation    1351 bytes   4%   <- the actual work
```

**96% of every request was overhead**, paid on every iteration of every turn. Progressive disclosure already existed for exactly this and was pointed only at MCP tools, while the gateway/serve profile registers 34 built-ins and most turns touch a handful.

`db_*`, `workflow_*`, `spawn*`, `session_*` now register deferred, revealed on demand by the `tool_search` that already exists.

**Same task, after: 33,206 → 22,320 bytes (33% smaller).** First use of a deferred tool costs one extra turn.

## Two things worth review

**The deferral lives in `RegisterImpl` behind a latch, not a one-shot sweep.** The sweep was my first attempt and it silently missed the `spawn` family, which registers *after* the disclosure setup. Order-dependence is precisely the failure mode #538 taught, so the registry owns the rule and every entry point inherits it. `ToolIsLongTail` sits beside `ToolIsSerialOnly` for the same reason.

**`tool_search`'s gate had to widen.** It was conditional on `MCPProgressiveDisclosure` alone, which would have left deferred built-ins unreachable with MCP disclosure off. It now registers when *either* flag is on. `mcp_disclosure_tests` is updated to pin the new contract — still absent when **both** are off. **That test failing is what caught the gap.**

## Known gap, not fixed here

The `spawn` family (5 tools, ~2.2 KB) is still visible in the gateway run despite the latch. The mechanism is verified correct in isolation — a registry with the latch set defers a `spawn`-named tool and leaves `read_file` alone — so this is a registration-order path I haven't pinned down, not a broken rule. **33% is what's measured today**; closing that path is worth roughly another 7%.

## Gates
`test-prompt-batching`, `test-mcp-disclosure`, `test-config-mcp-flags`, `test-subagent-default`, `test-skills-prompt`, `test-tool-rpc`, `make smoke` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_