### PR TITLE
TUI: accept, render and persist CJK input on the Delphi build

### DIFF
--- a/src/pkg/session/PasClaw.Session.Store.pas
+++ b/src/pkg/session/PasClaw.Session.Store.pas
@@ -578,21 +578,14 @@ function PeekSessionProfile(const Id: string): string;
 var
   Path, Text: string;
   Root, MetaObj: TJsonObject;
-  SL: TStringList;
 begin
   Result := '';
   Path := SessionPath(Id);
   if (Path = '') or (not FileExists(Path)) then Exit;
-  SL := TStringList.Create;
   try
-    try
-      SL.LoadFromFile(Path);
-      Text := SL.Text;
-    except
-      Exit;
-    end;
-  finally
-    SL.Free;
+    Text := ReadFileText(Path);   { UTF-8 on both arms; see TSession.Save }
+  except
+    Exit;
   end;
   Root := TJsonObject.Parse(Text);
   if Root = nil then Exit;
@@ -838,7 +831,10 @@ begin
   L := TStringList.Create;
   try
     try
-      L.LoadFromFile(P);
+      { The log is written as explicit UTF-8 a few dozen lines up; read it
+        back the same way. LoadFromFile without an encoding would decode it
+        as ANSI on Delphi and hand back mojibake for every CJK turn. }
+      L.Text := ReadFileText(P);
     except
       on E: Exception do
       begin
@@ -1505,13 +1501,16 @@ begin
       MoveFile requires the destination not exist -- delete first.
       Codex P2 on PR #117. }
     TmpPath := Path + '.tmp';
-    S := TStringList.Create;
-    try
-      S.Text := Root.ToJSON;
-      S.SaveToFile(TmpPath);
-    finally
-      S.Free;
-    end;
+    (* WriteFileText, not TStringList.SaveToFile. Without an encoding
+       argument, Delphi's TStrings.SaveToFile writes TEncoding.Default --
+       the system ANSI codepage on Windows -- so every non-ASCII
+       character in a transcript became '?' (or GBK bytes the UTF-8
+       loader then mangled) on disk. FPC wrote the UTF-8 bytes through
+       untouched, which is why the bug only showed on the Delphi build.
+       The append-only transcript log below already encoded UTF-8
+       explicitly; this is the same fix for the main record. Bug report:
+       CJK typed in the TUI not showing in the session log. *)
+    WriteFileText(TmpPath, Root.ToJSON);
     {$IFDEF MSWINDOWS}
     if FileExists(Path) then SysUtils.DeleteFile(Path);
     {$ENDIF}
@@ -1529,7 +1528,6 @@ end;
 procedure TSession.Load(const AId: string);
 var
   Path: string;
-  S: TStringList;
 begin
   FExists := False;
   SetLength(Messages, 0);
@@ -1540,13 +1538,10 @@ begin
   if Path = '' then Exit;          { unsafe id -- treat as not found }
   if not FileExists(Path) then Exit;
 
-  S := TStringList.Create;
-  try
-    S.LoadFromFile(Path);
-    if LoadFromText(S.Text) then FExists := True;
-  finally
-    S.Free;
-  end;
+  { ReadFileText decodes UTF-8 on both arms. TStringList.LoadFromFile
+    without an encoding decodes BOM-less UTF-8 as ANSI on Delphi, so a
+    correctly written transcript came back as mojibake. }
+  if LoadFromText(ReadFileText(Path)) then FExists := True;
 end;
 
 function TSession.LoadFromText(const Text: string): Boolean;

--- a/src/pkg/tui/PasClaw.TUI.pas
+++ b/src/pkg/tui/PasClaw.TUI.pas
@@ -99,6 +99,9 @@ type
     FSessScroll:        Integer;
     FChatScroll:        Integer;       { lines back from the bottom; 0 = pinned to latest }
     FInputBuf:          string;
+    FUtf8Pending:       string;        { POSIX only: bytes of a UTF-8 sequence still being assembled,
+                                         one byte per Char -- GetKey there yields one raw byte per call }
+    FUtf8Need:          Integer;       { POSIX only: continuation bytes still expected }
     FLoopThread:        TObject;       { TRunToolLoopThread -- opaque here to avoid forward-decl gymnastics }
     FLoopStartedAt:     TDateTime;
     FSpinnerFrame:      Integer;
@@ -1845,8 +1848,40 @@ begin
 end;
 
 procedure TTUI.HandleChatKey(Key: Integer);
+{$IFNDEF MSWINDOWS}
 var
