### PR TITLE
Studio: fix the access violation on exit

### DIFF
--- a/studio/MasterDetail.pas
+++ b/studio/MasterDetail.pas
@@ -11,7 +11,7 @@ uses
   FMX.Platform, FMX.Graphics, FMX.Dialogs, FMX.StdCtrls, FMX.Layouts, FMX.ListBox,
   FMX.Memo, FMX.Edit, FMX.TabControl, FMX.Controls.Presentation,
   FMX.ScrollBox, FMX.MultiView, FMX.Objects,
-  PasclawAccessibility;
+  PasclawAccessibility, PasclawAccessibilityMac, PasclawAccessibilityLinux;
 
 type
   TChatTurn = record
@@ -1631,8 +1631,15 @@ end;
 
 destructor TMasterDetailForm.Destroy;
 begin
-  { Drop the window subclass before the handle goes away. }
+  { Drop the accessibility hooks before the handle goes away. All three
+    are called because PasclawStudio.dpr installs all three; each is a
+    no-op on the platforms it does not serve. The Mac and Linux halves
+    were previously installed and never uninstalled -- on macOS that left
+    the contentView holding accessibility children whose Delphi side was
+    about to be freed. }
   UninstallAccessibility(Self);
+  UninstallMacAccessibility(Self);
+  UninstallLinuxAccessibility(Self);
   if FRelayWorkerTimer <> nil then
     FRelayWorkerTimer.Enabled := False;
   if FRelayWorkerProcessHandle <> 0 then

--- a/studio/PasclawAccessibility.pas
+++ b/studio/PasclawAccessibility.pas
@@ -715,6 +715,11 @@ function AccWndProc(Wnd: HWND; Msg: UINT; wParam: WPARAM; lParam: LPARAM): LRESU
 var
   Rec: THookRec;
 begin
+  { GHooks is nil once this unit has finalized. A message can still reach a
+    window we subclassed after that point, so check before dereferencing --
+    see the finalization block for why the teardown order allows it. }
+  if GHooks = nil then
+    Exit(DefWindowProc(Wnd, Msg, wParam, lParam));
   if not GHooks.TryGetValue(Wnd, Rec) then
     Exit(DefWindowProc(Wnd, Msg, wParam, lParam));
 
@@ -735,7 +740,7 @@ var
   Wnd: HWND;
   Rec: THookRec;
 begin
-  if Form = nil then Exit;
+  if (Form = nil) or (GHooks = nil) then Exit;
   Wnd := FormToHWND(Form);
   if Wnd = 0 then Exit;
   if GHooks.ContainsKey(Wnd) then Exit;   { idempotent }
@@ -753,7 +758,12 @@ var
   Wnd: HWND;
   Rec: THookRec;
 begin
-  if Form = nil then Exit;
+  { GHooks nil means this unit already finalized and the hook it held was
+    restored there. That is the normal path on shutdown, not an error: the
+    form's destructor calls us AFTER this unit is gone. Without this guard
+    the call dereferences a freed TDictionary -- an access violation on
+    every clean exit. }
+  if (Form = nil) or (GHooks = nil) then Exit;
   Wnd := FormToHWND(Form);
   if Wnd = 0 then Exit;
   if not GHooks.TryGetValue(Wnd, Rec) then Exit;
@@ -761,11 +771,45 @@ begin
   GHooks.Remove(Wnd);
 end;
 
+procedure ShutdownAccessibility;
+{ Body of the finalization below -- a procedure because initialization and
+  finalization sections cannot declare locals, and the restore loop needs
+  one. See the comment at the call site for the ordering this exists for. }
+var
+  Rec: THookRec;
+begin
+  if GHooks = nil then Exit;
+  for Rec in GHooks.Values do
+    if Rec.Wnd <> 0 then
+      SetWindowLongPtr(Rec.Wnd, GWL_WNDPROC, NativeInt(Rec.OldProc));
+  FreeAndNil(GHooks);
+end;
+
 initialization
   GHooks := TDictionary<HWND, THookRec>.Create;
 
 finalization
