### PR TITLE
Read the desktop tool's near misses instead of refusing them

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1047,7 +1047,11 @@ So four shapes are read as what they plainly mean, rather than refused:
 | `{"actions":"[{\"do\":\"tile\"}]"}` | the parsed array |
 | `{"action":"build_app","title":…}` or `{"do":"tile"}` | one action, `action` renamed to `do` |
 
-Same trade the app manifest makes when it reads `type` as a synonym for `kind`: a request should not fail over a word when what was meant is unambiguous. The misspelt key is *renamed*, not duplicated, so nothing downstream sees both.
+Same trade the app manifest makes when it reads `type` as a synonym for `kind`: a request should not fail over a word when what was meant is unambiguous.
+
+The rename applies **wherever an action object can arrive** — inside the documented array, inside a singular object under `actions`, inside a stringified array, at the top level. `runShellActions` looks up `SHELL_ACTIONS[a.do]` and reads nothing else, so an action that reaches the feed still keyed `action` is published, reported to the model as *sent*, and then dropped by the screen as unknown. A success the caller never receives is worse than the refusal this coercion replaced, so the misspelt key is renamed — not merely tolerated, and not duplicated alongside `do`.
+
+One exception, deliberately: if an item in an array cannot be read at all — not an object, or carrying no action name — the array is passed through exactly as it arrived. That is a malformed request rather than a near miss, and the screen naming it beats quietly reshaping the array around it.
 
 A call that genuinely carries no action is still an error — coercion is for near misses, not for guessing. But the error now contains a **worked call** the model can copy, because that text is the whole of what it reads before its retry, and "missing required argument" is not something you can act on.
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1034,6 +1034,23 @@ So the server names one executor. Each SSE subscriber is assigned an id and told
 
 Oldest-subscriber is arbitrary but *stable*, and stability is the property that matters: every command in a session lands on the same screen rather than scattering builds across tabs. The consequence worth knowing is that asking in a second tab can have the app open in the first one.
 
+### The near misses are accepted
+
+`desktop` is the only one of four sibling tools that takes a plural `actions` **array**; `project`, `task` and `agent` all take a singular `action` **string**. That is a strong prior toward the wrong key and the wrong arity, and it cost a real turn: *"build a book comparison app where I can enter 4 amazon book urls"* produced `desktop()` with no arguments at all and an error where the app should have been.
+
+So four shapes are read as what they plainly mean, rather than refused:
+
+| What arrived | Read as |
+|---|---|
+| `{"actions":[{"do":"tile"}]}` | itself — the documented shape |
+| `{"actions":{"do":"tile"}}` | a one-item list |
+| `{"actions":"[{\"do\":\"tile\"}]"}` | the parsed array |
+| `{"action":"build_app","title":…}` or `{"do":"tile"}` | one action, `action` renamed to `do` |
+
+Same trade the app manifest makes when it reads `type` as a synonym for `kind`: a request should not fail over a word when what was meant is unambiguous. The misspelt key is *renamed*, not duplicated, so nothing downstream sees both.
+
+A call that genuinely carries no action is still an error — coercion is for near misses, not for guessing. But the error now contains a **worked call** the model can copy, because that text is the whole of what it reads before its retry, and "missing required argument" is not something you can act on.
+
 ## Steering a running turn
 
 While a turn runs, the composer's button reads **Stop** — and pressing it stops. The Enter key carries the third meaning: **Enter with text in the box steers the running turn** instead of killing it. "Also make the header blue", typed mid-build, used to stop the build it was amending. The note goes to `/v1/steer` with the conversation's session id, the running loop picks it up at its next iteration, and the transcript shows it arrow-marked (`↳ also make the header blue`). Enter on an empty box still stops, so the keyboard-only path to Stop survives.