-  Ch: Char;
+  CP, L: Integer;
+{$ENDIF}
+
+  { Append one Unicode scalar to the UTF-16 buffer. Supplementary
+    characters (emoji) become a surrogate pair -- the buffer is a
+    UnicodeString, so that IS the correct in-memory form. }
+  procedure AppendCodePoint(ACP: Integer);
+  begin
+    if ACP < 32 then Exit;
+    if ACP > $FFFF then
+      FInputBuf := FInputBuf + Char($D800 + ((ACP - $10000) shr 10)) +
+                               Char($DC00 + ((ACP - $10000) and $3FF))
+    else
+      FInputBuf := FInputBuf + Char(ACP);
+  end;
+
+  { Backspace removes one CHARACTER: a surrogate pair goes together, or a
+    lone high surrogate would be left behind and corrupt the JSON the
+    session writes. }
+  procedure DeleteLastCodePoint;
+  var
+    N: Integer;
+  begin
+    N := Length(FInputBuf);
+    if N = 0 then Exit;
+    if (N >= 2) and (Ord(FInputBuf[N]) >= $DC00) and (Ord(FInputBuf[N]) <= $DFFF)
+       and (Ord(FInputBuf[N - 1]) >= $D800) and (Ord(FInputBuf[N - 1]) <= $DBFF) then
+      SetLength(FInputBuf, N - 2)
+    else
+      SetLength(FInputBuf, N - 1);
+  end;
+
 begin
   { Q with an empty input buffer quits -- discoverability path so
     users coming from the session pane don't have to learn that
@@ -1875,20 +1910,60 @@ begin
         if FChatScroll < 0 then FChatScroll := 0;
       end;
     8, 127:   { Backspace -- code differs by terminal; accept both }
-      if Length(FInputBuf) > 0 then
-        SetLength(FInputBuf, Length(FInputBuf) - 1);
+      DeleteLastCodePoint;
   else
-    { Printable ASCII / latin-1: append. We don't try to handle
-      escape sequences or multi-byte UTF-8 here -- DMVCFramework's
-      GetKey on Linux returns the raw byte for printable chars, on
-      Windows the VK_ codes for special keys; the printable range
-      32..126 is safe everywhere. Higher bytes pass through and
-      will render as their byte value on most terminals. }
-    if (Key >= 32) and (Key < 256) then
+    (* Printable input. This branch used to accept only 32..255 and
+       append Chr(Key), which lost every non-Latin character two
+       different ways: on Windows an IME character came through as
+       its AsciiChar -- the low byte of the UTF-16 unit, or #0 and
+       therefore a "special key" -- so Chinese either turned into
+       ASCII punctuation or vanished; on POSIX GetKey yields one raw
+       byte per call, so each byte of a 3-byte 你 became its own
+       Latin-1 WideChar and the buffer held mojibake, which then went
+       into the session file as-is. Bug report: CJK disappearing from
+       the input line and not showing in the session log. *)
+    if IsSpecialKey(Key) then Exit;   { arrows etc. this pane does not use }
+    {$IFDEF MSWINDOWS}
+    { GetKey now returns the KEY_EVENT's UnicodeChar (see the vendored
+      console's PasClaw patch note): one UTF-16 unit per event, and a
+      supplementary character as two events -- high then low surrogate
+      -- which appending in order reconstitutes. }
+    if (Key >= 32) and (Key <= $FFFF) then
+      FInputBuf := FInputBuf + Char(Key);
+    {$ELSE}
+    { POSIX: one raw byte per GetKey. Reassemble UTF-8 across calls; the
+      terminal delivers a character's bytes back to back, so the
+      partial state only ever spans a few iterations of the key loop. }
+    if FUtf8Need > 0 then
     begin
-      Ch := Chr(Key);
-      FInputBuf := FInputBuf + Ch;
+      if (Key and $C0) = $80 then
+      begin
+        FUtf8Pending := FUtf8Pending + Char(Key and $FF);
+        Dec(FUtf8Need);
+        if FUtf8Need = 0 then
+        begin
+          if Utf8DecodeCodePoint(FUtf8Pending, CP) then AppendCodePoint(CP);
+          FUtf8Pending := '';
+        end;
+        Exit;
+      end;
+      { The sequence was cut short by a non-continuation byte: drop the
+        partial character and let this byte start afresh below. }
+      FUtf8Pending := '';
+      FUtf8Need := 0;
     end;
+    L := Utf8SeqLen(Key and $FF);
+    if L = 1 then
+    begin
+      if Key >= 32 then FInputBuf := FInputBuf + Char(Key);
+    end
+    else if L > 1 then
+    begin
+      FUtf8Pending := Char(Key and $FF);
+      FUtf8Need := L - 1;
+    end;
+    { L = 0: a stray continuation byte or an invalid lead -- dropped. }
+    {$ENDIF}
   end;
 end;
 
@@ -2347,9 +2422,14 @@ begin
     InputLine := ' > ' + FInputBuf + '_'
   else
     InputLine := ' > ' + FInputBuf;
-  if Length(InputLine) > W then
-    InputLine := Copy(InputLine, Length(InputLine) - W + 1, W);
-  while Length(InputLine) < W do InputLine := InputLine + ' ';
+  { Measure in terminal cells, not Length(): a CJK character is one
+    Char and two cells, so the Length-based version both overflowed
+    the row (wrapping onto the next line and corrupting the frame)
+    and under-padded it. Keep the TAIL -- the cursor end is what the
+    operator is looking at -- and never cut a character in half. }
+  if VisibleLength(InputLine) > W then
+    InputLine := TruncateVisibleTail(InputLine, W);
+  InputLine := PadVisibleRight(InputLine, W);
   GotoXY(X, ChatBottom + 2);
   WriteAnsiText(ConsoleTheme.Text, InputLine);
 end;

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -53,9 +53,11 @@ function TruncateVisible(const S: string; MaxVis: Integer;
    character or a wide one. *)
 function TruncateVisibleTail(const S: string; MaxVis: Integer): string;
 
-(* Terminal cell width of one code point: 2 for East Asian Wide /
-   Fullwidth (CJK, Hangul, fullwidth forms, most emoji), 0 for combining
-   marks and zero-width joiners / spaces, 1 otherwise. The width helpers
+(* Terminal cell width of one code point IN ISOLATION: 2 for East Asian
+   Wide / Fullwidth (CJK, Hangul, fullwidth forms, most emoji), 0 for
+   combining marks, zero-width joiners / spaces and variation selectors,
+   1 otherwise. A following variation selector changes the answer -- see
+   the width helpers, which handle the pair. The width helpers
    above sum this, so a line of Chinese pads and wraps in cells rather
    than in characters -- the positioned TUI overflowed its rows and
    under-padded them before, because a 3-byte 你 counted as one column
@@ -341,6 +343,37 @@ begin
 end;
 {$ENDIF}
 
+(* Cell width of the code point just read, consuming a variation selector
+   that follows it.
+
+   VS16 (U+FE0F) promotes a text-presentation glyph to its two-cell emoji
+   form: U+2764 is a one-cell heart, U+2764 U+FE0F is the two-cell emoji
+   one. VS15 (U+FE0E) forces the one-cell text form. Counting the base as
+   1 and the selector as 0 reported one cell where terminals draw two,
+   which under-pads the row and truncates a column too late. Codex P2 on
+   PR #597.
+
+   i advances past the selector, so a caller copying S[Start..i-1] keeps
+   the base and its selector together -- splitting them would change how
+   the run renders.
+
+   Not handled: ZWJ sequences (a family emoji is several code points
+   joined by U+200D). Terminals disagree on those, so guessing a width
+   would trade one wrong answer for another. *)
+function WidthWithSelector(const S: string; var i: Integer; CP: Integer): Integer;
+var
+  j, Sel: Integer;
+begin
+  Result := CodePointCellWidth(CP);
+  if Result = 0 then Exit;   { the selector itself, or a combining mark }
+  j := i;
+  if NextCodePoint(S, j, Sel) then
+  begin
+    if Sel = $FE0F then begin Result := 2; i := j; end
+    else if Sel = $FE0E then begin Result := 1; i := j; end;
+  end;
+end;
+
 function VisibleLength(const S: string): Integer;
 { Strip ANSI escapes and count terminal cells. Iterates code points so a
   wide character counts two cells and a combining mark none -- see
@@ -364,7 +397,7 @@ begin
       inEsc := True;
       Continue;
     end;
-    Inc(Result, CodePointCellWidth(CP));
+    Inc(Result, WidthWithSelector(S, i, CP));
   end;
 end;
 
@@ -407,8 +440,9 @@ begin
       Continue;
     end;
     { A wide character that would straddle the boundary stays whole
-      and moves to the remainder -- never half a 你 on each row. }
-    w := CodePointCellWidth(CP);
+      and moves to the remainder -- never half a 你 on each row, and
+      never a base separated from its variation selector. }
+    w := WidthWithSelector(S, i, CP);
     if n + w > MaxVis then
     begin
       i := Start;
@@ -509,6 +543,8 @@ end;
 { True when B holds a well-formed UTF-8 byte sequence (rejects overlong forms,
   stray continuation bytes, and > U+10FFFF leads). Used to decide whether a file
   needs the Latin-1 fallback below. }
+function UTF8BytesToStr(const B: TBytes): string; forward;
+
 function BytesAreValidUTF8(const B: TBytes): Boolean;
 var
   i, n, Extra, j: Integer;
@@ -577,6 +613,47 @@ begin
   SetLength(Result, o);
 end;
 
+(* Decode B with the system ANSI code page, for files the pre-UTF-8
+   TStrings path wrote.
+
+   Windows only, and deliberately so. TStrings.SaveToFile with no encoding
+   wrote TEncoding.Default -- the machine's ANSI code page. On a CP932 /
+   CP936 / CP949 box that is MULTIBYTE, and those bytes are not valid
+   UTF-8, so ReadFileText's Latin-1 fallback would mojibake them; the next
+   Save then rewrites the mojibake as UTF-8 and the damage is permanent.
+   Trying the system code page first reads those legacy files correctly.
+   Codex P1 on PR #597.
+
+   Elsewhere the system code page is UTF-8 (already tried) or has no
+   distinct ANSI meaning, so this returns False and the caller falls
+   through to Latin-1, exactly as before.
+
+   Goes through UTF-8 bytes rather than assigning the UnicodeString to
+   `string` directly: that implicit re-encode through the ANSI code page is
+   the EEncodingError the ReadFileText comment below warns about. *)
+function AnsiBytesToStr(const B: TBytes; out S: string): Boolean;
+{$IFDEF MSWINDOWS}
+var
+  U: UnicodeString;
+{$ENDIF}
+begin
+  S := '';
+  Result := False;
+{$IFDEF MSWINDOWS}
+  if Length(B) = 0 then Exit;
+  try
+    U := TEncoding.ANSI.GetString(B);
+    if U = '' then Exit;
+    S := UTF8BytesToStr(TEncoding.UTF8.GetBytes(U));
+    Result := S <> '';
+  except
+    { A code page that cannot map these bytes is not an error here --
+      Latin-1 still has to produce something readable. }
+    Result := False;
+  end;
+{$ENDIF}
+end;
+
 { Wrap already-UTF-8 bytes as pasclaw's `string` WITHOUT any system-codepage
   round-trip: on FPC keep the bytes verbatim and tag them CP_UTF8; on Delphi
   decode to the native UnicodeString. Never raises. }
@@ -621,11 +698,14 @@ begin
     codepage -- raised EEncodingError ("No mapping for the Unicode character
     exists in the target multi-byte code page") on Windows for any file
     character with no mapping in the active codepage (common with legacy 8-bit
-    sources). Instead: pass valid UTF-8 through untouched, and reinterpret a
-    non-UTF-8 file as Latin-1 so it still reads as text and never raises. }
+    sources). Instead: pass valid UTF-8 through untouched; on Windows try
+    the system ANSI code page next, which is what the pre-UTF-8 TStrings
+    path wrote and the only correct reading of a legacy CP932/936/949
+    file; and reinterpret whatever is left as Latin-1 so it still reads as
+    text and never raises. }
   if BytesAreValidUTF8(Bytes) then
     Result := UTF8BytesToStr(Bytes)
-  else
+  else if not AnsiBytesToStr(Bytes, Result) then
     Result := UTF8BytesToStr(Latin1BytesToUTF8(Bytes));
 end;
 

--- a/src/pkg/utils/PasClaw.Utils.pas
+++ b/src/pkg/utils/PasClaw.Utils.pas
@@ -47,6 +47,33 @@ function PadVisibleRight(const S: string; W: Integer): string;
    leftover styling from a mid-line wrap. *)
 function TruncateVisible(const S: string; MaxVis: Integer;
                          out Remainder: string): string;
