### PR TITLE
Per-session profiles, plus three bugs found by running PasClaw against its own source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,16 @@ $(WEBUI_RES): src/pkg/gateway/webui.rc src/pkg/gateway/webui.html src/pkg/gatewa
 	@# unit so it -- and the embedded resource -- always recompiles.
 	@touch src/pkg/gateway/PasClaw.Gateway.WebUI.pas
 
-$(BIN): $(WEBUI_RES) | $(BUILDDIR) $(INDY_DIR)
+# Every unit $(BIN) is compiled from. Without this the binary had NO source
+# prerequisite at all: edit a .pas, run `make all`, get "Nothing to be done"
+# and keep the previous binary. Verifying a change then silently tested the
+# old build -- which is exactly how a stale binary reached a benchmark run.
+# vendor/Indy is deliberately absent: it only changes when $(INDY_DIR) fetches
+# it, it is already an order-only prerequisite, and globbing it would add
+# thousands of stats to every make invocation.
+PASCLAW_SOURCES := $(shell find src -type f \( -name '*.pas' -o -name '*.dpr' -o -name '*.inc' \) 2>/dev/null)
+
+$(BIN): $(WEBUI_RES) $(PASCLAW_SOURCES) | $(BUILDDIR) $(INDY_DIR)
 	@mkdir -p $(BUILDDIR)/lib
 	PASCLAW_VERSION='$(VERSION)' $(FPC) $(FPCFLAGS) src/pasclaw/PasClaw.dpr -o$(BIN)
 

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -84,6 +84,13 @@ uses
   PasClaw.Agent.Goals,
   PasClaw.Markdown.Render;
 
+{ ', profile X' for the session banner, or '' when the session runs on
+  stock defaults -- no profile line for the case that needs no words. }
+function ProfileSuffix(const Name: string): string;
+begin
+  if Name = '' then Result := '' else Result := ', profile ' + Name;
+end;
+
 type
   (* --orient / --no-orient: per-invocation override of
      Cfg.OrientTaskAware (task-aware MEMORY slicing, PasClaw.Agent.Orient).
@@ -1438,17 +1445,24 @@ begin
       finally below. }
     StartShellSession(Session.Meta.Id);
     SetCurrentSessionId(Session.Meta.Id);
+    { Stamp the profile this run resolved to so the session resumes under
+      it later. Only when empty: a session records the profile it was
+      CREATED under and keeps it, so an explicit --profile for one
+      invocation doesn't silently rewrite the session's binding. }
+    if Session.Meta.Profile = '' then Session.Meta.Profile := Cfg.ProfileName;
     if Session.MetaExists then
     begin
       SetLength(Msgs, Length(Session.Messages));
       for i := 0 to High(Session.Messages) do Msgs[i] := Session.Messages[i];
       SystemPromptOverride := Session.Meta.SystemPromptOverride;
       PrintLn(Ansi.Dim + '(resumed session ' + Session.Meta.Id +
-              ' -- ' + IntToStr(Length(Msgs)) + ' messages)' + Ansi.Reset);
+              ' -- ' + IntToStr(Length(Msgs)) + ' messages' +
+              ProfileSuffix(Session.Meta.Profile) + ')' + Ansi.Reset);
     end
     else
       PrintLn(Ansi.Dim + '(new session ' + Session.Meta.Id +
-              ' -- pasclaw resume ' + Session.Meta.Id + ' to continue later)' + Ansi.Reset);
+              ' -- pasclaw resume ' + Session.Meta.Id + ' to continue later' +
+              ProfileSuffix(Session.Meta.Profile) + ')' + Ansi.Reset);
 
     while True do
     begin
@@ -1856,7 +1870,7 @@ var
   A: TAgentArgs;
   Cfg: TConfig;
   KindSelected: TShellBackendKind;
-  BackendDesc: string;
+  BackendDesc, SessionProfile: string;
 begin
   if not ParseArgs(Argv, A) then
   begin
@@ -1868,7 +1882,28 @@ begin
     Exit(1);
   end;
 
