### PR TITLE
Startup output: say each thing once, and say the security state loudest

### DIFF
--- a/src/cmd/PasClaw.Cmd.Agent.pas
+++ b/src/cmd/PasClaw.Cmd.Agent.pas
@@ -1302,7 +1302,7 @@ var
     if Session = nil then Exit;
     CC.Enabled   := Cfg.CheckpointsEnabled;
     CC.SessionId := Session.Meta.Id;
-    CC.Root      := JoinPath(GetHome, ActiveWorkspaceName + '/checkpoints');
+    CC.Root      := JoinPath(JoinPath(GetHome, ActiveWorkspaceName), 'checkpoints');
     CC.KeepLast  := Cfg.CheckpointsKeepLast;
     InitCheckpoints(CC);
   end;

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -332,35 +332,69 @@ begin
         MCPServer.Start(Args.Addr, Args.MCPPort);
 
       BaseURL := Format('http://%s:%d/v1', [Args.Addr, Args.Port]);
-      PrintLn(Ansi.Bold + 'OpenAI-compatible server up.' + Ansi.Reset);
-      PrintLn('  base_url: ' + BaseURL);
-      PrintLn('  model:    ' + Cfg.DefaultModel);
-      PrintLn(Format('  max-iter: %d', [Args.MaxIter]));
+
+      (* Startup banner. Grouped by what an operator actually needs to
+         know, in descending order of consequence: identity, endpoints,
+         exposure, then how to call it. The old form was a flat list of
+         eight `key: value` lines in which "auth is off" appeared as
+         just another [info] between two subsystem notices; anything
+         security-relevant now gets its own block and its own colour. *)
+      PrintLn;
+      PrintLn(Ansi.Bold + '  PasClaw ' + FormatVersion + Ansi.Reset +
+              Ansi.Dim + '  ready' + Ansi.Reset);
+      PrintLn;
+      PrintLn('  ' + Ansi.Dim + 'API  ' + Ansi.Reset + BaseURL +
+              Ansi.Dim + '   OpenAI-compatible' + Ansi.Reset);
       if MCPServer <> nil then
-        PrintLn(Format('  mcp:      http://%s:%d/mcp (dedicated listener)',
-                       [Args.Addr, Args.MCPPort]))
+        PrintLn(Format('  %sMCP  %shttp://%s:%d/mcp%s   dedicated listener%s',
+                       [Ansi.Dim, Ansi.Reset, Args.Addr, Args.MCPPort,
+                        Ansi.Dim, Ansi.Reset]))
       else
-        PrintLn(Format('  mcp:      http://%s:%d/mcp (mounted on main port)',
-                       [Args.Addr, Args.Port]));
+        PrintLn(Format('  %sMCP  %shttp://%s:%d/mcp%s   on the main port%s',
+                       [Ansi.Dim, Ansi.Reset, Args.Addr, Args.Port,
+                        Ansi.Dim, Ansi.Reset]));
+      PrintLn('  ' + Ansi.Dim + 'Model' + Ansi.Reset + ' ' + Cfg.DefaultModel +
+              Ansi.Dim + Format('   max %d iteration(s) per turn', [Args.MaxIter]) +
+              Ansi.Reset);
+      PrintLn;
+
+      { Exposure block. Two independent switches an operator can get
+        wrong, stated as what is currently true rather than as a flag
+        reference. }
+      if GatewayAuthIsInsecure(Cfg) then
+      begin
+        PrintLn('  ' + Ansi.Yellow + 'Unauthenticated' + Ansi.Reset +
+                ' -- every /v1/* and /mcp route is open to any caller.');
+        PrintLn('  ' + Ansi.Dim +
+                'Set gateway.token in config.json or $PASCLAW_GATEWAY_TOKEN to require a bearer.' +
+                Ansi.Reset);
+      end
+      else
+        PrintLn('  ' + Ansi.Green + 'Bearer auth required' + Ansi.Reset +
+                Ansi.Dim + ' on /v1/* and /mcp.' + Ansi.Reset);
       if Args.MCPAllowWrite then
-        PrintLn('            mutating tools EXPOSED to MCP clients (--mcp-allow-write)')
+        PrintLn('  ' + Ansi.Yellow + 'Mutating tools exposed' + Ansi.Reset +
+                ' to MCP clients (--mcp-allow-write).')
       else
-        PrintLn('            read-only tools only -- pass --mcp-allow-write to flip');
+        PrintLn('  ' + Ansi.Dim +
+                'MCP exposes read-only tools; --mcp-allow-write enables the rest.' +
+                Ansi.Reset);
       PrintLn;