+(* Keep the TAIL of S within MaxVis visible columns by dropping whole
+   leading code points. For an input line, where the cursor end is what
+   the operator is looking at. Never splits a multi-byte / multi-unit
+   character or a wide one. *)
+function TruncateVisibleTail(const S: string; MaxVis: Integer): string;
+
+(* Terminal cell width of one code point: 2 for East Asian Wide /
+   Fullwidth (CJK, Hangul, fullwidth forms, most emoji), 0 for combining
+   marks and zero-width joiners / spaces, 1 otherwise. The width helpers
+   above sum this, so a line of Chinese pads and wraps in cells rather
+   than in characters -- the positioned TUI overflowed its rows and
+   under-padded them before, because a 3-byte 你 counted as one column
+   and rendered as two. Control characters count 1, matching what the
+   byte-counting version did, so nothing that passed before changes. *)
+function CodePointCellWidth(CP: Integer): Integer;
+
+(* UTF-8 by the byte, for callers that receive a byte stream -- the
+   Delphi TUI on POSIX gets one byte per GetKey and has to reassemble
+   the character itself. Utf8SeqLen: bytes in the sequence this lead
+   byte starts (1 for ASCII, 2..4, 0 for a continuation byte or an
+   invalid lead such as $C0/$C1/$F5+). Utf8DecodeCodePoint: decode a
+   complete sequence, rejecting a wrong length, bad continuation bytes,
+   overlong forms and surrogates. Seq holds one byte per Char so the
+   same code serves an AnsiString on FPC and a UnicodeString of byte
+   values on Delphi. *)
+function Utf8SeqLen(Lead: Byte): Integer;
+function Utf8DecodeCodePoint(const Seq: string; out CP: Integer): Boolean;
 function HasPrefix(const S, Prefix: string): Boolean;
 function HasSuffix(const S, Suffix: string): Boolean;
 function TrimQuotes(const S: string): string;
