### PR TITLE
Mid-turn steering was streaming-only, so a steer hit the NEXT turn instead of the running one

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -5750,6 +5750,11 @@ begin
     omits "mode", so OpenAI-compatible clients that don't know about
     plan keep working unchanged. }
   LoopCfg.Mode          := ParseModeFromBody(Body);
+  { Mid-turn steering, same as /v1/chat/completions. This endpoint never
+    set it, so a /v1/steer POST aimed at a running /v1/chat turn was
+    accepted, ignored by that turn, and then drained into whatever turn
+    ran next. Empty session => steering disabled (no-op). }
+  LoopCfg.SteeringKey   := ReqSessionId(ARequest);
   LoopCfg.Fallbacks     := FB;
   LoopCfg.FallbackModels := FBModels;
   LoopCfg.Options       := DefaultChatOptions;
@@ -6975,6 +6980,23 @@ begin
 
     CompId := GenChatCompletionId;
 
+    (* Mid-turn steering: key the loop's steering drain to THIS session
+       (raw X-PasClaw-Session) so a /v1/steer POST folds into the RUNNING
+       turn. Empty session => steering disabled (no-op).
+
+       Set ABOVE the stream/non-stream split, deliberately. This lived
+       inside the WantsStream arm, so `stream:false` requests ran with an
+       empty SteeringKey and never drained. The failure that shape
+       produces is worse than "steering does not work": PushSteering
+       still queues the message and answers {"ok":true,"pending":1}, so
+       the caller is told it landed. The running turn ignores it, the
+       entry survives on disk, and the NEXT turn -- a different question
+       -- drains it and injects "[user steering received mid-turn]" into
+       its system prompt. Verified end to end through the relay: a steer
+       sent during a stream:false turn was absent from that turn and
+       appeared in the first request of the following, unrelated one. *)
+    LoopCfg.SteeringKey := ReqSession;
+
     if WantsStream then
     begin
       { Dedicated guard for all streamed execution once headers are emitted.
@@ -7002,10 +7024,6 @@ begin
       Streamer := TSSEStreamer.Create(AContext, CompId, ReqModel, FDebugIO);
       LoopCfg.OnToolCall   := Streamer.NoteToolCall;
       LoopCfg.OnToolResult := Streamer.NoteToolResult;
-      { B -- mid-turn steering: key the loop's steering drain to THIS session
-        (raw X-PasClaw-Session) so a /v1/steer POST from the web UI folds into
-        the running turn. Empty session => steering disabled (no-op). }
-      LoopCfg.SteeringKey := ReqSession;
       { A -- cancel-on-disconnect: abort the loop + release the session turn
         lock when the SSE client goes away, instead of running to completion
         invisibly. BeforeTurn fires at each iteration top, so this aborts before


### PR DESCRIPTION
Your report was right, and it's in PasClaw rather than the web UI client.

`SteeringKey` was assigned **inside the `if WantsStream then` arm** of `HandleChatCompletions`, and `HandleChat` (`/v1/chat`) never assigned it at all. So any non-streaming turn ran with an empty `SteeringKey` and never drained the steering queue.

## Why it reads as "the harness stops working right"

The shape of the failure is worse than *"steering doesn't work"*:

- `PushSteering` queues the message **regardless** and answers `{"ok":true,"pending":1}` — so the caller is told it landed.
- The running turn ignores it.
- The entry **survives on disk**.
- The **next** turn — a different question — drains it and folds `[user steering received mid-turn]` into its system prompt.

So a mid-conversation course-correction silently does nothing to the turn you aimed it at, and then hijacks your next one.

## Reproduced end to end in the relay

The relay can hold a turn open at a chosen iteration, which makes this exactly observable:

1. `stream:false` turn opened and held mid-loop
2. `POST /v1/steer` `"STOP-AND-SAY-BANANA"` → `{"ok":true,"pending":1}`
3. advanced the loop — the running turn's request did **not** contain it
4. turn ended; the entry was **still on disk**
5. started an unrelated turn (*"what is the capital of France?"*) → `[user steering received mid-turn] - STOP-AND-SAY-BANANA` appeared in the system prompt of **that turn's first request**

## Fix

Hoist the assignment above the stream/non-stream split in `HandleChatCompletions`, and add it to `HandleChat`. Both endpoints now key the drain to the request's session for every request shape.

**Verified after, same procedure:** a steer sent during a `stream:false` turn reaches *that* turn (present in its system prompt at the next iteration), the queue is empty afterwards, and a steer sent during a `/v1/chat` turn reaches that turn too.

## Scope

The CLI was never affected — `Cmd.Agent` and the TUI set `SteeringKey` unconditionally from `Session.Meta.Id`. This was gateway-only, which matches you seeing it in the web UI.

Full suite: **340 assertions, 0 failures.**

## Not covered

I did not test the `/v1/responses` endpoint or the channel surfaces (Telegram/Slack), which pass their own steering keys. Only the two OpenAI-compatible chat endpoints were examined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_