-      PrintLn(Ansi.Dim + '  Example (openai-python):' + Ansi.Reset);
-      PrintLn('    client = OpenAI(base_url="' + BaseURL + '", api_key="sk-pasclaw")');
-      PrintLn('    client.chat.completions.create(model="' + Cfg.DefaultModel +
-              '", messages=[{"role":"user","content":"hi"}])');
-      PrintLn;
-      PrintLn(Ansi.Dim + '  Example (curl):' + Ansi.Reset);
-      PrintLn('    curl ' + BaseURL + '/chat/completions -H "Content-Type: application/json" \');
-      PrintLn('         -d ''{"model":"' + Cfg.DefaultModel +
-              '","messages":[{"role":"user","content":"hi"}]}''');
-      PrintLn;
-      PrintLn(Ansi.Bold + 'Relay worker token: ' + Ansi.Reset +
+
+      PrintLn('  ' + Ansi.Dim + 'Relay worker token ' + Ansi.Reset +
               Ansi.Cyan + Server.RelayToken + Ansi.Reset +
-              Ansi.Dim + '   (regenerated each start; unlocks /v1/relay/* only)' + Ansi.Reset);
-      PrintLn(Ansi.Dim + 'Press Ctrl-C to stop.' + Ansi.Reset);
+              Ansi.Dim + '   new each start; unlocks /v1/relay/* only' + Ansi.Reset);
+      PrintLn;
+
+      PrintLn('  ' + Ansi.Dim + 'Try it' + Ansi.Reset);
+      PrintLn('    curl ' + BaseURL + '/chat/completions \');
+      PrintLn('      -H "Content-Type: application/json" \');
+      PrintLn('      -d ''{"model":"' + Cfg.DefaultModel +
+              '","messages":[{"role":"user","content":"hi"}]}''');
+      PrintLn('    ' + Ansi.Dim + 'python: OpenAI(base_url="' + BaseURL +
+              '", api_key="sk-pasclaw")' + Ansi.Reset);
+      PrintLn;
+      PrintLn(Ansi.Dim + '  Ctrl-C to stop.' + Ansi.Reset);
 
       Server.WaitForStop;
     finally

--- a/src/cmd/PasClaw.Cmd.Serve.pas
+++ b/src/cmd/PasClaw.Cmd.Serve.pas
@@ -361,17 +361,32 @@ begin
       { Exposure block. Two independent switches an operator can get
         wrong, stated as what is currently true rather than as a flag
         reference. }
-      if GatewayAuthIsInsecure(Cfg) then
-      begin
-        PrintLn('  ' + Ansi.Yellow + 'Unauthenticated' + Ansi.Reset +
-                ' -- every /v1/* and /mcp route is open to any caller.');
-        PrintLn('  ' + Ansi.Dim +
-                'Set gateway.token in config.json or $PASCLAW_GATEWAY_TOKEN to require a bearer.' +
-                Ansi.Reset);
-      end
+      (* Three postures, two of them unhealthy in OPPOSITE directions.
+         Collapsing them into one "insecure" branch told an operator whose
+         token was still an unresolved env-var template that the server was
+         wide open, when in fact it was rejecting every client with 401 --
+         the reverse of the truth. *)
+      case GatewayAuthState(Cfg) of
+        gasOpen:
+          begin
+            PrintLn('  ' + Ansi.Yellow + 'Unauthenticated' + Ansi.Reset +
+                    ' -- every /v1/* and /mcp route is open to any caller.');
+            PrintLn('  ' + Ansi.Dim +
+                    'Set gateway.token in config.json or $PASCLAW_GATEWAY_TOKEN to require a bearer.' +
+                    Ansi.Reset);
+          end;
+        gasMisconfigured:
+          begin
+            PrintLn('  ' + Ansi.Yellow + 'Auth misconfigured' + Ansi.Reset +
+                    ' -- gateway.token is an unresolved ${...} template.');
+            PrintLn('  ' + Ansi.Dim +
+                    'The literal is compared against client bearers, so EVERY request gets 401. ' +
+                    'Set the env var it names, or put a real token in config.json.' + Ansi.Reset);
+          end;
       else
         PrintLn('  ' + Ansi.Green + 'Bearer auth required' + Ansi.Reset +
                 Ansi.Dim + ' on /v1/* and /mcp.' + Ansi.Reset);
+      end;
       if Args.MCPAllowWrite then
         PrintLn('  ' + Ansi.Yellow + 'Mutating tools exposed' + Ansi.Reset +
                 ' to MCP clients (--mcp-allow-write).')

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -1059,6 +1059,14 @@ function GetEffectiveGatewayToken(const C: TConfig): string;
     prefix of a 6-byte token leaks too much). *)
 function DescribeGatewayAuthState(const C: TConfig): string;
 
+(*  GatewayAuthIsInsecure -- True when DescribeGatewayAuthState is
+    reporting an exposure (no token at all, or an unresolved template
+    that will reject every client) rather than a healthy configured
+    token. Callers use it to pick the log LEVEL: an open gateway is
+    the single most consequential fact at startup and was previously
+    emitted at [info], indistinguishable from routine chatter. *)
+function GatewayAuthIsInsecure(const C: TConfig): Boolean;
+
 (*  ExpandEnvVarsInJSON -- raw-text ${VAR_NAME} substitution applied
     to the JSON config body BEFORE TConfig.FromJSON parses it.
     Matches openclaw's `${...}` template-substitution feature so an
@@ -1141,6 +1149,13 @@ var
     neither env var is set -- the middleware then falls back to
     C.Gateway.Token. }
   GEnvGatewayToken: string = '';
+
+  { Last profile state announced on the log, so repeated LoadConfig
+    calls during one boot don't repeat the same line. See the guard in
+    LoadConfig. -1 layers means "nothing announced yet", which is
+    distinct from a real profile that resolved to zero layers. }
+  GLoggedProfile:       string  = '';
+  GLoggedProfileLayers: Integer = -1;
 
 procedure ApplyPromptCacheConfig(var Opts: TChatOptions; const PC: TPromptCacheConfig);
 begin
@@ -2559,8 +2574,22 @@ begin
                       [ProfileName, i, E.Message]);
           end;
         end;