-  GHooks.Free;
+  (* Teardown order, and why this block has real work to do.
+
+     Units finalize in reverse initialization order. PasclawStudio.dpr
+     lists FMX.Forms before this unit, so FMX.Forms initializes first and
+     therefore finalizes LAST -- and it is FMX.Forms' finalization that
+     destroys Application, which frees MasterDetailForm, whose destructor
+     calls UninstallAccessibility. So the form is torn down strictly after
+     this point, and at this moment its window can still be subclassed and
+     its hook still in GHooks.
+
+     Two consequences, both handled here:
+
+       1. Any window still pointing at AccWndProc must be restored now.
+          Leaving our proc installed on a live window would fault on the
+          next message once this module's code is gone.
+
+       2. GHooks must be nil, not merely freed. The form destructor runs
+          later and calls UninstallAccessibility unconditionally; a freed
+          but non-nil pointer turns that into an access violation on every
+          clean exit. FreeAndNil plus the guards above make it a no-op. *)
+  ShutdownAccessibility;
 
 {$ELSE}
 

--- a/studio/PasclawAccessibilityLinux.pas
+++ b/studio/PasclawAccessibilityLinux.pas
@@ -422,8 +422,25 @@ initialization
   GObjects := TDictionary<string, TControl>.Create;
 
 finalization
-  { FreeAndNil, not Free -- the form destructor calls
-    UninstallLinuxAccessibility after this point. }
+  (* Mirror Uninstall's teardown here, for the same reason the Windows and
+     macOS halves do: this unit finalizes while the form is still alive, so
+     the form destructor's later UninstallLinuxAccessibility hits the
+     GObjects = nil guard and returns without doing any of it.
+
+     Lower stakes than the other two -- nothing registers an incoming D-Bus
+     handler, so there is no callback left pointing at freed state, and this
+     is a leak-and-ordering fix rather than a demonstrated fault. But
+     dropping the connection reference BEFORE dlclose is the right order:
+     unreffing after the library is unloaded is not possible at all.
+
+     FreeAndNil rather than Free for the later Uninstall call: nil makes it
+     a no-op instead of a fault. *)
+  if (GConn <> nil) and Assigned(dbus_connection_unref) then
+  begin
+    dbus_connection_unref(GConn);
+    GConn := nil;
+  end;
+  GForm := nil;
   FreeAndNil(GObjects);
   if GLib <> nil then dlclose(GLib);
 

--- a/studio/PasclawAccessibilityLinux.pas
+++ b/studio/PasclawAccessibilityLinux.pas
@@ -405,7 +405,10 @@ end;
 
 procedure UninstallLinuxAccessibility(Form: TCommonCustomForm);
 begin
-  if (Form = nil) or (GForm <> Form) then Exit;
+  { GObjects nil means this unit already finalized; the form destructor runs
+    after that and calls us unconditionally. Same guard as the other two
+    halves. }
+  if (Form = nil) or (GObjects = nil) or (GForm <> Form) then Exit;
   GObjects.Clear;
   if (GConn <> nil) and Assigned(dbus_connection_unref) then
   begin
@@ -419,7 +422,9 @@ initialization
   GObjects := TDictionary<string, TControl>.Create;
 
 finalization
-  GObjects.Free;
+  { FreeAndNil, not Free -- the form destructor calls
+    UninstallLinuxAccessibility after this point. }
+  FreeAndNil(GObjects);
   if GLib <> nil then dlclose(GLib);
 
 {$ELSE}

--- a/studio/PasclawAccessibilityMac.pas
+++ b/studio/PasclawAccessibilityMac.pas
@@ -446,6 +446,7 @@ var
   Kids: NSMutableArray;
 begin
   if Form = nil then Exit;
+  if GRoots = nil then Exit;
   if GRoots.ContainsKey(Form) then Exit;   { idempotent, as on Windows }
 
   Win := WindowHandleToPlatform(Form.Handle).Wnd;
@@ -472,7 +473,11 @@ var
   Win: NSWindow;
   View: NSView;
 begin
-  if Form = nil then Exit;
+  { GRoots nil means this unit already finalized. The form's destructor
+    runs later than that -- FMX.Forms initializes before this unit, so it
+    finalizes after -- and it calls us unconditionally. Guard, or that call
+    dereferences a freed dictionary. Same reasoning as the Windows half. }
+  if (Form = nil) or (GRoots = nil) then Exit;
   if not GRoots.TryGetValue(Form, Root) then Exit;
   NSAccessibilityPostNotification(Root.GetObjectID,
     StrToNSStr(NSAccessibilityUIElementDestroyedNotification));
