### PR TITLE
Security: /v1/fs served MCP OAuth tokens, and the relay token compare was not constant-time

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -4214,10 +4214,79 @@ begin
 end;
 {$ENDIF}{$ENDIF}
 
+{$IFDEF MSWINDOWS}
+(* Windows equivalent of the realpath() branch above.
+
+   Windows resolves aliases through REPARSE POINTS -- directory
+   junctions, symlinks, mount points -- and ExpandFileName does not
+   follow any of them. Without this, a junction anywhere inside a
+   browsable path could point at $PASCLAW_HOME/oauth (or at
+   config.json), PathInsideDirectory would compare the harmless alias,
+   and TFileStream would then happily follow the reparse point and
+   serve the secret. That is the same bypass PR #280 closed on Unix;
+   the canonicalisation was simply never written for Windows, so BOTH
+   the config-file check and the OAuth directory check inherited the
+   hole.
+
+   GetFinalPathNameByHandleW resolves the whole chain. The handle is
+   opened with dwDesiredAccess = 0 (query only, no read rights needed)
+   and FILE_FLAG_BACKUP_SEMANTICS, which is what permits opening a
+   DIRECTORY handle at all -- without it the oauth-directory case fails
+   and silently degrades to the lexical compare.
+
+   Declared here rather than taken from the RTL because
+   GetFinalPathNameByHandleW is absent from older FPC Windows headers.
+
+   NOT COMPILE-TESTED: this container has no Windows target or cross
+   units, so this branch has been reviewed by inspection only. It fails
+   safe -- any failure returns '' and the caller keeps the lexical path,
+   which is exactly today's behaviour. *)
+const
+  FILE_FLAG_BACKUP_SEMANTICS_ = $02000000;
+  FILE_NAME_NORMALIZED_       = $00000000;
+
+function GetFinalPathNameByHandleW(hFile: THandle; lpszFilePath: PWideChar;
+                                   cchFilePath, dwFlags: DWORD): DWORD; stdcall;
+  external 'kernel32.dll' name 'GetFinalPathNameByHandleW';
+
+function CanonicalPath(const P: string): string;
+var
+  H: THandle;
+  Buf: array[0..1023] of WideChar;
+  N: DWORD;
+  S: string;
+begin
+  Result := '';
+  if P = '' then Exit;
+  H := CreateFileW(PWideChar(WideString(P)), 0,
+                   FILE_SHARE_READ or FILE_SHARE_WRITE or FILE_SHARE_DELETE,
+                   nil, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS_, 0);
+  if H = INVALID_HANDLE_VALUE then Exit;
+  try
+    N := GetFinalPathNameByHandleW(H, @Buf[0], Length(Buf) - 1,
+                                   FILE_NAME_NORMALIZED_);
+    if (N = 0) or (N >= DWORD(Length(Buf))) then Exit;
+    Buf[N] := #0;
+    S := string(WideString(PWideChar(@Buf[0])));
+  finally
+    CloseHandle(H);
+  end;
+  { The API returns the \\?\ extended-length form; normalise it back so
+    the result compares against ordinary paths. \\?\UNC\srv\share is the
+    network spelling and becomes \\srv\share. }
+  if Copy(S, 1, 4) = '\\?\' then
+  begin
+    Delete(S, 1, 4);
+    if Copy(S, 1, 4) = 'UNC\' then S := '\\' + Copy(S, 5, MaxInt);
+  end;
+  Result := S;
+end;
+{$ENDIF}
+
 function IsRestrictedFsPath(const Path: string): Boolean;
 var
   Full, CfgFull, Base, OAuthDir: string;
-  {$IFDEF FPC}{$IFDEF UNIX}CP: string;{$ENDIF}{$ENDIF}
+  {$IF DEFINED(MSWINDOWS) or (DEFINED(FPC) and DEFINED(UNIX))}CP: string;{$IFEND}
 begin
   Result := False;
   if Path = '' then Exit;
@@ -4237,6 +4306,15 @@ begin
   CP := CanonicalPath(GetConfigPath);
   if CP <> '' then CfgFull := CP;
   {$ENDIF}{$ENDIF}
+  {$IFDEF MSWINDOWS}
+  { Same resolution on Windows, via reparse points. SameInode has no
+    Windows counterpart here, so a HARDLINK to the config file is still
+    only caught lexically -- recorded rather than implied. }
+  CP := CanonicalPath(Path);
+  if CP <> '' then Full := CP;
+  CP := CanonicalPath(GetConfigPath);
+  if CP <> '' then CfgFull := CP;
+  {$ENDIF}
   if (CfgFull <> '') and SameFileName(Full, CfgFull) then Exit(True);
 
   (* Secret DIRECTORIES, checked before the basename rules.
@@ -4260,10 +4338,12 @@ begin
      into these dirs are covered without anyone remembering to extend a
      list. *)
   OAuthDir := JoinPath(GetHome, 'oauth');
-  {$IFDEF FPC}{$IFDEF UNIX}
+  {$IF DEFINED(MSWINDOWS) or (DEFINED(FPC) and DEFINED(UNIX))}
+  { Resolve the guarded directory too, so an alias INSIDE the browsable
+    tree and the real directory canonicalise to the same string. }
   CP := CanonicalPath(OAuthDir);
   if CP <> '' then OAuthDir := CP;
-  {$ENDIF}{$ENDIF}
+  {$IFEND}
   if (OAuthDir <> '') and PathInsideDirectory(Full, OAuthDir) then Exit(True);
 
   { Basename denylist for the conventional secret files. }

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -4216,7 +4216,7 @@ end;
 
 function IsRestrictedFsPath(const Path: string): Boolean;
 var
-  Full, CfgFull, Base: string;
+  Full, CfgFull, Base, OAuthDir: string;
   {$IFDEF FPC}{$IFDEF UNIX}CP: string;{$ENDIF}{$ENDIF}
 begin
   Result := False;
@@ -4238,6 +4238,34 @@ begin
   if CP <> '' then CfgFull := CP;
   {$ENDIF}{$ENDIF}
   if (CfgFull <> '') and SameFileName(Full, CfgFull) then Exit(True);
+
+  (* Secret DIRECTORIES, checked before the basename rules.
+
+     $PASCLAW_HOME/oauth/<server>.json holds MCP OAuth material written
+     by PasClaw.MCP.OAuth.SaveTokens -- access_token and refresh_token
+     in cleartext. Its basename is whatever the MCP server is called,
+     so no basename rule can ever cover it, and a directory test is the
+     only shape that works.
+
+     Demonstrated before this guard existed: with sandbox.allow_read_paths
+     widened to include the home tree (a supported configuration),
+     GET /v1/fs/read?path=$PASCLAW_HOME/oauth/github.json returned the
+     live tokens, while the same request for config.json was correctly
+     refused. Same endpoint, same threat, one file protected and the
+     other not. Because the gateway ships with bearer auth OFF unless a
+     token is configured, that made third-party refresh tokens readable
+     by any caller who could reach the port.
+
+     Directory-scoped rather than by filename, so future files dropped
+     into these dirs are covered without anyone remembering to extend a
+     list. *)
+  OAuthDir := JoinPath(GetHome, 'oauth');
+  {$IFDEF FPC}{$IFDEF UNIX}
+  CP := CanonicalPath(OAuthDir);
+  if CP <> '' then OAuthDir := CP;
+  {$ENDIF}{$ENDIF}
+  if (OAuthDir <> '') and PathInsideDirectory(Full, OAuthDir) then Exit(True);
+
   { Basename denylist for the conventional secret files. }
   Base := LowerCase(ExtractFileName(Full));
   if Base = 'config.json' then Exit(True);
@@ -5149,8 +5177,17 @@ begin
   if Presented = '' then Presented := QueryToken;
   if Presented = '' then Exit;
 
-  Result := NormaliseTokenForCompare(Presented) =
-            NormaliseTokenForCompare(FRelayToken);
+  { Constant-time. The relay token is a real credential -- it lets a
+    worker claim inference requests and hand back arbitrary model
+    output, i.e. inject into the agent loop -- and it is only 40 bits
+    (8 Crockford base32 chars). The main gateway token has always been
+    compared with ConstantTimeStringEqual; this path used '=' and so
+    leaked a per-character timing signal that makes those 40 bits
+    searchable rather than guessable. Normalisation (case-fold, strip
+    hyphens) happens first so the operator-friendly formats still
+    match, then the comparison itself is length-then-XOR. }
+  Result := ConstantTimeStringEqual(NormaliseTokenForCompare(Presented),
+                                    NormaliseTokenForCompare(FRelayToken));
 end;
 
 procedure TGatewayServer.HandleRelayWorkerToken(ARequest: TIdHTTPRequestInfo;

--- a/src/tests/fs_secret_gate_tests.pas
+++ b/src/tests/fs_secret_gate_tests.pas
@@ -17,6 +17,7 @@ program fs_secret_gate_tests;
 uses
   SysUtils,
   {$IFDEF UNIX}BaseUnix,{$ENDIF}
+  PasClaw.Utils,           { JoinPath, GetHome }
   PasClaw.Config,          { GetConfigPath }
   PasClaw.Gateway.Server;  { IsRestrictedFsPath }
 
@@ -119,6 +120,28 @@ begin
   {$IFDEF UNIX}
   RunSymlinkChecks;
   {$ENDIF}
+
+  (* MCP OAuth token store. $PASCLAW_HOME/oauth/<server>.json holds
+     access_token and refresh_token in cleartext, and its basename is
+     whatever the MCP server happens to be called -- so no basename rule
+     can cover it and only a directory test works.
+
+     Demonstrated live before the guard existed: with
+     sandbox.allow_read_paths widened to the home tree,
+     GET /v1/fs/read?path=$PASCLAW_HOME/oauth/github.json returned the
+     tokens while config.json was correctly refused. Same endpoint, same
+     threat, one covered and one not. *)
+  AssertRestricted(JoinPath(JoinPath(GetHome, 'oauth'), 'github.json'),
+                   True,  'MCP OAuth token file hidden');
+  AssertRestricted(JoinPath(JoinPath(GetHome, 'oauth'), 'any-server-name.json'),
+                   True,  'OAuth store hidden whatever the server is called');
+  AssertRestricted(JoinPath(JoinPath(JoinPath(GetHome, 'oauth'), 'nested'), 'x.json'),
+                   True,  'nested file under oauth/ hidden');
+  { A sibling directory whose name merely starts with the same letters
+    must NOT be swept up -- the check is a path-boundary test, not a
+    string prefix. }
+  AssertRestricted(JoinPath(GetHome, 'oauth-notes.txt'),
+                   False, 'oauth-notes.txt is not inside oauth/ and stays visible');
 
   WriteLn('fs_secret_gate_tests: OK');
 end.


### PR DESCRIPTION
Two findings from an improve-mode security audit driven through the relay. Both were **exploited against a running gateway before the fix** and the same request re-run after.

## 1. OAuth token disclosure via `/v1/fs/read`

`PasClaw.MCP.OAuth.SaveTokens` writes `$PASCLAW_HOME/oauth/<server>.json` containing `access_token` and `refresh_token` in cleartext.

`IsRestrictedFsPath` — the guard whose entire purpose is keeping credentials out of the operator Files browser — was a **basename** denylist covering `config.json`, `.env*`, `.pem`, `.key`. The OAuth store defeats that structurally: its basename is whatever the remote MCP server is called, so no list of names could ever have covered it.

Demonstrated with `sandbox.allow_read_paths` widened to the home tree (a supported configuration):

```
GET /v1/fs/read?path=$PASCLAW_HOME/config.json
  -> {"error":"access to this file is restricted"}

GET /v1/fs/read?path=$PASCLAW_HOME/oauth/github.json
  -> {"access_token":"gho_LIVE_...","refresh_token":"ghr_LIVE_..."}
```

Same endpoint, same threat model, one file protected and the other handed over. **The gateway ships with bearer auth off unless a token is configured**, so in that configuration a third party's OAuth refresh token was readable by any caller who could reach the port.

Fixed with a **directory-scoped** check ahead of the basename rules — deliberately not another filename, so anything later dropped into `oauth/` is covered without someone remembering to extend a list. Canonicalised on Unix so the existing symlink/inode hardening from #280 applies to it too.

## 2. Relay token compared with plain equality

The relay worker token is a real credential: it lets a worker claim inference requests and return arbitrary model output — injection straight into the agent loop. It is 40 bits (8 Crockford base32 chars).

The main gateway token has always used `ConstantTimeStringEqual`. This sibling path, in the same file, used `=` and leaked a per-character timing signal — which is what turns 40 bits from guessable into searchable. Now uses the same helper (already exported): normalisation first so operator-friendly token spellings still match, then length-then-XOR.

## Tests

Four cases pin the OAuth gap: token file hidden; hidden whatever the server is named; hidden when nested; and a sibling `oauth-notes.txt` that must stay **visible** (the check is a path-boundary test, not a string prefix). Verified the tests bite — reverting the guard fails them.

Full suite: **326 assertions, 0 failures.**

## Deliberately not claimed

Five other home-root directories exist (`cache`, `mcp-cache`, `run`, `tmp`, `workspace-import-*`). All sit outside the `/v1/fs` browse root — which is exactly what was true of `oauth/` until `allow_read_paths` widened it — and their contents were **not** audited for credentials in this pass. Open question, not a clean bill of health. (`mcp-cache` has since been checked: tool schemas only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_