### PR TITLE
Studio a11y: TListBoxItem.ListBox is protected, so reach it the declared way

### DIFF
--- a/studio/PasclawAccessibility.pas
+++ b/studio/PasclawAccessibility.pas
@@ -71,7 +71,6 @@ type
     function VisibleChildCount: Integer;
     function SelfRoleId: Integer;
     function SelfName: string;
-    function SelfValue: string;
     function SelfState: Integer;
     { varChild is 0 for "this object" and 1..n for a child handled without
       its own IAccessible. Resolve once, here, so every method agrees. }
@@ -123,6 +122,27 @@ type
 
 var
   GHooks: TDictionary<HWND, THookRec>;
+
+type
+  (* TListBoxItem.ListBox is PROTECTED in FMX, so the item cannot name its
+     owner through public API. This is the standard Delphi access idiom: a
+     local descendant declared purely as a cast target, which lifts the
+     member into scope without touching FMX or guessing at the visual tree.
+
+     The alternative -- walking Parent until a TCustomListBox turns up --
+     was rejected because it depends on FMX's internal nesting (content
+     wrappers, virtualised item hosts) staying as it is today, and the
+     protected property already IS that lookup, maintained upstream. *)
+  TListBoxItemAccess = class(TListBoxItem);
+
+{ Owning list box, or nil when the item is not parented yet. Both call
+  sites need the same thing, and one helper keeps the cast in exactly one
+  place rather than four. }
+function OwningListBox(Item: TListBoxItem): TCustomListBox;
+begin
+  if Item = nil then Exit(nil);
+  Result := TListBoxItemAccess(Item).ListBox;
+end;
 
 { ---------------- control -> accessible facts ---------------- }
 
@@ -300,7 +320,6 @@ begin
 end;
 
 function TFmxAccessible.SelfRoleId: Integer; begin Result := RoleOf(FControl); end;
-function TFmxAccessible.SelfValue: string;   begin Result := ValueOf(FControl); end;
 function TFmxAccessible.SelfState: Integer;  begin Result := StateOf(FControl); end;
 
 function TFmxAccessible.SelfName: string;
@@ -540,6 +559,7 @@ function TFmxAccessible.accSelect(flagsSelect: Integer;
   varChild: OleVariant): HResult;
 var
   C: TControl;
+  LB: TCustomListBox;
 begin
   if not Resolve(varChild, C) then Exit(E_INVALIDARG);
   if C = nil then Exit(S_FALSE);
@@ -551,8 +571,9 @@ begin
   begin
     if C is TListBoxItem then
     begin
-      if TListBoxItem(C).ListBox <> nil then
-        TListBoxItem(C).ListBox.ItemIndex := TListBoxItem(C).Index
+      LB := OwningListBox(TListBoxItem(C));
+      if LB <> nil then
+        LB.ItemIndex := TListBoxItem(C).Index
       else
         TListBoxItem(C).IsSelected := True;
       Result := S_OK;
@@ -636,6 +657,7 @@ end;
 function TFmxAccessible.accDoDefaultAction(varChild: OleVariant): HResult;
 var
   C: TControl;
+  LB: TCustomListBox;
 begin
   if not Resolve(varChild, C) then Exit(E_INVALIDARG);
   if C is TButton then
@@ -662,8 +684,9 @@ begin
     -- then run the item's own OnClick if it has one. (Codex P1 on #557.) }
   if C is TListBoxItem then
   begin
-    if TListBoxItem(C).ListBox <> nil then
-      TListBoxItem(C).ListBox.ItemIndex := TListBoxItem(C).Index
+    LB := OwningListBox(TListBoxItem(C));
+    if LB <> nil then
+      LB.ItemIndex := TListBoxItem(C).Index
     else
       TListBoxItem(C).IsSelected := True;
     if Assigned(TListBoxItem(C).OnClick) then TListBoxItem(C).OnClick(C);


### PR DESCRIPTION
`dcc64` rejected four accesses to `TListBoxItem.ListBox` in the MSAA layer, taking `MasterDetail.pas` down with it:

```
E2362 Cannot access protected symbol TListBoxItem.ListBox   (554, 555, 665, 666)
E2015 Operator not applicable to this operand type          (cascade where it was dereferenced)
F2063 Could not compile used unit 'PasclawAccessibility.pas'
```

## The fix

The property is **protected** in FMX, so an item cannot name its owning list box through public API. Used the standard Delphi access idiom — a local descendant declared purely as a cast target — wrapped in a single `OwningListBox` helper so the cast lives in one place rather than at four call sites.

```pascal
type
  TListBoxItemAccess = class(TListBoxItem);

function OwningListBox(Item: TListBoxItem): TCustomListBox;
begin
  if Item = nil then Exit(nil);
  Result := TListBoxItemAccess(Item).ListBox;
end;
```

**Rejected the alternative** of walking `Parent` until a `TCustomListBox` turns up. That depends on FMX's internal nesting — content wrappers, virtualised item hosts — staying as it is today, whereas the protected property already *is* that lookup and is maintained upstream. The idiom reaches the maintained implementation rather than reimplementing it against assumptions I can't compile-check here.

Both call sites now take the result into a local instead of calling the helper twice (once to nil-test, once to dereference).

## The hint was worth checking, not just silencing

Also removed the dead `SelfValue` (`H2219`) — but I checked before deleting rather than assuming it was noise. It could have been an **unwired accessibility path**, which would have meant screen readers getting no value for edits and spin boxes. It isn't: `Get_accValue` already calls `ValueOf(C)` directly, so `SelfValue` was a redundant second spelling of the same thing. No behaviour change.

## Verification, and its limit

- `lint-studio` passes.
- The FPC build is untouched — `studio/` is Delphi-only.
- **Not compile-tested against `dcc64`** — no Delphi in this container. Same caveat as the other Windows/Delphi fixes this week: the idiom is standard and the visibility error names exactly what it solves, but your next `dcc64` run is the real check.

## Not addressed

Nothing else in the reported output. The only other item was the `H2219` hint, handled above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_