@@ -491,7 +496,12 @@ initialization
   GRoots := TObjectDictionary<TCommonCustomForm, TPasclawAXElement>.Create([doOwnsValues]);
 
 finalization
-  GRoots.Free;
+  { FreeAndNil, not Free: the form destructor calls UninstallMacAccessibility
+    after this point, and a freed-but-non-nil pointer would fault there.
+    doOwnsValues frees the elements; the contentView detach in Uninstall is
+    what keeps AppKit from holding a dangling child, so a form that skipped
+    Uninstall relies on the window being gone by now. }
+  FreeAndNil(GRoots);
 
 {$ELSE}
 

--- a/studio/PasclawAccessibilityMac.pas
+++ b/studio/PasclawAccessibilityMac.pas
@@ -467,41 +467,78 @@ begin
     StrToNSStr(NSAccessibilityCreatedNotification));
 end;
 
-procedure UninstallMacAccessibility(Form: TCommonCustomForm);
+(* Announce the element's removal and unhook it from the content view.
+
+   Both teardown paths must do this, which is why it is a procedure rather
+   than inline in Uninstall. AppKit RETAINS whatever setAccessibilityChildren
+   is given, so freeing the TPasclawAXElement without clearing the view
+   first leaves the view holding a child whose Delphi side is gone -- the
+   next accessibility query faults. Codex P2 on PR #583 caught the
+   finalization path doing exactly that. *)
+procedure DetachMacRoot(Form: TCommonCustomForm; Root: TPasclawAXElement);
 var
-  Root: TPasclawAXElement;
   Win: NSWindow;
   View: NSView;
 begin
-  { GRoots nil means this unit already finalized. The form's destructor
-    runs later than that -- FMX.Forms initializes before this unit, so it
-    finalizes after -- and it calls us unconditionally. Guard, or that call
-    dereferences a freed dictionary. Same reasoning as the Windows half. }
+  if Root <> nil then
+    NSAccessibilityPostNotification(Root.GetObjectID,
+      StrToNSStr(NSAccessibilityUIElementDestroyedNotification));
+  { Handle can be nil if the window was never realised, and
+    WindowHandleToPlatform(nil).Wnd would fault on the way to finding that
+    out. }
+  if (Form = nil) or (Form.Handle = nil) then Exit;
+  Win := WindowHandleToPlatform(Form.Handle).Wnd;
+  if Win = nil then Exit;
+  View := Win.contentView;
+  if View <> nil then View.setAccessibilityChildren(nil);
+end;
+
+procedure UninstallMacAccessibility(Form: TCommonCustomForm);
+var
+  Root: TPasclawAXElement;
+begin
+  { GRoots nil means this unit already finalized, which detached and freed
+    every root on the way out. The form's destructor runs later than that --
+    FMX.Forms initializes before this unit, so it finalizes after -- and it
+    calls us unconditionally. Guard, or that call dereferences a freed
+    dictionary. Same reasoning as the Windows half. }
   if (Form = nil) or (GRoots = nil) then Exit;
   if not GRoots.TryGetValue(Form, Root) then Exit;
-  NSAccessibilityPostNotification(Root.GetObjectID,
-    StrToNSStr(NSAccessibilityUIElementDestroyedNotification));
-  { Detach before freeing, or the view keeps a reference to an element whose
-    Delphi side is gone. }
-  Win := WindowHandleToPlatform(Form.Handle).Wnd;
-  if Win <> nil then
-  begin
-    View := Win.contentView;
-    if View <> nil then View.setAccessibilityChildren(nil);
-  end;
+  DetachMacRoot(Form, Root);
   GRoots.Remove(Form);   { owns the value; the dictionary frees it }
+end;
+
+procedure ShutdownMacAccessibility;
+{ Body of the finalization below -- a procedure because finalization
+  sections cannot declare locals. }
+var
+  Pair: TPair<TCommonCustomForm, TPasclawAXElement>;
+begin
+  if GRoots = nil then Exit;
+  for Pair in GRoots do
+    DetachMacRoot(Pair.Key, Pair.Value);
+  FreeAndNil(GRoots);
 end;
 
 initialization
   GRoots := TObjectDictionary<TCommonCustomForm, TPasclawAXElement>.Create([doOwnsValues]);
 
 finalization
