### PR TITLE
Gateway sessions are real sessions, so learn/scars cover every surface

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -341,6 +341,7 @@ type
     { Fill S.Messages + title/model/provider from a messages/title/model
       JSON body and Save. Raises on invalid JSON; caller maps to 400. }
     procedure SaveSessionFromBody(S: TSession; const Body: string);
+    procedure MergeToolDetailFromBody(S: TSession; const Body: string);
     { pasclaw.dev Code Vault browse (read-only). Search on /v1/vault?q=,
       read one entry's detail on /v1/vault/<slug>. Proxies the server-side
       PasClaw.Vault.Client so the browser needn't reach pasclaw.dev directly. }
@@ -3624,6 +3625,29 @@ begin
   Result.PutStr('provider',   Meta.Provider);
 end;
 
+procedure TGatewayServer.MergeToolDetailFromBody(S: TSession; const Body: string);
+{ Take only what the web UI owns out of a PUT body: the opaque tool-detail
+  blob. The transcript already on disk wins -- see the merge rationale at the
+  PUT site. Silent when the body carries no tool_details. }
+var
+  BodyObj: TJsonObject;
+  TDArr: TJsonArray;
+begin
+  BodyObj := TJsonObject.Parse(Body);
+  if BodyObj = nil then Exit;
+  try
+    TDArr := BodyObj.ChildArray('tool_details');
+    if TDArr = nil then Exit;
+    try
+      S.ToolDetail := TDArr.ToJSON;
+    finally
+      TDArr.Free;
+    end;
+  finally
+    BodyObj.Free;
+  end;
+end;
+
 procedure TGatewayServer.SaveSessionFromBody(S: TSession; const Body: string);
 var
   Title, Model: string;
@@ -3800,10 +3824,42 @@ begin
         assistant tool_calls) from the web UI's flattened view -- doing so
         would strip the structure terminal resume needs. The web UI forks
         to a new session on 409. New/plain sessions fall through. }
+      (* Rich transcript present: MERGE rather than refuse.
+
+         The 409 existed to prevent LOSS -- a flattened user/assistant PUT
+         would strip the tool turns terminal resume needs. But refusing is a
+         blunt instrument: the web UI's only recourse is to fork into a new
+         session, so a browser talking to a session the agent also writes
+         would spawn a fresh session every single turn.
+
+         Nothing about the flattened body is worth losing the rich messages
+         for, and nothing about the rich messages makes the body worthless:
+         the two carry different things. Keep the stored transcript, take the
+         parts the web UI genuinely owns -- tool_details, the card bodies it
+         renders on reload -- and drop its message array on the floor. No
+         loss, no 409, no fork.
+
+         New and plain sessions fall through to the full overwrite, which is
+         the path that was always correct for them. *)
       if S.MetaExists and SessionHasRichTurns(S.Messages) then
       begin
-        WriteJSON(AResp, 409,
-          '{"error":"session has tool/system turns; not overwriting from web UI"}');
+        try
+          MergeToolDetailFromBody(S, ReadRequestBody(ARequest));
+        except
+          on E: EArgumentException do
+          begin
+            WriteJSON(AResp, 400, '{"error":"' + JsonEscape(E.Message) + '"}');
+            Exit;
+          end;
+        end;
+        S.Touch;
+        S.Save;
+        Root := SessionMetaJSON(S.Meta);
+        try
+          WriteJSON(AResp, 200, Root.ToJSON);
+        finally
+          Root.Free;
+        end;
         Exit;
       end;
       try

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -794,6 +794,59 @@ begin
   end;
 end;
 
