### PR TITLE
Three defects the research loop found: silent JSON corruption, TLS advice that reproduces the error, and the missing remedy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ FPCFLAGS = -MDelphi -Sh -O2 -Xs -XX \
 
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 
-.PHONY: all clean run test test-doctor test-provider-retry smoke lint-pascal-shape test-workspaces test-projects test-apps test-mail test-desktop-routes test-desktop test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip lint-studio test-read-file-encoding test-db-tools test-session-port test-json-lenient test-rerank test-sentencepiece test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-compact test-prune test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
+.PHONY: all clean run test openssl-1.0 test-doctor test-provider-retry smoke lint-pascal-shape test-workspaces test-projects test-apps test-mail test-desktop-routes test-desktop test-hashline test-toolview test-anthropic-server-tools test-openai-server-tools test-tool-choice test-responses-tool-choice test-println-helper test-utf8-codepage-tag test-json-utf8-roundtrip lint-studio test-read-file-encoding test-db-tools test-session-port test-json-lenient test-rerank test-sentencepiece test-rerank-eval test-model-discovery test-cron-tool test-provider-catalog test-output-cache test-working-state test-compact test-prune test-ansi-width test-shell-filters test-learn test-stream-reliability test-kb-index test-kb-pdf test-agents-md test-checkpoints-zpaq test-orient-preamble test-component-config test-autoroute-apply test-fallback-models test-memory-distill test-memory-facts test-memory-autodistill test-checkpoints-redo test-build-roundtrip test-delphi-build print-version get-indy webui-res browser
 
 all: $(WEBUI_RES) $(BIN)
 
@@ -339,6 +339,39 @@ test-read-file-encoding: | $(BUILDDIR)
 # linter is the ONLY automated gate studio/ has -- and it was pinned to one
 # filename, which meant a new unit was born unchecked and `make lint-studio`
 # reported green on a file it never opened.