--- a/src/pkg/projects/PasClaw.Projects.Tools.pas
+++ b/src/pkg/projects/PasClaw.Projects.Tools.pas
@@ -49,6 +49,12 @@ function Tool_Project(const ArgsJSON: string; out ErrMsg: string): string;
 function Tool_Task(const ArgsJSON: string; out ErrMsg: string): string;
 function Tool_Desktop(const ArgsJSON: string; out ErrMsg: string): string;
 
+(* Exposed for tests: what a `desktop` call is READ as, before anything
+   is published. Returns the actions array as JSON, or '' when the call
+   carried nothing usable. Publishing is the side effect; this is the
+   decision, and the decision is what is worth pinning. *)
+function DesktopActionsJSON(const ArgsJSON: string): string;
+
 implementation
 
 uses
@@ -360,6 +366,104 @@ end;
    on the feed -- a desktop may be open, closed, or three of them may be
    connected at once, and blocking an agent turn on a browser that might
    not be there would be a worse contract than "asked". *)
+(* Turn what the model ACTUALLY sent into an actions array.
+
+   The documented shape is {"actions":[{"do":...}]} and the shell prompt
+   spells it out, but three sibling tools -- project, task, agent -- all
+   take a singular "action" STRING, so a model reaching for this one has
+   a strong prior toward the wrong key and the wrong arity. Observed in
+   real use: "build me a book comparison app" produced desktop() with no
+   arguments at all, the turn spent on an error instead of an app.
+
+   So the near misses are accepted rather than refused. Same trade the
+   app manifest makes when it reads "type" as a synonym for "kind": a
+   request should not fail over a word when what was meant is
+   unambiguous. Anything genuinely ambiguous still errors -- and the
+   error now shows a correct call, because the model's next move is a
+   retry and it should have the shape in front of it.
+
+   Returns nil when nothing usable is there; caller frees the result. *)
+function CoerceDesktopActions(Obj: TJsonObject): TJsonArray;
+var
+  One: TJsonObject;
+  Raw: string;
+begin
+  Result := nil;
+  if Obj = nil then Exit;
+
+  { 1. The documented shape. }
+  Result := Obj.ChildArray('actions');
+  if (Result <> nil) and (Result.Count > 0) then Exit;
+  if Result <> nil then FreeAndNil(Result);
+
+  { 2. A single action object under "actions" rather than a list. }
+  One := Obj.ChildObject('actions');
+  if One <> nil then
+  try
+    if One.Has('do') or One.Has('action') then
+    begin
+      Result := TJsonArray.Create;
+      Result.AddRaw(One.ToJSON);
+      Exit;
+    end;
+  finally
+    One.Free;
+  end;
+
+  { 3. The array as a STRING -- models stringify JSON arguments often
+       enough that refusing it is pedantry. }
+  Raw := Trim(Obj.GetStr('actions', ''));
+  if (Raw <> '') and (Raw[1] = '[') then
+  begin
+    try
+      Result := TJsonArray.Parse(Raw);
+    except
+      Result := nil;
+    end;
+    if (Result <> nil) and (Result.Count > 0) then Exit;
+    if Result <> nil then FreeAndNil(Result);
+  end;
+
+  (* 4. The action at the TOP level, unwrapped -- {"do":"tile"} or, from
+        the sibling tools' habit, {"action":"build_app","title":...}.
+        "action" is read as "do" only here, where there is no actions
+        array to disagree with it. *)
+  if Obj.Has('do') or (Trim(Obj.GetStr('action', '')) <> '') then
+  begin
+    One := TJsonObject.Parse(Obj.ToJSON);
+    try
+      if not One.Has('do') then
+        One.PutStr('do', Trim(Obj.GetStr('action', '')));
+      One.Remove('action');
+      Result := TJsonArray.Create;
+      Result.AddRaw(One.ToJSON);
+    finally
+      One.Free;
+    end;
+  end;
+end;
+
+function DesktopActionsJSON(const ArgsJSON: string): string;
+var
+  Obj: TJsonObject;
+  Arr: TJsonArray;
+  Err: string;
+begin
+  Result := '';
+  if not ArgObj(ArgsJSON, Obj, Err) then Exit;
+  try
+    Arr := CoerceDesktopActions(Obj);
+    if Arr = nil then Exit;
+    try
+      if Arr.Count > 0 then Result := Arr.ToJSON;
+    finally
+      Arr.Free;
+    end;
+  finally
+    Obj.Free;
+  end;
+end;
+
 function Tool_Desktop(const ArgsJSON: string; out ErrMsg: string): string;
 var
   Obj: TJsonObject;