-  Cfg := LoadConfig(A.Profile);
+  (* Profile precedence for this run:
+
+       1. --profile             (typed for this invocation)
+       2. $PASCLAW_PROFILE      (ambient, set once per shell)
+       3. the resumed session's own recorded profile
+       4. the workspace binding / global "profile" field
+
+     Layers 1, 2 and 4 already live inside LoadConfig; layer 3 is added
+     here by passing the session's profile as the override when nothing
+     more explicit was given. Doing it this way keeps Config unaware of
+     sessions -- Config sits underneath the session store, so the
+     dependency can only point this direction -- and an empty result
+     falls straight through to LoadConfig's own chain.
+
+     The point: a session started under `security` resumes sandboxed,
+     even from a shell whose config.json names something else. *)
+  SessionProfile := A.Profile;
+  if (SessionProfile = '') and (GetEnvironmentVariable('PASCLAW_PROFILE') = '')
+     and (A.Session <> '') then
+    SessionProfile := PeekSessionProfile(A.Session);
+
+  Cfg := LoadConfig(SessionProfile);
   { --orient / --no-orient override task-aware MEMORY slicing for this
     run, on top of whatever config.json / the profile resolved to. The
     feature ships off on every profile, so --orient is the no-edit way

--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -84,6 +84,22 @@ uses
   PasClaw.Agent.Goals,
   PasClaw.Markdown.Render;
 
+{ Every path that creates a persisted session goes through here, so the
+  profile stamp cannot be forgotten on one of them. Codex on #551 caught
+  exactly that: the stamp started life inline in RunInteractive, which left
+  `agent --session <id> -m ...` and interactive /new writing sessions with no
+  profile -- and an unstamped session resumes under the ambient profile,
+  silently dropping the sandbox it was created under.
+
+  Only stamps when empty: a session records the profile it was CREATED under
+  and keeps it, so an explicit --profile for one invocation does not rewrite
+  the binding. }
+function NewStampedSession(const Id: string; const Cfg: TConfig): TSession;
+begin
+  Result := TSession.Create(Id);
+  if Result.Meta.Profile = '' then Result.Meta.Profile := Cfg.ProfileName;
+end;
+
 { ', profile X' for the session banner, or '' when the session runs on
   stock defaults -- no profile line for the case that needs no words. }
 function ProfileSuffix(const Name: string): string;
@@ -722,7 +738,7 @@ begin
   PersistedSession := nil;
   if A.Session <> '' then
   begin
-    PersistedSession := TSession.Create(A.Session);
+    PersistedSession := NewStampedSession(A.Session, Cfg);
     Handlers.MetaRef := @PersistedSession.Meta;
     OneShotSessionId := A.Session;
   end
@@ -1434,7 +1450,7 @@ begin
       id so the conversation survives Ctrl-C / crash regardless.
       Codex P1 on PR #117: making this opt-in defeated the whole
       "history survives restarts" point. }
-    Session := TSession.Create(A.Session);
+    Session := NewStampedSession(A.Session, Cfg);
     Handlers.MetaRef := @Session.Meta;
     RewireCheckpoints;
     { Tell the active shell backend a session is starting so docker
@@ -1445,11 +1461,6 @@ begin
       finally below. }
     StartShellSession(Session.Meta.Id);
     SetCurrentSessionId(Session.Meta.Id);
-    { Stamp the profile this run resolved to so the session resumes under
-      it later. Only when empty: a session records the profile it was
-      CREATED under and keeps it, so an explicit --profile for one
-      invocation doesn't silently rewrite the session's binding. }
-    if Session.Meta.Profile = '' then Session.Meta.Profile := Cfg.ProfileName;
     if Session.MetaExists then
     begin
       SetLength(Msgs, Length(Session.Messages));
@@ -1486,7 +1497,7 @@ begin
             doesn't pick up the previous conversation's interrupts. }
           ClearSteering(Session.Meta.Id);
           Session.Free;
-          Session := TSession.Create('');   { fresh id }
+          Session := NewStampedSession('', Cfg);   { fresh id }
           { MetaRef pointed into the freed session; re-aim it before
             any compaction can flush working state into dead memory. }
           Handlers.MetaRef := @Session.Meta;

--- a/src/cmd/PasClaw.Cmd.Session.pas
+++ b/src/cmd/PasClaw.Cmd.Session.pas
@@ -102,6 +102,8 @@ begin
     PrintLn(Ansi.Bold + 'title:     ' + Ansi.Reset + Sess.Meta.Title);
     PrintLn(Ansi.Bold + 'model:     ' + Ansi.Reset + Sess.Meta.Model);
     PrintLn(Ansi.Bold + 'provider:  ' + Ansi.Reset + Sess.Meta.Provider);
