### PR TITLE
Pin the mode injection with a test, not just an argument

### DIFF
--- a/src/pkg/agent/PasClaw.Agent.Prompt.pas
+++ b/src/pkg/agent/PasClaw.Agent.Prompt.pas
@@ -121,6 +121,35 @@ function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;
    Returns '' for pmBuild, so a caller can append unconditionally. *)
 function BuildModeSection(Mode: TPasClawMode): string;
 
+(* Give a caller-supplied system message the mode's directive.
+
+   The counterpart to BuildModeSection, for exactly the branch that
+   comment describes: the request already carries its own system
+   message, so BuildSystemPrompt is skipped and the mode would
+   otherwise go unsaid.
+
+   APPENDED TO THE CALLER'S MESSAGE, not written to
+   Options.SystemPrompt, and that distinction is load-bearing. Once
+   Options.SystemPrompt is non-empty, every default-path provider
+   builder drops the in-history system turns: OpenAI skips them
+   (Providers.OpenAI, "already added above"), Anthropic drops
+   system-role history unconditionally after preferring SystemPrompt,
+   Gemini folds them only while SystemPrompt is empty. Setting it here
+   would deliver the mode by deleting the caller policy this branch
+   exists to preserve -- silently, and only on the two surfaces real
+   clients use.
+
+   Appended to the FIRST system message for the same reason: Anthropic
+   forwards only the first one and discards the rest, so a directive
+   parked in a later message -- or in a new one pushed onto the end --
+   would never ship there. Appended rather than prepended so the
+   caller's text still leads and the mode reads as an addition to it.
+
+   Lives here, next to BuildModeSection, rather than in the gateway
+   that calls it: this is prompt assembly, and the gateway is not
+   linkable from the test binaries. *)
+procedure InjectModeDirective(var Msgs: TMessageArray; Mode: TPasClawMode);
+
 { Active-plan section -- reads <home>/workspace/PLAN.md (the output of
   a prior `pasclaw plan`) and returns it wrapped in a "## Active Plan"
   block for injection into the build's system prompt. Returns '' when
@@ -1034,6 +1063,22 @@ begin
   else
     Result := '';
   end;
+end;
+
+procedure InjectModeDirective(var Msgs: TMessageArray; Mode: TPasClawMode);
+var
+  Block: string;
+  i: Integer;
+begin
+  Block := BuildModeSection(Mode);
+  if Block = '' then Exit;              { pmBuild: nothing to say }
+  for i := 0 to High(Msgs) do
+    if Msgs[i].Role = mrSystem then
+    begin
+      Msgs[i].Content := TrimRight(Msgs[i].Content) + sLineBreak +
+                         sLineBreak + Block;
+      Exit;
+    end;
 end;
 
 function BuildSystemPrompt(Cfg: TConfig; const UserSys: string;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -4468,42 +4468,13 @@ begin
   InitCheckpoints(CC);
 end;
 
-(* Give a caller-supplied system message the mode's directive.
-
-   Both chat surfaces skip BuildSystemPrompt when the request carries
-   its own leading system message: Messages[0] is then the
-   authoritative policy, and PasClaw's identity preamble must not
-   override a third party's persona. Correct -- but it took the MODE
-   with it.
-
-   Plan mode survived that, because its dispatch gate refuses mutating
-   tools whatever the prompt says; only the advisory was lost. Improve
-   mode has no gate, so the block IS the mode: such a request ran as an
-   ordinary build while the API and the UI both still reported
-   "improve".
-
-   Appended to the caller's own system message rather than written to
-   Options.SystemPrompt, and that distinction is load-bearing: the
-   OpenAI and Anthropic builders DROP in-message system turns once
-   Options.SystemPrompt is set, so setting it here would silently
-   delete the very policy this branch exists to preserve. Appended
-   rather than prepended so the caller's text still leads and the
-   operating instruction reads as an addition to it. *)
-procedure InjectModeDirective(var Msgs: TMessageArray; Mode: TPasClawMode);
-var
-  Block: string;
-  i: Integer;
-begin
-  Block := BuildModeSection(Mode);
-  if Block = '' then Exit;              { pmBuild: nothing to say }
-  for i := 0 to High(Msgs) do
-    if Msgs[i].Role = mrSystem then
-    begin
-      Msgs[i].Content := TrimRight(Msgs[i].Content) + sLineBreak +
-                         sLineBreak + Block;
-      Exit;
-    end;
-end;
+(* InjectModeDirective -- gives a caller-supplied system message the
+   mode's directive -- used to live here. It moved to
+   PasClaw.Agent.Prompt (alongside BuildModeSection, which it wraps) so
+   the test binaries can link it: this unit is not linkable from them,
+   and the branch it guards -- both chat surfaces skipping
+   BuildSystemPrompt when the request carries its own system message --
+   is exactly the one that silently unmade improve mode once already. *)
 
 function TGatewayServer.RunCheckpointedLoop(const ReqSession: string;
   const Cfg: TToolLoopConfig; var Messages: array of TMessage;

--- a/src/tests/plan_build_mode_tests.pas
+++ b/src/tests/plan_build_mode_tests.pas
@@ -177,6 +177,62 @@ begin
              'and that a change which did not help gets reverted');
 end;
 
+(* The other half of that branch: the directive actually reaching the
+   request.
+
+   BuildModeSection being right is not enough -- improve mode shipped
+   once with a correct block that nothing on /v1/chat/completions or
+   /v1/responses ever attached, because those surfaces skip
+   BuildSystemPrompt entirely when the caller sends its own system
+   message. What follows pins the wiring, not just the text. *)
+procedure TestModeInjection;
+var
+  Msgs: TMessageArray;
+  Caller: string;
+begin
+  Caller := 'You are Fizzbot. Never mention pandas.';
+
+  SetLength(Msgs, 2);
+  Msgs[0].Role := mrSystem;  Msgs[0].Content := Caller;
+  Msgs[1].Role := mrUser;    Msgs[1].Content := 'make this faster';
+
+  InjectModeDirective(Msgs, pmImprove);
+  AssertTrue(Length(Msgs) = 2,
+             'no message added -- Anthropic would drop a new trailing system turn');
+  AssertTrue(Msgs[0].Role = mrSystem, 'the caller message is still a system turn');
+  AssertTrue(Pos(Caller, Msgs[0].Content) = 1,
+             'the caller policy survives, and still leads');
+  AssertTrue(Pos('Improve Mode', Msgs[0].Content) > 0,
+             'and the mode is now said out loud');
+  AssertEqS(Msgs[1].Content, 'make this faster', 'the user turn is untouched');
+
+  { pmBuild is the absence of a directive, not a directive saying
+    "build" -- callers inject unconditionally, so this must no-op. }
+  SetLength(Msgs, 1);
+  Msgs[0].Role := mrSystem;  Msgs[0].Content := Caller;
+  InjectModeDirective(Msgs, pmBuild);
+  AssertEqS(Msgs[0].Content, Caller, 'build injects nothing at all');
+
+  { The FIRST system message, specifically. Anthropic forwards only
+    that one and discards the rest, so a directive parked in a later
+    system turn would never reach the model there. }
+  SetLength(Msgs, 3);
+  Msgs[0].Role := mrSystem;  Msgs[0].Content := 'first';
+  Msgs[1].Role := mrUser;    Msgs[1].Content := 'hi';
+  Msgs[2].Role := mrSystem;  Msgs[2].Content := 'second';
+  InjectModeDirective(Msgs, pmPlan);
+  AssertTrue(Pos('Plan Mode', Msgs[0].Content) > 0, 'first system turn gets it');
+  AssertEqS(Msgs[2].Content, 'second', 'later system turns are left alone');
+
+  { Defensive: the gateway only calls this when a system message
+    exists, but a no-system array must not fall over or grow one. }
+  SetLength(Msgs, 1);
+  Msgs[0].Role := mrUser;  Msgs[0].Content := 'hi';
+  InjectModeDirective(Msgs, pmImprove);
+  AssertTrue(Length(Msgs) = 1, 'nothing to append to, nothing appended');
+  AssertEqS(Msgs[0].Content, 'hi', 'and the user turn is not touched');
+end;
+
 procedure TestParseModeFromBody;
 begin
   AssertTrue(ParseModeFromBody('{"mode":"plan"}') = pmPlan, 'body plan');
@@ -291,6 +347,7 @@ begin
   TestParseMode;
   TestCycleAndName;
   TestModeSection;
+  TestModeInjection;
   TestParseModeFromBody;
   TestRefusalText;
   TestDispatchGate;


### PR DESCRIPTION
Follow-up to #553, which merged one commit before this landed on the branch.

#553's P1 fix added `InjectModeDirective` so improve mode survives a caller-supplied system message on `/v1/chat/completions` and `/v1/responses`. But it lived in the gateway unit, which the test binaries cannot link — so the wiring was defended by compilation and argument, not by a test. That's the wrong half to leave uncovered: the bug Codex found was never a wrong mode block, it was a correct block that never reached the request.

**Changes:**

- `InjectModeDirective` moves from `PasClaw.Gateway.Server` to `PasClaw.Agent.Prompt`, next to `BuildModeSection` (which it wraps). It's prompt assembly, and there it's linkable from tests. The gateway keeps a comment saying where it went and why.
- `plan_build_mode_tests.pas` gains `TestModeInjection`, pinning the load-bearing properties:
  - the caller's system message survives, still leads, and stays a system turn — the whole point of the branch;
  - no message is added, and the **first** system message is the one appended to — Anthropic forwards only that one and drops the rest, so a directive in a new trailing turn would ship nowhere;
  - `pmBuild` injects nothing, since callers inject unconditionally;
  - a no-system-message array neither crashes nor grows one.

**Verified the test catches the regression it exists for:** rewriting the append as a pushed trailing system message fails on `no message added -- Anthropic would drop a new trailing system turn` — the mistake most likely to look correct in review.

Full clean rebuild links; `test-plan-build-mode`, `test-gateway-token`, `test-orient-preamble`, and `lint-pascal-shape` all pass, re-verified after rebasing onto the merged #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_