-  { FreeAndNil, not Free: the form destructor calls UninstallMacAccessibility
-    after this point, and a freed-but-non-nil pointer would fault there.
-    doOwnsValues frees the elements; the contentView detach in Uninstall is
-    what keeps AppKit from holding a dangling child, so a form that skipped
-    Uninstall relies on the window being gone by now. }
-  FreeAndNil(GRoots);
+  (* Detach every root from its view BEFORE freeing, exactly as the Windows
+     half restores every window proc before freeing GHooks.
+
+     This unit finalizes while MasterDetailForm and its native contentView
+     are still alive -- FMX.Forms is a dependency of this one, so it
+     initializes earlier and finalizes later, and it is FMX.Forms'
+     finalization that destroys Application and with it the form. So
+     doOwnsValues freeing the TPasclawAXElement objects here would leave
+     AppKit holding retained accessibility children pointing at freed
+     memory, and the form destructor's later UninstallMacAccessibility
+     cannot clean up after us -- its GRoots = nil guard returns first.
+
+     FreeAndNil rather than Free for that same later call: nil makes it a
+     no-op instead of a fault. *)
+  ShutdownMacAccessibility;
 
 {$ELSE}
 


### PR DESCRIPTION
Studio AVs on every clean exit. The MSAA hook's global dictionary is freed while the form that reaches for it is still alive.

## Teardown order

Units finalize in reverse initialization order. `MasterDetail` uses `PasclawAccessibility`, so the accessibility unit initializes first and finalizes second. `FMX.Forms` is a dependency of both, initializes before either, and therefore finalizes **last** — and it is `FMX.Forms`' finalization that destroys `Application`, which frees `MasterDetailForm`.

```
1. PasclawAccessibility.finalization  ->  GHooks.Free
2. FMX.Forms.finalization  ->  Application.Destroy  ->  form freed
3. TMasterDetailForm.Destroy:1635  ->  UninstallAccessibility(Self)
4. UninstallAccessibility  ->  GHooks.TryGetValue on freed memory   <-- AV
```

Step 4 is the fault, and nothing about it is intermittent. The existing `Wnd = 0` guard does not short-circuit it: the native window handle is still valid in the destructor *body*, because it is the inherited destructor that releases it. So the dangling dictionary is reached every time.

## Fixes

- **`FreeAndNil`, not `Free`.** A freed-but-non-nil pointer is exactly what turns the late call into a fault; nil makes it a no-op.
- **Nil guards** in `AccWndProc`, `InstallAccessibility` and `UninstallAccessibility`, so reaching them after finalization is handled rather than undefined.
- **The finalization now restores every window still subclassed** before freeing. Leaving `AccWndProc` installed on a live window would fault on the next message once this module's code is gone.

Same `Free`-without-nil shape existed in the macOS and Linux halves and is fixed there too.

## Also: two backends were installed and never uninstalled

`PasclawStudio.dpr` installs all three accessibility backends, but the form destructor only called `UninstallAccessibility` — the Windows one. `UninstallMacAccessibility` and `UninstallLinuxAccessibility` were dead code, never invoked from anywhere.

All three are now called, matching the `.dpr`. On macOS this matters beyond symmetry: `GRoots` is a `TObjectDictionary` with `doOwnsValues`, so skipping the uninstall left the `contentView` holding accessibility children whose Delphi side was about to be freed.

## Verification — please read before merging

**I have not run this.** The container this was developed in has no Delphi toolchain, so the FMX app cannot be built or launched here.

- Root cause traced by reading the unit dependency graph and finalization order; the fix follows from it.
- `make lint-studio` passes — 0 findings across all four touched files. That is structural only: it does not compile FMX or execute anything.
- **The exit path needs one run on Windows to confirm.**

## If it still AVs after this

The next candidate is `TMasterDetailForm.Destroy` freeing `FSessionCache`, `FTurns`, `FQueuedPrompts` and the rest while `FRelayTimer` and `FStatsTimer` are still enabled — only `FRelayWorkerTimer` gets disabled there. Left alone deliberately: that is a hunch, not a traced cause, and changing shutdown code speculatively while one concrete cause is on the table would make the result harder to attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_