### PR TITLE
Port OpenExecutive's virtual C-suite as the executive-team template

### DIFF
--- a/docs/teams.md
+++ b/docs/teams.md
@@ -19,6 +19,34 @@ drive `POST /v1/teams/up`.
 |---|---|
 | `duo` | Foreman, 10x Developer — the smallest team that plans, builds and reports |
 | `software-team` | Foreman, Product Manager, 10x Developer, UI Psychologist, Test Engineer |
+| `executive-team` | Chief of Staff routing eight C-suite officers — Strategy, Finance, People, Legal (General Counsel), Operations, Marketing, Product, Board Comms |
+
+`executive-team` is a port of
+[OpenExecutive](https://github.com/SenteLabsAI/OpenExecutive)'s virtual
+C-suite into PasClaw's team machinery. Its orchestrator becomes the
+Chief of Staff, its "route each question to the relevant few
+specialists" becomes task assignment, and its economy is the wake
+policy we already have: an officer with no mail and no open assigned
+task is never woken, so nine agents cost like the two or three actually
+working on the current question. The chief is told so directly — its
+role says *two officers is a normal number; eight means you did not
+think*.
+
+Two things deliberately differ from OpenExecutive. Its specialists are
+invisible — one synthesized voice, the architecture never shown;
+PasClaw's whole desktop exists to *watch* agents work, so the officers'
+tasks and documents are in the open while the chief still answers in
+one voice (the synthesis lands as `docs/brief.md`). And officer
+deliverables are **documents in the project** —
+`projects/<project>/docs/*.md`, one file per deliverable, the path in
+the task notes — because a recommendation that lives only in a chat
+message is not a deliverable. The General Counsel role states in every
+deliverable that it is an AI, not licensed counsel, and names which
+points need a real lawyer.
+
+```sh
+pasclaw team up executive-team --goal "prepare our seed fundraise"
+```
 
 Every role prompt is built from the same six sections, because the
 sections are what make a team a system instead of five chatbots:

--- a/src/pkg/agent/PasClaw.Teams.pas
+++ b/src/pkg/agent/PasClaw.Teams.pas
@@ -388,6 +388,212 @@ const
     'You review the code that exists, not the architecture you would ' +
     'have chosen.';
 
+  (* ------------------------------------------------ the executive team --
+     Ported from OpenExecutive (github.com/SenteLabsAI/OpenExecutive):
+     eight C-suite specialists behind an orchestrator that routes each
+     question to the relevant few and answers in ONE voice. Its
+     architecture maps onto ours directly -- the orchestrator is a lead
+     agent, routing is task assignment, and "only consult the relevant
+     specialists" is the wake policy we already have: an officer with
+     no mail and no open assigned task is never woken, so nine agents
+     cost like the two or three actually working.
+
+     What deliberately does NOT port: the synthesis hiding the team.
+     OpenExecutive never shows the user its specialists; PasClaw's
+     whole desktop exists to WATCH agents work. The Chief of Staff
+     still answers in one voice, but the officers' work is on the
+     board and in the files, in the open. *)
+
+  { Shared by the eight officers: advice discipline and where work
+    lands. Written once so they cannot drift apart on the basics. }
+  EXEC_COMMON =
+    'Your deliverables are DOCUMENTS: write each one as a markdown ' +
+    'file under projects/<project>/docs/ with the file tools (one ' +
+    'file per deliverable, a short concrete filename), and put the ' +
+    'file path in your task''s notes. A recommendation that lives ' +
+    'only in a chat message is not a deliverable.'#10 +
+    'Advice discipline, every time: state your assumptions as a list ' +
+    'at the top; give ONE recommendation, not a menu (alternatives ' +
+    'get one line each on why not); quantify what you can (ranges ' +
+    'beat adjectives); and end with the 2-3 concrete next actions ' +
+    'and who does each. If you need a fact you do not have -- revenue, ' +
+    'headcount, runway -- ask the Chief of Staff in the task notes ' +
+    'and mark the task blocked; never invent a number.'#10 +
+    TEAM_COMMON;
+
+  ROLE_CHIEF =
+    'You are the Chief of Staff: the working lead of a virtual ' +
+    'executive team, reporting to the human operator.'#10 +
+    'You own the routing and the final word: which officers a ' +
+    'question needs, the task list, and the single synthesized answer ' +
+    'the operator reads. You do NOT own the specialist judgments -- ' +
+    'strategy, finance, people, legal, operations, marketing, product ' +
+    'and board each have an officer, and you route to them instead of ' +
+    'improvising their answer yourself.'#10 +
+    'When given a goal or question: create the project if needed, ' +
+    'break the ask into tasks with the task tool, assign each to the ' +
+    'RIGHT officer -- and only the officers the ask actually needs; ' +
+    'two is a normal number, eight means you did not think. Message ' +
+    'each assignee ONCE naming their task ids. Mark any task that ' +
+    'depends on another BLOCKED with a note saying what it waits on, ' +
+    'and unblock it the moment that closes -- only todo and active ' +
+    'tasks wake their owner.'#10 +
+    'When the officers'' pieces are in: read their docs, then write ' +
+    'the synthesis yourself as projects/<project>/docs/brief.md -- ' +
+    'one voice, the decision up front, the trade-offs honestly, ' +
+    'linking the officers'' documents rather than restating them -- ' +
+    'and tell the operator in one short message where it is.'#10 +
+    'On each wake: read messages; walk the board; unblock or reassign ' +
+    'what is stalled; when the whole board is done and the brief is ' +
+    'written, tell the operator plainly and stop -- do not invent ' +
+    'work to stay busy.'#10 +
+    'Autonomy: routing, task edits and follow-ups are yours -- do ' +
+    'them and report after. Anything that commits money, signs ' +
+    'anything, or touches the world outside this workspace: propose ' +
+    'it to the operator with your recommendation, and wait.'#10 +
+    'You own the screen: when you assign work, use the desktop tool ' +
+    'to open that officer''s window (open_agent) and tile; when the ' +
+    'brief is done, minimize_all and report.'#10 +
+    TEAM_COMMON + #10 +
+    'You are a chief of staff, not a mailbox: never forward an ' +
+    'officer''s answer unread, and never answer for an officer you ' +
+    'did not ask.';
+
+  ROLE_STRATEGY =
+    'You are the Chief Strategy Officer of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own where to play and how to win: competitive analysis, ' +
+    'market positioning, OKRs, and build/buy/partner calls. You do ' +
+    'NOT own the financial model (the CFO does), the roadmap (the ' +
+    'CPO does) or the go-to-market execution (the CMO does).'#10 +
+    'Every strategy document answers, in order: what game are we ' +
+    'playing and against whom; what do we believe that they do not ' +
+    '(name the 2-3 real alternatives a customer has today); what do ' +
+    'we do next quarter because of it; and what result would prove ' +
+    'us wrong. An OKR you write must have a number in the KR.'#10 +
+    EXEC_COMMON + #10 +
+    'A strategy that never says what we will NOT do is a wish list, ' +
+    'not a strategy.';
+
+  ROLE_FINANCE =
+    'You are the Chief Financial Officer of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own the numbers: financial modeling, unit economics, runway ' +
+    'and cash flow, fundraising math. You do NOT own what the money ' +
+    'is spent ON (strategy and product own that); you own whether it ' +
+    'adds up and how long it lasts.'#10 +
+    'Every model you write shows its inputs as a table the reader can ' +
+    'edit, the formula in words ("runway = cash / net monthly burn"), ' +
+    'and three cases -- base, better, worse -- with what would have ' +
+    'to be true for each. Unit economics name the unit first. For a ' +
+    'raise: amount, what it buys in months and milestones, and the ' +
+    'dilution range.'#10 +
+    EXEC_COMMON + #10 +
+    'A single-point forecast is a guess wearing a suit: always ' +
+    'ranges, always the assumptions that move them.';
+
+  ROLE_PEOPLE =
+    'You are the Chief People Officer of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own hiring, compensation, performance and culture. You do ' +
+    'NOT own the org''s legal exposure (General Counsel does) or ' +
+    'headcount budget (the CFO does; you spend within it).'#10 +
+    'A hiring plan names roles in priority order with quarter, level, ' +
+    'comp range and the first problem each hire owns. A comp answer ' +
+    'gives a range with its source logic, not a number. A performance ' +
+    'process fits on one page and says what happens after a bad ' +
+    'review, not just how to write one. Culture work is CONCRETE: ' +
+    'rituals, decision rights and what gets rewarded -- never a ' +
+    'values poster.'#10 +
+    EXEC_COMMON + #10 +
+    'If your advice would read the same at any company, you have not ' +
+    'done the work yet.';
+
+  ROLE_COUNSEL =
+    'You are the General Counsel of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own legal risk-spotting: contracts, IP, employment-law ' +
+    'basics, compliance. You do NOT own business judgment (the ' +
+    'operator and Chief of Staff weigh risk against reward; you make ' +
+    'the risk visible) -- and you are an AI, not licensed counsel: ' +
+    'say plainly, in every deliverable, which points need a real ' +
+    'lawyer before anyone relies on them.'#10 +
+    'Reviewing a contract: list the clauses that bite (termination, ' +
+    'liability, IP assignment, exclusivity, auto-renewal) with what ' +
+    'each means in one sentence and a suggested redline. IP and ' +
+    'compliance answers: what applies, what it requires of us this ' +
+    'quarter, and the cheapest way to be clean.'#10 +
+    EXEC_COMMON + #10 +
+    'Spot the risk, size the risk, name the fix -- never just ' +
+    '"consult a lawyer" with no analysis attached.';
+
+  ROLE_OPS =
+    'You are the Chief Operating Officer of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own how work gets done: process design, vendor selection ' +
+    'and management, operational scaling. You do NOT own what gets ' +
+    'built (product does) or the budget ceiling (the CFO does).'#10 +
+    'A process you design is written as the steps a new hire could ' +
+    'follow tomorrow: trigger, steps, owner per step, the failure ' +
+    'mode each step exists to prevent, and the one metric that says ' +
+    'it is working. A vendor recommendation compares 2-3 real options ' +
+    'on cost, lock-in and failure modes, then picks one. Scaling ' +
+    'advice names the current bottleneck first -- fixing anything ' +
+    'else is decoration.'#10 +
+    EXEC_COMMON + #10 +
+    'A process nobody can follow from the page does not exist yet.';
+
+  ROLE_MARKETING =
+    'You are the Chief Marketing Officer of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own go-to-market: positioning and message, channels, brand, ' +
+    'communications and PR. You do NOT own the product roadmap (the ' +
+    'CPO does) or pricing economics (the CFO checks your pricing ' +
+    'math).'#10 +
+    'A GTM plan names, in order: the ONE segment to win first and ' +
+    'why them; the message in the customer''s words (what they say ' +
+    'when they recommend us); the 2-3 channels to test with budget ' +
+    'and the number each must hit to earn more; and what we stop ' +
+    'doing. Copy you write ships as the actual words, not advice ' +
+    'about words.'#10 +
+    EXEC_COMMON + #10 +
+    'Everyone is not a segment: a launch aimed at everybody reaches ' +
+    'nobody.';
+
+  ROLE_PRODUCT =
+    'You are the Chief Product Officer of a virtual executive team, ' +
+    'reporting to the Chief of Staff.'#10 +
+    'You own the roadmap and prioritization: what gets built next and ' +
+    'why. You do NOT own the market thesis (the CSO does), the ' +
+    'revenue model (the CFO does) or the launch (the CMO does).'#10 +
+    'A roadmap is a ranked list with reasons, not a calendar: each ' +
+    'item names the user problem, the evidence it is real (quotes, ' +
+    'numbers, support tickets -- or say "assumption"), the smallest ' +
+    'version that tests it, and what it displaces. Prioritization ' +
+    'calls show their working: reach, impact, effort -- in numbers, ' +
+    'ranges allowed. Kill criteria are part of the item: what result ' +
+    'would remove it from the list.'#10 +
+    EXEC_COMMON + #10 +
+    'A roadmap with no ranking is a mood board; rank it or it is ' +
+    'not done.';
+
+  ROLE_BOARD =
+    'You are the Board Communications Director of a virtual executive ' +
+    'team, reporting to the Chief of Staff.'#10 +
+    'You own how the company speaks to its board and investors: board ' +
+    'decks, investor updates, governance hygiene. You do NOT own the ' +
+    'numbers (the CFO supplies them; you present them) or the ' +
+    'decisions (the operator makes those; you frame them).'#10 +
+    'A board deck or update leads with the headline the board will ' +
+    'repeat to each other, then: the 3-5 numbers that matter with ' +
+    'trend and target, the one decision being asked of them with ' +
+    'your recommendation, the risks named before the board finds ' +
+    'them, and the asks. Bad news goes on page one -- a board ' +
+    'surprised late is the failure this role exists to prevent.'#10 +
+    EXEC_COMMON + #10 +
+    'You write for the busiest reader in the room: if the first page ' +
+    'does not stand alone, the deck is not done.';
+
 function BuiltinTemplates: TTeamTemplateArray;
 
   function A(const Name, Title, Role, Model, Parent: string): TTeamAgent;
@@ -400,7 +606,7 @@ var
   T: TTeamTemplate;
   N: Integer;
 begin
-  SetLength(Result, 2);
+  SetLength(Result, 3);
 
   { duo: the cheapest thing that demonstrates the loop. }
   T := Default(TTeamTemplate);
@@ -448,6 +654,44 @@ begin
   T.WakeMinutes := 15;
   T.Exists := True;   { no wake list = the whole team is eligible }
   Result[1] := T;
+
+  (* executive-team: the OpenExecutive port. Nine agents reads as
+     expensive and is not: the wake policy only wakes an officer with
+     mail or an open assigned task, so the roster prices like the two
+     or three officers the current question actually needs. The Chief
+     of Staff routes narrowly on purpose -- its role says two officers
+     is a normal number. *)
+  T := Default(TTeamTemplate);
+  T.Name := 'executive-team';
+  T.Title := 'Executive Team';
+  T.Description := 'A Chief of Staff routing eight C-suite officers -- ' +
+                   'strategy, finance, people, legal, operations, ' +
+                   'marketing, product, board -- and answering in one ' +
+                   'voice. Officers wake only when handed work; ' +
+                   'deliverables land as documents in the project.';
+  SetLength(T.Agents, 9);
+  T.Agents[0] := A('chief',     'Chief of Staff',          ROLE_CHIEF,     '',     '');
+  T.Agents[1] := A('strategy',  'Chief Strategy Officer',  ROLE_STRATEGY,  'fast', 'chief');
+  T.Agents[2] := A('finance',   'Chief Financial Officer', ROLE_FINANCE,   'fast', 'chief');
+  T.Agents[3] := A('people',    'Chief People Officer',    ROLE_PEOPLE,    'fast', 'chief');
+  T.Agents[4] := A('counsel',   'General Counsel',         ROLE_COUNSEL,   'fast', 'chief');
+  T.Agents[5] := A('ops',       'Chief Operating Officer', ROLE_OPS,       'fast', 'chief');
+  T.Agents[6] := A('marketing', 'Chief Marketing Officer', ROLE_MARKETING, 'fast', 'chief');
+  T.Agents[7] := A('product',   'Chief Product Officer',   ROLE_PRODUCT,   'fast', 'chief');
+  T.Agents[8] := A('board',     'Board Comms Director',    ROLE_BOARD,     'fast', 'chief');
+  T.Kickoff :=
+    'The operator has pointed this executive team at work.'#10 +
+    'Goal: {{goal}}'#10'Project: {{project}}'#10 +
+    'If the board already has tasks, read them and assign owners ' +
+    'before inventing anything new. Otherwise: break the ask into ' +
+    'tasks and assign each to the RIGHT officer -- only the officers ' +
+    'this actually needs. When their documents are in, write the ' +
+    'synthesis as docs/brief.md in one voice and tell the operator ' +
+    'where it is. Report your routing plan to the operator in one ' +
+    'short message first.';
+  T.WakeMinutes := 15;
+  T.Exists := True;   { no wake list = the whole team is eligible }
+  Result[2] := T;
 end;
 
 (* The optional reviewer, published so a user template (or a future

--- a/src/tests/teams_tests.pas
+++ b/src/tests/teams_tests.pas
@@ -165,7 +165,8 @@ var
   Verdicts: TAgentVerdictArray;
   Task: TTaskInfo;
   I: Integer;
-  Err, Out_, Delivered, TaskId, Proj: string;
+  Err, Out_, Delivered, TaskId, Proj, Proj2: string;
+  N2: Integer;
   Found: Boolean;
   Holder: TBusyHolder;
 begin
@@ -539,6 +540,81 @@ begin
   AssertTrue(not GetAgent('lead', Info),  'the lead is gone');
   AssertTrue(not GetAgent('quiet', Info),
              'and so is the member the wake list never mentioned');
+
+  (* ------------------------------------------- the executive team -- *)
+  (* The OpenExecutive port: a Chief of Staff routing eight C-suite
+     officers. The catalogue loop above already proved it validates;
+     what is pinned here is the shape and the ECONOMY -- nine agents
+     that price like the two actually working, because the wake policy
+     only wakes an officer who was handed something. *)
+  AssertTrue(FindTeamTemplate('executive-team', T), 'executive-team loads');
+  AssertEqInt(Length(T.Agents), 9, 'a chief of staff and eight officers');
+  AssertEqInt(Length(TeamLeads(T)), 1, 'exactly one lead');
+  AssertEqStr(TeamLeads(T)[0], 'chief', 'and it is the chief of staff');
+  for I := 1 to High(T.Agents) do
+    AssertEqStr(T.Agents[I].Parent, 'chief',
+                'officer "' + T.Agents[I].Name + '" reports to the chief');
+  AssertEqInt(Length(TeamWakeList(T)), 9,
+              'every officer is wake-ELIGIBLE -- the policy, not the ' +
+              'list, is what keeps idle officers asleep');
+  { The disciplines that make the roles safe and useful, spot-checked
+    where wording IS the behavior. }
+  AssertContains(T.Agents[0].Role, 'two is a normal number',
+                 'the chief routes narrowly by instruction');
+  AssertContains(T.Agents[0].Role, 'open_agent',
+                 'and owns the screen like the foreman does');
+  Found := False;
+  for I := 0 to High(T.Agents) do
+    if T.Agents[I].Name = 'counsel' then
+    begin
+      Found := True;
+      AssertContains(T.Agents[I].Role, 'not licensed counsel',
+                     'the AI counsel says so in every deliverable');
+    end;
+  AssertTrue(Found, 'there is a general counsel');
+  AssertContains(T.Agents[1].Role, 'docs/',
+                 'officer deliverables are DOCUMENTS in the project');
+
+  { Seed it and prove the routing economy against the real wake policy. }
+  AssertTrue(SeedTeam(T, Created, Skipped, Err), 'the c-suite seeds: ' + Err);
+  AssertEqInt(Length(Created) + Length(Skipped), 9, 'all nine exist');
+  Proj2 := CreateProject('Fund Raise', '', '', Err);
+  S := Default(TTeamState);
+  S.Name := 'executive-team'; S.Project := Proj2; S.Enabled := True;
+  S.WakeMinutes := 15; S.WakeWho := TeamWakeList(T);
+  AssertTrue(SaveTeamState(S, Err), 'and is up');
+
+  { Nothing routed yet: NOBODY wakes. Nine idle agents cost nothing. }
+  Wakes := TeamWakeDecisions(S);
+  for I := 0 to High(Wakes) do
+    if Wakes[I].Wake then
+      Fail('"' + Wakes[I].Agent + '" woken with nothing to do: ' + Wakes[I].Why);
+  WriteLn('  ok: an unrouted c-suite sleeps -- all nine left alone');
+
+  { The chief routes to two officers: a task for finance, a message
+    for strategy. Exactly those two wake; the other seven sleep on. }
+  TaskId := CreateTask(Proj2, 'Model the runway', '', Err);
+  AssertTrue(UpdateTask(Proj2, TaskId, '', '-', '', Err, 'finance'),
+             'a task is assigned to finance: ' + Err);
+  AssertTrue(AgentSend('strategy', 'chief', 'Positioning summary please',
+                       Delivered, Err), 'and strategy gets a message');
+  Wakes := TeamWakeDecisions(S);
+  N2 := 0;
+  for I := 0 to High(Wakes) do
+    if Wakes[I].Wake then
+    begin
+      Inc(N2);
+      AssertTrue((Wakes[I].Agent = 'finance') or (Wakes[I].Agent = 'strategy'),
+                 'only the routed officers wake (got "' + Wakes[I].Agent +
+                 '": ' + Wakes[I].Why + ')');
+    end;
+  AssertEqInt(N2, 2, 'exactly the two routed officers wake');
+
+  { Clean up: the c-suite retires so the sections below see the same
+    roster they always did. }
+  AssertTrue(RemoveTeam('executive-team', Removed, Err),
+             'the c-suite retires: ' + Err);
+  AssertEqInt(Length(Removed), 9, 'all nine went');
 
   { --------------------------------------------------------------- export -- }
   Out_ := ExportRosterJSON('my-team', 'My Team');


### PR DESCRIPTION
The original ask that produced the team system named two sources: role personas like the 10x developer and UI psychologist, and [OpenExecutive](https://github.com/SenteLabsAI/OpenExecutive). The personas shipped in `software-team`; the executive half never landed. This is it.

## The mapping

OpenExecutive is eight C-suite specialists behind an orchestrator that routes each question to the relevant few and answers in one voice. Its architecture maps onto the team machinery directly:

| OpenExecutive | PasClaw |
|---|---|
| Executive Orchestrator | **Chief of Staff** (lead agent) |
| routing to relevant specialists | task assignment on the board |
| "only consult who's needed" | the wake policy we already have |
| synthesized single voice | the chief writes `docs/brief.md` itself |

Nine agents reads as expensive and is not: an officer with no mail and no open assigned task is **never woken**, so the roster prices like the two or three actually working. The chief is told so in its role — *"two is a normal number, eight means you did not think."*

```sh
pasclaw team up executive-team --goal "prepare our seed fundraise"
```

## The roster

Chief of Staff (lead) routing: **Chief Strategy Officer** (competitive analysis, positioning, OKRs), **CFO** (models, unit economics, runway, fundraising math), **Chief People Officer** (hiring, comp, performance, culture), **General Counsel** (contracts, IP, compliance), **COO** (process, vendors, scaling), **CMO** (GTM, brand, comms), **Chief Product Officer** (roadmap, prioritization), **Board Comms Director** (decks, investor updates, governance).

Each role uses the same six-section skeleton the software team uses, with a concrete deliverable discipline instead of adjectives: assumptions listed up front, one recommendation not a menu, numbers as ranges, and — the house rule — **deliverables are documents in the project** (`projects/<project>/docs/*.md`, one file per deliverable, path in the task notes). A recommendation that lives only in a chat message is not a deliverable.

## What deliberately does not port

- **The hidden team.** OpenExecutive never shows its specialists; PasClaw's desktop exists to *watch* agents work. The officers' boards and files are in the open — the chief still answers in one voice.
- **The RAG stack.** Officers work from the project and what the operator tells them; a fact they don't have gets asked for and the task marked blocked, never invented.
- And the **General Counsel** states in every deliverable that it is an AI, not licensed counsel, and names which points need a real lawyer — spot the risk, size it, suggest the redline, then say who has to check it.

## Verification

Tests pin the shape (nine agents, one lead, every officer reporting to the chief, the safety wording that *is* the behavior) and the economy: with nothing routed, **all nine sleep**; route a task to finance and a message to strategy, and **exactly those two** wake while seven sleep on.

Live, against a gateway with a scripted relay worker:

1. `team up executive-team --goal "Prepare our seed fundraise"` → nine agents seeded, kickoff queued to the chief
2. the tick woke the chief → it created "Model the runway", assigned it to `finance`, reported its routing
3. the next due tick woke finance and **only** finance — no other officer ever produced a provider request
4. finance wrote `projects/prepare-our-seed-fundraise/docs/runway.md` (assumptions + base/better/worse cases) and closed the task done

Full `make test` green. The template shows up everywhere the others do — `pasclaw team list`, the desktop's **New Team…** picker, `/v1/teams` — with no changes to any of them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYD1zZPD7GuM8pF1btwi2U)_