@@ -370,15 +474,25 @@ begin
   Result := '';
   if not ArgObj(ArgsJSON, Obj, ErrMsg) then Exit;
   try
-    Arr := Obj.ChildArray('actions');
+    Arr := CoerceDesktopActions(Obj);
     if (Arr = nil) or (Arr.Count = 0) then
     begin
-      ErrMsg := 'missing required argument: actions (a non-empty array of ' +
-                '{"do":...} objects)';
+      { A worked example, not just a complaint: this text is what the
+        model reads before its retry, and "here is the call" recovers a
+        turn that "missing required argument" spends. }
+      ErrMsg := 'missing required argument: actions. Send an array of ' +
+                '{"do":...} objects, e.g. ' +
+                '{"actions":[{"do":"build_app","title":"Book compare",' +
+                '"brief":"enter four Amazon book URLs and compare them"}]} ' +
+                'or {"actions":[{"do":"tile"}]}. Note the plural "actions" ' +
+                'and "do" -- this tool takes a LIST of actions, unlike the ' +
+                'project/task/agent tools which take a single "action".';
+      if Arr <> nil then Arr.Free;
       Exit;
     end;
     N := Arr.Count;
     Body := Arr.ToJSON;
+    Arr.Free;
   finally
     Obj.Free;
   end;

--- a/src/pkg/projects/PasClaw.Projects.Tools.pas
+++ b/src/pkg/projects/PasClaw.Projects.Tools.pas
@@ -383,27 +383,122 @@ end;
    retry and it should have the shape in front of it.
 
    Returns nil when nothing usable is there; caller frees the result. *)
+
+(* One action object as the desktop will actually dispatch it: the
+   sibling tools' "action" renamed to the "do" the client reads.
+
+   Renamed, not merely tolerated. runShellActions looks up
+   SHELL_ACTIONS[a.do] and nothing else, so an object still keyed
+   "action" would be published, reported to the model as sent, and then
+   rejected by the screen as an unknown action. A success the caller
+   never receives is worse than the refusal this coercion replaced.
+
+   '' when there is no action name to dispatch on. *)
+function NormalizedAction(Src: TJsonObject): string;
+var
+  One: TJsonObject;
+  Verb: string;
+begin
+  Result := '';
+  if Src = nil then Exit;
+  Verb := Trim(Src.GetStr('do', ''));
+  if Verb = '' then Verb := Trim(Src.GetStr('action', ''));
+  if Verb = '' then Exit;
+  One := TJsonObject.Parse(Src.ToJSON);
+  try
+    One.PutStr('do', Verb);
+    One.Remove('action');
+    Result := One.ToJSON;
+  finally
+    One.Free;
+  end;
+end;
+
+(* The same rename across a whole array, because a model that got the
+   arity right and the key wrong -- {"actions":[{"action":"tile"}]} --
+   fails in exactly the way above.
+
+   nil means "nothing to rename, use what arrived". The rebuild happens
+   only when every item is an object with a name to dispatch on: one
+   item we cannot read is a malformed request rather than a near miss,
+   and passing the original through so the screen names it is better
+   than quietly reshaping around it. Caller frees. *)
+function RenamedItems(Src: TJsonArray): TJsonArray;
+var
+  I: Integer;
+  Item: TJsonObject;
+  Need: Boolean;
+begin
+  Result := nil;
+  if (Src = nil) or (Src.Count = 0) then Exit;
+
+  Need := False;
+  for I := 0 to Src.Count - 1 do
+  begin
+    Item := Src.ItemObject(I);
+    try
+      if Item = nil then Exit;
+      if Trim(Item.GetStr('do', '')) = '' then
+      begin
+        if Trim(Item.GetStr('action', '')) = '' then Exit;
+        Need := True;
+      end;
+    finally
+      Item.Free;
+    end;
+  end;
+  if not Need then Exit;
+
+  Result := TJsonArray.Create;
+  for I := 0 to Src.Count - 1 do
+  begin
+    Item := Src.ItemObject(I);
+    try
+      Result.AddRaw(NormalizedAction(Item));
+    finally
+      Item.Free;
+    end;
+  end;
+end;
+
+(* Whatever we settled on, with the rename applied. Every path lands
+   here so no shape can reach the feed keyed the way the client cannot
+   read. *)
+function Dispatchable(var Arr: TJsonArray): TJsonArray;
+var
+  Fixed: TJsonArray;
+begin
+  Result := Arr;
+  Fixed := RenamedItems(Arr);
+  if Fixed <> nil then
+  begin
+    FreeAndNil(Arr);
+    Result := Fixed;
+  end;
+end;
+
 function CoerceDesktopActions(Obj: TJsonObject): TJsonArray;
 var
   One: TJsonObject;