+# Fetch the OpenSSL 1.0.2 pair a native Linux build needs for TLS.
+#
+# The vendored Indy targets OpenSSL 1.0.x and refuses 1.1.0+ outright; every
+# current distribution ships 3.x only, so a freshly built pasclaw cannot make
+# an HTTPS request -- no web_fetch, and no provider API call either. The
+# Dockerfile has solved this since it was written (see its openssl-1.0
+# stage), but that fix reached the image and nothing else: a developer
+# running `make all` got a TLS error whose advice was to install the very
+# version being rejected.
+#
+# Same source as the Dockerfile: the last 1.0.2u package from
+# snapshot.debian.org's frozen debian-archive, which is immutable and will
+# not rot when Debian retires the codename. Lands in $(BUILDDIR) because
+# ProbeOpenSSL defaults its search to the binary's own directory, so a build
+# that has run this needs no PASCLAW_OPENSSL_DIR and no other setup.
+OPENSSL_SNAPSHOT    ?= 20240331T102506Z
+OPENSSL_DEB_VERSION ?= 1.0.2u-1~deb9u7
+OPENSSL_ARCH        ?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
+OPENSSL_DEB_URL      = https://snapshot.debian.org/archive/debian-archive/$(OPENSSL_SNAPSHOT)/debian-security/pool/updates/main/o/openssl1.0/libssl1.0.2_$(OPENSSL_DEB_VERSION)_$(OPENSSL_ARCH).deb
+
+openssl-1.0: | $(BUILDDIR)
+	@echo "fetching $(OPENSSL_DEB_URL)"
+	@rm -rf $(BUILDDIR)/.ossl && mkdir -p $(BUILDDIR)/.ossl
+	@curl -fsSL --retry 3 --max-time 90 "$(OPENSSL_DEB_URL)" -o $(BUILDDIR)/.ossl/libssl.deb
+	@dpkg-deb -x $(BUILDDIR)/.ossl/libssl.deb $(BUILDDIR)/.ossl/x
+	@cp $(BUILDDIR)/.ossl/x/usr/lib/*-linux-*/libssl.so.1.0.2    $(BUILDDIR)/
+	@cp $(BUILDDIR)/.ossl/x/usr/lib/*-linux-*/libcrypto.so.1.0.2 $(BUILDDIR)/
+	@# Indy dlopens the plain names; the versioned files are what the deb ships.
+	@ln -sf libssl.so.1.0.2    $(BUILDDIR)/libssl.so
+	@ln -sf libcrypto.so.1.0.2 $(BUILDDIR)/libcrypto.so
+	@rm -rf $(BUILDDIR)/.ossl
+	@echo "OpenSSL 1.0.2 ready in $(BUILDDIR) -- TLS will work from this build"
+
 lint-studio:
 	@for f in studio/*.pas; do python3 scripts/lint-studio.py "$$f" || exit 1; done
 	@python3 scripts/gen-studio-icons.py --check

--- a/src/pkg/json/PasClaw.JSON.pas
+++ b/src/pkg/json/PasClaw.JSON.pas
@@ -230,6 +230,144 @@ begin
   inherited Destroy;
 end;
 
+function PreDecodeUnicodeEscapes(const S: string): string;
+(* fpjson (FPC 3.2.2 jsonscanner.pp) collects a \uXXXX escape into a
+   `String[4]` buffer. A lone escape fits (<= 3 UTF-8 bytes), and a real
+   surrogate pair fits exactly (4 bytes) -- but the scanner runs the SAME
+   combining path for ANY two adjacent escapes, so a pair of adjacent BMP
+   escapes (up to 3+3 bytes) is silently truncated to 4:
+
+       U+26A0 U+FE0F (warning sign + variation selector, escaped)
+         ->  E2 9A A0 EF        (should be E2 9A A0 EF B8 8F)
+       U+4E2D U+6587 (CJK, escaped)
+         ->  E4 B8 AD E6        (the second char loses its tail)
+
+   Producers that emit ASCII-safe JSON -- Python's json.dump default
+   (ensure_ascii=True), and most defensive serializers -- escape every
+   non-ASCII char, so any run of adjacent non-ASCII characters corrupts.
+   The scanner's raw-byte path is lossless (verified with raw emoji bytes),
+   so the workaround is to decode the escapes ourselves before fpjson sees
+   them. Rules:
+     - only escapes INSIDE string literals are touched (same state walk as
+       SanitizeLenientJSON above);
+     - codepoints < $80 stay escaped -- un-escaping a quote would inject a
+       raw quote and break the parse;
+     - surrogate pairs combine to the astral codepoint (4-byte UTF-8);
+       unpaired surrogates are left for fpjson (a lone escape fits its
+       buffer, so nothing is lost);
+     - anything malformed passes through untouched for fpjson to reject.
+   Input without \u escapes round-trips byte-for-byte. *)
+var
+  i, n, U, U2: Integer;
+  InStr: Boolean;
+  SB: TStringBuilder;
+
+  function HexAt(Pos: Integer; out V: Integer): Boolean;
+  var
+    k, d: Integer;
+    C: Char;
+  begin
+    Result := False;
+    V := 0;
+    if Pos + 3 > n then Exit;
+    for k := 0 to 3 do
+    begin
+      C := S[Pos + k];
+      case C of
+        '0'..'9': d := Ord(C) - Ord('0');
+        'A'..'F': d := Ord(C) - Ord('A') + 10;
+        'a'..'f': d := Ord(C) - Ord('a') + 10;
+      else
+        Exit;
+      end;
+      V := V * 16 + d;
+    end;
+    Result := True;
+  end;
+
+  procedure AppendUtf8(CP: Integer);
+  begin
+    if CP < $800 then
+    begin
+      SB.Append(Chr($C0 or (CP shr 6)));
+      SB.Append(Chr($80 or (CP and $3F)));
+    end
+    else if CP < $10000 then
+    begin
+      SB.Append(Chr($E0 or (CP shr 12)));
+      SB.Append(Chr($80 or ((CP shr 6) and $3F)));
+      SB.Append(Chr($80 or (CP and $3F)));
+    end
+    else
+    begin
+      SB.Append(Chr($F0 or (CP shr 18)));
+      SB.Append(Chr($80 or ((CP shr 12) and $3F)));
+      SB.Append(Chr($80 or ((CP shr 6) and $3F)));
+      SB.Append(Chr($80 or (CP and $3F)));
+    end;
+  end;
+
+begin
+  if Pos('\u', S) = 0 then Exit(S);
+  n := Length(S);
+  InStr := False;
+  SB := TStringBuilder.Create(n + 16);
+  try
+    i := 1;
+    while i <= n do
+    begin
+      if not InStr then
+      begin
+        if S[i] = '"' then InStr := True;
+        SB.Append(S[i]);
+        Inc(i);
+        Continue;
+      end;
+      { inside a string literal }
+      if S[i] = '"' then
+      begin
+        InStr := False;
+        SB.Append(S[i]);
+        Inc(i);
+        Continue;
+      end;
+      if (S[i] = '\') and (i < n) then
+      begin
+        if (S[i + 1] = 'u') and HexAt(i + 2, U) and (U >= $80) then
+        begin
+          if (U >= $D800) and (U <= $DBFF) and (i + 11 <= n) and
+             (S[i + 6] = '\') and (S[i + 7] = 'u') and HexAt(i + 8, U2) and
+             (U2 >= $DC00) and (U2 <= $DFFF) then
+          begin
+            AppendUtf8($10000 + ((U - $D800) shl 10) + (U2 - $DC00));
+            Inc(i, 12);
+            Continue;
+          end;
+          if (U < $D800) or (U > $DFFF) then
+          begin
+            AppendUtf8(U);
+            Inc(i, 6);
+            Continue;
+          end;
+          { unpaired surrogate: fall through, fpjson copes with a lone escape }
+        end;
+        { any other escape (\n, \", \\, \u00XX, malformed \u): copy the
+          backslash AND its follower verbatim so a \\ never re-enters the
+          escape scan as a fresh backslash }
+        SB.Append(S[i]);
+        SB.Append(S[i + 1]);
+        Inc(i, 2);
+        Continue;
+      end;
+      SB.Append(S[i]);
+      Inc(i);
+    end;
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
 function FPCParseData(const S: string; out ErrMsg: string): TJSONData;
 { Strict parse of S to a TJSONData, or nil on any scanner/parser error (with
   the message in ErrMsg). Handles the DefaultSystemCodePage dance documented
@@ -242,7 +380,9 @@ var
 begin
   Result := nil;
   ErrMsg := '';
-  Stream := TStringStream.Create(S);
+  { decode adjacent \uXXXX escapes before fpjson's String[4] buffer can
+    truncate them -- see PreDecodeUnicodeEscapes above }
+  Stream := TStringStream.Create(PreDecodeUnicodeEscapes(S));
   try
     PrevCP := DefaultSystemCodePage;
     if PrevCP <> CP_UTF8 then DefaultSystemCodePage := CP_UTF8;

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -810,10 +810,23 @@ begin
       'OpenSSL will not work and installing it again will not help.' + sLineBreak;
 
   Result := Result +
-    {$IFDEF MSWINDOWS}
+    {$IF DEFINED(MSWINDOWS)}
     'Get 1.0.2 binaries from github.com/IndySockets/OpenSSL-Binaries and' + sLineBreak +
     'place libeay32.dll and ssleay32.dll next to pasclaw.exe, or set' + sLineBreak +
     'PASCLAW_OPENSSL_DIR to a directory containing them.';
+    {$ELSEIF DEFINED(DARWIN)}
+    { macOS names and loads these differently from Linux, so it needs its
+      own remedy. IdGlobal.HackLoadFileName builds name + version + ext on
+      Darwin (libssl.1.0.2.dylib) but name + ext + version elsewhere
+      (libssl.so.1.0.2), and `make openssl-1.0` is Debian-only -- it wants
+      dpkg-deb and copies Linux ELF objects, which cannot load here. }
+    'Homebrew''s openssl@1.0 formula is gone, so the usual sources are a' + sLineBreak +
+    'MacPorts openssl10 install or a local 1.0.2 build. Place' + sLineBreak +
+    'libssl.1.0.2.dylib and libcrypto.1.0.2.dylib next to the pasclaw' + sLineBreak +
+    'binary, or point PASCLAW_OPENSSL_DIR at a directory holding them.' + sLineBreak +
+    'LibreSSL also works: Indy accepts the .35/.43/.44 dylibs macOS ships,' + sLineBreak +
+    'so PASCLAW_OPENSSL_DIR=/usr/lib is worth trying first.' + sLineBreak +
+    'Do NOT run `make openssl-1.0` -- that target fetches Linux .so files.';
     {$ELSE}
     'Run `make openssl-1.0` -- it fetches the 1.0.2u pair into the build' + sLineBreak +
     'directory, where this binary already looks, so no further setup is' + sLineBreak +

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -815,10 +815,12 @@ begin
     'place libeay32.dll and ssleay32.dll next to pasclaw.exe, or set' + sLineBreak +
     'PASCLAW_OPENSSL_DIR to a directory containing them.';
     {$ELSE}
-    'Get 1.0.2 binaries from github.com/IndySockets/OpenSSL-Binaries and' + sLineBreak +
-    'place libcrypto.so.1.0.0 and libssl.so.1.0.0 next to the pasclaw' + sLineBreak +
-    'binary, or set PASCLAW_OPENSSL_DIR to a directory containing them.' + sLineBreak +
-    'Your distribution package is 3.x and will NOT work.';
+    'Run `make openssl-1.0` -- it fetches the 1.0.2u pair into the build' + sLineBreak +
+    'directory, where this binary already looks, so no further setup is' + sLineBreak +
+    'needed. (The Docker image has always bundled these; that target is' + sLineBreak +
+    'the same thing for a native build.) Otherwise place libssl.so.1.0.2' + sLineBreak +
+    'and libcrypto.so.1.0.2 next to the pasclaw binary, or point' + sLineBreak +
+    'PASCLAW_OPENSSL_DIR at a directory holding them.';
     {$ENDIF}
 end;
 

--- a/src/pkg/providers/PasClaw.Providers.HTTP.pas
+++ b/src/pkg/providers/PasClaw.Providers.HTTP.pas
@@ -770,17 +770,55 @@ begin
   GSSLAvailable := LoadOpenSSLLibrary;
 end;
 
+(* Two different failures reach here and they need different advice.
+
+   NOT FOUND: no libcrypto/libssl where the loader looked.
+
+   WRONG VERSION: found, and rejected. The vendored Indy supports OpenSSL
+   1.0.2 and earlier -- IdSSLOpenSSLHeaders checks the version and bails on
+   1.1.0 or above, with its own comment saying 1.1.0 "made MAJOR changes
+   that we do not support yet". 1.0.2 went end-of-life in 2019, so every
+   current Linux distribution ships 3.x and every current Linux install
+   lands in this branch.
+
+   That is why the old message was worse than no message on Linux: it said
+   "install OpenSSL via your package manager", which installs 3.x, which is
+   rejected -- following the instruction exactly reproduced the failure. The
+   only thing that works is a 1.0.x build, and the Indy project publishes
+   those at github.com/IndySockets/OpenSSL-Binaries. Naming it is the whole
+   fix; without it the error is a dead end.
+
+   Detected by string rather than by a status code because Indy surfaces the
+   distinction only in WhichFailedToLoad's text. Crude, and a false negative
+   just prints both remedies, which is the safe direction. *)
 function OpenSSLHelpMessage: string;
+var
+  Detail: string;
+  VersionRejected: Boolean;
 begin
+  Detail := WhichFailedToLoad;
+  VersionRejected := Pos('Unsupported SSL Library version', Detail) > 0;
+
   Result :=
     'TLS support requires OpenSSL but the libraries could not be loaded.' + sLineBreak +
-    'Indy reports: ' + WhichFailedToLoad + sLineBreak +
+    'Indy reports: ' + Detail + sLineBreak;
+
+  if VersionRejected then
+    Result := Result +
+      'That library was FOUND but is too new. This build of Indy supports' + sLineBreak +
+      'OpenSSL 1.0.2 and earlier; 1.1.0+ and 3.x are rejected. Your system' + sLineBreak +
+      'OpenSSL will not work and installing it again will not help.' + sLineBreak;
+
+  Result := Result +
     {$IFDEF MSWINDOWS}
-    'On Windows, place libeay32.dll and ssleay32.dll next to pasclaw.exe,' + sLineBreak +
-    'or set PASCLAW_OPENSSL_DIR to a directory containing them.';
+    'Get 1.0.2 binaries from github.com/IndySockets/OpenSSL-Binaries and' + sLineBreak +
+    'place libeay32.dll and ssleay32.dll next to pasclaw.exe, or set' + sLineBreak +
+    'PASCLAW_OPENSSL_DIR to a directory containing them.';
     {$ELSE}
-    'On Linux/macOS, install OpenSSL (libssl + libcrypto) via your package' + sLineBreak +
-    'manager, or set PASCLAW_OPENSSL_DIR to a directory containing them.';
+    'Get 1.0.2 binaries from github.com/IndySockets/OpenSSL-Binaries and' + sLineBreak +
+    'place libcrypto.so.1.0.0 and libssl.so.1.0.0 next to the pasclaw' + sLineBreak +
+    'binary, or set PASCLAW_OPENSSL_DIR to a directory containing them.' + sLineBreak +
+    'Your distribution package is 3.x and will NOT work.';
     {$ENDIF}
 end;
 

--- a/src/tests/json_utf8_roundtrip_tests.pas
+++ b/src/tests/json_utf8_roundtrip_tests.pas
@@ -319,7 +319,7 @@ var
   J: TJsonObject;
   Got: string;
 begin
-  J := TJsonObject.Parse('{"k":"a' + '\' + 'u0022' + '"}');
+  J := TJsonObject.Parse('{"k":"a' + '\' + 'u0022' + 'b"}');
   try
     Got := J.GetStr('k', '');
   finally
@@ -358,6 +358,11 @@ begin
   TestUnicodeEscapeBMP3Byte;
   TestUnicodeEscapeInKey;
   TestSurrogatePairEscape;
+  TestAdjacentEscapePairCJK;
+  TestAdjacentEscapeTrioVariationSelector;
+  TestSurrogatePairAsEscapes;
+  TestEscapedBackslashNotDecoded;
+  TestLowCodepointEscapeUntouched;
   TestArrayElementRoundTrip;
   WriteLn('json_utf8_roundtrip_tests: OK');
 end.

--- a/src/tests/json_utf8_roundtrip_tests.pas
+++ b/src/tests/json_utf8_roundtrip_tests.pas
@@ -214,7 +214,7 @@ var
 const
   Want = #$F0#$9F#$98#$80;
 begin
-  J := TJsonObject.Parse('{"k":"😀"}');
+  J := TJsonObject.Parse('{"k":"' + #$F0#$9F#$98#$80 + '"}');
   try
     Got := J.GetStr('k', '');
   finally
@@ -222,6 +222,111 @@ begin
   end;
   AssertBytesEqual(Got, Want,
     'surrogate pair 😀 decodes to 4-byte UTF-8 (😀)');
+end;
+
+procedure TestAdjacentEscapePairCJK;
+(* Pass-16 improve-loop find. fpjson's scanner (FPC 3.2.2
+   jsonscanner.pp) accumulates \uXXXX escapes in a String[4] --
+   sized for one surrogate pair (exactly 4 UTF-8 bytes) but shared
+   by the combining path for ANY two adjacent escapes, so two
+   adjacent 3-byte BMP escapes (6 bytes) silently truncate to 4.
+   Python's json.dump default (ensure_ascii=True) emits exactly
+   this shape for all non-ASCII text, so any adjacent pair of CJK
+   chars or an emoji + variation selector corrupted every relay
+   write_file payload. PreDecodeUnicodeEscapes decodes the escapes
+   to raw UTF-8 before fpjson sees them. NOTE: Pascal string
+   literals do not process backslashes, so the concatenated
+   backslash-u sequences below really are escape text -- unlike the raw-byte
+   literals in the tests above, these exercise the escape path. *)
+var
+  J: TJsonObject;
+  Got: string;
+const
+  Want = #$E4#$B8#$AD + #$E6#$96#$87;   { U+4E2D U+6587 }
+begin
+  J := TJsonObject.Parse('{"k":"' + '\' + 'u4e2d' + '\' + 'u6587' + '"}');
+  try
+    Got := J.GetStr('k', '');
+  finally
+    J.Free;
+  end;
+  AssertBytesEqual(Got, Want,
+    'adjacent BMP \uXXXX escapes decode without String[4] truncation');
+end;
+
+procedure TestAdjacentEscapeTrioVariationSelector;
+{ The shape that surfaced the bug: warning sign U+26A0 + variation
+  selector U+FE0F + check mark U+2705, all escaped and adjacent.
+  Before the fix the middle escape lost its trailing two bytes. }
+var
+  J: TJsonObject;
+  Got: string;
+const
+  Want = #$E2#$9A#$A0 + #$EF#$B8#$8F + #$E2#$9C#$85;
+begin
+  J := TJsonObject.Parse('{"k":"' + '\' + 'u26a0' + '\' + 'ufe0f' + '\' + 'u2705' + '"}');
+  try
+    Got := J.GetStr('k', '');
+  finally
+    J.Free;
+  end;
+  AssertBytesEqual(Got, Want,
+    'escaped emoji + variation selector round-trips byte-exact');
+end;
+
+procedure TestSurrogatePairAsEscapes;
+{ Real surrogate pair spelled as escapes -- must combine to one
+  4-byte astral codepoint, not decode as two lone WideChars. }
+var
+  J: TJsonObject;
+  Got: string;
+const
+  Want = #$F0#$9F#$98#$80;   { U+1F600 }
+begin
+  J := TJsonObject.Parse('{"k":"' + '\' + 'ud83d' + '\' + 'ude00' + '"}');
+  try
+    Got := J.GetStr('k', '');
+  finally
+    J.Free;
+  end;
+  AssertBytesEqual(Got, Want,
+    'escaped surrogate pair combines to 4-byte UTF-8');
+end;
+
+procedure TestEscapedBackslashNotDecoded;
+{ '\\u1234' is a literal backslash followed by the text u1234 --
+  the pre-decoder must not treat the second backslash-u as an
+  escape. Guards the escape-state walk. }
+var
+  J: TJsonObject;
+  Got: string;
+begin
+  J := TJsonObject.Parse('{"k":"' + '\\' + 'u1234' + '"}');
+  try
+    Got := J.GetStr('k', '');
+  finally
+    J.Free;
+  end;
+  AssertBytesEqual(Got, '\' + 'u1234',
+    'escaped backslash before u is not decoded as a unicode escape');
+end;
+
+procedure TestLowCodepointEscapeUntouched;
+{ " is a double quote. Pre-decoding it to a raw quote would
+  terminate the JSON string early -- it must stay escaped for
+  fpjson, which decodes it correctly on its lone-escape path. }
+var
+  J: TJsonObject;
+  Got: string;
+begin
+  J := TJsonObject.Parse('{"k":"a' + '\' + 'u0022' + '"}');
+  try
+    Got := J.GetStr('k', '');
+  finally
+    J.Free;
+  end;
+  AssertBytesEqual(Got, 'a"b',
+    'sub-$80 \uXXXX escapes are left for fpjson and still decode');
 end;
 
 procedure TestArrayElementRoundTrip;


### PR DESCRIPTION
Three defects found by driving PasClaw through its own relay for sixteen research passes. None were found by reading code — each one broke a real task and was caught by the loop's verify step.

## 1. `fix(json)`: adjacent `\uXXXX` escapes silently truncate

fpjson (FPC 3.2.2, `jsonscanner.pp`) accumulates `\uXXXX` escapes in a `String[4]` ShortString. A lone escape fits (≤ 3 UTF-8 bytes) and a real surrogate pair fits exactly (4 bytes) — but the scanner runs the **same combining path for any two adjacent escapes**, so two adjacent BMP escapes (up to 6 bytes) truncate to 4:

```
"⚠️"  ->  E2 9A A0 EF        (variation selector loses 2 of its 3 bytes)
"中文"  ->  E4 B8 AD E6        (the second CJK character loses its tail)
```

Producers that emit ASCII-safe JSON escape *every* non-ASCII character — Python's `json.dump` default (`ensure_ascii=True`) among them — so any adjacent run of CJK, emoji-with-variation-selector, or accented text corrupted on **every parse**: relay worker payloads, provider responses, MCP messages.

Found when a relay `write_file` landed 70 bytes short of its staged payload. By then 19 already-corrupted glyphs were sitting in a committed document from earlier writes, and nothing had reported an error — the parse succeeded, it just returned different bytes than it was given.

**Fix:** `PreDecodeUnicodeEscapes` decodes escapes for codepoints ≥ `$80` (surrogate pairs combined into their astral codepoint) to raw UTF-8 before fpjson parses. The scanner's raw-byte path is lossless, which the existing round-trip tests already pin. Escapes below `$80` are deliberately left escaped, so a decoded quote can't terminate its own string literal. Wired into `FPCParseData`, which covers strict, lenient, object and array parses. No-op for input containing no `\u` escapes (early exit).

**On the tests:** the five new cases build their escape literals by concatenation, because the pre-existing "escape" tests contain *raw UTF-8* — Pascal string literals never process backslashes, so whatever wrote them decoded the escapes at authoring time, and they have been pinning the raw-byte path under escape-test names. `TestSurrogatePairEscape` is restored to intentionally-raw form and `TestSurrogatePairAsEscapes` now covers the escaped spelling.

## 2. `OpenSSL guidance`: the error message named a remedy that reproduces the error

Every `web_fetch` through the relay failed with:

> TLS support requires OpenSSL … install OpenSSL (libssl + libcrypto) via your package manager

Following that instruction exactly reproduces the failure. Indy reported `Unsupported SSL Library version: 300000D0` — OpenSSL 3.0.13 **was found and rejected**. The vendored `IdSSLOpenSSLHeaders` bails on 1.1.0 or above, and 1.0.2 went end-of-life in 2019, so every current distribution's package manager installs precisely the version that cannot work. The advice was worse than silence: a dead end delivered in the confident tone of a diagnosis.

The message now distinguishes *not found* from *found and rejected*, says plainly that the system OpenSSL will not work, and names where 1.0.x binaries actually come from. Detection is by Indy's message text because that is the only place the distinction surfaces; a false negative just prints both remedies, which is the safe direction.

Per review, macOS now has its own arm rather than inheriting the Linux one — see below.

## 3. `make openssl-1.0`: the remedy the repo already had

The Docker image has always fetched OpenSSL 1.0.2 to make TLS work. A native Linux build had no equivalent, so the fix for #2 pointed at a manual download. This target does what the Dockerfile does, into `build/`.

## Review round (Codex, three findings — all legitimate)

- **The five new regression cases were never called.** They were defined but absent from the main block, so `make test-json-utf8-roundtrip` reported OK without executing any of them — the same defect the survey this work came from calls the field-wide blind spot: a tool reporting green on cases it never covered. Now wired in, and shown to bite: with `PreDecodeUnicodeEscapes` unwired, `TestAdjacentEscapePairCJK` fails with `got=[E4 B8 AD E6] want=[E4 B8 AD E6 96 87]`.
- **A broken fixture** — `TestLowCodepointEscapeUntouched` built `{"k":"a""}` but asserted `a"b`, so it would have failed on fixture data the moment it ran. Trailing `b` restored.
- **macOS had no usable remedy.** The non-Windows arm routed every platform to `make openssl-1.0`, which is Debian-only (needs `dpkg-deb`, unpacks a `.deb`, copies Linux ELF objects). macOS also names the files differently — `IdGlobal.HackLoadFileName` builds name+version+ext on Darwin (`libssl.1.0.2.dylib`) versus name+ext+version elsewhere (`libssl.so.1.0.2`) — so the old text named files that cannot exist there. Darwin now gets correct dylib names, real sources, the LibreSSL `.35/.43/.44` dylibs Indy already accepts as the first thing to try, and an explicit warning not to run the Linux target. The chain also moved from `{$IFDEF MSWINDOWS}` to `{$IF DEFINED(MSWINDOWS)}` because `{$ELSEIF}` only pairs with `{$IF}`; verified balanced under `-dDARWIN`.

## Verification

- `make` clean build; `make test` full suite **326 assertions, 0 failures**.
- The JSON regression cases are verified to actually fail without the fix, not merely to pass with it.
- `make openssl-1.0` runs end to end, and `web_fetch` works afterward.
- The document corrupted by #1 was rewritten byte-exact through the rebuilt binary: 54 intact glyphs, 0 mangled.

## Not included

`pasclaw update --check` can hang indefinitely on its HTTPS call. `FetchLatestRelease` **does** request a 30-second budget (`GetJSONURL(Url, Headers, 30)`) and both client constructors set `ConnectTimeout`/`ReadTimeout` from it — but the stall happens in the TLS handshake, where Indy does not honor them. It is invisible while TLS is unavailable, because the call then fails fast; supply working TLS (as `make openssl-1.0` now does) and point it at an endpoint that accepts and then stalls, and it blocks forever — inside the `smoke` target, so `make test` blocks with it. Pre-existing, needs a real diagnosis in the Indy/TLS layer rather than a bolted-on guard, and orthogonal to these three fixes, so it is filed here rather than patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6