### PR TITLE
/v1/responses had the same steering gap that #571 fixed for the chat endpoints

### DIFF
--- a/src/pkg/gateway/PasClaw.Gateway.Server.pas
+++ b/src/pkg/gateway/PasClaw.Gateway.Server.pas
@@ -8824,6 +8824,12 @@ begin
       LoopCfg.MaxIterations := FMaxIter;
       LoopCfg.Parallel := True;
       LoopCfg.Mode          := ParseModeFromBody(Body);  { PR #290 }
+      { Mid-turn steering, same as /v1/chat and /v1/chat/completions. This
+        endpoint runs a session-keyed loop (RunCheckpointedLoop with
+        ReqSessionId) but never set the key, so a /v1/steer aimed at a
+        running /v1/responses turn was accepted, ignored by that turn, and
+        left on disk for whichever turn drained next. }
+      LoopCfg.SteeringKey   := ReqSessionId(ARequest);
       LoopCfg.Fallbacks     := FB;
       LoopCfg.FallbackModels := FBModels;
       LoopCfg.Options       := DefaultChatOptions;


### PR DESCRIPTION
Follow-up to #571. That PR merged with only its **first** commit — the `/v1/responses` fix landed on the branch afterwards and never reached main, so this is a fresh branch off current main carrying it.

Confirmed against main: only two of the three session-keyed handlers set the key.

```
$ git show origin/main:...Gateway.Server.pas | grep -n 'SteeringKey :='
5757:  LoopCfg.SteeringKey   := ReqSessionId(ARequest);   HandleChat
7098:    LoopCfg.SteeringKey := ReqSession;               HandleChatCompletions
                                                          HandleResponses -- missing
```

## The gap

`/v1/responses` runs a session-keyed loop (`RunCheckpointedLoop` with `ReqSessionId`) but never set `SteeringKey`, so it had the identical failure #571 describes: a steer aimed at a running `/v1/responses` turn is accepted with `{"ok":true,"pending":1}`, **ignored by that turn**, and left on disk for whichever turn drains next.

**Verified in the relay on the current merged base** — not carried over from the earlier run: steer sent mid-turn, present in the running turn's system prompt at the next iteration, queue empty afterwards.

With this, every session-keyed loop in the gateway sets the key: `HandleChat`, `HandleChatCompletions`, `HandleResponses`.

## The rest of the audit (unchanged from the commit message)

Every production tool-loop invocation was checked, not just the endpoints originally examined.

- **`RunDesktopTurn`** — not a gap. Takes no session at all (`SystemPrompt`/`Prompt` only), so there is no key to steer with and no queue to leak from.
- **The seven channels** (Telegram, Discord, Email, IRC, LINE, Matrix, WhatsApp) — not the same bug. None reference steering, which the Steering unit header already documents as intended: channels get their own key *"when they wire concurrent polling (currently CLI-only)"*. They poll serially — the `TThread` is the poller, not a per-message worker — so a mid-turn message cannot reach a running channel loop; it waits at the transport. And since nothing drains a channel key, there is no leak vector. Wiring them is a feature, not a fix.
- **Heartbeat, Subagent, SubagentBg** — not applicable. Background and child loops; a subagent draining its parent's steering queue would be a bug in the other direction.

## Residual, recorded not fixed

`/v1/steer` accepts an arbitrary session string and queues unconditionally, so a steer for a session that never runs a turn sits on disk indefinitely. Unbounded but harmless, and separate from the reported symptom.

Full suite: **340 assertions, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_