-  Raw: string;
+  Raw, Norm: string;
 begin
   Result := nil;
   if Obj = nil then Exit;
 
   { 1. The documented shape. }
   Result := Obj.ChildArray('actions');
-  if (Result <> nil) and (Result.Count > 0) then Exit;
+  if (Result <> nil) and (Result.Count > 0) then Exit(Dispatchable(Result));
   if Result <> nil then FreeAndNil(Result);
 
   { 2. A single action object under "actions" rather than a list. }
   One := Obj.ChildObject('actions');
   if One <> nil then
   try
-    if One.Has('do') or One.Has('action') then
+    Norm := NormalizedAction(One);
+    if Norm <> '' then
     begin
       Result := TJsonArray.Create;
-      Result.AddRaw(One.ToJSON);
+      Result.AddRaw(Norm);
       Exit;
     end;
   finally
@@ -420,26 +515,19 @@ begin
     except
       Result := nil;
     end;
-    if (Result <> nil) and (Result.Count > 0) then Exit;
+    if (Result <> nil) and (Result.Count > 0) then Exit(Dispatchable(Result));
     if Result <> nil then FreeAndNil(Result);
   end;
 
   (* 4. The action at the TOP level, unwrapped -- {"do":"tile"} or, from
         the sibling tools' habit, {"action":"build_app","title":...}.
-        "action" is read as "do" only here, where there is no actions
-        array to disagree with it. *)
-  if Obj.Has('do') or (Trim(Obj.GetStr('action', '')) <> '') then
+        "action" is read as an action name only here and in 2, where
+        there is no actions array to disagree with it. *)
+  Norm := NormalizedAction(Obj);
+  if Norm <> '' then
   begin
-    One := TJsonObject.Parse(Obj.ToJSON);
-    try
-      if not One.Has('do') then
-        One.PutStr('do', Trim(Obj.GetStr('action', '')));
-      One.Remove('action');
-      Result := TJsonArray.Create;
-      Result.AddRaw(One.ToJSON);
-    finally
-      One.Free;
-    end;
+    Result := TJsonArray.Create;
+    Result.AddRaw(Norm);
   end;
 end;
 

--- a/src/tests/projects_tests.pas
+++ b/src/tests/projects_tests.pas
@@ -251,6 +251,37 @@ begin
   ExpectContains(DesktopActionsJSON('{"do":"tile"}'),
                  '"tile"', 'a bare top-level action is wrapped');
 