@@ -199,38 +226,146 @@ begin
   for i := 1 to Count do Result := Result + S;
 end;
 
-function VisibleLength(const S: string): Integer;
-{ Strip ANSI escapes and count display columns; treats UTF-8 multi-byte runs
-  as one column each. This is approximate but adequate for box drawing. }
+function Utf8SeqLen(Lead: Byte): Integer;
+begin
+  if Lead < $80 then Result := 1
+  else if (Lead >= $C2) and (Lead <= $DF) then Result := 2
+  else if (Lead >= $E0) and (Lead <= $EF) then Result := 3
+  else if (Lead >= $F0) and (Lead <= $F4) then Result := 4
+  else Result := 0;
+end;
+
+function Utf8DecodeCodePoint(const Seq: string; out CP: Integer): Boolean;
 var
-  i, n: Integer;
-  c: Byte;
+  L, i, B: Integer;
+begin
+  Result := False;
+  CP := 0;
+  if Seq = '' then Exit;
+  L := Utf8SeqLen(Ord(Seq[1]) and $FF);
+  if (L = 0) or (Length(Seq) <> L) then Exit;
+  B := Ord(Seq[1]) and $FF;
+  case L of
+    1: CP := B;
+    2: CP := B and $1F;
+    3: CP := B and $0F;
+    4: CP := B and $07;
+  end;
+  for i := 2 to L do
+  begin
+    B := Ord(Seq[i]) and $FF;
+    if (B and $C0) <> $80 then Exit;
+    CP := (CP shl 6) or (B and $3F);
+  end;
+  { Overlong forms and UTF-16 surrogates are not valid scalar values. }
+  case L of
+    2: if CP < $80 then Exit;
+    3: if (CP < $800) or ((CP >= $D800) and (CP <= $DFFF)) then Exit;
+    4: if (CP < $10000) or (CP > $10FFFF) then Exit;
+  end;
+  Result := True;
+end;
+
+function CodePointCellWidth(CP: Integer): Integer;
+begin
+  { Zero-width: combining marks, ZW space/joiners, variation selectors. }
+  if ((CP >= $0300) and (CP <= $036F)) or
+     ((CP >= $200B) and (CP <= $200F)) or
+     (CP = $2060) or (CP = $FEFF) or
+     ((CP >= $FE00) and (CP <= $FE0F)) or
+     ((CP >= $FE20) and (CP <= $FE2F)) then
+    Exit(0);
+  { Wide / fullwidth (East Asian Width W and F) plus the emoji blocks
+    terminals draw two cells wide. }
+  if ((CP >= $1100)  and (CP <= $115F))  or
+     ((CP >= $2E80)  and (CP <= $A4CF) and (CP <> $303F)) or
+     ((CP >= $AC00)  and (CP <= $D7A3))  or
+     ((CP >= $F900)  and (CP <= $FAFF))  or
+     ((CP >= $FE30)  and (CP <= $FE4F))  or
+     ((CP >= $FF00)  and (CP <= $FF60))  or
+     ((CP >= $FFE0)  and (CP <= $FFE6))  or
+     ((CP >= $1F300) and (CP <= $1F64F)) or
+     ((CP >= $1F680) and (CP <= $1F6FF)) or
+     ((CP >= $1F900) and (CP <= $1FAFF)) or
+     ((CP >= $20000) and (CP <= $3FFFD)) then
+    Exit(2);
+  Result := 1;
+end;
+
+(* Step one code point through S starting at index i (1-based), leaving
+   i just past it. FPC: S is UTF-8 bytes; a stray continuation byte or a
+   truncated / malformed sequence yields U+FFFD and advances one byte,
+   so bad input costs one column rather than an exception. Delphi: S is
+   UTF-16; a surrogate pair is combined, a lone surrogate passes through
+   as itself. *)
+function NextCodePoint(const S: string; var i: Integer; out CP: Integer): Boolean;
+{$IFDEF FPC}
+var
+  L: Integer;
+begin
+  Result := False;
+  CP := 0;
+  if i > Length(S) then Exit;
+  L := Utf8SeqLen(Byte(S[i]));
+  if (L = 0) or (i + L - 1 > Length(S)) or
+     (not Utf8DecodeCodePoint(Copy(S, i, L), CP)) then
+  begin
+    CP := $FFFD;
+    Inc(i);
+    Exit(True);
+  end;
+  Inc(i, L);
+  Result := True;
+end;
+{$ELSE}
+var
+  W1, W2: Integer;
+begin
+  Result := False;
+  CP := 0;
+  if i > Length(S) then Exit;
+  W1 := Ord(S[i]);
+  Inc(i);
+  if (W1 >= $D800) and (W1 <= $DBFF) and (i <= Length(S)) then
+  begin
+    W2 := Ord(S[i]);
+    if (W2 >= $DC00) and (W2 <= $DFFF) then
+    begin
+      CP := $10000 + ((W1 - $D800) shl 10) + (W2 - $DC00);
+      Inc(i);
+      Exit(True);
+    end;
+  end;
+  CP := W1;
+  Result := True;
+end;
+{$ENDIF}
+
+function VisibleLength(const S: string): Integer;
+{ Strip ANSI escapes and count terminal cells. Iterates code points so a
+  wide character counts two cells and a combining mark none -- see
+  CodePointCellWidth for why the byte-per-column version was wrong. }
+var
+  i, CP: Integer;
   inEsc: Boolean;
 begin
-  n := 0;
+  Result := 0;
   inEsc := False;
   i := 1;
-  while i <= Length(S) do
+  while NextCodePoint(S, i, CP) do
   begin
-    c := Byte(S[i]);
     if inEsc then
     begin
-      if c = Ord('m') then inEsc := False;
-      Inc(i);
+      if CP = Ord('m') then inEsc := False;
       Continue;
     end;
-    if c = 27 then { ESC }
+    if CP = 27 then { ESC }
     begin
       inEsc := True;
-      Inc(i);
       Continue;
     end;
-    { Skip continuation bytes 10xxxxxx, count lead bytes only. }
-    if (c and $C0) <> $80 then
-      Inc(n);
-    Inc(i);
+    Inc(Result, CodePointCellWidth(CP));
   end;