+procedure PersistGatewaySession(const Cfg: TConfig;
+                                const SessionId, Title: string;
+                                const ProviderName, Model: string;
+                                const Loop: TToolLoopResult);
+(* Persist a gateway turn as a REAL session when the request named one.
+
+   The stats buckets (_gateway_v1_chat and friends) deliberately keep
+   counters and no transcript -- they aggregate stateless passthrough, where
+   the conversation belongs to the caller. But a request that carries
+   X-PasClaw-Session (or an OpenAI `user` field we map to one) is not
+   passthrough: the operator has named a durable conversation, and every
+   other surface treats that as a session on disk.
+
+   Without this the gateway was the only surface whose sessions never
+   existed, which quietly disabled the whole failure-learning chain for it:
+   `pasclaw learn` mines sessions, `--write-scars` turns recurring failures
+   into SCARS.md, and SCARS.md feeds the prompt. Someone driving PasClaw
+   through the web UI, the desktop app or the HTTP API got none of it, and
+   the agent kept relearning mistakes it had already made there.
+
+   Opt-in by construction -- no session id, no transcript, so stateless API
+   traffic is unchanged. Stats still go to the bucket either way; this is
+   additive. *)
+var
+  S: TSession;
+  i: Integer;
+begin
+  if Trim(SessionId) = '' then Exit;
+  if not IsSafeSessionId(SessionId) then Exit;
+  try
+    S := TSession.Create(SessionId);
+    try
+      if S.Meta.Title = '' then S.Meta.Title := Title;
+      if Model        <> '' then S.Meta.Model    := Model;
+      if ProviderName <> '' then S.Meta.Provider := ProviderName;
+      SetLength(S.Messages, Length(Loop.FinalMessages));
+      for i := 0 to High(Loop.FinalMessages) do
+        S.Messages[i] := Loop.FinalMessages[i];
+      S.Meta.SystemPromptOverride := Loop.FinalSystemPrompt;
+      S.AutoTitle;
+      S.Touch;
+      S.Save;
+    finally
+      S.Free;
+    end;
+  except
+    { A transcript we could not write must never fail the request the
+      caller actually asked for. }
+    on E: Exception do
+      LogWarn('gateway: could not persist session %s: %s', [SessionId, E.Message]);
+  end;
+end;
+
 procedure AccumulateGatewayStats(const Cfg: TConfig;
                                  const BucketId, Title: string;
                                  const ProviderName, Model: string;
@@ -5427,6 +5480,8 @@ begin
     WriteJSON(AResp, 502, '{"error":"loop failed"}');
     Exit;
   end;
+  PersistGatewaySession(FCfg, ReqSessionId(ARequest), '(gateway: /v1/chat)',
+                        LoopCfg.Provider.GetName, LoopCfg.Model, Loop);
   AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT,
                          '(gateway: /v1/chat)',
                          LoopCfg.Provider.GetName, LoopCfg.Model, Loop);
@@ -6652,7 +6707,11 @@ begin
         StreamClosed := Streamer.Closed;
         Exit;
       end;
-      AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
+      PersistGatewaySession(FCfg, ReqSession, '(gateway: /v1/chat/completions)',
+                            LoopCfg.Provider.GetName, ReqModel, Loop);
+      PersistGatewaySession(FCfg, ReqSession, '(gateway: /v1/chat/completions)',
+                          LoopCfg.Provider.GetName, ReqModel, Loop);
+    AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
                              '(gateway: /v1/chat/completions)',
                              LoopCfg.Provider.GetName, ReqModel, Loop);
       if Loop.LastResp.FinishReason <> '' then

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -833,6 +833,25 @@ begin
       SetLength(S.Messages, Length(Loop.FinalMessages));
       for i := 0 to High(Loop.FinalMessages) do
         S.Messages[i] := Loop.FinalMessages[i];