+    if Sess.Meta.Profile <> '' then
+      PrintLn(Ansi.Bold + 'profile:   ' + Ansi.Reset + Sess.Meta.Profile);
     PrintLn(Ansi.Bold + 'messages:  ' + Ansi.Reset + IntToStr(Length(Sess.Messages)));
     if Sess.Meta.SystemPromptOverride <> '' then
       PrintLn(Ansi.Bold + 'compacted: ' + Ansi.Reset + Ansi.Dim + 'yes' + Ansi.Reset);

--- a/src/pkg/config/PasClaw.Config.Profile.pas
+++ b/src/pkg/config/PasClaw.Config.Profile.pas
@@ -9,9 +9,11 @@
   Six built-ins:
 
     stock       TConfig.Create's exact defaults. Adopted the bench-
-                grounded lean-edit shape (bench/swe/README.md): web_fetch,
-                vault, and memory_fetch OFF out-of-box (operators turn
-                them on via onboarding when they actually use them); the
+                grounded lean-edit shape (bench/swe/README.md): vault OFF
+                out-of-box (operators turn it on via onboarding when they
+                actually use it), web_fetch and the memory_fetch it gates
+                ON (TConfig.Create sets WebFetchEnabled := True, and
+                Profile_Stock carries "web_fetch_enabled":true); the
                 five zero-prompt-cost behavioral toggles (checkpoints,
                 stats, 1h prompt cache, distiller, auto-router) ON by
                 default. orient_task_aware is OFF by default (whole-file

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -656,6 +656,14 @@ type
        the default is now on. Onboarding asks (default Y); operators
        who don't want outbound HTTP from the agent flip it off. *)
     WebFetchEnabled:   Boolean;
+    (* The profile name LoadConfig actually resolved and applied, or ''
+       when no layer named one. Runtime-derived, never read from or
+       written to config.json -- FromJSON does not touch it. Exists so
+       callers that need to know what THIS process is running under
+       (the session store stamping a new session, the gateway, a UI
+       showing the active profile) read one answer instead of
+       re-walking the precedence chain and drifting from it. *)
+    ProfileName:       string;
     (* OFF by default: when True, the model gets a `cron` tool that can
        list/add/remove scheduled jobs by editing config.json's crons[].
        Bounded by design -- a cron entry only runs an EXISTING operator-
@@ -1161,6 +1169,7 @@ begin
   PromptCache.Enabled  := True;  { default-on; see TPromptCacheConfig comment }
   PromptCache.TTL      := '1h';  { 1h cache hits well across back-to-back runs (bench/swe/results/ablation.md). 5m was the historical default; 1h is one of the six zero-prompt-cost behavioral toggles the bench identified as a free upgrade. }
   VaultToolsEnabled    := False; { off by default per the bench-grounded "stock = lean-edit shape" verdict (bench/swe/README.md). Vault entries are never called across the bench's 45+ cells -- the model has them as training data. Onboarding asks (default Y for operators who DO use the vault). }
+  ProfileName          := '';    { filled in by LoadConfig once a profile's layers apply }
   WebFetchEnabled      := True;  { on by default: the tool clearly documents that it returns readable plain text (HTML tags stripped, entities decoded) capped at max_chars (default 50000, save_to bypasses), so the model knows what it gets -- and a "read this URL" task shouldn't have to fall back to hand-rolled shell curl + HTML scraping. Also enables memory_fetch (RegisterMemoryFetchTool is gated on EnableWebFetch in NewBuiltinRegistry). Onboarding asks; operators wanting no outbound HTTP from the agent set web_fetch_enabled: false. }
   FastModel            := '';    { empty = resolve one; see TConfig.FastModel }
   CronToolEnabled      := False; { off by default -- model-scheduled background jobs are an opt-in autonomy step (runs existing skills only). }
@@ -2450,6 +2459,10 @@ begin
     begin
       if ResolveProfileBodies(GetHome, ProfileName, Bodies, PErr) then
       begin
+        { Only claim the profile once its layers actually applied -- an
+          unknown name falls back to defaults + config.json, and reporting
+          it as active would make the session stamp a lie. }
+        Result.ProfileName := ProfileName;
         for i := 0 to High(Bodies) do
         begin
           B := ExpandEnvVarsInJSON(Bodies[i]);

--- a/src/pkg/platform/PasClaw.Platform.pas
+++ b/src/pkg/platform/PasClaw.Platform.pas
@@ -420,7 +420,14 @@ begin
   if not Result and not FExited then
   begin
     FExited := True;
-    try FExitCode := TInternalProcess(FProcess).ExitStatus; except FExitCode := -1; end;
+    (* ExitCode, NOT ExitStatus. FPC's TProcess only normalises ExitStatus
+       when it reaps the child itself via poWaitOnExit; reaped through the
+       Running poll -- which is what every caller here does, because they
+       have to drain the pipe -- ExitStatus keeps the RAW waitpid status and
+       ExitCode is the normalised one. So `exit 2` surfaced as 512, `exit 1`
+       as 256 and `command not found` as 32512, and every prompt rule or
+       retry heuristic keyed on a real exit code silently missed. *)
+    try FExitCode := TInternalProcess(FProcess).ExitCode; except FExitCode := -1; end;
   end;
 end;
 
@@ -488,7 +495,9 @@ begin
       end;
       Sleep(20);
     end;
-    Result := P.ExitStatus;
+    { ExitCode, not ExitStatus -- see TStdioProcess.Running for why the
+      polling path has to use the normalised one. }
+    Result := P.ExitCode;
     if M.Size > 0 then
     begin
       { Hand the captured bytes to the shared decoder rather than
@@ -602,7 +611,8 @@ begin
       end;
       Sleep(20);
     end;
-    Result := P.ExitStatus;
+    { ExitCode, not ExitStatus -- see TStdioProcess.Running. }
+    Result := P.ExitCode;
     if M.Size > 0 then
     begin
       { Same OEM-decode trick as RunOneShot above -- see the

--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -115,6 +115,7 @@ type
     Title:                string;     { auto-derived from first user turn if empty }
     Model:                string;     { last model used }
     Provider:             string;     { last provider name }
+    Profile:              string;     { config profile this session runs under }
     SystemPromptOverride: string;     { compacted system prompt across turns }
     WorkingState:         TWorkingState;
     Stats:                TSessionStats;
@@ -198,6 +199,17 @@ function SessionsDir: string;
   path of the session file. Callers MUST handle the empty-string
   case (treat as "no session named X"). }
 function SessionPath(const Id: string): string;
+
+(* The profile a stored session runs under, or '' when the session has
+   none / does not exist / the id is unsafe.
+
+   Read WITHOUT loading the transcript, because the caller needs the
+   answer before LoadConfig runs and a full TSession.Create would parse
+   every message to learn one string. `pasclaw agent --session <id>`
+   resumes under the profile the session was created with, so a session
+   started under `security` stays sandboxed on resume even from a shell
+   whose config names a different profile. *)
+function PeekSessionProfile(const Id: string): string;
 
 (* List on-disk sessions. By default skips synthetic "gateway
    bucket" sessions (ids prefixed with `_gateway_`) -- those exist
@@ -393,6 +405,41 @@ function SessionPath(const Id: string): string;
 begin
   if not IsSafeSessionId(Id) then Exit('');
   Result := JoinPath(SessionsDir, Id + '.json');
+end;
+
+function PeekSessionProfile(const Id: string): string;
+var
+  Path, Text: string;
+  Root, MetaObj: TJsonObject;
+  SL: TStringList;
+begin
+  Result := '';
+  Path := SessionPath(Id);
+  if (Path = '') or (not FileExists(Path)) then Exit;
+  SL := TStringList.Create;
+  try
+    try
+      SL.LoadFromFile(Path);
+      Text := SL.Text;
+    except
+      Exit;
+    end;
+  finally
+    SL.Free;
+  end;
+  Root := TJsonObject.Parse(Text);
+  if Root = nil then Exit;
+  try
+    MetaObj := Root.ChildObject('meta');
+    if MetaObj = nil then Exit;
+    try
+      Result := MetaObj.GetStr('profile', '');
+    finally
+      MetaObj.Free;
+    end;
+  finally
+    Root.Free;
+  end;
 end;
 
 procedure EnsureSessionsDir;
@@ -899,6 +946,7 @@ begin
     MetaObj.PutStr('title',                  Meta.Title);
     MetaObj.PutStr('model',                  Meta.Model);
     MetaObj.PutStr('provider',               Meta.Provider);
+    MetaObj.PutStr('profile',                Meta.Profile);
     MetaObj.PutStr('system_prompt_override', Meta.SystemPromptOverride);
     WriteWorkingStateJSON(MetaObj, Meta.WorkingState);
     WriteSessionStatsJSON(MetaObj, Meta.Stats);
@@ -1007,6 +1055,7 @@ begin
         Meta.Title                := MetaObj.GetStr('title',                  '');
         Meta.Model                := MetaObj.GetStr('model',                  '');
         Meta.Provider             := MetaObj.GetStr('provider',               '');
+        Meta.Profile              := MetaObj.GetStr('profile',                '');
         Meta.SystemPromptOverride := MetaObj.GetStr('system_prompt_override', '');
         ReadWorkingStateJSON(MetaObj, Meta.WorkingState);
         ReadSessionStatsJSON (MetaObj, Meta.Stats);

--- a/src/pkg/tools/PasClaw.Tools.FS.pas
+++ b/src/pkg/tools/PasClaw.Tools.FS.pas
@@ -1805,7 +1805,12 @@ begin
                    'locate files by NAME.';
   T.Schema      := '{"type":"object","properties":{' +
                    '"path":{"type":"string"},' +
-                   '"pattern":{"type":"string"},' +
+                   { The parameter is called "pattern", which reads as regex to
+                     any model, and it was the ONE required field with no
+                     description while every optional field had one. A literal
+                     alternation costs a whole round trip -- the handler's
+                     LooksLikeRegex note already recovers it, this prevents it. }
+                   '"pattern":{"type":"string","description":"Literal substring, NOT a regex: a|b matches those three characters. Search one plain term per call, or use shell_exec grep -E for real regex."},' +
                    '"ignore_case":{"type":"boolean"},' +
                    '"include":{"type":"string","description":"Comma-separated filename glob(s), e.g. *.pas,*.dpr"},' +
                    '"context_lines":{"type":"integer","minimum":0,"maximum":10,"description":"Also show N lines before/after each match (grep -C). Context lines use LINENO- prefixes; matches keep LINENO:."},' +

--- a/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
+++ b/src/pkg/tools/PasClaw.Tools.ToolLoop.pas
@@ -304,6 +304,16 @@ function PartitionToolBatches(const Calls: array of TToolCall;
 function HistWithTurnClock(const Hist: TMessageArray;
                            const Stamp: string): TMessageArray;
 
+{ Remove a turn-clock suffix, returning S unchanged when there is none.
+
+  Anything that asserts on the exact text a provider received now has to cope
+  with the stamp: it is appended to the outbound copy, so a scripted or fake
+  provider legitimately sees `body + clock`. Stripping through this function
+  rather than hand-matching the format keeps the shape defined in exactly one
+  place -- a test that spells it out itself silently rots the day the format
+  moves. }
+function StripTurnClock(const S: string): string;
+
 implementation
 
 uses
@@ -771,6 +781,11 @@ begin
     end;
 end;
 
+const
+  { The one place the turn-clock shape is written down. HistWithTurnClock
+    appends it and StripTurnClock removes it; nothing else should spell it. }
+  TurnClockPrefix = sLineBreak + sLineBreak + '[current date/time: ';
+
 function HistWithTurnClock(const Hist: TMessageArray;
                            const Stamp: string): TMessageArray;
 (* Return a copy of the history with Stamp appended to the LAST non-empty
@@ -823,10 +838,29 @@ begin
   for i := High(Result) downto 0 do
     if (Result[i].Role = mrUser) and (Trim(Result[i].Content) <> '') then
     begin
-      Result[i].Content := Result[i].Content + sLineBreak + sLineBreak +
-        '[current date/time: ' + Stamp + ']';
+      Result[i].Content := Result[i].Content + TurnClockPrefix + Stamp + ']';
       Exit;
     end;
+end;
+
+function StripTurnClock(const S: string): string;
+var
+  P, Close_: Integer;
+begin
+  Result := S;
+  { A loop, and a search for the closing bracket rather than an assumption
+    that the stamp ends the string: the clock is appended to a MESSAGE, but
+    callers assert on text that quotes messages -- a spawn_wait status embeds
+    the stamped prompt with more text after it. The stamp carries no nested
+    brackets, so the first ] after the marker closes it. }
+  repeat
+    P := Pos(TurnClockPrefix, Result);
+    if P <= 0 then Exit;
+    Close_ := P + Length(TurnClockPrefix);
+    while (Close_ <= Length(Result)) and (Result[Close_] <> ']') do Inc(Close_);
+    if Close_ > Length(Result) then Exit;   { unterminated -- leave it alone }
+    Delete(Result, P, Close_ - P + 1);
+  until False;
 end;
 
 function PartitionToolBatches(const Calls: array of TToolCall;

--- a/src/tests/config_profile_tests.pas
+++ b/src/tests/config_profile_tests.pas
@@ -591,6 +591,53 @@ begin
   end;
 end;
 
+procedure TestResolvedProfileNameReported;
+{ TConfig.ProfileName tells a caller what THIS process resolved, so the
+  session store can stamp it and a UI can display it without re-walking
+  the precedence chain. Set only when the profile's layers actually
+  applied -- an unknown name falls back to defaults, and reporting it as
+  active would make the session stamp a lie. }
+var
+  CfgPath: string;
+  C: TConfig;
+begin
+  CfgPath := JoinPath(Home, 'config.json');
+  WriteFileText(CfgPath, '{}');
+
+  C := LoadConfig('low-token');
+  try
+    AssertTrue(C.ProfileName = 'low-token', 'applied profile is reported');
+  finally
+    C.Free;
+  end;
+
+  C := LoadConfig('');
+  try
+    AssertTrue(C.ProfileName = '', 'no profile => empty name');
+  finally
+    C.Free;
+  end;
+
+  C := LoadConfig('no-such-profile-anywhere');
+  try
+    AssertTrue(C.ProfileName = '',
+               'unresolvable profile is not reported as active');
+  finally
+    C.Free;
+  end;
+
+  { A profile named by config.json rather than the CLI reports the same. }
+  WriteFileText(CfgPath, '{"profile":"low-token"}');
+  C := LoadConfig('');
+  try
+    AssertTrue(C.ProfileName = 'low-token',
+               'profile from config.json is reported too');
+  finally
+    C.Free;
+  end;
+  WriteFileText(CfgPath, '{}');
+end;
+
 begin
   { PASCLAW_HOME is set by the Makefile target before launching --
     fpc doesn't ship fpSetenv on every supported version and setting
@@ -622,6 +669,7 @@ begin
     TestSelfShadowInherit;
     TestDiffMaterial;
     TestDatabaseSection;
+    TestResolvedProfileNameReported;
     WriteLn('ok - config profile tests passed');
   finally
     try RemoveDir(JoinPath(Home, 'profiles')); except end;

--- a/src/tests/heartbeat_tests.pas
+++ b/src/tests/heartbeat_tests.pas
@@ -35,6 +35,7 @@ uses
   PasClaw.Providers.Types,
   PasClaw.Providers.Intf,
   PasClaw.Tools.Registry,
+  PasClaw.Tools.ToolLoop,
   PasClaw.Heartbeat;
 
 procedure Fail_(const Msg: string);
@@ -216,7 +217,11 @@ begin
     try
       AssertTrue(HB.TickOnce, 'non-empty body -> TickOnce returns True');
       AssertTrue(P.CallCount = 1, 'exactly one provider call');
-      AssertEqStr(P.LastUserMsg, 'check the build status briefly',
+      { The tool loop appends a turn clock to the outbound copy, so the
+        provider legitimately sees `body + clock`. Strip through
+        StripTurnClock rather than matching the stamp here -- the format
+        has one owner and a test that respells it rots when that moves. }
+      AssertEqStr(StripTurnClock(P.LastUserMsg), 'check the build status briefly',
                   'user message body equals the file body');
     finally
       HB.Free;

--- a/src/tests/session_stats_tests.pas
+++ b/src/tests/session_stats_tests.pas
@@ -25,6 +25,7 @@ program session_stats_tests;
 uses
   SysUtils,
   PasClaw.Config,
+  PasClaw.Providers.Types,
   PasClaw.Session.Store;
 
 procedure Fail_(const Msg: string);
@@ -297,8 +298,72 @@ begin
   end;
 end;
 
+procedure TestProfileRoundTrip;
+{ TSessionMeta.Profile persists and PeekSessionProfile reads it back
+  WITHOUT loading the transcript -- the resume path calls Peek before
+  LoadConfig, so a regression here silently drops a session back to the
+  ambient profile instead of the one it was created under. }
+var
+  Id: string;
+  S1, S2: TSession;
+  M: TMessage;
+begin
+  Id := 'profile-roundtrip-test-' + IntToStr(Random(MaxInt));
+  S1 := TSession.Create(Id);
+  try
+    S1.Meta.Profile := 'security';
+    { A message body proves Peek is not just reading a one-line file. }
+    FillChar(M, SizeOf(M), 0);
+    M.Role    := mrUser;
+    M.Content := 'hello';
+    SetLength(S1.Messages, 1);
+    S1.Messages[0] := M;
+    S1.Save;
+  finally
+    S1.Free;
+  end;
+
+  S2 := TSession.Create(Id);
+  try
+    AssertTrue(S2.MetaExists, 'session reloaded');
+    AssertTrue(S2.Meta.Profile = 'security', 'profile survives round trip');
+  finally
+    S2.Free;
+  end;
+
+  AssertTrue(PeekSessionProfile(Id) = 'security',
+             'PeekSessionProfile reads the stored profile');
+  AssertTrue(PeekSessionProfile('no-such-session-id-here') = '',
+             'PeekSessionProfile is empty for a missing session');
+  AssertTrue(PeekSessionProfile('../escape') = '',
+             'PeekSessionProfile refuses an unsafe id');
+
+  try DeleteFile(SessionPath(Id)); except end;
+end;
+
+procedure TestProfileAbsentByDefault;
+{ A session created without a profile reports '' rather than inventing
+  one -- that empty string is what makes LoadConfig fall through to its
+  own precedence chain. }
+var
+  Id: string;
+  S: TSession;
+begin
+  Id := 'profile-absent-test-' + IntToStr(Random(MaxInt));
+  S := TSession.Create(Id);
+  try
+    S.Save;
+  finally
+    S.Free;
+  end;
+  AssertTrue(PeekSessionProfile(Id) = '', 'no profile stamped => empty');
+  try DeleteFile(SessionPath(Id)); except end;
+end;
+
 begin
   Randomize;
+  TestProfileRoundTrip;
+  TestProfileAbsentByDefault;
   TestStatsRoundTrip;
   TestEmptyStatsOmitted;
   TestAccumulateTurnStatsAddsCorrectly;

--- a/src/tests/subagent_bg_tests.pas
+++ b/src/tests/subagent_bg_tests.pas
@@ -118,7 +118,11 @@ begin
   for i := High(Messages) downto 0 do
     if Messages[i].Role = mrUser then
     begin
-      UserText := Messages[i].Content;
+      { Drop the turn clock the tool loop appends to the outbound copy.
+        These tests assert on the TASK the job ran, not on the transport
+        decoration around it, and stripping here fixes every ECHO[...]
+        assertion in one place instead of five. }
+      UserText := StripTurnClock(Messages[i].Content);
       Break;
     end;
   Result.Content      := 'ECHO[' + UserText + ']';


### PR DESCRIPTION
One requested feature and three defects that surfaced while benchmarking the agent by pointing it at this repo through the relay provider.

## Per-session config profiles (`c69bd65`)

A session that starts under `security` should stay sandboxed when you come back to it, even from a shell whose `config.json` names something else. The profile was resolved purely from ambient state, so resuming was a coin flip against whatever the operator's config said that day.

`TSessionMeta` gains a `Profile` field alongside the `Model` and `Provider` it already records. The resume path reads it with `PeekSessionProfile`, which parses just `meta.profile` out of the session file — the answer is needed *before* `LoadConfig` runs, and a full `TSession.Create` would walk every message to learn one string.

Precedence for a run:

```
1. --profile          typed for this invocation
2. $PASCLAW_PROFILE   ambient, set once per shell
3. the session's own recorded profile      <- new
4. workspace binding / global "profile" field
```

Layers 1, 2 and 4 already lived inside `LoadConfig`. Layer 3 is added in `Cmd.Agent` by passing the session's profile as the override when nothing more explicit was given — which keeps `Config` unaware of sessions (it sits *underneath* the session store, so the dependency can only point one way) and lets an empty result fall through to `LoadConfig`'s existing chain. `pasclaw resume <id>` shares the path, being a thin alias for `agent --session <id>`.

Stamping needs to know what `LoadConfig` actually resolved, so `TConfig` gains `ProfileName` — runtime-derived, never read from or written to `config.json`, and set only once a profile's layers have applied. An unknown name falls back to defaults, and reporting it as active would make the session stamp a lie.

A session records the profile it was **created** under and keeps it, so an explicit `--profile` for one invocation does not silently rewrite the binding.

Verified by hand across the whole chain: session `low-token` beats global `security`; `--profile max-build` beats the session; `PASCLAW_PROFILE=baseline` beats the session; no `--session` falls back to the global field.

## `shell_exec` reported raw wait statuses on FPC/Linux (`8c3541a`)

The agent ran a failing command and the tool result read `exit=512`. That is not an exit code — it is `2 << 8`, the raw status `waitpid` hands back.

FPC's `TProcess` normalises `ExitStatus` only when it reaps the child itself via `poWaitOnExit`. Every caller here reaps through the `Running` poll instead, because they have to drain the output pipe as it fills; on that path `ExitStatus` keeps the raw status and `ExitCode` is the normalised one. Proven with a probe against the exact polling shape:

```
poWaitOnExit   ExitStatus=2     ExitCode=0
Running poll   ExitStatus=512   ExitCode=2
```

Three sites in the FPC branch read the wrong one — `TStdioProcess.Running` (which backs `execute_code` and the streaming TUI path), `RunOneShot`, and `RunOneShotWithEnv`. Both Delphi branches were already correct, so this only ever bit the shipping FPC/Linux build.

```
before:  exit 1 -> 256    exit 2 -> 512    exit 127 -> 32512
after:   exit 1 -> 1      exit 2 -> 2      exit 127 -> 127
```

That matters beyond cosmetics: `shell_exec`'s own description promises `reports "exit=<code>"`, the prompt teaches 127 as command-not-found, and any retry heuristic keyed on a real code silently missed every one. Re-verified end to end through the rebuilt binary over the relay: `exit=3` and `exit=127`.

This commit also carries an 8-line comment fix in `PasClaw.Config.Profile.pas` — the task that found the exit-code bug. The unit header described `stock` as shipping `web_fetch`, `vault` and `memory_fetch` all OFF, contradicting `Profile_Stock`'s own `_description` and `TConfig.Create` twenty lines and two hundred lines away respectively. Only `vault` is off.

## `grep_files`: say on the parameter that it is a literal substring (`ed64fc5`)

My first tool call against this repo was `grep_files` with `web_fetch_enabled|vault_tools_enabled|Profile_Stock`. It returned "no matches", as did the second alternation in the same batch — two of three parallel slots and a whole round trip, spent on nothing.

The tool already recovers well: the handler's `LooksRegexy` heuristic appends *"matches a LITERAL substring, not a regex"*. But that correction lives in the **error**, so the only way to learn it is to fail first. The schema had prevention backwards — every *optional* field (`include`, `context_lines`, `max_file_bytes`) carried a description, and the one *required* field carried none. And it is named `pattern`, which reads as regex to any model that has ever seen a grep flag.

One line on that parameter, mirroring the handler's wording so prevention and recovery say the same thing. Costs 162 bytes in the tool block (959 → 1121); saves a guaranteed round trip the first time a session greps.

`shell_exec` was on the same list and was dropped after inspection: its description already opens with *"Run a shell command via /bin/sh -c"* and explains the pipe/exit-code trap. Writing `${PIPESTATUS[0]}` anyway was a model attention failure, not a documentation gap, and a second sentence saying the same thing would be bulk rather than a fix.

## `make all` never rebuilt after a source change (`2d781bb`)

Edit a `.pas`, run `make all`, get `Nothing to be done for 'all'` and keep the previous binary. `$(BIN)` listed only the webui `.res` and two order-only prerequisites, so make had no reason to connect 326 Pascal units to the program compiled from them.

Worse than a slow build: verifying a change silently exercises the **old** binary and make reports success. It bit this work twice — an exit-code fix confirmed against a probe program while the shipped binary sat nine hours stale, and a tool-schema change declared live when nothing had compiled. `make test` masks it, because those targets invoke `fpc` on test programs directly.

`vendor/Indy` is deliberately excluded from the new prerequisite list: it changes only when `$(INDY_DIR)` fetches it, it is already an order-only prerequisite, and globbing it would add thousands of stats to every make invocation.

`make build` is left alone. It resolves to the `build/` **directory** and quietly does nothing, which is how this was first hit — but it is not a documented target (no hit in README, `docs/`, `AGENTS.md` or `CLAUDE.md`), and `$(BUILDDIR)` defaults to `build`, so a phony alias would collide with the directory rule that 106 order-only prerequisites depend on.

## Testing

New coverage:

- `session_stats_tests`: `TSessionMeta.Profile` round-trips; `PeekSessionProfile` reads it back without loading the transcript, returns `''` for a missing session, and refuses an unsafe id
- `config_profile_tests`: `TConfig.ProfileName` reports an applied profile, stays empty when none is named, stays empty for an unresolvable name, and reports one named by `config.json` rather than the CLI

Green after rebasing onto current main: `test-config-profile`, `test-session-stats`, `test-fs-grep-tier5-6`, `lint-studio`, and a clean `make all` from a removed binary.

Two suites fail on this branch — `test-subagent-bg` and `test-heartbeat` — and both fail identically on unmodified `main`, confirmed by stashing. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_