-  Result := n;
 end;
 
 function PadVisibleRight(const S: string; W: Integer): string;
@@ -245,8 +380,7 @@ end;
 function TruncateVisible(const S: string; MaxVis: Integer;
                          out Remainder: string): string;
 var
-  i, n: Integer;
-  c: Byte;
+  i, Start, CP, n, w: Integer;
   inEsc, anyEsc: Boolean;
 begin
   Result    := '';
@@ -257,31 +391,31 @@ begin
   i         := 1;
   while i <= Length(S) do
   begin
-    c := Byte(S[i]);
+    Start := i;
+    if not NextCodePoint(S, i, CP) then Break;
     if inEsc then
     begin
-      Result := Result + S[i];
-      if c = Ord('m') then inEsc := False;
-      Inc(i);
+      Result := Result + Copy(S, Start, i - Start);
+      if CP = Ord('m') then inEsc := False;
       Continue;
     end;
-    if c = 27 then
+    if CP = 27 then
     begin
-      Result := Result + S[i];
+      Result := Result + Copy(S, Start, i - Start);
       inEsc  := True;
       anyEsc := True;
-      Inc(i);
       Continue;
     end;
-    { Count lead bytes (visible chars); continuation bytes
-      (10xxxxxx) ride along with their lead. }
-    if (c and $C0) <> $80 then
+    { A wide character that would straddle the boundary stays whole
+      and moves to the remainder -- never half a 你 on each row. }
+    w := CodePointCellWidth(CP);
+    if n + w > MaxVis then
     begin
-      if n >= MaxVis then Break;
-      Inc(n);
+      i := Start;
+      Break;
     end;
-    Result := Result + S[i];
-    Inc(i);
+    Inc(n, w);
+    Result := Result + Copy(S, Start, i - Start);
   end;
   { Emit a final ANSI reset on the prefix when we opened any
     escapes -- otherwise a wrap mid-styled-run would carry the
@@ -289,6 +423,19 @@ begin
   if anyEsc then Result := Result + #27 + '[0m';
   if i <= Length(S) then
     Remainder := Copy(S, i, MaxInt);
+end;
+
+function TruncateVisibleTail(const S: string; MaxVis: Integer): string;
+var
+  i, CP: Integer;
+begin
+  Result := S;
+  while (Result <> '') and (VisibleLength(Result) > MaxVis) do
+  begin
+    i := 1;
+    if not NextCodePoint(Result, i, CP) then Break;
+    Result := Copy(Result, i, MaxInt);
+  end;
 end;
 
 function HasPrefix(const S, Prefix: string): Boolean;

--- a/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
+++ b/src/pkg/vendor/dmvcframework/MVCFramework.Console.pas
@@ -50,6 +50,19 @@ unit MVCFramework.Console;
   {$DEFINE PASCLAW_CONSOLE_DARWIN}
 {$IFEND}
 
+// PasClaw patch (Unicode input): GetKey used to return the KEY_EVENT's
+// AsciiChar on Windows, which for an IME-entered character is the low
+// byte of its UTF-16 unit (你 U+4F60 -> '`') or #0 (一 U+4E00 -> "special
+// key" VK_PACKET) -- Chinese either turned into ASCII punctuation or
+// vanished from the TUI input line. It now reads the record through
+// ReadConsoleInputW and returns UnicodeChar, so printable results are
+// UTF-16 code units (a supplementary character arrives as two events,
+// high then low surrogate). That means printable codes exceed 255, so the
+// special-key encoding moved from 256+VK to KEY_SPECIAL_BASE+VK, above
+// U+10FFFF, and IsSpecialKey tests that base; nothing outside this unit
+// and the KEY_* constants encoded the old base. POSIX GetKey is unchanged
+// and still returns raw bytes; the TUI reassembles UTF-8 from them.
+
 interface
 
 uses
@@ -73,10 +86,13 @@ uses
     ;
 
 const
-  KEY_UP    = 256 + 38;  // VK_UP
-  KEY_DOWN  = 256 + 40;  // VK_DOWN
-  KEY_LEFT  = 256 + 37;  // VK_LEFT
-  KEY_RIGHT = 256 + 39;  // VK_RIGHT
+  // Special keys are encoded above the Unicode range so a printable code
+  // point can never collide with one (256+VK_UP was U+0126, 'Ħ').
+  KEY_SPECIAL_BASE = $110000;
+  KEY_UP    = KEY_SPECIAL_BASE + 38;  // VK_UP
+  KEY_DOWN  = KEY_SPECIAL_BASE + 40;  // VK_DOWN
+  KEY_LEFT  = KEY_SPECIAL_BASE + 37;  // VK_LEFT
+  KEY_RIGHT = KEY_SPECIAL_BASE + 39;  // VK_RIGHT
   KEY_ESCAPE = 27;
   KEY_ENTER = 13;
   ESC = #27;
@@ -1018,12 +1034,12 @@ var
 begin
   Result := False;
   Init;
-  if PeekConsoleInput(GInputHandle, InputRecord, 1, NumRead) and (NumRead > 0) then
+  if PeekConsoleInputW(GInputHandle, InputRecord, 1, NumRead) and (NumRead > 0) then
   begin
     if (InputRecord.EventType = KEY_EVENT) and InputRecord.Event.KeyEvent.bKeyDown then
       Result := True
     else
-      ReadConsoleInput(GInputHandle, InputRecord, 1, NumRead);
+      ReadConsoleInputW(GInputHandle, InputRecord, 1, NumRead);
   end;
 end;
 
@@ -1107,21 +1123,25 @@ var
 begin
   Init;
   repeat
-    if ReadConsoleInput(GInputHandle, InputRecord, 1, NumRead) then
+    if ReadConsoleInputW(GInputHandle, InputRecord, 1, NumRead) then
     begin
       if (InputRecord.EventType = KEY_EVENT) then
       begin
         KeyEvent := InputRecord.Event.KeyEvent;
         if KeyEvent.bKeyDown then
         begin
-          if KeyEvent.AsciiChar <> #0 then
+          // UnicodeChar, not AsciiChar: the W record carries the UTF-16
+          // unit, and IME input (CJK, emoji) only exists there. Control
+          // keys still arrive here as their control code (#8, #13, #27,
+          // Ctrl+B = #2), so callers' small-number checks are unchanged.
+          if KeyEvent.UnicodeChar <> #0 then
           begin
-            Result := Ord(KeyEvent.AsciiChar);
+            Result := Ord(KeyEvent.UnicodeChar);
             Exit;
           end
           else
           begin
-            Result := 256 + KeyEvent.wVirtualKeyCode;
+            Result := KEY_SPECIAL_BASE + KeyEvent.wVirtualKeyCode;
             Exit;
           end;
         end;
@@ -1262,7 +1282,7 @@ end;
 
 function IsSpecialKey(KeyCode: Integer): Boolean;
 begin
-  Result := KeyCode > 255;
+  Result := KeyCode >= KEY_SPECIAL_BASE;
 end;
 
 // ============================================================================

--- a/src/tests/ansi_width_tests.pas
+++ b/src/tests/ansi_width_tests.pas
@@ -14,6 +14,24 @@ program ansi_width_tests;
   doesn't break wrap math (Codex P2 on PR #182). A regression
   here would silently under-pad styled chat rows or split lines
   in the middle of a CSI sequence.
+
+  Also covers the Unicode half added for the CJK bug report (Chinese
+  disappearing from the TUI input line):
+
+    CodePointCellWidth  -- 2 cells for CJK / Hangul / fullwidth /
+                           emoji, 0 for combining marks and ZW chars.
+    VisibleLength etc.  -- now sum cells per code point, so 你好 is
+                           4 columns, and TruncateVisible never leaves
+                           half a wide character on a row.
+    TruncateVisibleTail -- keep the cursor end of an input line.
+    Utf8SeqLen / Utf8DecodeCodePoint -- the byte-stream decoder the
+                           Delphi TUI uses on POSIX, where GetKey
+                           hands over one byte at a time.
+
+  Under FPC `string` is UTF-8 bytes, so the literals below are byte
+  escapes rather than relying on the source codepage. The Delphi
+  (UTF-16) arm of NextCodePoint is not exercised here -- no Delphi
+  toolchain in CI -- and is stated as such.
 *)
 
 {$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
@@ -124,10 +142,131 @@ begin
               'iterated truncation covers all 6 visible columns');
 end;
 