+
+      (* Append the answer. RunToolLoop returns FinalMessages as the history
+         it fed the provider, and exits the moment a response arrives with no
+         tool calls -- so the assistant turn carrying that response is in
+         Loop.Content and NOT in the array. Copying the array verbatim
+         persisted a transcript that stops one turn short: a no-tool request
+         saved only the incoming history, and a tool-using one stopped at the
+         last tool result. The reply the caller actually received was the one
+         thing missing, from the session, from a web reload, and from
+         anything `pasclaw learn` reads. (Codex P1 on #556.)
+
+         Guarded on non-empty so a turn that genuinely produced no text -- an
+         aborted stream, a hard provider failure -- does not gain a blank
+         assistant turn that never existed. *)
+      if Trim(Loop.Content) <> '' then
+      begin
+        SetLength(S.Messages, Length(S.Messages) + 1);
+        S.Messages[High(S.Messages)] := MakeMessage(mrAssistant, Loop.Content);
+      end;
       S.Meta.SystemPromptOverride := Loop.FinalSystemPrompt;
       S.AutoTitle;
       S.Touch;
@@ -3625,13 +3644,55 @@ begin
   Result.PutStr('provider',   Meta.Provider);
 end;
 
+{ One entry of the web UI's tool_details array as raw JSON. Entries are
+  either a structure (the cards for that turn) or null, and there is no
+  generic raw accessor on TJsonArray, so try both shapes and fall back to
+  null rather than dropping the array on an unexpected element. }
+function ToolDetailEntryRaw(Arr: TJsonArray; Index: Integer): string;
+var
+  O: TJsonObject;
+  A: TJsonArray;
+begin
+  Result := 'null';
+  if Arr = nil then Exit;
+  A := Arr.ItemArray(Index);
+  if A <> nil then
+  try
+    Exit(A.ToJSON);
+  finally
+    A.Free;
+  end;
+  O := Arr.ItemObject(Index);
+  if O <> nil then
+  try
+    Exit(O.ToJSON);
+  finally
+    O.Free;
+  end;
+end;
+
 procedure TGatewayServer.MergeToolDetailFromBody(S: TSession; const Body: string);
-{ Take only what the web UI owns out of a PUT body: the opaque tool-detail
-  blob. The transcript already on disk wins -- see the merge rationale at the
-  PUT site. Silent when the body carries no tool_details. }
+(* Take only what the web UI owns out of a PUT body -- the opaque tool-detail
+   blob -- and REINDEX it onto the transcript we kept.
+
+   The blob is index-aligned to what the browser displays: a flat list of
+   user and assistant turns. S.Messages is deliberately the agent's
+   transcript, which interleaves system and tool turns and assistant turns
+   carrying tool_calls. Storing the array unchanged passes the store's
+   count guard and still lands every card on the wrong message -- entry 2
+   means "the third thing the user saw", not "S.Messages[2]". After a
+   tool-using turn the cards attach to the wrong assistant turn or vanish.
+   (Codex P2 on #556.)
+
+   So walk the retained transcript, and hand each user/assistant turn the
+   next blob entry in order; everything else gets null. The flattened view
+   is exactly the subsequence of user/assistant turns, so ordinal N in the
+   blob belongs to the Nth such turn -- that mapping is what makes this
+   recoverable rather than guesswork. *)
 var
   BodyObj: TJsonObject;
-  TDArr: TJsonArray;
+  TDArr, Out_: TJsonArray;
+  i, Flat: Integer;
 begin
   BodyObj := TJsonObject.Parse(Body);
   if BodyObj = nil then Exit;
@@ -3639,7 +3700,26 @@ begin
     TDArr := BodyObj.ChildArray('tool_details');
     if TDArr = nil then Exit;
     try
-      S.ToolDetail := TDArr.ToJSON;
+      Out_ := TJsonArray.Create;
+      try
+        Flat := 0;
+        for i := 0 to High(S.Messages) do
+        begin
+          if S.Messages[i].Role in [mrUser, mrAssistant] then
+          begin
+            if Flat < TDArr.Count then
+              Out_.AddRaw(ToolDetailEntryRaw(TDArr, Flat))
+            else
+              Out_.AddRaw('null');
+            Inc(Flat);
+          end
+          else
+            Out_.AddRaw('null');
+        end;
+        S.ToolDetail := Out_.ToJSON;
+      finally
+        Out_.Free;
+      end;
     finally
       TDArr.Free;
     end;
@@ -6765,9 +6845,7 @@ begin
       end;
       PersistGatewaySession(FCfg, ReqSession, '(gateway: /v1/chat/completions)',
                             LoopCfg.Provider.GetName, ReqModel, Loop);
-      PersistGatewaySession(FCfg, ReqSession, '(gateway: /v1/chat/completions)',
-                          LoopCfg.Provider.GetName, ReqModel, Loop);
-    AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
+      AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
                              '(gateway: /v1/chat/completions)',
                              LoopCfg.Provider.GetName, ReqModel, Loop);
       if Loop.LastResp.FinishReason <> '' then
@@ -6840,6 +6918,12 @@ begin
         '{"error":{"message":"tool loop failed","type":"server_error"}}');
       Exit;
     end;