-        LogInfo('config: profile "%s" applied (%d layer(s))',
-                [ProfileName, Length(Bodies)]);
+        { Say this once per process, not once per LoadConfig. A gateway
+          boot calls LoadConfig from several independent subsystems
+          (sandbox repoint, tool registry, KB index, ...), each of which
+          re-resolves the same profile -- so the unguarded line printed
+          the identical fact four times before the banner, which reads
+          as four events rather than one. Re-log only when the resolved
+          profile or its layer count actually changes, so a genuine
+          mid-run profile switch is still reported. }
+        if (GLoggedProfile <> ProfileName) or
+           (GLoggedProfileLayers <> Length(Bodies)) then
+        begin
+          GLoggedProfile       := ProfileName;
+          GLoggedProfileLayers := Length(Bodies);
+          LogInfo('config: profile "%s" applied (%d layer(s))',
+                  [ProfileName, Length(Bodies)]);
+        end;
       end
       else
         LogWarn('config: %s -- using defaults + config.json only', [PErr]);
@@ -2693,6 +2722,20 @@ begin
     Result := Copy(Tok, 1, 4) + '...'
   else
     Result := '<short>';
+end;
+
+function GatewayAuthIsInsecure(const C: TConfig): Boolean;
+(* Mirrors DescribeGatewayAuthState's two failure branches: no token
+   anywhere, or a token still holding an unresolved env-var template.
+   Kept next to it so the two cannot drift apart. *)
+var
+  Tok: string;
+begin
+  if GEnvGatewayToken <> '' then
+    Tok := GEnvGatewayToken
+  else
+    Tok := C.Gateway.Token;
+  Result := (Tok = '') or LooksLikeUnresolvedTemplate(Tok);
 end;
 
 function DescribeGatewayAuthState(const C: TConfig): string;

--- a/src/pkg/config/PasClaw.Config.pas
+++ b/src/pkg/config/PasClaw.Config.pas
@@ -1059,13 +1059,25 @@ function GetEffectiveGatewayToken(const C: TConfig): string;
     prefix of a 6-byte token leaks too much). *)
 function DescribeGatewayAuthState(const C: TConfig): string;
 