+const
+  { UTF-8 byte forms, so the test does not depend on the source codepage. }
+  NI    = #$E4#$BD#$A0;           { 你  U+4F60 }
+  HAO   = #$E5#$A5#$BD;           { 好  U+597D }
+  SHI   = #$E4#$B8#$96;           { 世  U+4E16 }
+  JIE   = #$E7#$95#$8C;           { 界  U+754C }
+  GRIN  = #$F0#$9F#$98#$80;       { 😀 U+1F600, 4 bytes, 2 cells }
+  ACUTE = #$CC#$81;               { U+0301 combining acute, 0 cells }
+  ZWSP  = #$E2#$80#$8B;           { U+200B zero-width space }
+  EACUTE_NFC = #$C3#$A9;          { é U+00E9 precomposed, 1 cell }
+
+procedure TestCodePointCellWidth;
+begin
+  AssertEqInt(CodePointCellWidth(Ord('a')),  1, 'ascii is 1 cell');
+  AssertEqInt(CodePointCellWidth($4F60),     2, 'CJK ideograph is 2 cells');
+  AssertEqInt(CodePointCellWidth($AC00),     2, 'Hangul syllable is 2 cells');
+  AssertEqInt(CodePointCellWidth($FF21),     2, 'fullwidth A is 2 cells');
+  AssertEqInt(CodePointCellWidth($1F600),    2, 'emoji is 2 cells');
+  AssertEqInt(CodePointCellWidth($0301),     0, 'combining acute is 0 cells');
+  AssertEqInt(CodePointCellWidth($200B),     0, 'zero-width space is 0 cells');
+  AssertEqInt(CodePointCellWidth($00E9),     1, 'latin e-acute is 1 cell');
+  AssertEqInt(CodePointCellWidth($303F),     1, 'the one narrow hole in the CJK block');
+end;
+
+procedure TestVisibleLengthCountsCells;
+begin
+  AssertEqInt(VisibleLength(NI + HAO), 4,
+              'two CJK characters are four columns, not two and not six bytes');
+  AssertEqInt(VisibleLength('a' + NI + 'b'), 4, 'mixed ascii and CJK');
+  AssertEqInt(VisibleLength(ESC + '[1m' + NI + ESC + '[0m'), 2,
+              'ANSI around a wide char still counts only the char');
+  AssertEqInt(VisibleLength(GRIN), 2, 'four-byte emoji is two cells');
+  AssertEqInt(VisibleLength('e' + ACUTE), 1, 'combining mark adds no width');
+  AssertEqInt(VisibleLength(ZWSP), 0, 'zero-width space is zero');
+  AssertEqInt(VisibleLength(EACUTE_NFC), 1, 'precomposed accent is one cell');
+  { Malformed input costs one column per bad byte, never an exception. }
+  AssertEqInt(VisibleLength(#$E4#$B8), 2, 'truncated sequence: one column per byte');
+  AssertEqInt(VisibleLength(#$80), 1, 'stray continuation byte: one column');
+end;
+
+procedure TestTruncateVisibleNeverSplitsWide;
+var
+  Prefix, Rem: string;
+begin
+  { 你好世界 is 8 cells. Room for 5: 你好 fit (4), 世 would make 6. }
+  Prefix := TruncateVisible(NI + HAO + SHI + JIE, 5, Rem);
+  AssertEqStr(Prefix, NI + HAO, 'wide char that would straddle stays whole');
+  AssertEqStr(Rem, SHI + JIE, 'and moves to the remainder intact');
+  AssertEqInt(VisibleLength(Prefix), 4, 'prefix width is under the cap, not over');
+
+  Prefix := TruncateVisible('a' + NI, 2, Rem);
+  AssertEqStr(Prefix, 'a', 'one cell left: a two-cell char does not squeeze in');
+  AssertEqStr(Rem, NI, 'it is the remainder');
+
+  Prefix := TruncateVisible(NI + HAO, 4, Rem);
+  AssertEqStr(Prefix, NI + HAO, 'exact fit');
+  AssertEqStr(Rem, '', 'nothing left');
+end;
+
+procedure TestPadVisibleRightCjk;
+var
+  Padded: string;
+begin
+  Padded := PadVisibleRight(NI + HAO, 6);
+  AssertEqInt(VisibleLength(Padded), 6, 'pads to six cells');
+  AssertEqStr(Copy(Padded, Length(Padded) - 1, 2), '  ',
+              'exactly two spaces appended, not four');
+end;
+
+procedure TestTruncateVisibleTail;
+begin
+  AssertEqStr(TruncateVisibleTail('abcdef', 3), 'def', 'keeps the tail');
+  AssertEqStr(TruncateVisibleTail('a' + NI + HAO, 4), NI + HAO,
+              'drops the leading ascii to fit two wide chars');
+  AssertEqStr(TruncateVisibleTail(NI + HAO + SHI, 3), SHI,
+              'drops whole wide chars until it fits -- never half of one');
+  AssertEqStr(TruncateVisibleTail('abc', 3), 'abc', 'already fits');
+  AssertEqStr(TruncateVisibleTail('', 3), '', 'empty stays empty');
+end;
+
+procedure TestUtf8SeqLen;
+begin
+  AssertEqInt(Utf8SeqLen($41), 1, 'ascii lead');
+  AssertEqInt(Utf8SeqLen($C3), 2, 'two-byte lead');
+  AssertEqInt(Utf8SeqLen($E4), 3, 'three-byte lead');
+  AssertEqInt(Utf8SeqLen($F0), 4, 'four-byte lead');
+  AssertEqInt(Utf8SeqLen($80), 0, 'continuation byte is not a lead');
+  AssertEqInt(Utf8SeqLen($C0), 0, 'overlong lead C0 rejected');
+  AssertEqInt(Utf8SeqLen($C1), 0, 'overlong lead C1 rejected');
+  AssertEqInt(Utf8SeqLen($F5), 0, 'lead beyond U+10FFFF rejected');
+  AssertEqInt(Utf8SeqLen($FF), 0, 'FF is never valid');
+end;
+
+procedure TestUtf8DecodeCodePoint;
+var
+  CP: Integer;
+begin
+  if not Utf8DecodeCodePoint('A', CP) then Fail('ascii decodes');
+  AssertEqInt(CP, $41, 'ascii value');
+  if not Utf8DecodeCodePoint(EACUTE_NFC, CP) then Fail('two-byte decodes');
+  AssertEqInt(CP, $E9, 'e-acute value');
+  if not Utf8DecodeCodePoint(NI, CP) then Fail('three-byte decodes');
+  AssertEqInt(CP, $4F60, 'ni value');
+  if not Utf8DecodeCodePoint(GRIN, CP) then Fail('four-byte decodes');
+  AssertEqInt(CP, $1F600, 'grin value');
+  { Rejections -- each is a way the byte stream can arrive damaged. }
+  if Utf8DecodeCodePoint(#$E4#$B8, CP) then Fail('short sequence must fail');
+  if Utf8DecodeCodePoint(#$E4#$41#$AD, CP) then Fail('bad continuation must fail');
+  if Utf8DecodeCodePoint(#$C0#$80, CP) then Fail('overlong NUL must fail');
+  if Utf8DecodeCodePoint(#$ED#$A0#$80, CP) then Fail('encoded surrogate must fail');
+  if Utf8DecodeCodePoint('', CP) then Fail('empty must fail');
+  if Utf8DecodeCodePoint(#$80, CP) then Fail('lone continuation must fail');
+end;
+
 begin
   TestVisibleLengthSkipsAnsi;
   TestPadVisibleRightCountsAnsiAsZero;
   TestTruncateVisibleKeepsAnsiIntact;
+  TestCodePointCellWidth;
+  TestVisibleLengthCountsCells;
+  TestTruncateVisibleNeverSplitsWide;
+  TestPadVisibleRightCjk;
+  TestTruncateVisibleTail;
+  TestUtf8SeqLen;
+  TestUtf8DecodeCodePoint;
   TestTruncateVisibleIterates;
   WriteLn('ansi_width_tests: OK');
 end.

--- a/src/tests/ansi_width_tests.pas
+++ b/src/tests/ansi_width_tests.pas
@@ -152,6 +152,9 @@ const
   ACUTE = #$CC#$81;               { U+0301 combining acute, 0 cells }
   ZWSP  = #$E2#$80#$8B;           { U+200B zero-width space }
   EACUTE_NFC = #$C3#$A9;          { é U+00E9 precomposed, 1 cell }
+  HEART = #$E2#$9D#$A4;           { ❤  U+2764, text presentation, 1 cell }
+  VS16  = #$EF#$B8#$8F;           { U+FE0F emoji presentation selector }
+  VS15  = #$EF#$B8#$8E;           { U+FE0E text presentation selector }
 
 procedure TestCodePointCellWidth;
 begin
@@ -222,6 +225,36 @@ begin
   AssertEqStr(TruncateVisibleTail('', 3), '', 'empty stays empty');
 end;
 
+procedure TestVariationSelectors;
+(* Codex P2 on PR #597. VS16 promotes the preceding glyph to its two-cell
+   emoji form; VS15 forces the one-cell text form. Counting the selector as
+   an independent zero-width character reported one cell for ❤️ where
+   terminals draw two. *)
+var
+  Prefix, Rem: string;
+begin
+  AssertEqInt(VisibleLength(HEART), 1, 'bare heart is one cell');
+  AssertEqInt(VisibleLength(HEART + VS16), 2,
+              'heart + VS16 is the two-cell emoji form');
+  AssertEqInt(VisibleLength(HEART + VS15), 1,
+              'heart + VS15 stays the one-cell text form');
+  AssertEqInt(VisibleLength('a' + HEART + VS16 + 'b'), 4,
+              'selector width counts inside a run');
+  { An emoji already wide by block stays 2 with a selector, not 3. }
+  AssertEqInt(VisibleLength(GRIN + VS16), 2,
+              'an already-wide emoji plus VS16 is still two cells');
+  { The pair must never be split: base and selector move together. }
+  Prefix := TruncateVisible('a' + HEART + VS16 + 'b', 2, Rem);
+  AssertEqStr(Prefix, 'a', 'two cells left: the emoji pair does not fit');
+  AssertEqStr(Rem, HEART + VS16 + 'b',
+              'and the base keeps its selector in the remainder');
+  Prefix := TruncateVisible('a' + HEART + VS16 + 'b', 3, Rem);
+  AssertEqStr(Prefix, 'a' + HEART + VS16, 'three cells: pair fits whole');
+  AssertEqStr(Rem, 'b', 'remainder is what follows the pair');
+  AssertEqStr(TruncateVisibleTail('ab' + HEART + VS16, 2), HEART + VS16,
+              'tail keeps the pair together too');
+end;
+
 procedure TestUtf8SeqLen;
 begin
   AssertEqInt(Utf8SeqLen($41), 1, 'ascii lead');
@@ -265,6 +298,7 @@ begin
   TestTruncateVisibleNeverSplitsWide;
   TestPadVisibleRightCjk;
   TestTruncateVisibleTail;
+  TestVariationSelectors;
   TestUtf8SeqLen;
   TestUtf8DecodeCodePoint;
   TestTruncateVisibleIterates;

--- a/src/tests/read_file_encoding_tests.pas
+++ b/src/tests/read_file_encoding_tests.pas
@@ -50,6 +50,23 @@ begin
   Dir := GetTempDir(False);
   if Dir = '' then Dir := '.';
 
+  { --- legacy multibyte bytes must still read as text, never raise ---
+    CP932 for the Japanese "日本" is 93 FA 96 7B: not valid UTF-8. On
+    Windows the ANSI step decodes it correctly; here it lands on Latin-1.
+    Either way ReadFileText must return well-formed UTF-8 and not throw. --- }
+  Path := Dir + PathDelim + 'pasclaw-cp932-legacy.txt';
+  WriteRaw(Path, [$93, $FA, $96, $7B]);
+  Body := '';
+  try
+    Body := ReadFileText(Path);
+  except
+    on E: Exception do
+      Check(False, 'legacy multibyte file raised ' + E.ClassName);
+  end;
+  Check(Body <> '', 'legacy multibyte file reads as some text');
+  Check(StrIsValidUTF8(Body), 'legacy multibyte file yields valid UTF-8');
+  DeleteFile(Path);
+
   { --- validator sanity --- }
   Check(BytesAreValidUTF8(TBytes.Create($E2, $98, $83)), 'validator: accepts UTF-8 snowman');
   Check(not BytesAreValidUTF8(TBytes.Create($93, $94)), 'validator: rejects cp1252 quotes');


### PR DESCRIPTION
Verifies and fixes a bug report: Chinese characters disappear from the TUI input field and do not show in the session log.

**Verified — and it is two bugs with two different causes, both confined to the Delphi positioned TUI.** The FPC line-based TUI is clean: a live probe here shows `ReadLn` delivering intact UTF-8, `JsonEscape` passing it through, and a session round-tripping byte-for-byte (`E4 BD A0 …` → `你好世界`).

## Bug 1 — characters vanish from the input line

**Windows.** The vendored `MVCFramework.Console.GetKey` returned the `KEY_EVENT`'s `AsciiChar`. For an IME-entered character that is the **low byte of its UTF-16 unit** — `你` U+4F60 became `` ` ``, `好` U+597D became `}` — or `#0`, which the code turned into "special key" `256 + VK_PACKET`, and the TUI's `Key < 256` filter dropped. So Chinese either turned into ASCII punctuation or vanished, and nothing reached the session because nothing reached the buffer.

`GetKey` now reads through `ReadConsoleInputW` and returns `UnicodeChar`. Printable codes therefore exceed 255, so the special-key encoding moved from `256+VK` to `KEY_SPECIAL_BASE+VK` above U+10FFFF (`256+VK_UP` was U+0126 `Ħ`), and `IsSpecialKey` tests that base. Nothing outside the unit encoded the old base; the `KEY_*` constants carry the new one.

**POSIX (Delphi build).** `GetKey` yields one raw byte per call, and the TUI appended `Chr(Key)` for anything 32..255 — so each byte of a 3-byte `你` became its own Latin-1 WideChar, the buffer held mojibake, and that mojibake went into the session file as-is. `HandleChatKey` now reassembles UTF-8 across calls (`Utf8SeqLen` / `Utf8DecodeCodePoint`, new in `PasClaw.Utils` and tested there) and appends the code point, as a surrogate pair when supplementary. Backspace removes a whole character, pair included.

## Bug 2 — not in the session log

`TSession.Save` wrote via `TStringList.SaveToFile` and `Load` read via `LoadFromFile`, **both without an encoding**. On Delphi that is `TEncoding.Default` — the system ANSI codepage on Windows — so every non-ASCII character became `?` (or GBK bytes the UTF-8 loader then mangled) on disk, and BOM-less UTF-8 read back as mojibake. FPC passed the bytes through untouched, which is why the bug only showed on the Delphi build. The store's append-only transcript log already encoded UTF-8 explicitly — someone hit this once before on one path. All four session-store sites now go through `WriteFileText` / `ReadFileText`, which are UTF-8 on both arms.

## Rendering

`VisibleLength` counted a 3-byte `你` as one column; the terminal draws it in two, so a row of Chinese overflowed and wrapped onto the next line, corrupting the frame. The width helpers now iterate code points — UTF-8 on FPC, UTF-16 on Delphi — and sum `CodePointCellWidth` (2 for East Asian Wide/Fullwidth and the emoji blocks, 0 for combining marks and zero-width characters). Every existing caller inherits this: the chat pane, `RenderMsgLines`' wrap math, CliUI's boxes. `TruncateVisible` never leaves half a wide character on a row; the input line keeps its cursor end via the new `TruncateVisibleTail`. Control characters still count one cell, so nothing that passed before changes.

## Tests

`ansi_width_tests` grew to 70 assertions covering cell width, wide-char truncation, tail truncation, and the UTF-8 decoder (2/3/4-byte, overlong, encoded surrogates, bad continuation). **Each new behaviour negative-verified before being trusted**: CJK downgraded to one cell, overlong leads accepted, and `TruncateVisible` allowed to split a wide character each fail the specific assertion written for them. Full `make test` green, 78 suites.

## Not verified here — stated plainly

- The Delphi TUI and the vendored console are Delphi-only; FPC never compiles that branch. The Windows `GetKey` change and the POSIX byte reassembly were written blind against the RTL and pass only the shape lint. **They need one run on Windows with an IME.**
- The session-store encoding fix is behaviour-neutral on FPC (which was never broken), so no FPC test can discriminate it; it too rests on reading the Delphi RTL's `TStrings` defaults.
- Nine other units have the same unencoded `SaveToFile`/`LoadFromFile` shape (exports, SCARS, MCP cache, fetched pages, …). Same class, separate follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGQKz579j1ZnDRwmr6h1V6)_