+    { The non-streaming branch needs this too. It lived only inside the
+      WantsStream arm, so `stream:false` -- the main OpenAI-compatible flow
+      -- updated the bucket and never wrote its named session. (Codex P1
+      on #556.) }
+    PersistGatewaySession(FCfg, ReqSession, '(gateway: /v1/chat/completions)',
+                          LoopCfg.Provider.GetName, ReqModel, Loop);
     AccumulateGatewayStats(FCfg, GW_BUCKET_V1_CHAT_COMPLETIONS,
                            '(gateway: /v1/chat/completions)',
                            LoopCfg.Provider.GetName, ReqModel, Loop);

--- a/src/tests/session_endpoint_tests.pas
+++ b/src/tests/session_endpoint_tests.pas
@@ -195,9 +195,16 @@ begin
 end;
 
 procedure TestRichTurnDetection;
-{ The PUT handler refuses (409) to overwrite a session with tool/system
-  turns or assistant tool_calls so the web UI can't strip an agent
-  transcript. Pin the predicate that gate keys off. }
+{ SessionHasRichTurns decides whether a /v1/sessions PUT overwrites or
+  merges. A session carrying tool/system turns or assistant tool_calls is
+  the agent's, not the web UI's: the PUT keeps the transcript on disk and
+  takes only the tool-detail blob out of the body.
+
+  It used to answer 409 instead, which prevented loss but forced the web UI
+  to fork -- and once the gateway persists its own transcripts, a browser
+  sharing that session would fork on every turn. The predicate is unchanged;
+  what changed is the branch it selects. Pin it either way, because both
+  behaviours key off exactly this. }
 var
   Msgs: TMessageArray;
 begin
@@ -228,6 +235,55 @@ begin
   { Empty transcript is not rich. }
   SetLength(Msgs, 0);
   AssertTrue(not SessionHasRichTurns(Msgs), 'empty transcript is not rich');
+end;
+
+procedure TestToolDetailReplaceKeepsTranscript;
+{ The merge branch rewrites ToolDetail and leaves Messages alone. That is
+  only safe if the store treats the two independently, so pin it: a rich
+  transcript survives a ToolDetail swap of the same length.
+
+  Same-length deliberately -- Save drops a blob with MORE entries than the
+  transcript (see TestToolDetailStalenessGuard), and the web UI's flattened
+  view is never longer than the agent's, so the realistic merge is
+  shorter-or-equal. }
+var
+  Id: string;
+  S1, S2: TSession;
+begin
+  Id := 'merge-keeps-transcript-' + IntToStr(Random(MaxInt));
+  S1 := TSession.Create(Id);
+  try
+    SetLength(S1.Messages, 3);
+    S1.Messages[0] := MakeMessage(mrUser, 'build it');
+    S1.Messages[1] := MakeMessage(mrAssistant, 'running a tool');
+    S1.Messages[2] := MakeMessage(mrTool, 'exit=0');
+    S1.ToolDetail := '[null,null,{"old":true}]';
+    S1.Save;
+  finally
+    S1.Free;
+  end;
+
+  S2 := TSession.Create(Id);
+  try
+    AssertTrue(SessionHasRichTurns(S2.Messages),
+               'the reloaded transcript is rich');
+    { What the merge branch does: blob in, transcript untouched. }
+    S2.ToolDetail := '[null,null,{"new":true}]';
+    S2.Save;
+  finally
+    S2.Free;
+  end;
+
+  S2 := TSession.Create(Id);
+  try
+    AssertTrue(Length(S2.Messages) = 3, 'all three turns survived the merge');
+    AssertTrue(S2.Messages[2].Role = mrTool, 'the tool turn is still a tool turn');
+    AssertTrue(Pos('"new"', S2.ToolDetail) > 0, 'the new blob landed');
+    AssertTrue(Pos('"old"', S2.ToolDetail) = 0, 'the old blob is gone');
+  finally
+    S2.Free;
+  end;
+  DeleteFile(SessionPath(Id));
 end;
 
 procedure TestToolDetailStalenessGuard;
@@ -309,6 +365,7 @@ begin
   TestRoundTrip;
   TestListSurfacesSession;
   TestRichTurnDetection;
+  TestToolDetailReplaceKeepsTranscript;
   TestToolDetailStalenessGuard;
   WriteLn('session_endpoint_tests: OK');
 end.

--- a/src/tests/session_endpoint_tests.pas
+++ b/src/tests/session_endpoint_tests.pas
@@ -286,6 +286,86 @@ begin
   DeleteFile(SessionPath(Id));
 end;
 
+procedure TestFinalAnswerIsPersisted;
+{ RunToolLoop returns FinalMessages as the history it FED the provider and
+  exits as soon as a tool-less response arrives -- so the assistant turn
+  carrying that response lives in Loop.Content, not the array. A gateway
+  session that copies the array verbatim stops one turn short and loses the
+  only thing the caller actually received.
+
+  Pinned at the store level: an assistant turn appended after a tool turn
+  round-trips, and the transcript still reads user / assistant / tool /
+  assistant. }
+var
+  Id: string;
+  S1, S2: TSession;
+begin
+  Id := 'final-answer-test-' + IntToStr(Random(MaxInt));
+  S1 := TSession.Create(Id);
+  try
+    SetLength(S1.Messages, 4);
+    S1.Messages[0] := MakeMessage(mrUser,      'do the thing');
+    S1.Messages[1] := MakeMessage(mrAssistant, 'calling a tool');
+    S1.Messages[2] := MakeMessage(mrTool,      'exit=0');
+    S1.Messages[3] := MakeMessage(mrAssistant, 'done, here is the answer');
+    S1.Save;
+  finally
+    S1.Free;
+  end;
+  S2 := TSession.Create(Id);
+  try
+    AssertTrue(Length(S2.Messages) = 4, 'all four turns persisted');
+    AssertTrue(S2.Messages[3].Role = mrAssistant, 'the last turn is the answer');
+    AssertTrue(Pos('here is the answer', S2.Messages[3].Content) > 0,
+               'the answer text survived');
+  finally
+    S2.Free;
+  end;
+  DeleteFile(SessionPath(Id));
+end;
+
+procedure TestToolDetailIndicesFollowTheTranscript;
+{ The web UI's tool_details array is indexed against what it DISPLAYS -- a
+  flat list of user/assistant turns. The retained transcript interleaves
+  tool turns, so entry N is the Nth displayed turn, not S.Messages[N].
+  Storing it unchanged passes the count guard and still puts every card on
+  the wrong message.
+
+  This pins the mapping rule the merge implements: the flattened view is
+  the subsequence of user/assistant turns, so the Nth blob entry belongs to
+  the Nth such turn and every other slot is null. }
+var
+  Msgs: TMessageArray;
+  i, Flat: Integer;
+  Slot: array of Integer;
+begin
+  SetLength(Msgs, 5);
+  Msgs[0] := MakeMessage(mrUser,      'ask');
+  Msgs[1] := MakeMessage(mrAssistant, 'tool time');
+  Msgs[2] := MakeMessage(mrTool,      'exit=0');
+  Msgs[3] := MakeMessage(mrSystem,    'note');
+  Msgs[4] := MakeMessage(mrAssistant, 'answer');
+
+  { Slot[i] = which flattened index message i draws its cards from, or -1. }
+  SetLength(Slot, Length(Msgs));
+  Flat := 0;
+  for i := 0 to High(Msgs) do
+    if Msgs[i].Role in [mrUser, mrAssistant] then
+    begin
+      Slot[i] := Flat;
+      Inc(Flat);
+    end
+    else
+      Slot[i] := -1;
+
+  AssertTrue(Slot[0] = 0, 'user turn takes flattened entry 0');
+  AssertTrue(Slot[1] = 1, 'first assistant takes entry 1');
+  AssertTrue(Slot[2] = -1, 'a tool turn takes no card');
+  AssertTrue(Slot[3] = -1, 'a system turn takes no card');
+  AssertTrue(Slot[4] = 2, 'the second assistant takes entry 2, not entry 4');
+  AssertTrue(Flat = 3, 'three displayed turns out of five stored');
+end;
+
 procedure TestToolDetailStalenessGuard;
 { ToolDetail (the web UI's tool-card blob) is index-aligned to Messages.
   Paths outside the web UI's own PUT mutate Messages directly (TUI /clear,
@@ -366,6 +446,8 @@ begin
   TestListSurfacesSession;
   TestRichTurnDetection;
   TestToolDetailReplaceKeepsTranscript;
+  TestFinalAnswerIsPersisted;
+  TestToolDetailIndicesFollowTheTranscript;
   TestToolDetailStalenessGuard;
   WriteLn('session_endpoint_tests: OK');
 end.


### PR DESCRIPTION
`pasclaw learn` mines saved sessions, `--write-scars` turns recurring failures into SCARS.md, and SCARS.md feeds the prompt. That chain worked for the CLI, and for the web UI only because the *browser* posts its transcript back through `/v1/sessions`. Everything else got nothing.

The gateway kept stats buckets and no transcript. A full multi-turn run left this:

```
sessions/_gateway_v1_chat.json  ->  messages: 0
meta.stats: input_tokens 13000, output_tokens 9300
```

22k tokens accounted for, nothing kept, so `pasclaw learn` answered `(no saved sessions to mine)`. `X-PasClaw-Session` was read for steering and checkpoint selection, then dropped. The desktop app, any HTTP integration and the relay all sit behind those endpoints, and none of them could ever produce a scar — the agent kept relearning mistakes it had already made there.

## What changed

**`PersistGatewaySession`** writes `Loop.FinalMessages` to the session the request names, alongside the existing bucket accounting rather than instead of it. Wired into `/v1/chat` and both `/v1/chat/completions` paths. No session id, no transcript — stateless passthrough, where the conversation belongs to the caller, is byte-identical to before.

**`/v1/sessions` PUT merges instead of 409.** This is the part that makes the above safe without a flag, and it is a real change to an existing route, so here is the full reasoning.

The 409 existed to prevent *loss*: the web UI knows only the user/assistant turns it displays, and a blind PUT of that flattened view over an agent transcript would strip the tool turns terminal resume needs. Refusing worked, but it is blunt — the web UI's only recourse is to fork into a fresh session. Once the gateway persists its own transcripts, a browser sharing that session would fork **on every turn**.

Nothing about the flattened body is worth losing the rich messages for, and nothing about the rich messages makes the body worthless: the web UI owns exactly one thing the agent does not produce, the opaque `tool_details` blob for its cards. So the merge keeps the transcript on disk and takes only that blob. No loss, no 409, no fork.

`SessionHasRichTurns` is unchanged — it still makes the decision, it just selects a different branch.

## Why not a config flag

An earlier version of this was gated behind `gateway_persist_sessions`, default off, because the 409 interaction had not been solved yet. That was correctly rejected: a flag nobody turns on delivers nothing while still costing config surface, a code path and maintenance. Solving the interaction is what removes the need for one.

## Verified end to end, no configuration

One `/v1/chat` with `X-PasClaw-Session: defaulton`, on a home with no `gateway_persist_sessions` key at all:

```
before   sessions/ -> only _gateway_v1_chat.json (383 B, messages: 0)
         learn     -> "(no saved sessions to mine)"

after    sessions/defaulton.json -> messages: 3, roles [user, assistant, tool]
         learn     -> "scanned 1 session(s), found 1 unique pattern(s)"
```

The pattern is not written to SCARS yet, and should not be — `learn` requires a pattern to recur across at least two sessions before naming it. The point is that it is now *visible*.

## Testing

Full `make -k test`: **1,457 lines, zero FAIL, zero make errors.**

`session_endpoint_tests` gains `TestToolDetailReplaceKeepsTranscript`, pinning the property the merge relies on — the store treats `Messages` and `ToolDetail` independently, so swapping the blob leaves a rich transcript intact. Same-length blob deliberately: `Save` drops one with more entries than the transcript, and the web UI's flattened view is never longer than the agent's, so shorter-or-equal is the realistic case.

`TestRichTurnDetection`'s comment described the 409 it no longer performs; rewritten to document the merge and why the refusal went.

**Known gap:** the HTTP PUT path itself has no automated test — the merge is verified through the store-level property plus a live gateway by hand, because covering the route properly means standing up an Indy listener in a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_