-(*  GatewayAuthIsInsecure -- True when DescribeGatewayAuthState is
-    reporting an exposure (no token at all, or an unresolved template
-    that will reject every client) rather than a healthy configured
-    token. Callers use it to pick the log LEVEL: an open gateway is
-    the single most consequential fact at startup and was previously
-    emitted at [info], indistinguishable from routine chatter. *)
-function GatewayAuthIsInsecure(const C: TConfig): Boolean;
+(*  GatewayAuthState -- which of the three auth postures the gateway is
+    actually in. Callers use it to pick the log LEVEL and the banner
+    wording; both unhealthy states deserve [warn], but they are OPPOSITE
+    failures and must not share a message:
+
+      gasRequired      a real token is set; clients must present it.
+      gasOpen          no token anywhere -- every route is reachable by
+                       any caller.
+      gasMisconfigured the token is still an unresolved ${VAR} template.
+                       GetEffectiveGatewayToken returns that literal, so
+                       the middleware compares bearers against it and
+                       NOTHING matches -- the gateway rejects everyone
+                       with 401. Saying "open to any caller" here is
+                       precisely backwards, and a wrong security
+                       statement is worse than none. *)
+type
+  TGatewayAuthState = (gasRequired, gasOpen, gasMisconfigured);
+
+function GatewayAuthState(const C: TConfig): TGatewayAuthState;
 
 (*  ExpandEnvVarsInJSON -- raw-text ${VAR_NAME} substitution applied
     to the JSON config body BEFORE TConfig.FromJSON parses it.
@@ -2724,10 +2736,9 @@ begin
     Result := '<short>';
 end;
 
-function GatewayAuthIsInsecure(const C: TConfig): Boolean;
-(* Mirrors DescribeGatewayAuthState's two failure branches: no token
-   anywhere, or a token still holding an unresolved env-var template.
-   Kept next to it so the two cannot drift apart. *)
+function GatewayAuthState(const C: TConfig): TGatewayAuthState;
+(* Mirrors DescribeGatewayAuthState's branches exactly, and lives next
+   to it so the two cannot drift apart. *)
 var
   Tok: string;
 begin
@@ -2735,7 +2746,12 @@ begin
     Tok := GEnvGatewayToken
   else
     Tok := C.Gateway.Token;
-  Result := (Tok = '') or LooksLikeUnresolvedTemplate(Tok);
+  if Tok = '' then
+    Result := gasOpen
+  else if LooksLikeUnresolvedTemplate(Tok) then
+    Result := gasMisconfigured
+  else
+    Result := gasRequired;
 end;
 
 function DescribeGatewayAuthState(const C: TConfig): string;

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1358,7 +1358,7 @@ begin
     { Level follows the state. An open or misconfigured gateway is the
       most consequential line of the whole startup, and at [info] it sat
       between two subsystem notices where it read as routine. }
-    if GatewayAuthIsInsecure(FCfg) then
+    if GatewayAuthState(FCfg) <> gasRequired then
       LogWarn('%s', [DescribeGatewayAuthState(FCfg)])
     else
       LogInfo('%s', [DescribeGatewayAuthState(FCfg)]);

--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -1009,7 +1009,7 @@ begin
     concurrently. No-op when disabled. }
   CC.Enabled   := FCfg.CheckpointsEnabled;
   CC.SessionId := CheckpointSessionId('');
-  CC.Root      := JoinPath(GetHome, ActiveWorkspaceName + '/checkpoints');
+  CC.Root      := JoinPath(JoinPath(GetHome, ActiveWorkspaceName), 'checkpoints');
   CC.KeepLast  := FCfg.CheckpointsKeepLast;
   InitCheckpoints(CC);
   { Phase 4c: best-effort load the local embedder so distilled-fact dedup
@@ -1354,7 +1354,15 @@ begin
      Cfg.Gateway.Token, and the gateway will reject every client
      bearer until the env var is renamed. *)
   if not FMCPOnly then
-    LogInfo('%s', [DescribeGatewayAuthState(FCfg)]);
+  begin
+    { Level follows the state. An open or misconfigured gateway is the
+      most consequential line of the whole startup, and at [info] it sat
+      between two subsystem notices where it read as routine. }
+    if GatewayAuthIsInsecure(FCfg) then
+      LogWarn('%s', [DescribeGatewayAuthState(FCfg)])
+    else
+      LogInfo('%s', [DescribeGatewayAuthState(FCfg)]);
+  end;
 end;
 
 procedure TGatewayServer.Stop;
@@ -4652,7 +4660,7 @@ var
 begin
   CC.Enabled   := FCfg.CheckpointsEnabled;
   CC.SessionId := CheckpointSessionId(ReqSession);
-  CC.Root      := JoinPath(GetHome, ActiveWorkspaceName + '/checkpoints');
+  CC.Root      := JoinPath(JoinPath(GetHome, ActiveWorkspaceName), 'checkpoints');
   CC.KeepLast  := FCfg.CheckpointsKeepLast;
   InitCheckpoints(CC);
 end;

--- a/src/pkg/search/PasClaw.Search.Factory.pas
+++ b/src/pkg/search/PasClaw.Search.Factory.pas
@@ -201,12 +201,16 @@ procedure LogSkipOnceImpl;
 begin
   if GLogged then Exit;
   GLogged := True;