+  (* The two near misses COMBINED -- right arity, wrong key. The client
+     dispatches on SHELL_ACTIONS[a.do] and reads nothing else, so an
+     action that reaches the feed still keyed "action" is published,
+     reported to the model as sent, and then rejected by the screen. A
+     success the caller never receives is the worst of the three
+     outcomes, so the rename has to happen wherever an action object
+     can arrive -- not only at the top level. *)
+  ExpectContains(DesktopActionsJSON('{"actions":{"action":"build_app","title":"X"}}'),
+                 '"do"', 'a singular object under "actions" is renamed too');
+  ExpectTrue(Pos('"action"', DesktopActionsJSON(
+               '{"actions":{"action":"build_app","title":"X"}}')) = 0,
+             'and does not keep the key the client cannot read');
+  ExpectContains(DesktopActionsJSON('{"actions":[{"action":"tile"}]}'),
+                 '"do"', 'an item inside the documented array is renamed');
+  ExpectTrue(Pos('"action"', DesktopActionsJSON('{"actions":[{"action":"tile"}]}')) = 0,
+             'and that one loses the wrong key as well');
+  ExpectContains(DesktopActionsJSON('{"actions":"[{\"action\":\"tile\"}]"}'),
+                 '"do"', 'a stringified array is renamed on the way through');
+
+  { Every item keeps its own name; the rename is not a broadcast. }
+  Out_ := DesktopActionsJSON('{"actions":[{"do":"tile"},{"action":"refresh"}]}');
+  ExpectContains(Out_, 'tile', 'a mixed array keeps the item that was right');
+  ExpectContains(Out_, 'refresh', 'and renames only the one that was wrong');
+  ExpectTrue(Pos('"action"', Out_) = 0, 'with no stray key left behind');
+
+  (* An item we cannot read is a malformed request, not a near miss:
+     pass it through so the screen names it rather than reshaping the
+     array around it. *)
+  ExpectContains(DesktopActionsJSON('{"actions":[{"do":"tile"},{"note":"hi"}]}'),
+                 '"note"', 'an unreadable item is passed through untouched');
+
   { Nothing usable stays an error -- coercion is for near misses, not guesses. }
   ExpectStr(DesktopActionsJSON('{}'), '', 'an empty call reads as nothing');
   ExpectStr(DesktopActionsJSON('{"actions":[]}'), '', 'an empty array too');

--- a/src/tests/projects_tests.pas
+++ b/src/tests/projects_tests.pas
@@ -220,6 +220,54 @@ begin
   Out_ := Tool_Task('{"action":"job","project":"invoice-desk","id":"T0002"}', Err);
   ExpectTrue(Err <> '', 'reporting against a missing task is an error');
 