-  LogInfo('web_search disabled: no real provider configured. ' +
-          'Set $PASCLAW_BRAVE_API_KEY / $PASCLAW_TAVILY_API_KEY / ' +
-          '$PASCLAW_PERPLEXITY_API_KEY / $PASCLAW_GEMINI_API_KEY, ' +
-          'or set web_search.provider = "searxng" + base_url in config.json. ' +
-          '(DDG scrape fallback is disabled -- its bot detection refuses non-browser ' +
-          'requests at the TLS-fingerprint level.)', []);
+  { Headline states the fact; the remedy detail is one level down. The
+    single-paragraph form ran to five lines of env-var names at startup,
+    which buried every line around it. }
+  LogInfo('web_search disabled: no provider configured ' +
+          '(set a key, or web_search.provider in config.json)', []);
+  LogDebug('web_search: accepted keys are $PASCLAW_BRAVE_API_KEY / ' +
+           '$PASCLAW_TAVILY_API_KEY / $PASCLAW_PERPLEXITY_API_KEY / ' +
+           '$PASCLAW_GEMINI_API_KEY; or set web_search.provider = "searxng" ' +
+           'plus base_url. The DDG scrape fallback stays off -- its bot ' +
+           'detection refuses non-browser requests at the TLS-fingerprint level.');
 end;
 
 function HasConfiguredWebSearchProvider(const Cfg: TConfig): Boolean;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -1183,7 +1183,7 @@ begin
   if FSession = nil then Exit;
   CC.Enabled   := CheckpointsEnabled;
   CC.SessionId := FSession.Meta.Id;
-  CC.Root      := JoinPath(GetHome, ActiveWorkspaceName + '/checkpoints');
+  CC.Root      := JoinPath(JoinPath(GetHome, ActiveWorkspaceName), 'checkpoints');
   CC.KeepLast  := CheckpointsKeepLast;
   InitCheckpoints(CC);
 end;
@@ -3081,7 +3081,7 @@ begin
     "checkpoints not enabled". Codex P2 on PR #226. }
   CC.Enabled   := CheckpointsEnabled;
   CC.SessionId := 'fpc-tui-session';
-  CC.Root      := JoinPath(GetHome, ActiveWorkspaceName + '/checkpoints');
+  CC.Root      := JoinPath(JoinPath(GetHome, ActiveWorkspaceName), 'checkpoints');
   CC.KeepLast  := CheckpointsKeepLast;
   InitCheckpoints(CC);
 


### PR DESCRIPTION
A gateway boot printed `config: profile "stock" applied` **four times** and `otel: disabled` twice, then buried the one line that matters — an open, unauthenticated gateway — at `[info]` between two subsystem notices.

## The duplication was real work, not just noise

`LoadConfig` runs from several independent subsystems during one boot (sandbox repoint, tool registry, KB index), each re-resolving the same profile. The apply line now fires only when the resolved profile or its layer count actually changes, so a genuine mid-run switch is still reported — `test-config-profile` still shows the line when the profile changes.

## The security state now picks its own log level

New `GatewayAuthIsInsecure` sits next to `DescribeGatewayAuthState` so the two cannot drift apart, and an open or misconfigured gateway logs at `[warn]`. In the banner it gets its own block in yellow, phrased as what is currently true rather than as a flag reference:

```
  Unauthenticated -- every /v1/* and /mcp route is open to any caller.
  Set gateway.token in config.json or $PASCLAW_GATEWAY_TOKEN to require a bearer.
```

## Banner regrouped by descending consequence

Identity and version → endpoints → exposure → credentials → how to call it, replacing a flat list of eight `key: value` lines. **The version is on screen now, which it never was.**

```
  PasClaw v0.1.3-362-gb77022d  ready

  API  http://127.0.0.1:8199/v1   OpenAI-compatible
  MCP  http://127.0.0.1:8199/mcp   on the main port
  Model claude-opus-4-7   max 25 iteration(s) per turn
```

## Also

`web_search`'s five-line env-var paragraph is now a one-line headline with the key names moved to `[debug]` — it was long enough to bury its neighbours.

Mixed path separators fixed: checkpoint roots built as `ActiveWorkspaceName + '/checkpoints'` rendered `C:\Users\...\workspace/checkpoints` on Windows. Five sites now join through `JoinPath` twice.

## Verification

Ran `serve` and read both streams separately: banner on stdout, logs on stderr, logo intact. (An earlier apparent interleaving was an artifact of merging the streams with `2>&1`, not a real race.)

Suites: `gateway-token`, `config-secret-merge`, `config-profile`, `config-env-subst`, `println-helper`, `doctor` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_