+  (* ------------------------------------------ what a `desktop` call reads as -- *)
+  (* The documented shape, and then the four near misses seen in real
+     use. `desktop` is the only one of four sibling tools taking a
+     plural "actions" ARRAY -- project, task and agent all take a
+     singular "action" STRING -- so the wrong key and the wrong arity
+     are the mistakes to expect, and refusing them spends a turn. *)
+  ExpectContains(DesktopActionsJSON('{"actions":[{"do":"tile"}]}'),
+                 '"tile"', 'the documented shape passes through');
+
+  ExpectContains(DesktopActionsJSON('{"actions":{"do":"tile"}}'),
+                 '"tile"', 'a single action object under "actions" is wrapped');
+  ExpectTrue(Pos('[', DesktopActionsJSON('{"actions":{"do":"tile"}}')) = 1,
+             'and it comes back as an array');
+
+  ExpectContains(DesktopActionsJSON('{"actions":"[{\"do\":\"tile\"}]"}'),
+                 '"tile"', 'a stringified array is parsed');
+
+  { The sibling tools' habit, at the top level. }
+  ExpectContains(DesktopActionsJSON(
+                   '{"action":"build_app","title":"Book compare",' +
+                   '"brief":"four Amazon URLs"}'),
+                 '"build_app"', 'a top-level singular "action" is read as "do"');
+  ExpectContains(DesktopActionsJSON(
+                   '{"action":"build_app","title":"Book compare"}'),
+                 'Book compare', 'and its siblings ride along');
+  ExpectTrue(Pos('"action"', DesktopActionsJSON('{"action":"tile"}')) = 0,
+             'the misspelt key is not passed on as well as "do"');
+
+  ExpectContains(DesktopActionsJSON('{"do":"tile"}'),
+                 '"tile"', 'a bare top-level action is wrapped');
+
+  { Nothing usable stays an error -- coercion is for near misses, not guesses. }
+  ExpectStr(DesktopActionsJSON('{}'), '', 'an empty call reads as nothing');
+  ExpectStr(DesktopActionsJSON('{"actions":[]}'), '', 'an empty array too');
+  ExpectStr(DesktopActionsJSON('{"project":"notes"}'), '',
+            'arguments with no action at all read as nothing');
+
+  (* And the refusal has to carry a call the model can copy: this text is
+     the whole of what it reads before its retry. The turn that prompted
+     this was spent on "missing required argument" and produced no app. *)
+  Out_ := Tool_Desktop('{}', Err);
+  ExpectTrue(Err <> '', 'an empty desktop call is still an error');
+  ExpectContains(Err, '{"actions":[{"do":"build_app"',
+                 'the error shows a correct call');
+  Out_ := Tool_Desktop('{"actions":[{"do":"tile"}]}', Err);
+  ExpectStr(Err, '', 'a good call is clean');
+  ExpectContains(Out_, '1 desktop action', 'and reports what it sent');
+
   { --------------------------------------------------- workspace isolation -- }
   { Projects belong to a workspace: switching desktops must switch boards. }
   CreateWorkspace('Home');


### PR DESCRIPTION
Typing *"build a book comparison app where I can enter 4 amazon book urls"* into Ask PasClaw produced

```
⏺ desktop()
  ⎿ ✗ missing required argument: actions (a non-empty array of {"do":...} objects)
```

A whole turn spent on an error where the app should have been.

## Why it happens

`desktop` is the only one of four sibling tools that takes a plural `actions` **array**. `project`, `task` and `agent` all take a singular `action` **string**. The schema does declare `"required":["actions"]` and the shell prompt spells the shape out, so the empty call is a model slip — but it is the slip this tool surface invites.

## What changed

Four near misses are now read as what they plainly mean rather than refused:

| What arrives | Read as |
|---|---|
| `{"actions":[{"do":"tile"}]}` | itself — the documented shape |
| `{"actions":{"do":"tile"}}` | a one-item list |
| `{"actions":"[{\"do\":\"tile\"}]"}` | the parsed array |
| `{"action":"build_app","title":…}` or `{"do":"tile"}` | one action, `action` renamed to `do` |

The misspelt key is *renamed*, not duplicated, so nothing downstream sees both.

This is the same trade the app manifest already makes when it reads `type` as a synonym for `kind`: a request should not fail over a word when what was meant is unambiguous.

A call that genuinely carries no action is **still an error** — coercion is for near misses, not for guessing. But the refusal now contains a worked call the model can copy, because that text is the whole of what it reads before its retry and "missing required argument" is not something you can act on.

## Verification

Against a live gateway with the relay standing in for the model, asserting on the **SSE frame the screen received** rather than on the tool's return string:

- **Pre-fix binary: 5/11.** All four near misses reproduce the reported error string verbatim.
- **Fixed binary: 11/11.** All four are delivered as commands; the empty call and the empty array are still refused, now with the worked example.
- **End to end in a real browser** (Playwright, Ask PasClaw, the reported sentence, model emitting the sibling-tool shape): the project is created and the app is written and served. Before the fix that call died at the error.

`projects_tests` gains 11 assertions over a new `DesktopActionsJSON` seam — the coercion decision, separated from the publish side effect. `make test` is clean.

## Not changed

The project slug is derived from the **brief**, not the title (`build_app` passes `a.brief || a.title` to `createAppFrom`), so this app lands at `app-where-i-can-enter-4` rather than `book-compare`. Pre-existing, and out of scope here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_